### PR TITLE
Harden production deploy environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:
-      name: production
+      name: Production
       url: ${{ steps.deploy.outputs.deployment_url }}
     env:
       VERCEL_CLI_VERSION: 50.37.3

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": {
-      "main": false
-    }
+    "deploymentEnabled": false
   },
   "crons": [
     {


### PR DESCRIPTION
## Summary
- Align the CI deploy job with the canonical GitHub Production environment name.
- Disable Vercel automatic Git deployments for all branches so GitHub Actions remains the controlled build/deploy path.

## Deployment security settings applied live
- Protected main with required core-validate and web-validate checks.
- Required PR flow on main with admin enforcement, no force pushes, no branch deletion, linear history, and conversation resolution.
- Restricted the Production environment to protected branches and disabled admin bypass.
- Removed duplicate repo-level DATABASE_URL after confirming it exists as a Production environment secret.

## Remaining manual secret move
- VERCEL_TOKEN and SENTRY_AUTH_TOKEN are still repo-level because GitHub does not expose existing secret values and no local copies were present. Re-enter them as Production environment secrets, then delete the repo-level copies.