### PR TITLE
[codex] Add Court referendum flow

### DIFF
--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./parameters": "./src/parameters/index.ts",
+    "./referendums": "./src/referendums/index.ts",
     "./datasets/government-code-map": "./src/datasets/government-code-map.ts",
     "./datasets/governments": "./src/datasets/governments.ts",
     "./datasets/us-wishocratic-items": "./src/datasets/us-wishocratic-items.ts",

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -73,6 +73,10 @@ export * from './utils/index';
 export type { Parameter, Citation, SourceType, Confidence, ParameterName } from './parameters/index';
 export type { FormatParameterOptions } from './parameters/index';
 
+// Hand-edited referendum bodies (use @optimitron/data/referendums for full access)
+// These are referendum content that doesn't yet flow through the auto-generated
+// QMD pipeline in parameters-calculations-citations.ts.
+
 // Version
 export const VERSION = '0.1.0';
 export * from './pipelines/fetch-country-timeseries';

--- a/packages/data/src/referendums/court-of-humanity.ts
+++ b/packages/data/src/referendums/court-of-humanity.ts
@@ -1,0 +1,76 @@
+/**
+ * Court of Humanity referendum body.
+ *
+ * Hand-edited because `parameters-calculations-citations.ts` is
+ * AUTO-GENERATED from QMD source files in the manual repo
+ * (`disease-eradication-plan/knowledge/...`), and the Python generator
+ * does not yet pull `court-of-humanity.qmd` into its source list. Putting
+ * the body here lets us ship without a cross-repo PR.
+ *
+ * When the Python generator catches up and `shareableSnippets.courtOfHumanityText`
+ * starts appearing in the auto-generated file, this module can be deleted
+ * and the import in `packages/web/src/config/referendums.ts` switched to
+ * `shareableSnippets.courtOfHumanityText`. Keep the export shape compatible
+ * (`{ markdown, sourceFile, updatedAt, originalName }`) to make that
+ * migration trivial.
+ *
+ * Treaty body (`onePercentTreatyText`) intentionally stays in the
+ * auto-generated file because the QMD pipeline already produces it.
+ */
+export const COURT_OF_HUMANITY_TEXT = {
+  markdown: `*Should every person have the legal right to seek justice against any government that kills, injures, or harms them or their family?*
+
+This is the question your species never put to itself. The reason is structural: the people who would have called the vote are the people who would have lost it.
+
+WHEREAS, if a hospital kills your mother through negligence, you can sue. If a drug company hides safety data, you can sue. If a private security contractor shoots a child by accident, you can sue. If a government does the exact same thing, you cannot;
+
+WHEREAS, the legal doctrine that protects governments is called sovereign immunity, and it descends, without architectural modification, from the principle that the king can do no wrong;
+
+WHEREAS, your species abolished the divine right of kings in the 18th century. You retained the one part of it that needed abolishing;
+
+WHEREAS, sovereign immunity is waivable. Governments can give it up at any time. The United States has waived it for postal-truck collisions, malpractice at federal hospitals, and slip-and-falls in federal buildings. It has not waived it for invading the wrong country, droning the wrong wedding, or imprisoning the wrong person for thirty years. The exclusion is structural, not accidental;
+
+WHEREAS, governments killed approximately [310 million](https://manual.WarOnDisease.org/knowledge/problem/cost-of-war.html) of their own and other governments' citizens in the last century, including approximately [102 million](https://manual.WarOnDisease.org/knowledge/problem/cost-of-war.html) children, and the families of these humans were collectively awarded approximately zero dollars;
+
+WHEREAS, your governments' own actuaries value a statistical human life at \\$13.7 million (DOT) to \\$10 million (other agencies). The wrongful-death exposure on those 310 million humans alone runs to roughly \\$3.1 quadrillion before you count the people they would have grown up to become;
+
+WHEREAS, this number is large because the harm is large, not because the math is wrong;
+
+WHEREAS, allowing governments to kill people without consequence is not a feature of democracy. It is the structural form of organized crime, with the addition of a flag;
+
+WHEREAS, the question for you is not whether sovereign immunity is correct. The question is whether you noticed it exists, and whether, having noticed, you are willing to leave it in place;
+
+WHEREAS, the Court of Humanity does not require any government to consent to its existence. It derives its jurisdiction from human consent — specifically, the consent of any verified human who chooses to join. There are approximately 8 billion of those;
+
+WHEREAS, a court whose jurisdiction is human consent rather than sovereign consent has no problem getting humans to show up. The hard part has always been the other one;
+
+WHEREAS, the [International Criminal Court](https://manual.WarOnDisease.org/knowledge/solution/court-of-humanity.html) does not work because it requires the offending governments to either cooperate with prosecutions of themselves or be ignored when they refuse. The Court of Humanity replaces the cooperation gap with a capital-markets enforcement layer. Governments that refuse to honor judgments find their bondholders' lawyers — who are very good — pointed at them in their own domestic courts;
+
+WHEREAS, those bondholders are aligned with the judgments because the judgments are the asset. Compliance pays. Non-compliance is a default event. Default events trigger cross-default clauses on every other instrument the same government has issued. Sovereign immunity stops at the bond market, where the king has been bowing for centuries;
+
+WHEREAS, the [1% Treaty](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html) becomes the standing settlement offer. A government facing approximately \\$104 quadrillion in cumulative wrongful-death exposure can accept the Treaty's redirect-1%-to-clinical-trials terms in exchange for capped, prospective liability. This is what your species calls a deal;
+
+WHEREAS, voting no requires saying out loud "I believe my government should be allowed to kill my family with no consequences," which almost no human will say when asked, which is why the question, once asked, wins;
+
+WHEREAS, this also seems suboptimal to leave in place;
+
+NOW, THEREFORE, the undersigned humans, having noticed, hereby join the Court of Humanity, as follows:
+
+**Article I**: The Court of Humanity is composed of the verified humans who have joined it. Membership is the act of recording your name as a member; no further training, dues, or robes are required. As of joining, you are simultaneously the plaintiff class, the jury pool, and the body whose collective consent constitutes the court's jurisdiction.
+
+**Article II**: Each member, by joining, declares that the doctrine of sovereign immunity is hereby waived as to any government that has killed, injured, or unlawfully harmed them or their family without due process. Members may bring claims in any forum that will hear them — domestic courts, international tribunals, the Court of Humanity itself — and shall not have those claims dismissed on sovereign-immunity grounds within the Court's jurisdiction.
+
+**Article III**: Standing extends to any verified human, anywhere, against any government, anywhere, for any wrongful act of killing, injuring, or unlawfully detaining a person. Verification is via World ID or equivalent proof-of-personhood mechanism. One human, one membership, one vote on cases brought before the jury.
+
+**Article IV**: Judgments are enforced through capital markets, not coercion. Governments that fail to honor judgments find their compliant political opponents funded via the [Political Incentive Fund](https://manual.WarOnDisease.org/knowledge/solution/aligning-incentives.html), and find the [Incentive Alignment Bonds](https://manual.WarOnDisease.org/knowledge/appendix/incentive-alignment-bonds-paper.html) issued against their wrongful conduct selling at a price that reflects the market's view of their continued non-compliance. The court does not need an army; it needs only that bondholders have lawyers, which they do.
+
+**Article V**: The [1% Treaty](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html) is hereby established as the standing settlement offer. Governments may accept the Treaty's terms — redirecting 1% of annual military spending to pragmatic clinical trials, with bondholder and political-incentive structures attached — in exchange for prospective liability caps on Court of Humanity claims arising from acts predating Treaty ratification. The Treaty is the off-ramp. The Court is the road that produces the off-ramp.
+
+**Article VI**: Membership in the Court of Humanity is irrevocable for the lifetime of the member, but no member may bind their heirs or descendants. Each subsequent generation joins by their own consent. The Court has no head of state, no annual budget, no dues, and no way to be voted out by anyone other than its own members. In this respect it resembles every other institution your species has ever built that actually works.
+
+IN WITNESS WHEREOF, the undersigned humans, being of sound mind (debatable) and tired of watching their governments kill their families with no consequences, hereby join the Court of Humanity.
+`,
+  sourceFile: "knowledge/solution/court-of-humanity.qmd",
+  updatedAt: "2026-05-03",
+  originalName: "court-of-humanity-text",
+} as const;

--- a/packages/data/src/referendums/index.ts
+++ b/packages/data/src/referendums/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Hand-edited referendum bodies that are NOT yet sourced from the Python
+ * QMD pipeline (which generates `parameters-calculations-citations.ts`).
+ * Each entry here mirrors the `ShareableSnippet` shape used by
+ * `shareableSnippets.*` for trivial migration when the QMD pipeline
+ * catches up.
+ */
+export { COURT_OF_HUMANITY_TEXT } from "./court-of-humanity";

--- a/packages/db/prisma/migrations/20260503210000_add_referendum_content_fields/migration.sql
+++ b/packages/db/prisma/migrations/20260503210000_add_referendum_content_fields/migration.sql
@@ -1,0 +1,45 @@
+-- Add first-class ballot/content fields for API-created referendums.
+
+CREATE TYPE "ReferendumKind" AS ENUM (
+  'GENERAL',
+  'DECLARATION',
+  'TREATY',
+  'MEMBERSHIP',
+  'COURT_CASE',
+  'AMENDMENT',
+  'BUDGET'
+);
+
+ALTER TABLE "Referendum"
+  ADD COLUMN "question" TEXT,
+  ADD COLUMN "kind" "ReferendumKind" NOT NULL DEFAULT 'GENERAL',
+  ADD COLUMN "bodyMarkdown" TEXT,
+  ADD COLUMN "publishedAt" TIMESTAMP(3),
+  ADD COLUMN "lockedAt" TIMESTAMP(3),
+  ADD COLUMN "contentHash" TEXT;
+
+UPDATE "Referendum"
+SET
+  "question" = CASE
+    WHEN "slug" = 'one-percent-treaty'
+      THEN 'Should governments redirect 1% of military spending to pragmatic clinical trials and disease eradication by adopting the 1% Treaty?'
+    WHEN "slug" = 'declaration-of-optimization'
+      THEN 'Do you endorse the Declaration of Optimization?'
+    WHEN "slug" = 'court-of-humanity'
+      THEN 'Should every person have the legal right to seek justice against any government that kills, injures, or harms them or their family?'
+    ELSE COALESCE(NULLIF("description", ''), "title")
+  END,
+  "kind" = CASE
+    WHEN "slug" = 'one-percent-treaty' THEN 'TREATY'::"ReferendumKind"
+    WHEN "slug" = 'declaration-of-optimization' THEN 'DECLARATION'::"ReferendumKind"
+    WHEN "slug" = 'court-of-humanity' THEN 'MEMBERSHIP'::"ReferendumKind"
+    ELSE "kind"
+  END,
+  "publishedAt" = COALESCE("publishedAt", "createdAt")
+WHERE "question" IS NULL;
+
+ALTER TABLE "Referendum"
+  ALTER COLUMN "question" SET NOT NULL;
+
+CREATE INDEX "Referendum_kind_status_idx" ON "Referendum"("kind", "status");
+CREATE INDEX "Referendum_contentHash_idx" ON "Referendum"("contentHash");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4153,6 +4153,18 @@ enum ReferendumStatus {
   CLOSED
 }
 
