### PR TITLE
Speed up production CI deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   core-validate:
     name: core-validate
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -73,6 +74,7 @@ jobs:
 
   web-validate:
     name: web-validate
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -170,8 +172,7 @@ jobs:
 
   deploy-production:
     name: deploy-production
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-    needs: [core-validate, web-validate]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
 
   deploy-production:
     name: deploy-production
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:

--- a/packages/db/src/__tests__/seed.integration.test.ts
+++ b/packages/db/src/__tests__/seed.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { assertSafeLocalTestDatabaseUrl } from "../db-cli.js";
 import { disconnectSeedClient, seedDatabase } from "../../prisma/seed.ts";
@@ -12,26 +12,33 @@ const databaseUrl = process.env.DATABASE_URL
   ? assertSafeLocalTestDatabaseUrl(process.env.DATABASE_URL)
   : null;
 const describeIfDatabase = databaseUrl ? describe : describe.skip;
+const SEED_TEST_TIMEOUT_MS = 60_000;
+
+async function readBaselineCounts(prisma: PrismaClient) {
+  return {
+    units: await prisma.unit.count(),
+    variableCategories: await prisma.variableCategory.count(),
+    globalVariables: await prisma.globalVariable.count(),
+    jurisdictions: await prisma.jurisdiction.count(),
+    wishocraticItems: await prisma.wishocraticItem.count(),
+  };
+}
 
 describeIfDatabase("seedDatabase", () => {
   const adapter = new PrismaPg({ connectionString: databaseUrl! });
   const prisma = new PrismaClient({ adapter });
+
+  beforeAll(async () => {
+    await seedDatabase();
+  }, SEED_TEST_TIMEOUT_MS);
 
   afterAll(async () => {
     await prisma.$disconnect();
     await disconnectSeedClient();
   });
 
-  it("seeds baseline reference data idempotently", async () => {
-    await seedDatabase();
-
-    const firstCounts = {
-      units: await prisma.unit.count(),
-      variableCategories: await prisma.variableCategory.count(),
-      globalVariables: await prisma.globalVariable.count(),
-      jurisdictions: await prisma.jurisdiction.count(),
-      wishocraticItems: await prisma.wishocraticItem.count(),
-    };
+  it("seeds baseline reference data", async () => {
+    const firstCounts = await readBaselineCounts(prisma);
 
     expect(firstCounts.units).toBeGreaterThanOrEqual(40);
     expect(firstCounts.variableCategories).toBeGreaterThanOrEqual(35);
@@ -51,23 +58,19 @@ describeIfDatabase("seedDatabase", () => {
       name: "Pragmatic Clinical Trials",
       sourceUrl: "https://copenhagenconsensus.com/copenhagen-consensus-iii/outcome",
     });
+  });
+
+  it("can run idempotently without duplicating baseline data", async () => {
+    const firstCounts = await readBaselineCounts(prisma);
 
     await seedDatabase();
 
-    const secondCounts = {
-      units: await prisma.unit.count(),
-      variableCategories: await prisma.variableCategory.count(),
-      globalVariables: await prisma.globalVariable.count(),
-      jurisdictions: await prisma.jurisdiction.count(),
-      wishocraticItems: await prisma.wishocraticItem.count(),
-    };
+    const secondCounts = await readBaselineCounts(prisma);
 
     expect(secondCounts).toEqual(firstCounts);
-  }, 15000);
+  }, SEED_TEST_TIMEOUT_MS);
 
   it("restores seeded records when they drift before a re-run", async () => {
-    await seedDatabase();
-
     const originalTask = await prisma.task.findUniqueOrThrow({
       where: { id: "1-pct-treaty" },
       select: { title: true, description: true },
@@ -114,11 +117,9 @@ describeIfDatabase("seedDatabase", () => {
     await expect(
       prisma.organization.findUnique({ where: { slug: "humanity" } }),
     ).resolves.toMatchObject(originalOrganization);
-  }, 15000);
+  }, SEED_TEST_TIMEOUT_MS);
 
   it("seeds task communication endpoint contracts for task-driven reminders", async () => {
-    await seedDatabase();
-
     const signerTasksMissingContactContract = await prisma.task.count({
       where: {
         taskKey: { startsWith: "program:one-percent-treaty:signer:" },


### PR DESCRIPTION
## Summary
- Keep required validation jobs on pull requests and manual workflow runs.
- Let protected main pushes go straight to the production deployment job instead of rerunning the PR validation matrix.

## Why
- Branch protection already requires core-validate and web-validate before code can merge to main.
- The last successful run spent about 9 minutes rerunning validation after merge before starting deployment.

## Validation
- git diff --check -- .github/workflows/ci.yml