### PR TITLE
Cache production Next build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Cache Next.js production build
+        uses: actions/cache@v4
+        with:
+          path: packages/web/.next/cache
+          key: nextjs-production-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('packages/web/src/**', 'packages/web/next.config.js', 'packages/web/package.json') }}
+          restore-keys: |
+            nextjs-production-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nextjs-production-${{ runner.os }}-
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nextjs-${{ runner.os }}-
+
       - name: Verify Vercel configuration
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary\n- restore the Next.js build cache in deploy-production before Vercel builds the prebuilt artifact\n- fall back to the existing web validation cache family when a production cache is not warm yet\n\n## Verification\n- git diff --check -- .github/workflows/ci.yml\n\n## Notes\n- actionlint is not installed locally; pnpm dlx actionlint did not provide a binary.