+/// High-level referendum shape. The kind controls default public action copy
+/// and keeps the canonical yes/no question separate from body text.
+enum ReferendumKind {
+  GENERAL
+  DECLARATION
+  TREATY
+  MEMBERSHIP
+  COURT_CASE
+  AMENDMENT
+  BUDGET
+}
+
 /// Lifecycle for a Court of Humanity case.
 enum CourtCaseStatus {
   DRAFT
@@ -4200,8 +4212,26 @@ model Referendum {
   /// URL-safe slug for routing
   slug String @unique
 
-  /// Rich description or framing text
+  /// Canonical yes/no ballot question voters answer
+  question String
+
+  /// High-level referendum type for default action and result semantics
+  kind ReferendumKind @default(GENERAL)
+
+  /// Short summary or framing text for cards, lists, and metadata
   description String?
+
+  /// Full public referendum body in Markdown. This is the detail text, not the ballot question.
+  bodyMarkdown String?
+
+  /// First publication timestamp for public referendum content
+  publishedAt DateTime?
+
+  /// Content lock timestamp. Locked referendums should be amended, not edited in place.
+  lockedAt DateTime?
+
+  /// SHA-256 hash of the canonical question/description/body payload
+  contentHash String?
 
   /// User who created this referendum (optional for system-created ones)
   createdByUserId String?
@@ -4234,6 +4264,8 @@ model Referendum {
 
   @@index([slug])
   @@index([status])
+  @@index([kind, status])
+  @@index([contentHash])
   @@index([jurisdictionId])
   @@index([createdByUserId])
 }

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -43,6 +43,7 @@ import {
 import {
   TREATY_REFERENDUM_SLUG,
   DECLARATION_REFERENDUM_SLUG,
+  COURT_OF_HUMANITY_REFERENDUM_SLUG,
 } from "../src/constants.js";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { pathToFileURL } from "node:url";
@@ -1464,6 +1465,23 @@ async function seedReferendums() {
     create: declarationReferendumData,
   });
   console.log("  ✓ Declaration of Optimization referendum");
+
+  const courtReferendumData = {
+    title: "The Court of Humanity",
+    slug: COURT_OF_HUMANITY_REFERENDUM_SLUG,
+    description:
+      "Should every person have the legal right to seek justice against any government " +
+      "that kills, injures, or harms them or their family? Join the decentralized court " +
+      "where 8 billion humans are the jury and sovereign immunity is abolished.",
+    status: ReferendumStatus.ACTIVE,
+  } satisfies Prisma.ReferendumUncheckedCreateInput;
+
+  await prisma.referendum.upsert({
+    where: { slug: COURT_OF_HUMANITY_REFERENDUM_SLUG },
+    update: courtReferendumData,
+    create: courtReferendumData,
+  });
+  console.log("  ✓ Court of Humanity referendum");
 }
 
 export async function seedReferenceData() {

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -31,6 +31,7 @@ import {
   JurisdictionType,
   PersonConditionStatus,
   PersonLifeStatus,
+  ReferendumKind,
   ReferendumStatus,
   ReferendumVoteSource,
   TaskCommunicationEndpointKind,
@@ -46,12 +47,14 @@ import {
   COURT_OF_HUMANITY_REFERENDUM_SLUG,
 } from "../src/constants.js";
 import { PrismaPg } from "@prisma/adapter-pg";
+import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 import {
   US_WISHOCRATIC_JURISDICTION,
   getUSWishocraticCatalogRecords,
   listGovernmentLeaders,
 } from "@optimitron/data";
+import { COURT_OF_HUMANITY_TEXT } from "@optimitron/data/referendums";
 import {
   getAllConditions,
   getAllTreatments,
@@ -70,6 +73,7 @@ import {
   EARTH_OPTIMIZATION_PRIZE_DEADLINE,
   EARTH_OPTIMIZATION_PRIZE_DEADLINE_YEAR,
   EARTH_OPTIMIZATION_PRIZE_INCOME_GROWTH_EFFECT_PP_PER_YEAR,
+  shareableSnippets,
 } from "@optimitron/data/parameters";
 import { WORLD_LEADERS } from "@optimitron/data/datasets/world-leaders";
 import {
@@ -101,6 +105,27 @@ function slugify(input: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .replace(/-{2,}/g, "-");
+}
+
+function normalizeReferendumContentText(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function buildReferendumContentHash(input: {
+  question: string;
+  description?: string | null;
+  bodyMarkdown?: string | null;
+}) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        question: input.question.trim(),
+        description: normalizeReferendumContentText(input.description),
+        bodyMarkdown: normalizeReferendumContentText(input.bodyMarkdown),
+      }),
+    )
+    .digest("hex");
 }
 
 async function upsertUnit(data: Prisma.UnitUncheckedCreateInput) {
@@ -1433,16 +1458,33 @@ export interface SeedDatabaseOptions {
 
 async function seedReferendums() {
   console.log("🗳️  Seeding referendums...");
+  const publishedAt = new Date("2026-05-03T00:00:00.000Z");
+  const buildReferendumData = (
+    data: Omit<Prisma.ReferendumUncheckedCreateInput, "contentHash"> & {
+      question: string;
+    },
+  ): Prisma.ReferendumUncheckedCreateInput => ({
+    ...data,
+    contentHash: buildReferendumContentHash({
+      question: data.question,
+      description: data.description ?? null,
+      bodyMarkdown: data.bodyMarkdown ?? null,
+    }),
+  });
 
-  const treatyReferendumData = {
+  const treatyReferendumData = buildReferendumData({
     title: "The 1% Treaty",
     slug: TREATY_REFERENDUM_SLUG,
+    question:
+      "Should governments redirect 1% of military spending to pragmatic clinical trials and disease eradication by adopting the 1% Treaty?",
+    kind: ReferendumKind.TREATY,
     description:
-      "Should your government redirect 1% of military spending to pragmatic clinical trials? " +
-      "The 1% Treaty would fund evidence-based health optimization at a fraction of current costs. " +
-      "Every verified vote makes pluralistic ignorance harder to maintain.",
+      "The 1% Treaty redirects one percent of military spending into pragmatic clinical trials so disease gets less time to kill people.",
+    bodyMarkdown: shareableSnippets.onePercentTreatyText.markdown,
+    publishedAt,
+    lockedAt: null,
     status: ReferendumStatus.ACTIVE,
-  } satisfies Prisma.ReferendumUncheckedCreateInput;
+  });
 
   await prisma.referendum.upsert({
     where: { slug: TREATY_REFERENDUM_SLUG },
@@ -1451,13 +1493,21 @@ async function seedReferendums() {
   });
   console.log("  ✓ 1% Treaty referendum");
 
-  const declarationReferendumData = {
+  const declarationReferendumData = buildReferendumData({
     title: "Declaration of Optimization",
     slug: DECLARATION_REFERENDUM_SLUG,
+    question: "Do you endorse the Declaration of Optimization?",
+    kind: ReferendumKind.DECLARATION,
     description:
       "Sign the Declaration of Optimization to declare your support for evidence-based governance.",
+    bodyMarkdown: [
+      shareableSnippets.whyOptimizationIsNecessary.markdown,
+      shareableSnippets.declarationOfOptimization.markdown,
+    ].join("\n\n"),
+    publishedAt,
+    lockedAt: null,
     status: ReferendumStatus.ACTIVE,
-  } satisfies Prisma.ReferendumUncheckedCreateInput;
+  });
 
   await prisma.referendum.upsert({
     where: { slug: DECLARATION_REFERENDUM_SLUG },
@@ -1466,15 +1516,19 @@ async function seedReferendums() {
   });
   console.log("  ✓ Declaration of Optimization referendum");
 
-  const courtReferendumData = {
+  const courtReferendumData = buildReferendumData({
     title: "The Court of Humanity",
     slug: COURT_OF_HUMANITY_REFERENDUM_SLUG,
+    question:
+      "Should every person have the legal right to seek justice against any government that kills, injures, or harms them or their family?",
+    kind: ReferendumKind.MEMBERSHIP,
     description:
-      "Should every person have the legal right to seek justice against any government " +
-      "that kills, injures, or harms them or their family? Join the decentralized court " +
-      "where 8 billion humans are the jury and sovereign immunity is abolished.",
+      "Join the decentralized court where 8 billion humans are the jury and sovereign immunity is abolished.",
+    bodyMarkdown: COURT_OF_HUMANITY_TEXT.markdown,
+    publishedAt,
+    lockedAt: null,
     status: ReferendumStatus.ACTIVE,
-  } satisfies Prisma.ReferendumUncheckedCreateInput;
+  });
 
   await prisma.referendum.upsert({
     where: { slug: COURT_OF_HUMANITY_REFERENDUM_SLUG },

--- a/packages/db/src/__tests__/seed.integration.test.ts
+++ b/packages/db/src/__tests__/seed.integration.test.ts
@@ -8,6 +8,7 @@ import {
   OrgStatus,
   OrgType,
   PrismaClient,
+  ReferendumKind,
   ReferendumVoteSource,
   SubjectType,
   TaskCommunicationAudience,
@@ -244,6 +245,63 @@ describeIfDatabase("seedDatabase", () => {
     await expect(
       prisma.organization.findUnique({ where: { slug: "humanity" } }),
     ).resolves.toMatchObject(originalOrganization);
+  }, SEED_TEST_TIMEOUT_MS);
+
+  it("seeds canonical referendum ballot text and content metadata", async () => {
+    const referendums = await prisma.referendum.findMany({
+      where: {
+        slug: {
+          in: [
+            "one-percent-treaty",
+            "declaration-of-optimization",
+            "court-of-humanity",
+          ],
+        },
+        deletedAt: null,
+      },
+      select: {
+        slug: true,
+        title: true,
+        question: true,
+        kind: true,
+        description: true,
+        bodyMarkdown: true,
+        publishedAt: true,
+        lockedAt: true,
+        contentHash: true,
+      },
+    });
+
+    expect(referendums).toHaveLength(3);
+    expect(referendums).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          slug: "one-percent-treaty",
+          kind: ReferendumKind.TREATY,
+          question: expect.stringContaining("redirect 1% of military spending"),
+          bodyMarkdown: expect.stringContaining("Article I"),
+          lockedAt: null,
+          contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        }),
+        expect.objectContaining({
+          slug: "declaration-of-optimization",
+          kind: ReferendumKind.DECLARATION,
+          question: "Do you endorse the Declaration of Optimization?",
+          bodyMarkdown: expect.stringContaining("unanimous Declaration"),
+          contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        }),
+        expect.objectContaining({
+          slug: "court-of-humanity",
+          kind: ReferendumKind.MEMBERSHIP,
+          question: expect.stringContaining("legal right to seek justice"),
+          bodyMarkdown: expect.stringContaining("sovereign immunity"),
+          contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        }),
+      ]),
+    );
+    for (const referendum of referendums) {
+      expect(referendum.publishedAt).toBeInstanceOf(Date);
+    }
   }, SEED_TEST_TIMEOUT_MS);
 
   it("seeds task communication endpoint contracts for task-driven reminders", async () => {

--- a/packages/db/src/constants.ts
+++ b/packages/db/src/constants.ts
@@ -7,3 +7,4 @@
 
 export const TREATY_REFERENDUM_SLUG = "one-percent-treaty";
 export const DECLARATION_REFERENDUM_SLUG = "declaration-of-optimization";
+export const COURT_OF_HUMANITY_REFERENDUM_SLUG = "court-of-humanity";

--- a/packages/db/src/zod/index.ts
+++ b/packages/db/src/zod/index.ts
@@ -186,6 +186,17 @@ export type ReferendumVoteSource = z.infer<typeof ReferendumVoteSourceSchema>;
 export const ReferendumStatusSchema = z.enum(['DRAFT', 'ACTIVE', 'CLOSED']);
 export type ReferendumStatus = z.infer<typeof ReferendumStatusSchema>;
 
+export const ReferendumKindSchema = z.enum([
+  'GENERAL',
+  'DECLARATION',
+  'TREATY',
+  'MEMBERSHIP',
+  'COURT_CASE',
+  'AMENDMENT',
+  'BUDGET',
+]);
+export type ReferendumKind = z.infer<typeof ReferendumKindSchema>;
+
 export const CourtCaseStatusSchema = z.enum(['DRAFT', 'OPEN', 'VOTING', 'JUDGED', 'ARCHIVED']);
 export type CourtCaseStatus = z.infer<typeof CourtCaseStatusSchema>;
 
@@ -1584,7 +1595,13 @@ export const ReferendumSchema = z.object({
   id: z.string(),
   title: z.string(),
   slug: z.string(),
+  question: z.string(),
+  kind: ReferendumKindSchema.default('GENERAL'),
   description: z.string().nullable().optional(),
+  bodyMarkdown: z.string().nullable().optional(),
+  publishedAt: nullableDateSchema,
+  lockedAt: nullableDateSchema,
+  contentHash: z.string().nullable().optional(),
   createdByUserId: z.string().nullable().optional(),
   jurisdictionId: z.string().nullable().optional(),
   status: ReferendumStatusSchema.default('ACTIVE'),

--- a/packages/web/src/app/agencies/dcongress/referendums/[slug]/page.tsx
+++ b/packages/web/src/app/agencies/dcongress/referendums/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth-utils";
 import { getReferendumStats } from "@/lib/verified-votes.server";
@@ -14,14 +16,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   const referendum = await prisma.referendum.findUnique({
     where: { slug, deletedAt: null },
-    select: { title: true, description: true },
+    select: { title: true, question: true, description: true },
   });
 
   if (!referendum) return { title: "Referendum Not Found" };
 
   return {
     title: `${referendum.title} | Optimitron`,
-    description: referendum.description ?? `Vote on: ${referendum.title}`,
+    description: referendum.description ?? referendum.question,
   };
 }
 
@@ -66,7 +68,23 @@ export default async function ReferendumPage({ params, searchParams }: Props) {
             {referendum.description}
           </p>
         )}
+        <div className="mt-6 border-4 border-primary bg-brutal-yellow p-5 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+          <p className="mb-2 text-xs font-black uppercase tracking-[0.2em] text-brutal-yellow-foreground">
+            Ballot Question
+          </p>
+          <p className="text-xl font-black leading-snug text-brutal-yellow-foreground">
+            {referendum.question}
+          </p>
+        </div>
       </section>
+
+      {referendum.bodyMarkdown && (
+        <section className="prose prose-neutral mb-10 max-w-none border-4 border-primary bg-background p-6 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {referendum.bodyMarkdown}
+          </ReactMarkdown>
+        </section>
+      )}
 
       {/* Vote tally */}
       <section className="mb-10">

--- a/packages/web/src/app/agencies/dcongress/referendums/page.tsx
+++ b/packages/web/src/app/agencies/dcongress/referendums/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { prisma } from "@/lib/prisma";
-import { referendumLink } from "@/lib/routes";
+import { ROUTES, referendumLink } from "@/lib/routes";
 import { getRouteMetadata } from "@/lib/metadata";
 
 export const metadata = getRouteMetadata(referendumLink);
@@ -13,6 +13,8 @@ export default async function ReferendumsIndexPage() {
       id: true,
       title: true,
       slug: true,
+      question: true,
+      kind: true,
       description: true,
       createdAt: true,
       _count: { select: { votes: { where: { deletedAt: null } } } },
@@ -48,7 +50,7 @@ export default async function ReferendumsIndexPage() {
           {referendums.map((referendum) => (
             <Link
               key={referendum.id}
-              href={`/referendum/${referendum.slug}`}
+              href={`${ROUTES.referendum}/${referendum.slug}`}
               className="block border-4 border-primary bg-background p-6 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[12px_12px_0px_0px_rgba(0,0,0,1)]"
             >
               <div className="flex items-start justify-between gap-4">
@@ -56,6 +58,9 @@ export default async function ReferendumsIndexPage() {
                   <h2 className="text-xl font-black uppercase text-foreground mb-2">
                     {referendum.title}
                   </h2>
+                  <p className="mb-2 text-base font-black text-foreground">
+                    {referendum.question}
+                  </p>
                   {referendum.description && (
                     <p className="text-sm font-bold text-foreground line-clamp-2">
                       {referendum.description}

--- a/packages/web/src/app/api/referendums/route.test.ts
+++ b/packages/web/src/app/api/referendums/route.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findMany: vi.fn(),
+  findUnique: vi.fn(),
+  create: vi.fn(),
+  requireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-utils", () => ({
+  requireAuth: mocks.requireAuth,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    referendum: {
+      findMany: mocks.findMany,
+      findUnique: mocks.findUnique,
+      create: mocks.create,
+    },
+  },
+}));
+
+import { GET, POST } from "./route";
+
+function makePostRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/referendums", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/referendums", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.requireAuth.mockResolvedValue({ userId: "user_1" });
+    mocks.findUnique.mockResolvedValue(null);
+    mocks.create.mockImplementation(async ({ data }) => ({
+      id: "ref_1",
+      status: "ACTIVE",
+      createdAt: new Date("2026-05-03T00:00:00.000Z"),
+      ...data,
+    }));
+  });
+
+  it("lists referendum ballot fields and content metadata", async () => {
+    mocks.findMany.mockResolvedValue([
+      {
+        id: "ref_1",
+        title: "Tiny Referendum",
+        slug: "tiny-referendum",
+        question: "Should this tiny referendum exist?",
+        kind: "GENERAL",
+        description: "A small test.",
+        status: "ACTIVE",
+        publishedAt: new Date("2026-05-03T00:00:00.000Z"),
+        lockedAt: null,
+        contentHash: "a".repeat(64),
+        createdAt: new Date("2026-05-03T00:00:00.000Z"),
+        _count: { votes: 0 },
+      },
+    ]);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      referendums: [
+        {
+          slug: "tiny-referendum",
+          question: "Should this tiny referendum exist?",
+          kind: "GENERAL",
+          contentHash: "a".repeat(64),
+        },
+      ],
+    });
+    expect(mocks.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          question: true,
+          kind: true,
+          publishedAt: true,
+          lockedAt: true,
+          contentHash: true,
+        }),
+      }),
+    );
+  });
+
+  it("requires a canonical ballot question when creating a referendum", async () => {
+    const res = await POST(
+      makePostRequest({
+        title: "Tiny Referendum",
+        slug: "tiny-referendum",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Title, slug, and question are required",
+    });
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it("creates API referendums with body markdown and a content hash", async () => {
+    const res = await POST(
+      makePostRequest({
+        title: "Tiny Referendum",
+        slug: "tiny-referendum",
+        question: "Should this tiny referendum exist?",
+        description: "A small test.",
+        bodyMarkdown: "Details.",
+        kind: "GENERAL",
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mocks.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        title: "Tiny Referendum",
+        slug: "tiny-referendum",
+        question: "Should this tiny referendum exist?",
+        description: "A small test.",
+        bodyMarkdown: "Details.",
+        kind: "GENERAL",
+        createdByUserId: "user_1",
+        publishedAt: expect.any(Date),
+        lockedAt: null,
+        contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      }),
+    });
+    await expect(res.json()).resolves.toMatchObject({
+      referendum: {
+        slug: "tiny-referendum",
+        question: "Should this tiny referendum exist?",
+        bodyMarkdown: "Details.",
+        kind: "GENERAL",
+      },
+    });
+  });
+});

--- a/packages/web/src/app/api/referendums/route.ts
+++ b/packages/web/src/app/api/referendums/route.ts
@@ -1,6 +1,46 @@
 import { NextResponse } from "next/server";
+import { createHash } from "node:crypto";
+import type { ReferendumKind } from "@optimitron/db";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/auth-utils";
+
+const REFERENDUM_KINDS = new Set([
+  "GENERAL",
+  "DECLARATION",
+  "TREATY",
+  "MEMBERSHIP",
+  "COURT_CASE",
+  "AMENDMENT",
+  "BUDGET",
+]);
+
+function cleanRequiredString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function cleanOptionalString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function buildReferendumContentHash(input: {
+  question: string;
+  description?: string | null;
+  bodyMarkdown?: string | null;
+}) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        question: input.question.trim(),
+        description: cleanOptionalString(input.description),
+        bodyMarkdown: cleanOptionalString(input.bodyMarkdown),
+      }),
+    )
+    .digest("hex");
+}
 
 export async function GET() {
   try {
@@ -11,8 +51,13 @@ export async function GET() {
         id: true,
         title: true,
         slug: true,
+        question: true,
+        kind: true,
         description: true,
         status: true,
+        publishedAt: true,
+        lockedAt: true,
+        contentHash: true,
         createdAt: true,
         _count: { select: { votes: { where: { deletedAt: null } } } },
       },
@@ -31,15 +76,19 @@ export async function GET() {
 export async function POST(request: Request) {
   try {
     const { userId } = await requireAuth();
-    const { title, slug, description } = (await request.json()) as {
-      title: string;
-      slug: string;
-      description?: string;
-    };
+    const body = (await request.json()) as Record<string, unknown>;
+    const title = cleanRequiredString(body.title);
+    const slug = cleanRequiredString(body.slug);
+    const question = cleanRequiredString(body.question);
+    const description = cleanOptionalString(body.description);
+    const bodyMarkdown = cleanOptionalString(body.bodyMarkdown);
+    const requestedKind = (
+      cleanOptionalString(body.kind) ?? "GENERAL"
+    ).toUpperCase();
 
-    if (!title || !slug) {
+    if (!title || !slug || !question) {
       return NextResponse.json(
-        { error: "Title and slug are required" },
+        { error: "Title, slug, and question are required" },
         { status: 400 },
       );
     }
@@ -50,6 +99,14 @@ export async function POST(request: Request) {
         { status: 400 },
       );
     }
+
+    if (!REFERENDUM_KINDS.has(requestedKind)) {
+      return NextResponse.json(
+        { error: "Invalid referendum kind" },
+        { status: 400 },
+      );
+    }
+    const kind = requestedKind as ReferendumKind;
 
     const existing = await prisma.referendum.findUnique({ where: { slug } });
     if (existing) {
@@ -63,7 +120,17 @@ export async function POST(request: Request) {
       data: {
         title,
         slug,
-        description: description ?? null,
+        question,
+        kind,
+        description,
+        bodyMarkdown,
+        publishedAt: new Date(),
+        lockedAt: null,
+        contentHash: buildReferendumContentHash({
+          question,
+          description,
+          bodyMarkdown,
+        }),
         createdByUserId: userId,
       },
     });

--- a/packages/web/src/app/court/page.tsx
+++ b/packages/web/src/app/court/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { ReferendumStepperPage } from "@/components/referendum/ReferendumStepperPage";
+import { COURT_OF_HUMANITY_SLUG } from "@/lib/court-of-humanity";
+import { getRouteMetadata } from "@/lib/metadata";
+import { courtLink } from "@/lib/routes";
+import { getSiteFromHeaders } from "@/lib/site";
+
+export async function generateMetadata(): Promise<Metadata> {
+  return getRouteMetadata(courtLink);
+}
+
+interface CourtPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+/**
+ * Court of Humanity referendum page. The shared referendum config supplies
+ * the Court-specific "join/member" action copy and referral URL behavior.
+ */
+export default async function CourtPage({ searchParams }: CourtPageProps) {
+  const params = await searchParams;
+  const hdrs = await headers();
+  const site = getSiteFromHeaders(hdrs);
+  const referralCode = typeof params.ref === "string" ? params.ref : null;
+  const dashboardUrl =
+    site.key === "onePercentTreaty" ? "/dashboard?welcome=1" : undefined;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <ReferendumStepperPage
+        slug={COURT_OF_HUMANITY_SLUG}
+        referralCode={referralCode}
+        authCallbackUrl={dashboardUrl}
+        postSignRedirectUrl={dashboardUrl}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/app/court/page.tsx
+++ b/packages/web/src/app/court/page.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { ReferendumStepperPage } from "@/components/referendum/ReferendumStepperPage";
 import { COURT_OF_HUMANITY_SLUG } from "@/lib/court-of-humanity";
 import { getRouteMetadata } from "@/lib/metadata";
+import { getReferendumPageContent } from "@/lib/referendum-content.server";
 import { courtLink } from "@/lib/routes";
 import { getSiteFromHeaders } from "@/lib/site";
 
@@ -25,12 +26,15 @@ export default async function CourtPage({ searchParams }: CourtPageProps) {
   const referralCode = typeof params.ref === "string" ? params.ref : null;
   const dashboardUrl =
     site.key === "onePercentTreaty" ? "/dashboard?welcome=1" : undefined;
+  const referendumContent = await getReferendumPageContent(COURT_OF_HUMANITY_SLUG);
 
   return (
     <div className="min-h-screen bg-background">
       <ReferendumStepperPage
         slug={COURT_OF_HUMANITY_SLUG}
         referralCode={referralCode}
+        question={referendumContent?.question}
+        bodyMarkdown={referendumContent?.bodyMarkdown}
         authCallbackUrl={dashboardUrl}
         postSignRedirectUrl={dashboardUrl}
       />

--- a/packages/web/src/app/declaration/page.tsx
+++ b/packages/web/src/app/declaration/page.tsx
@@ -1,14 +1,21 @@
 import { ReferendumStepperPage } from "@/components/referendum/ReferendumStepperPage";
 import { DECLARATION_SLUG } from "@/lib/declaration";
 import { getRouteMetadata } from "@/lib/metadata";
+import { getReferendumPageContent } from "@/lib/referendum-content.server";
 import { declarationLink } from "@/lib/routes";
 
 export const metadata = getRouteMetadata(declarationLink);
 
-export default function DeclarationPage() {
+export default async function DeclarationPage() {
+  const referendumContent = await getReferendumPageContent(DECLARATION_SLUG);
+
   return (
     <div className="min-h-screen bg-background">
-      <ReferendumStepperPage slug={DECLARATION_SLUG} />
+      <ReferendumStepperPage
+        slug={DECLARATION_SLUG}
+        question={referendumContent?.question}
+        bodyMarkdown={referendumContent?.bodyMarkdown}
+      />
     </div>
   );
 }

--- a/packages/web/src/app/treaty/page.tsx
+++ b/packages/web/src/app/treaty/page.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { getOptionalReferendumSiteContent } from "@/content/referendum-sites";
 import { ReferendumStepperPage } from "@/components/referendum/ReferendumStepperPage";
 import { getRouteMetadata, getSiteMetadata } from "@/lib/metadata";
+import { getReferendumPageContent } from "@/lib/referendum-content.server";
 import { ROUTES, treatyLink } from "@/lib/routes";
 import { getSiteFromHeaders } from "@/lib/site";
 import { TREATY_REFERENDUM_SLUG } from "@/lib/treaty";
@@ -32,12 +33,15 @@ export default async function TreatyPage({ searchParams }: TreatyPageProps) {
   const referralCode = typeof params.ref === "string" ? params.ref : null;
   const treatyDashboardUrl =
     site.key === "onePercentTreaty" ? "/dashboard?welcome=1" : undefined;
+  const referendumContent = await getReferendumPageContent(TREATY_REFERENDUM_SLUG);
 
   return (
     <div className="min-h-screen bg-background">
       <ReferendumStepperPage
         slug={TREATY_REFERENDUM_SLUG}
         referralCode={referralCode}
+        question={referendumContent?.question}
+        bodyMarkdown={referendumContent?.bodyMarkdown}
         authCallbackUrl={treatyDashboardUrl}
         postSignRedirectUrl={treatyDashboardUrl}
       />

--- a/packages/web/src/components/prize/VoteTokenBalanceCard.tsx
+++ b/packages/web/src/components/prize/VoteTokenBalanceCard.tsx
@@ -162,7 +162,7 @@ export function VoteTokenBalanceCard() {
                 >
                   <div className="flex-1 min-w-0">
                     <Link
-                      href={`/referendum/${mint.referendum.slug}`}
+                      href={`${ROUTES.referendum}/${mint.referendum.slug}`}
                       className="text-sm font-black text-foreground hover:text-brutal-pink transition-colors truncate block"
                     >
                       {mint.referendum.title}

--- a/packages/web/src/components/referendum/ReferendumSignatureBox.tsx
+++ b/packages/web/src/components/referendum/ReferendumSignatureBox.tsx
@@ -13,6 +13,11 @@ import { buildUserReferralUrl } from "@/lib/url";
 import { getUserDisplayName } from "@/lib/user-display";
 import { cn } from "@/lib/utils";
 
+type ReferralUser = {
+  handle?: string | null;
+  referralCode?: string | null;
+};
+
 export interface ReferendumSignatureBoxProps {
   referendumSlug: string;
   title: string;
@@ -29,6 +34,15 @@ export interface ReferendumSignatureBoxProps {
   signedShare?: ReactNode;
   variant?: "stepper" | "reader";
   showReaderShell?: boolean;
+  submitLabel?: string;
+  submittingLabel?: string;
+  authTitle?: string;
+  emailButtonLabel?: string;
+  emailPendingButtonLabel?: string;
+  buildShareUrl?: (
+    user: ReferralUser | null | undefined,
+    baseUrl?: string,
+  ) => string;
   /**
    * Render the pre-checked "display publicly" toggle. Only shown for
    * authenticated users — unauthenticated flow keeps the existing behavior
@@ -53,6 +67,12 @@ export function ReferendumSignatureBox({
   signedShare,
   variant = "stepper",
   showReaderShell = true,
+  submitLabel = "Sign",
+  submittingLabel = "...",
+  authTitle = "Finish Signing",
+  emailButtonLabel = "Email Me a Link to Finish Signing",
+  emailPendingButtonLabel = "Sending Finish-Signing Link...",
+  buildShareUrl = buildUserReferralUrl,
   showPrivacyToggle = false,
 }: ReferendumSignatureBoxProps) {
   const router = useRouter();
@@ -62,7 +82,7 @@ export function ReferendumSignatureBox({
   const [error, setError] = useState<string | null>(null);
   const [makePublic, setMakePublic] = useState(true);
 
-  const referralUrl = buildUserReferralUrl(session?.user);
+  const referralUrl = buildShareUrl(session?.user);
   const isReader = variant === "reader";
   const shellClass = isReader && showReaderShell
     ? "rounded-[24px] border border-[#8e6b48]/25 bg-[#f7f1e4]/88 px-6 py-6 shadow-[0_12px_24px_rgba(58,42,25,0.08)]"
@@ -207,11 +227,11 @@ export function ReferendumSignatureBox({
           referralCode={referralCode}
           compact
           variant={isReader ? "document" : "default"}
-          title="Finish Signing"
+          title={authTitle}
           subtitle={authPromptText}
           googleButtonLabel="Finish with Google"
-          emailButtonLabel="Email Me a Link to Finish Signing"
-          emailPendingButtonLabel="Sending Finish-Signing Link..."
+          emailButtonLabel={emailButtonLabel}
+          emailPendingButtonLabel={emailPendingButtonLabel}
         />
       </div>
     );
@@ -234,7 +254,7 @@ export function ReferendumSignatureBox({
         disabled={signing}
         className={cn(buttonClass, "w-full")}
       >
-        {signing ? "..." : "Sign"}
+        {signing ? submittingLabel : submitLabel}
       </Button>
       {showPrivacyToggle && status === "authenticated" ? (
         <div className="mt-4">

--- a/packages/web/src/components/referendum/ReferendumStepperPage.test.ts
+++ b/packages/web/src/components/referendum/ReferendumStepperPage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ReactElement } from "react";
 import React from "react";
+import { COURT_OF_HUMANITY_SLUG } from "@/lib/court-of-humanity";
 import { DECLARATION_SLUG } from "@/lib/declaration";
 import { TREATY_REFERENDUM_SLUG } from "@/lib/treaty";
 
@@ -45,6 +46,22 @@ describe("ReferendumStepperPage", () => {
 
     expect(signature.props.referendumSlug).toBe(DECLARATION_SLUG);
     expect(signature.props.referralCode).toBe("alice");
+  }, 20000);
+
+  it("passes the active display mode to the generic signature surface", async () => {
+    const element = await renderPage({
+      slug: COURT_OF_HUMANITY_SLUG,
+      referralCode: "alice",
+    });
+    const signatureSlot = element.props.signatureSlot as (
+      mode: "stepper" | "reader",
+    ) => ReactElement;
+
+    const stepperSignature = signatureSlot("stepper");
+    const readerSignature = signatureSlot("reader");
+
+    expect(stepperSignature.props.variant).toBe("stepper");
+    expect(readerSignature.props.variant).toBe("reader");
   }, 20000);
 
   it("keeps the treaty on the treaty vote flow", async () => {

--- a/packages/web/src/components/referendum/ReferendumStepperPage.test.ts
+++ b/packages/web/src/components/referendum/ReferendumStepperPage.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReactElement } from "react";
+import React from "react";
+import { DECLARATION_SLUG } from "@/lib/declaration";
+import { TREATY_REFERENDUM_SLUG } from "@/lib/treaty";
+
+vi.mock("@/components/referendum/ReferendumStepper", () => ({
+  ReferendumStepper: () => null,
+  splitIntoSlides: (markdown: string) => markdown.split(/\n\n+/).filter(Boolean),
+}));
+vi.mock("@/components/landing/TreatyVoteFlow", () => ({
+  TreatyVoteFlow: () => null,
+}));
+vi.mock("@/components/site/ReferendumSiteInlineSign", () => ({
+  ReferendumSiteInlineSign: () => null,
+}));
+
+describe("ReferendumStepperPage", () => {
+  async function renderPage(slug: string, referralCode?: string | null) {
+    (globalThis as typeof globalThis & { React: typeof React }).React = React;
+    const { ReferendumStepperPage } = await import("./ReferendumStepperPage");
+    return (ReferendumStepperPage as unknown as (props: {
+      slug: string;
+      referralCode?: string | null;
+    }) => ReactElement)({ slug, referralCode });
+  }
+
+  it("uses the generic signature surface for non-treaty referendums", async () => {
+    const element = await renderPage(DECLARATION_SLUG, "alice");
+    const signatureSlot = element.props.signatureSlot as (
+      mode: "stepper" | "reader",
+    ) => ReactElement;
+
+    const signature = signatureSlot("reader");
+
+    expect(signature.props.referendumSlug).toBe(DECLARATION_SLUG);
+    expect(signature.props.referralCode).toBe("alice");
+  }, 20000);
+
+  it("keeps the treaty on the treaty vote flow", async () => {
+    const element = await renderPage(TREATY_REFERENDUM_SLUG);
+    const signatureSlot = element.props.signatureSlot as (
+      mode: "stepper" | "reader",
+    ) => ReactElement;
+
+    const signature = signatureSlot("reader");
+
+    expect(signature.props.referendumSlug).toBeUndefined();
+    expect(signature.props.authCallbackUrl).toBe("/treaty");
+  }, 20000);
+});

--- a/packages/web/src/components/referendum/ReferendumStepperPage.test.ts
+++ b/packages/web/src/components/referendum/ReferendumStepperPage.test.ts
@@ -16,17 +16,27 @@ vi.mock("@/components/site/ReferendumSiteInlineSign", () => ({
 }));
 
 describe("ReferendumStepperPage", () => {
-  async function renderPage(slug: string, referralCode?: string | null) {
+  async function renderPage(props: {
+    slug: string;
+    referralCode?: string | null;
+    question?: string | null;
+    bodyMarkdown?: string | null;
+  }) {
     (globalThis as typeof globalThis & { React: typeof React }).React = React;
     const { ReferendumStepperPage } = await import("./ReferendumStepperPage");
     return (ReferendumStepperPage as unknown as (props: {
       slug: string;
       referralCode?: string | null;
-    }) => ReactElement)({ slug, referralCode });
+      question?: string | null;
+      bodyMarkdown?: string | null;
+    }) => ReactElement)(props);
   }
 
   it("uses the generic signature surface for non-treaty referendums", async () => {
-    const element = await renderPage(DECLARATION_SLUG, "alice");
+    const element = await renderPage({
+      slug: DECLARATION_SLUG,
+      referralCode: "alice",
+    });
     const signatureSlot = element.props.signatureSlot as (
       mode: "stepper" | "reader",
     ) => ReactElement;
@@ -38,7 +48,7 @@ describe("ReferendumStepperPage", () => {
   }, 20000);
 
   it("keeps the treaty on the treaty vote flow", async () => {
-    const element = await renderPage(TREATY_REFERENDUM_SLUG);
+    const element = await renderPage({ slug: TREATY_REFERENDUM_SLUG });
     const signatureSlot = element.props.signatureSlot as (
       mode: "stepper" | "reader",
     ) => ReactElement;
@@ -47,5 +57,16 @@ describe("ReferendumStepperPage", () => {
 
     expect(signature.props.referendumSlug).toBeUndefined();
     expect(signature.props.authCallbackUrl).toBe("/treaty");
+  }, 20000);
+
+  it("prefers database question and markdown body when supplied", async () => {
+    const element = await renderPage({
+      slug: DECLARATION_SLUG,
+      question: "Do you endorse the tiny test referendum?",
+      bodyMarkdown: "First detail.\n\nSecond detail.",
+    });
+
+    expect(element.props.introText).toBe("Do you endorse the tiny test referendum?");
+    expect(element.props.slides).toEqual(["First detail.", "Second detail."]);
   }, 20000);
 });

--- a/packages/web/src/components/referendum/ReferendumStepperPage.tsx
+++ b/packages/web/src/components/referendum/ReferendumStepperPage.tsx
@@ -47,6 +47,7 @@ export function ReferendumStepperPage({
         referralCode={referralCode}
         authCallbackUrl={authCallbackUrl}
         postSignRedirectUrl={postSignRedirectUrl}
+        variant={mode}
         showReaderShell={mode === "reader"}
       />
     );

--- a/packages/web/src/components/referendum/ReferendumStepperPage.tsx
+++ b/packages/web/src/components/referendum/ReferendumStepperPage.tsx
@@ -2,7 +2,10 @@
 
 import type { ReactNode } from "react";
 import { notFound } from "next/navigation";
-import { ReferendumStepper } from "@/components/referendum/ReferendumStepper";
+import {
+  ReferendumStepper,
+  splitIntoSlides,
+} from "@/components/referendum/ReferendumStepper";
 import { TreatyVoteFlow } from "@/components/landing/TreatyVoteFlow";
 import { ReferendumSiteInlineSign } from "@/components/site/ReferendumSiteInlineSign";
 import { getReferendumConfig } from "@/config/referendums";
@@ -11,6 +14,8 @@ import { TREATY_REFERENDUM_SLUG } from "@/lib/treaty";
 interface ReferendumStepperPageProps {
   slug: string;
   referralCode?: string | null;
+  question?: string | null;
+  bodyMarkdown?: string | null;
   authCallbackUrl?: string;
   postSignRedirectUrl?: string;
   /**
@@ -24,12 +29,15 @@ interface ReferendumStepperPageProps {
 export function ReferendumStepperPage({
   slug,
   referralCode = null,
+  question = null,
+  bodyMarkdown = null,
   authCallbackUrl,
   postSignRedirectUrl,
   signatureSlot,
 }: ReferendumStepperPageProps) {
   const config = getReferendumConfig(slug);
   if (!config) return notFound();
+  const slides = bodyMarkdown ? splitIntoSlides(bodyMarkdown) : config.slides;
   const defaultSignatureSlot = (mode: "stepper" | "reader") =>
     config.slug === TREATY_REFERENDUM_SLUG ? (
       <TreatyVoteFlow authCallbackUrl={authCallbackUrl ?? config.authCallbackUrl} />
@@ -45,8 +53,8 @@ export function ReferendumStepperPage({
 
   return (
     <ReferendumStepper
-      introText={config.introText}
-      slides={config.slides}
+      introText={question ?? config.introText}
+      slides={slides}
       backgroundImages={config.backgroundImages}
       audioManifestPath={config.audioManifestPath}
       audioBasePath={config.audioBasePath}

--- a/packages/web/src/components/referendum/ReferendumStepperPage.tsx
+++ b/packages/web/src/components/referendum/ReferendumStepperPage.tsx
@@ -1,25 +1,47 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { notFound } from "next/navigation";
 import { ReferendumStepper } from "@/components/referendum/ReferendumStepper";
 import { TreatyVoteFlow } from "@/components/landing/TreatyVoteFlow";
+import { ReferendumSiteInlineSign } from "@/components/site/ReferendumSiteInlineSign";
 import { getReferendumConfig } from "@/config/referendums";
+import { TREATY_REFERENDUM_SLUG } from "@/lib/treaty";
 
 interface ReferendumStepperPageProps {
   slug: string;
   referralCode?: string | null;
   authCallbackUrl?: string;
   postSignRedirectUrl?: string;
+  /**
+   * Override the default signature UI. Defaults to `<TreatyVoteFlow />`
+   * (slider + YES/NO + auth) for the 1% Treaty. Other referendums (e.g.
+   * Court of Humanity) pass a binary "join" component instead.
+   */
+  signatureSlot?: (mode: "stepper" | "reader") => ReactNode;
 }
 
 export function ReferendumStepperPage({
   slug,
-  referralCode: _referralCode = null,
-  authCallbackUrl: _authCallbackUrl,
-  postSignRedirectUrl: _postSignRedirectUrl,
+  referralCode = null,
+  authCallbackUrl,
+  postSignRedirectUrl,
+  signatureSlot,
 }: ReferendumStepperPageProps) {
   const config = getReferendumConfig(slug);
   if (!config) return notFound();
+  const defaultSignatureSlot = (mode: "stepper" | "reader") =>
+    config.slug === TREATY_REFERENDUM_SLUG ? (
+      <TreatyVoteFlow authCallbackUrl={authCallbackUrl ?? config.authCallbackUrl} />
+    ) : (
+      <ReferendumSiteInlineSign
+        referendumSlug={config.slug}
+        referralCode={referralCode}
+        authCallbackUrl={authCallbackUrl}
+        postSignRedirectUrl={postSignRedirectUrl}
+        showReaderShell={mode === "reader"}
+      />
+    );
 
   return (
     <ReferendumStepper
@@ -28,7 +50,7 @@ export function ReferendumStepperPage({
       backgroundImages={config.backgroundImages}
       audioManifestPath={config.audioManifestPath}
       audioBasePath={config.audioBasePath}
-      signatureSlot={() => <TreatyVoteFlow />}
+      signatureSlot={signatureSlot ?? defaultSignatureSlot}
     />
   );
 }

--- a/packages/web/src/components/referendum/ReferendumVoteSection.tsx
+++ b/packages/web/src/components/referendum/ReferendumVoteSection.tsx
@@ -88,7 +88,7 @@ export function ReferendumVoteSection({
   }
 
   if (!isAuthenticated) {
-    const signInHref = getSignInPath(`/referendum/${referendumSlug}`, {
+    const signInHref = getSignInPath(`${ROUTES.referendum}/${referendumSlug}`, {
       referralCode,
     });
 

--- a/packages/web/src/components/site/ReferendumSiteInlineSign.test.ts
+++ b/packages/web/src/components/site/ReferendumSiteInlineSign.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReactElement } from "react";
+import React from "react";
+import { COURT_OF_HUMANITY_SLUG } from "@/lib/court-of-humanity";
+
+vi.mock("@/components/referendum/ReferendumSignatureBox", () => ({
+  ReferendumSignatureBox: () => null,
+}));
+vi.mock("@/components/landing/TreatyReminderComposer", () => ({
+  TreatyReminderComposer: () => null,
+}));
+vi.mock("@/components/shared/ParameterValue", () => ({
+  ParameterValue: () => null,
+}));
+
+describe("ReferendumSiteInlineSign", () => {
+  it("passes Court membership labels, referral attribution, and share URL behavior", async () => {
+    (globalThis as typeof globalThis & { React: typeof React }).React = React;
+    const { ReferendumSiteInlineSign } = await import(
+      "./ReferendumSiteInlineSign"
+    );
+
+    const element = (ReferendumSiteInlineSign as unknown as (props: {
+      referendumSlug: string;
+      referralCode?: string | null;
+    }) => ReactElement)({
+      referendumSlug: COURT_OF_HUMANITY_SLUG,
+      referralCode: "alice",
+    });
+
+    expect(element.props.referralCode).toBe("alice");
+    expect(element.props.submitLabel).toBe("Join");
+    expect(element.props.submittingLabel).toBe("Joining...");
+    expect(element.props.authTitle).toBe("Finish Joining");
+    expect(element.props.emailButtonLabel).toBe(
+      "Email Me a Link to Finish Joining",
+    );
+    expect(element.props.emailPendingButtonLabel).toBe(
+      "Sending Finish-Joining Link...",
+    );
+    expect(
+      element.props.buildShareUrl(
+        { handle: "member-1", referralCode: "fallback" },
+        "https://example.org",
+      ),
+    ).toBe("https://example.org/court?ref=member-1");
+  }, 20000);
+});

--- a/packages/web/src/components/site/ReferendumSiteInlineSign.tsx
+++ b/packages/web/src/components/site/ReferendumSiteInlineSign.tsx
@@ -16,6 +16,7 @@ export function ReferendumSiteInlineSign({
   authCallbackUrl,
   postSignRedirectUrl,
   title,
+  variant = "reader",
   showPrivacyToggle,
   showReaderShell = false,
 }: {
@@ -24,6 +25,7 @@ export function ReferendumSiteInlineSign({
   authCallbackUrl?: string;
   postSignRedirectUrl?: string;
   title?: string;
+  variant?: "stepper" | "reader";
   showPrivacyToggle?: boolean;
   showReaderShell?: boolean;
 }) {
@@ -76,7 +78,7 @@ export function ReferendumSiteInlineSign({
       signedTitle={config.signedTitle}
       signedBody={signedBody}
       signedShare={signedShare}
-      variant="reader"
+      variant={variant}
       showReaderShell={showReaderShell}
       submitLabel={config.action.submitLabel}
       submittingLabel={config.action.submittingLabel}

--- a/packages/web/src/components/site/ReferendumSiteInlineSign.tsx
+++ b/packages/web/src/components/site/ReferendumSiteInlineSign.tsx
@@ -12,12 +12,16 @@ import { TREATY_REFERENDUM_SLUG } from "@/lib/treaty";
 
 export function ReferendumSiteInlineSign({
   referendumSlug,
+  referralCode = null,
+  authCallbackUrl,
   postSignRedirectUrl,
   title,
-  showPrivacyToggle = false,
+  showPrivacyToggle,
   showReaderShell = false,
 }: {
   referendumSlug: string | null;
+  referralCode?: string | null;
+  authCallbackUrl?: string;
   postSignRedirectUrl?: string;
   title?: string;
   showPrivacyToggle?: boolean;
@@ -62,9 +66,10 @@ export function ReferendumSiteInlineSign({
       referendumSlug={config.slug}
       title={title ?? config.title}
       authPromptText={config.authPromptText}
-      authCallbackUrl={postSignRedirectUrl ?? config.authCallbackUrl}
+      authCallbackUrl={authCallbackUrl ?? postSignRedirectUrl ?? config.authCallbackUrl}
       postSignRedirectUrl={postSignRedirectUrl}
-      storePendingVote={(name) => config.storePendingVote(name, null)}
+      referralCode={referralCode}
+      storePendingVote={(name) => config.storePendingVote(name, referralCode)}
       clearPendingVote={() => config.clearPendingVote()}
       shareText={config.shareText}
       emailSubject={config.emailSubject}
@@ -73,7 +78,13 @@ export function ReferendumSiteInlineSign({
       signedShare={signedShare}
       variant="reader"
       showReaderShell={showReaderShell}
-      showPrivacyToggle={showPrivacyToggle}
+      submitLabel={config.action.submitLabel}
+      submittingLabel={config.action.submittingLabel}
+      authTitle={config.action.authTitle}
+      emailButtonLabel={config.action.emailButtonLabel}
+      emailPendingButtonLabel={config.action.emailPendingButtonLabel}
+      buildShareUrl={config.action.buildShareUrl}
+      showPrivacyToggle={showPrivacyToggle ?? config.showPrivacyToggle ?? false}
     />
   );
 }

--- a/packages/web/src/components/treaty/TreatyContent.tsx
+++ b/packages/web/src/components/treaty/TreatyContent.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { getReferendumConfig } from "@/config/referendums";
 import { readerMarkdownComponents } from "@/components/referendum/ReferendumStepper";
 import { ReferendumSiteInlineSign } from "@/components/site/ReferendumSiteInlineSign";
+import { ROUTES } from "@/lib/routes";
 import { TREATY_REFERENDUM_SLUG } from "@/lib/treaty";
 
 /**
@@ -34,6 +36,21 @@ export function TreatyContent() {
           {slide}
         </ReactMarkdown>
       ))}
+      <div className="border-t border-[#8e6b48]/30 pt-10 text-center">
+        <p className="text-xs font-black uppercase tracking-[0.22em] text-[var(--treaty-ink-muted)] sm:text-sm">
+          Next: the enforcement stack
+        </p>
+        <Link
+          href={ROUTES.court}
+          className="mt-3 inline-block text-xl font-bold text-[var(--treaty-ink)] underline decoration-[#8e6b48]/60 decoration-2 underline-offset-4 [font-family:var(--v0-font-libre-baskerville)] hover:decoration-[var(--treaty-ink)] sm:text-2xl"
+        >
+          Join the Court of Humanity →
+        </Link>
+        <p className="mt-3 text-sm font-bold leading-7 text-[var(--treaty-ink-soft)] [font-family:var(--v0-font-libre-baskerville)] sm:text-base">
+          The treaty is the off-ramp. The Court is the road that produces the
+          off-ramp.
+        </p>
+      </div>
       <div className="border-t border-[#8e6b48]/30 pt-12">
         <ReferendumSiteInlineSign
           referendumSlug={TREATY_REFERENDUM_SLUG}

--- a/packages/web/src/config/__tests__/site-variant-ui.test.ts
+++ b/packages/web/src/config/__tests__/site-variant-ui.test.ts
@@ -99,6 +99,7 @@ describe("site variant UI config", () => {
       "Sign as Organization",
       "Donate",
       "Why",
+      "Court of Humanity",
       "Legal",
       "Privacy",
       "Terms",

--- a/packages/web/src/config/referendums.ts
+++ b/packages/web/src/config/referendums.ts
@@ -7,15 +7,38 @@ import {
   VOTER_LIVES_SAVED,
   VOTER_SUFFERING_HOURS_PREVENTED,
 } from "@optimitron/data/parameters";
+import { COURT_OF_HUMANITY_TEXT } from "@optimitron/data/referendums";
 import { splitIntoSlides } from "@/components/referendum/ReferendumStepper";
+import { COURT_OF_HUMANITY_SLUG } from "@/lib/court-of-humanity";
 import { DECLARATION_SLUG } from "@/lib/declaration";
 import { getHandleOrReferralCode } from "@/lib/referral.client";
 import { storage } from "@/lib/storage";
 import { TREATY_REFERENDUM_SLUG } from "@/lib/treaty";
 import { getTreatyWishocraticAllocation } from "@/lib/treaty-vote";
+import { buildCourtReferralUrl, buildUserReferralUrl } from "@/lib/url";
+
+type ReferendumShareUser = {
+  handle?: string | null;
+  referralCode?: string | null;
+};
+
+export type ReferendumKind = "declaration" | "treaty" | "membership";
+
+export interface ReferendumActionConfig {
+  submitLabel: string;
+  submittingLabel: string;
+  authTitle: string;
+  emailButtonLabel: string;
+  emailPendingButtonLabel: string;
+  buildShareUrl: (
+    user: ReferendumShareUser | null | undefined,
+    baseUrl?: string,
+  ) => string;
+}
 
 export interface ReferendumConfig {
   slug: string;
+  kind: ReferendumKind;
   introText: string;
   slides: string[];
   backgroundImages?: string[];
@@ -28,10 +51,30 @@ export interface ReferendumConfig {
   emailSubject: string;
   signedTitle: string;
   signedBody: string;
+  action: ReferendumActionConfig;
+  showPrivacyToggle?: boolean;
   storePendingVote: (name: string, referralCode: string | null) => void;
   clearPendingVote: () => void;
   syncPending: (session?: Session | null) => Promise<void>;
 }
+
+const signAction: ReferendumActionConfig = {
+  submitLabel: "Sign",
+  submittingLabel: "...",
+  authTitle: "Finish Signing",
+  emailButtonLabel: "Email Me a Link to Finish Signing",
+  emailPendingButtonLabel: "Sending Finish-Signing Link...",
+  buildShareUrl: buildUserReferralUrl,
+};
+
+const joinAction: ReferendumActionConfig = {
+  submitLabel: "Join",
+  submittingLabel: "Joining...",
+  authTitle: "Finish Joining",
+  emailButtonLabel: "Email Me a Link to Finish Joining",
+  emailPendingButtonLabel: "Sending Finish-Joining Link...",
+  buildShareUrl: buildCourtReferralUrl,
+};
 
 async function postVote(
   slug: string,
@@ -127,6 +170,7 @@ async function syncPendingTreatyAllocation(): Promise<boolean> {
 
 const declarationConfig: ReferendumConfig = {
   slug: DECLARATION_SLUG,
+  kind: "declaration",
   introText: "Please quickly skim and sign the Declaration of Optimization.",
   slides: [
     ...splitIntoSlides(shareableSnippets.whyOptimizationIsNecessary.markdown),
@@ -145,6 +189,7 @@ const declarationConfig: ReferendumConfig = {
   signedTitle: "Declaration Signed",
   signedBody:
     "Share your link. Every signature is one more reason your government will pretend it always supported this.",
+  action: signAction,
   storePendingVote: (name) => {
     storage.setDeclarationSigned({
       signedAt: new Date().toISOString(),
@@ -168,6 +213,7 @@ const declarationConfig: ReferendumConfig = {
 
 const treatyConfig: ReferendumConfig = {
   slug: TREATY_REFERENDUM_SLUG,
+  kind: "treaty",
   introText:
     "Please end war and disease by quickly skimming and signing the 1% Treaty.",
   slides: splitIntoSlides(shareableSnippets.onePercentTreatyText.markdown),
@@ -183,6 +229,7 @@ const treatyConfig: ReferendumConfig = {
   signedTitle: "Thank you for ending war and disease!",
   signedBody:
     `For each person you get to sign with your link, you will be personally to blame for saving ${fmtRaw(VOTER_LIVES_SAVED.value, 2)} lives and preventing ${fmtRaw(VOTER_SUFFERING_HOURS_PREVENTED.value, 2)} hours of suffering.`,
+  action: signAction,
   storePendingVote: (_name, referralCode) =>
     storage.setPendingTreatyVote({
       answer: "YES",
@@ -224,9 +271,56 @@ const treatyConfig: ReferendumConfig = {
   },
 };
 
+/**
+ * Court of Humanity referendum — framed as "join" rather than "sign" since
+ * the user is becoming a member of the decentralized court / jury, not
+ * petitioning for a one-time policy change. Underlying data model is the
+ * same `ReferendumVote` table; the "join" treatment lives entirely in the
+ * copy fields below.
+ */
+const courtOfHumanityConfig: ReferendumConfig = {
+  slug: COURT_OF_HUMANITY_SLUG,
+  kind: "membership",
+  introText:
+    "Please join the Court of Humanity by quickly skimming and signing below.",
+  slides: splitIntoSlides(COURT_OF_HUMANITY_TEXT.markdown),
+  title: "Joined this day, {date}, in the year of our ongoing confusion.",
+  authPromptText:
+    "Verify your identity to become a member of the Court of Humanity.",
+  authCallbackUrl: "/court",
+  shareText:
+    "I just joined the Court of Humanity. Sovereign immunity is now slightly less of a thing. Join too:",
+  emailSubject: "I joined the Court of Humanity",
+  signedTitle: "You are a member of the Court of Humanity.",
+  signedBody:
+    "For each human you bring into the Court with your link, the jury grows by one and sovereign immunity weakens by an amount your governments' lawyers will quietly notice.",
+  action: joinAction,
+  showPrivacyToggle: true,
+  storePendingVote: (_name, referralCode) =>
+    storage.setPendingCourtOfHumanityVote({
+      answer: "YES",
+      referredBy: referralCode,
+      timestamp: new Date().toISOString(),
+    }),
+  clearPendingVote: () => storage.removePendingCourtOfHumanityVote(),
+  syncPending: async (session) => {
+    const pending = storage.getPendingCourtOfHumanityVote();
+    if (!pending) return;
+    const ok = await postVote(
+      COURT_OF_HUMANITY_SLUG,
+      pending.answer,
+      pending.referredBy,
+    );
+    if (!ok) return;
+    storage.removePendingCourtOfHumanityVote();
+    cacheVoteStatus(session, pending.answer);
+  },
+};
+
 export const REFERENDUMS: Record<string, ReferendumConfig> = {
   [DECLARATION_SLUG]: declarationConfig,
   [TREATY_REFERENDUM_SLUG]: treatyConfig,
+  [COURT_OF_HUMANITY_SLUG]: courtOfHumanityConfig,
 };
 
 export function getReferendumConfig(slug: string): ReferendumConfig | null {

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -3,6 +3,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import {
   OrgStatus,
   OrgType,
+  ReferendumKind,
   ReferendumStatus,
   TaskClaimPolicy,
   TaskStatus,
@@ -293,7 +294,13 @@ beforeEach(() => {
     id: "ref-new",
     title: "Trial Abundance Referendum",
     slug: "trial-abundance-referendum",
+    question: "Should we fund pragmatic trials?",
+    kind: ReferendumKind.GENERAL,
     description: "Should we fund pragmatic trials?",
+    bodyMarkdown: null,
+    contentHash: "a".repeat(64),
+    lockedAt: null,
+    publishedAt: null,
     status: ReferendumStatus.DRAFT,
     jurisdictionId: null,
     createdByUserId: "user-1",
@@ -1008,28 +1015,52 @@ describe("MCP server tool dispatch", () => {
         name: "createReferendum",
         arguments: {
           title: "Trial Abundance Referendum",
+          question: "Should we fund pragmatic trials?",
           description: "Should we fund pragmatic trials?",
         },
       });
 
       expect(result.isError).toBeFalsy();
       expect(mocks.referendumCreate).toHaveBeenCalledWith({
-        data: {
+        data: expect.objectContaining({
           title: "Trial Abundance Referendum",
           slug: "trial-abundance-referendum",
+          question: "Should we fund pragmatic trials?",
+          kind: ReferendumKind.GENERAL,
           description: "Should we fund pragmatic trials?",
           status: ReferendumStatus.DRAFT,
+          contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+          lockedAt: null,
+          publishedAt: null,
           createdByUserId: "user-1",
-        },
+        }),
         select: expect.any(Object),
       });
       const body = parseToolBody(result);
       expect(body.referendum).toMatchObject({
         id: "ref-new",
         slug: "trial-abundance-referendum",
+        question: "Should we fund pragmatic trials?",
+        kind: ReferendumKind.GENERAL,
+        contentHash: "a".repeat(64),
         status: ReferendumStatus.DRAFT,
         voteCount: 0,
       });
+    });
+
+    it("createReferendum requires a canonical ballot question", async () => {
+      const client = await setup("user-1", ALL_SCOPES, { isAdmin: true });
+      const result = await client.callTool({
+        name: "createReferendum",
+        arguments: {
+          title: "Trial Abundance Referendum",
+          description: "Should we fund pragmatic trials?",
+        },
+      });
+
+      expect(result.isError).toBeTruthy();
+      expect(parseToolBody(result).error).toBe("question is required");
+      expect(mocks.referendumCreate).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/web/src/lib/court-data.server.ts
+++ b/packages/web/src/lib/court-data.server.ts
@@ -4,9 +4,11 @@ import {
   CourtCasePartyCapacity,
   CourtCasePartyRole,
   CourtCaseStatus,
+  ReferendumKind,
   ReferendumStatus,
   SubjectType,
 } from "@optimitron/db/enums";
+import { createHash } from "node:crypto";
 import { z } from "zod";
 import { prisma } from "./prisma";
 import { slugify } from "./slugify";
@@ -34,6 +36,27 @@ const optionalUrl = optionalTrimmedString(MAX_URL_LENGTH).refine(
   (value) => value === null || /^https?:\/\//i.test(value),
   "Use an http(s) URL.",
 );
+
+function normalizeReferendumContentText(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function buildReferendumContentHash(input: {
+  question: string;
+  description?: string | null;
+  bodyMarkdown?: string | null;
+}) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        question: input.question.trim(),
+        description: normalizeReferendumContentText(input.description),
+        bodyMarkdown: normalizeReferendumContentText(input.bodyMarkdown),
+      }),
+    )
+    .digest("hex");
+}
 
 const optionalDate = z.unknown().transform((value) => {
   if (value instanceof Date) return value;
@@ -675,18 +698,28 @@ export async function openCourtCaseJuryVote(input: unknown, db: DbClient = prism
 
   const questionKey = data.questionKey ?? "verdict";
   const referendumSlug = slugify(`court-${courtCase.slug}-${questionKey}`);
-  const title = data.questionTitle ?? `Should humanity find for the plaintiffs in ${courtCase.title}?`;
+  const question = data.questionTitle ?? `Should humanity find for the plaintiffs in ${courtCase.title}?`;
+  const title = question;
   const description = `Court of Humanity jury vote for ${courtCase.title}.`;
+  const contentHash = buildReferendumContentHash({ question, description });
 
   const referendum = await db.referendum.upsert({
     where: { slug: referendumSlug },
     update: {
+      contentHash,
       description,
+      kind: ReferendumKind.COURT_CASE,
+      question,
       status: ReferendumStatus.ACTIVE,
     },
     create: {
+      contentHash,
       createdByUserId: data.createdByUserId,
       description,
+      kind: ReferendumKind.COURT_CASE,
+      lockedAt: null,
+      publishedAt: new Date(),
+      question,
       slug: referendumSlug,
       status: ReferendumStatus.ACTIVE,
       title,
@@ -696,6 +729,8 @@ export async function openCourtCaseJuryVote(input: unknown, db: DbClient = prism
       slug: true,
       title: true,
       status: true,
+      question: true,
+      kind: true,
       description: true,
     },
   });

--- a/packages/web/src/lib/court-of-humanity.ts
+++ b/packages/web/src/lib/court-of-humanity.ts
@@ -1,0 +1,14 @@
+/**
+ * Slug for the Court of Humanity referendum. Lives in its own file
+ * (mirroring `lib/treaty.ts` and `lib/declaration.ts`) so the slug constant
+ * can be imported from the API route, the config module, the storage layer,
+ * and the seed without forming an import cycle.
+ *
+ * The Court of Humanity is framed as something users JOIN (becoming a
+ * member of the decentralized court / jury), not "sign" — but the
+ * underlying data model is the same `ReferendumVote` table as the 1% Treaty
+ * (one YES vote per user per referendum). The "join" framing lives entirely
+ * in the UX/copy layer (referendum config: introText, signedTitle,
+ * signedBody, shareText, etc.). See `config/referendums.ts`.
+ */
+export const COURT_OF_HUMANITY_SLUG = "court-of-humanity";

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -18,6 +18,7 @@ import {
   McpToolCallStatus,
   OrgStatus,
   OrgType,
+  ReferendumKind,
   ReferendumStatus,
   TaskCategory,
   TaskClaimPolicy,
@@ -1405,9 +1406,15 @@ const REFERENDUM_SELECT = {
   },
   createdAt: true,
   createdByUserId: true,
+  bodyMarkdown: true,
+  contentHash: true,
   description: true,
   id: true,
   jurisdictionId: true,
+  kind: true,
+  lockedAt: true,
+  publishedAt: true,
+  question: true,
   slug: true,
   status: true,
   title: true,
@@ -1424,6 +1431,28 @@ function parseReferendumStatus(value: unknown, fallback: ReferendumStatus) {
   return ReferendumStatus[normalized as keyof typeof ReferendumStatus] ?? null;
 }
 
+function parseReferendumKind(value: unknown, fallback: ReferendumKind) {
+  const normalized = optionalString(value)?.toUpperCase();
+  if (!normalized) return fallback;
+  return ReferendumKind[normalized as keyof typeof ReferendumKind] ?? null;
+}
+
+function buildReferendumContentHash(input: {
+  question: string;
+  description?: string | null;
+  bodyMarkdown?: string | null;
+}) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        question: input.question.trim(),
+        description: optionalString(input.description),
+        bodyMarkdown: optionalString(input.bodyMarkdown),
+      }),
+    )
+    .digest("hex");
+}
+
 function referendumPath(slug: string) {
   return `/agencies/dcongress/referendums/${slug}`;
 }
@@ -1431,12 +1460,18 @@ function referendumPath(slug: string) {
 function summarizeReferendum(referendum: ReferendumToolRecord) {
   return {
     createdAt: referendum.createdAt.toISOString(),
+    bodyMarkdown: referendum.bodyMarkdown,
+    contentHash: referendum.contentHash,
     createdByUserId: referendum.createdByUserId,
     description: referendum.description,
     id: referendum.id,
     jurisdictionId: referendum.jurisdictionId,
+    kind: referendum.kind,
+    lockedAt: referendum.lockedAt?.toISOString() ?? null,
     organizationPositionCount: referendum._count.organizationPositions,
     path: referendumPath(referendum.slug),
+    publishedAt: referendum.publishedAt?.toISOString() ?? null,
+    question: referendum.question,
     slug: referendum.slug,
     status: referendum.status,
     surveyCount: referendum._count.surveys,
@@ -3438,7 +3473,28 @@ const TASK_TOOL_DEFINITIONS = [
         },
         description: {
           type: "string",
-          description: "Public framing text for the referendum page.",
+          description: "Short public summary for cards, lists, and metadata.",
+        },
+        question: {
+          type: "string",
+          description: "Canonical yes/no ballot question voters answer.",
+        },
+        bodyMarkdown: {
+          type: "string",
+          description: "Full public referendum detail text in Markdown.",
+        },
+        kind: {
+          type: "string",
+          enum: [
+            "GENERAL",
+            "DECLARATION",
+            "TREATY",
+            "MEMBERSHIP",
+            "COURT_CASE",
+            "AMENDMENT",
+            "BUDGET",
+          ],
+          description: "Referendum kind. Defaults to GENERAL.",
         },
         status: {
           type: "string",
@@ -3450,7 +3506,7 @@ const TASK_TOOL_DEFINITIONS = [
           description: "Optional jurisdiction ID if this referendum is scoped.",
         },
       },
-      required: ["title"],
+      required: ["title", "question"],
     },
   },
   {
@@ -6138,19 +6194,38 @@ export function createMcpServer(
           const prisma = await getPrisma();
           const title = optionalString(a.title);
           if (!title) return err("title is required");
+          const question = optionalString(a.question);
+          if (!question) return err("question is required");
           const slug = slugify(optionalString(a.slug) ?? title);
           if (!slug) return err("slug could not be derived from title");
           const status = parseReferendumStatus(a.status, ReferendumStatus.DRAFT);
           if (!status) {
             return err("status must be one of DRAFT, ACTIVE, or CLOSED");
           }
+          const kind = parseReferendumKind(a.kind, ReferendumKind.GENERAL);
+          if (!kind) {
+            return err(
+              "kind must be one of GENERAL, DECLARATION, TREATY, MEMBERSHIP, COURT_CASE, AMENDMENT, or BUDGET",
+            );
+          }
 
           const description = optionalString(a.description);
+          const bodyMarkdown = optionalString(a.bodyMarkdown);
           const jurisdictionId = optionalString(a.jurisdictionId);
           const data: Prisma.ReferendumUncheckedCreateInput = {
             title,
             slug,
+            question,
+            kind,
             status,
+            contentHash: buildReferendumContentHash({
+              question,
+              description,
+              bodyMarkdown,
+            }),
+            lockedAt: null,
+            publishedAt: status === ReferendumStatus.DRAFT ? null : new Date(),
+            ...(bodyMarkdown ? { bodyMarkdown } : {}),
             ...(description ? { description } : {}),
             ...(jurisdictionId ? { jurisdictionId } : {}),
             ...(userId ? { createdByUserId: userId } : {}),

--- a/packages/web/src/lib/referendum-content.server.ts
+++ b/packages/web/src/lib/referendum-content.server.ts
@@ -1,0 +1,18 @@
+import { prisma } from "@/lib/prisma";
+
+export interface ReferendumPageContent {
+  question: string;
+  bodyMarkdown: string | null;
+}
+
+export async function getReferendumPageContent(
+  slug: string,
+): Promise<ReferendumPageContent | null> {
+  return prisma.referendum.findUnique({
+    where: { slug, deletedAt: null },
+    select: {
+      question: true,
+      bodyMarkdown: true,
+    },
+  });
+}

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -52,6 +52,7 @@ export const ROUTES = {
   politicians: "/politicians",
   // The Treaty
   treaty: "/treaty",
+  court: "/court",
   vote: "/vote",
   why: "/why",
   legal: "/legal",
@@ -602,6 +603,16 @@ export const treatyLink: NavItem = {
     "The full text of the treaty that redirects 1% of military spending to clinical trials. Read it, sign it, share it. Every signature from an official account is verified on the public ledger.",
   tagline: "1% of war budgets → clinical trials",
   cta: "Read the Treaty",
+};
+
+export const courtLink: NavItem = {
+  href: ROUTES.court,
+  label: "Court of Humanity",
+  emoji: "⚖️",
+  description:
+    "Join the decentralized court where 8 billion humans are the jury and sovereign immunity is a choice nobody chose. Verified members can seek justice against any government that kills, injures, or harms them or their family.",
+  tagline: "8B humans · 1 jury · 0 sovereign immunity",
+  cta: "Join the Court",
 };
 
 export const readTreatyLink: NavItem = {

--- a/packages/web/src/lib/site-sitemap.ts
+++ b/packages/web/src/lib/site-sitemap.ts
@@ -18,6 +18,7 @@ interface SiteSitemapRoute {
 const STATIC_SITEMAP_ROUTES: SiteSitemapRoute[] = [
   { path: ROUTES.home, priority: 1.0, changeFrequency: "daily" },
   { path: ROUTES.treaty, priority: 0.95, changeFrequency: "weekly" },
+  { path: ROUTES.court, priority: 0.85, changeFrequency: "weekly" },
   { path: ROUTES.vote, priority: 0.95, changeFrequency: "daily" },
   { path: ROUTES.questions, priority: 0.75, changeFrequency: "monthly" },
   { path: ROUTES.survey, priority: 0.95, changeFrequency: "weekly" },

--- a/packages/web/src/lib/site.ts
+++ b/packages/web/src/lib/site.ts
@@ -12,6 +12,7 @@ import {
   coalitionLink,
   conditionsLink,
   communityLinks,
+  courtLink,
   dfdaLink,
   dihLink,
   donateLink,
@@ -529,7 +530,7 @@ const WAR_ON_DISEASE_UI: SiteVariantUiConfig = {
       },
       {
         title: "Reference",
-        items: [whyLink, legalLink, privacyLink, termsLink],
+        items: [whyLink, courtLink, legalLink, privacyLink, termsLink],
       },
     ],
   },
@@ -570,6 +571,7 @@ const ONE_PERCENT_TREATY_UI: SiteVariantUiConfig = {
         title: "Proof",
         items: [
           whyLink,
+          courtLink,
           peopleLink,
           coalitionLink,
           endorseLink,
@@ -1026,6 +1028,7 @@ const WAR_ON_DISEASE_CONFIG: SiteConfig = {
     restrictToAllowlist: true,
     publicPrefixes: [
       ROUTES.treaty,
+      ROUTES.court,
       ROUTES.tasks,
       ROUTES.people,
       ROUTES.governments,
@@ -1150,6 +1153,7 @@ const ONE_PERCENT_TREATY_CONFIG: SiteConfig = {
   routePolicy: {
     canonicalPrefixes: [
       ROUTES.treaty,
+      ROUTES.court,
       ROUTES.people,
       ROUTES.governments,
       ROUTES.declaration,
@@ -1165,6 +1169,7 @@ const ONE_PERCENT_TREATY_CONFIG: SiteConfig = {
     restrictToAllowlist: true,
     publicPrefixes: [
       ROUTES.treaty,
+      ROUTES.court,
       ROUTES.tasks,
       ROUTES.people,
       ROUTES.governments,

--- a/packages/web/src/lib/storage.ts
+++ b/packages/web/src/lib/storage.ts
@@ -18,6 +18,7 @@ const STORAGE_KEYS = {
   chatProvider: "opto-chat-provider",
   declarationSigned: "declaration_signed",
   pendingDeclarationVote: "pending_declaration_vote",
+  pendingCourtOfHumanityVote: "pending_court_of_humanity_vote",
   reasoningState: "reasoning_state",
   treatyFlowVariant: "treaty_flow_variant",
 } as const;
@@ -49,6 +50,12 @@ export type DeclarationSignedState = {
 
 export type PendingDeclarationVoteState = {
   answer: string;
+  timestamp: string;
+};
+
+export type PendingCourtOfHumanityVoteState = {
+  answer: string;
+  referredBy: string | null;
   timestamp: string;
 };
 
@@ -208,6 +215,15 @@ export const storage = {
     setStorageItem(STORAGE_KEYS.pendingDeclarationVote, data),
   removePendingDeclarationVote: () =>
     removeStorageItem(STORAGE_KEYS.pendingDeclarationVote),
+
+  getPendingCourtOfHumanityVote: () =>
+    getStorageItem<PendingCourtOfHumanityVoteState>(
+      STORAGE_KEYS.pendingCourtOfHumanityVote,
+    ),
+  setPendingCourtOfHumanityVote: (data: PendingCourtOfHumanityVoteState) =>
+    setStorageItem(STORAGE_KEYS.pendingCourtOfHumanityVote, data),
+  removePendingCourtOfHumanityVote: () =>
+    removeStorageItem(STORAGE_KEYS.pendingCourtOfHumanityVote),
 
   getVoteStatusCache: () => getStorageItem<VoteStatusCache>(STORAGE_KEYS.voteStatusCache),
   setVoteStatusCache: (data: VoteStatusCache) =>

--- a/packages/web/src/lib/url.ts
+++ b/packages/web/src/lib/url.ts
@@ -39,6 +39,22 @@ export function buildUserReferralUrl(
   return buildReferralUrl(getHandleOrReferralCode(user), baseUrl);
 }
 
+function buildPathReferralUrl(
+  path: string,
+  identifier?: string | null,
+  baseUrl: string = getBaseUrl(),
+): string {
+  const base = `${baseUrl}${path}`;
+  return identifier ? `${base}?ref=${encodeURIComponent(identifier)}` : base;
+}
+
+export function buildCourtReferralUrl(
+  user: { handle?: string | null; referralCode?: string | null } | null | undefined,
+  baseUrl: string = getBaseUrl(),
+): string {
+  return buildPathReferralUrl(ROUTES.court, getHandleOrReferralCode(user), baseUrl);
+}
+
 export function buildUserInviteReferralUrl(
   user: { handle?: string | null; referralCode?: string | null } | null | undefined,
   inviteToken?: string | null,


### PR DESCRIPTION
## Summary

- add the Court of Humanity referendum flow with Court-specific join/member labels and referral preservation
- add first-class referendum content fields: `question`, `kind`, `bodyMarkdown`, `publishedAt`, `lockedAt`, and `contentHash`
- seed canonical Treaty, Declaration, and Court ballot questions plus markdown bodies from shared source content
- let the referendum API and MCP create referendums with reusable ballot/content metadata instead of hardcoding every referendum page
- render DB-backed referendum question/body content on the Treaty, Court, Declaration, and generic referendum pages

## Why

Referendums are doing more than one thing: Treaty votes create signatories, Court votes create members/jurors, and future court cases need their own ballot questions. The model now separates the short yes/no ballot question from card metadata and long body content, while keeping the implementation simple enough to create referendums through the API.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `pnpm --filter @optimitron/web test -- src/app/api/referendums/route.test.ts src/components/referendum/ReferendumStepperPage.test.ts --reporter=dot`
- `pnpm --filter @optimitron/web run typecheck:fast`
- `pnpm --filter @optimitron/db prisma:validate`
- `pnpm --filter @optimitron/db test:integration`