### PR TITLE
[codex] Add organization MCP tools and polish treaty flow

### DIFF
--- a/packages/web/e2e/treaty-vote-click.spec.ts
+++ b/packages/web/e2e/treaty-vote-click.spec.ts
@@ -10,22 +10,26 @@ async function completeSliderAndVote(page: Page): Promise<void> {
   const slider = voteSection.locator('input[type="range"]');
   await expect(slider).toBeVisible({ timeout: 15_000 });
 
-  const box = await slider.boundingBox();
-  expect(box, "slider track should have geometry").not.toBeNull();
-  if (!box) return;
-
-  const y = box.y + box.height / 2;
-  const targetX = box.x + box.width * 0.3;
-  const startX = box.x + box.width / 2;
-
-  await page.mouse.move(startX, y);
-  await page.mouse.down();
-  await page.mouse.move(targetX, y, { steps: 8 });
-  await page.mouse.up();
-  await slider.dispatchEvent("input");
-  await slider.dispatchEvent("change");
-
   const submit = voteSection.locator("button:has-text('SUBMIT')");
+  for (const targetRatio of [0.3, 0.25, 0.35]) {
+    const box = await slider.boundingBox();
+    expect(box, "slider track should have geometry").not.toBeNull();
+    if (!box) return;
+
+    const y = box.y + box.height / 2;
+    const targetX = box.x + box.width * targetRatio;
+    const startX = box.x + box.width / 2;
+
+    await page.mouse.move(startX, y);
+    await page.mouse.down();
+    await page.mouse.move(targetX, y, { steps: 12 });
+    await page.mouse.up();
+
+    if (await submit.isVisible({ timeout: 1_500 }).catch(() => false)) {
+      break;
+    }
+  }
+
   await expect(submit).toBeVisible({ timeout: 10_000 });
   const scrollYBeforeSubmit = await page.evaluate(() => window.scrollY);
   await submit.click();

--- a/packages/web/e2e/treaty-vote-click.spec.ts
+++ b/packages/web/e2e/treaty-vote-click.spec.ts
@@ -27,10 +27,39 @@ async function completeSliderAndVote(page: Page): Promise<void> {
 
   const submit = voteSection.locator("button:has-text('SUBMIT')");
   await expect(submit).toBeVisible({ timeout: 10_000 });
+  const scrollYBeforeSubmit = await page.evaluate(() => window.scrollY);
   await submit.click();
 
   const yesButton = voteSection.locator("button:has-text('YES')");
   await expect(yesButton).toBeVisible({ timeout: 10_000 });
+  const maxSubmitScrollDelta = await page.evaluate(
+    (scrollYBeforeSubmit) =>
+      new Promise<number>((resolve) => {
+        const startedAt = performance.now();
+        let maxDelta = 0;
+
+        const sample = () => {
+          maxDelta = Math.max(
+            maxDelta,
+            Math.abs(window.scrollY - scrollYBeforeSubmit),
+          );
+
+          if (performance.now() - startedAt >= 700) {
+            resolve(maxDelta);
+            return;
+          }
+
+          requestAnimationFrame(sample);
+        };
+
+        requestAnimationFrame(sample);
+      }),
+    scrollYBeforeSubmit,
+  );
+  expect(
+    maxSubmitScrollDelta,
+    "submitting the allocation slider should not auto-scroll the page",
+  ).toBeLessThan(80);
   await yesButton.click();
 }
 

--- a/packages/web/src/components/Footer.tsx
+++ b/packages/web/src/components/Footer.tsx
@@ -47,25 +47,27 @@ export default function Footer({ siteKey = "optimitron" }: FooterProps) {
         </div>
 
         <div className="mt-10 border-t border-border pt-6 text-center text-sm font-bold text-muted-foreground">
-          <p>
-            {config.bottomText}
-            {config.sourceLink ? (
-              <>
-                {" "}
-                <NavItemLink
-                  item={config.sourceLink}
-                  variant="custom"
-                  external
-                  className="font-bold text-foreground hover:underline"
-                >
-                  Source code
-                </NavItemLink>{" "}
-                open for inspection by any sufficiently curious primate.
-              </>
-            ) : null}
-          </p>
-          <p className="mt-3 text-xs">
-            Published by {site.organizationName}. Contact{" "}
+          {config.bottomText || config.sourceLink ? (
+            <p>
+              {config.bottomText}
+              {config.sourceLink ? (
+                <>
+                  {" "}
+                  <NavItemLink
+                    item={config.sourceLink}
+                    variant="custom"
+                    external
+                    className="font-bold text-foreground hover:underline"
+                  >
+                    Source code
+                  </NavItemLink>{" "}
+                  open for inspection by any sufficiently curious primate.
+                </>
+              ) : null}
+            </p>
+          ) : null}
+          <p className="text-xs">
+            {site.organizationName}. Contact{" "}
             <a href={`mailto:${site.publicContactEmail}`} className="underline hover:no-underline">
               {site.publicContactEmail}
             </a>

--- a/packages/web/src/components/landing/TreatyFlowShell.tsx
+++ b/packages/web/src/components/landing/TreatyFlowShell.tsx
@@ -7,10 +7,10 @@ const paper = "var(--treaty-paper)";
 const paperRule = "#d8c7a4";
 
 export const treatyPrimaryButtonClass =
-  "min-h-12 justify-center gap-3 !border !border-[var(--treaty-ink)] bg-[var(--treaty-ink)] px-5 py-3 text-sm font-black uppercase tracking-[0.14em] text-[#fffaf0] !shadow-none hover:!translate-x-0 hover:!translate-y-0 hover:bg-[#3a2a19] active:!translate-x-0 active:!translate-y-0 disabled:cursor-not-allowed disabled:opacity-50";
+  "min-h-12 justify-center gap-3 !border !border-black bg-white px-5 py-3 text-sm font-black uppercase tracking-[0.14em] text-black !shadow-none hover:!translate-x-0 hover:!translate-y-0 hover:bg-black hover:text-white active:!translate-x-0 active:!translate-y-0 disabled:cursor-not-allowed disabled:opacity-50";
 
 export const treatySecondaryButtonClass =
-  "min-h-12 justify-center gap-3 !border !border-[var(--treaty-ink)] bg-transparent px-5 py-3 text-sm font-black uppercase tracking-[0.14em] text-[var(--treaty-ink)] !shadow-none hover:!translate-x-0 hover:!translate-y-0 hover:bg-[#efe4cf] active:!translate-x-0 active:!translate-y-0 disabled:cursor-not-allowed disabled:opacity-50";
+  "min-h-12 justify-center gap-3 !border !border-black bg-white px-5 py-3 text-sm font-black uppercase tracking-[0.14em] text-black !shadow-none hover:!translate-x-0 hover:!translate-y-0 hover:bg-black hover:text-white active:!translate-x-0 active:!translate-y-0 disabled:cursor-not-allowed disabled:opacity-50";
 
 export const treatyInputClass =
   "!border !border-[var(--treaty-ink)] bg-[#fffdf8] text-[var(--treaty-ink)] !shadow-none [font-family:var(--v0-font-libre-baskerville)] placeholder:text-[var(--treaty-ink-muted)]/55 focus:!shadow-none focus-visible:outline-[var(--treaty-ink)]";

--- a/packages/web/src/components/landing/TreatyVoteFlow.tsx
+++ b/packages/web/src/components/landing/TreatyVoteFlow.tsx
@@ -10,6 +10,7 @@ import { useSearchParams } from "next/navigation";
 import { storage } from "@/lib/storage";
 import { TreatyPostVoteShareFlow } from "@/components/landing/TreatyPostVoteShareFlow";
 import { AuthForm } from "@/components/auth/AuthForm";
+import { NeobrutalistLoaderMark } from "@/components/ui/neobrutalist-loader";
 import { syncPendingReferendumVotes } from "@/lib/referendum-vote-sync";
 import { getHandleOrReferralCode } from "@/lib/referral.client";
 import confetti from "canvas-confetti";
@@ -584,7 +585,11 @@ export function TreatyVoteFlow({
               className="py-2 sm:py-4"
               contentClassName="max-w-2xl justify-start pt-0 pb-6 sm:pt-0 sm:pb-12"
             >
-              <div className="space-y-4 text-center">
+              <div className="space-y-6 text-center">
+                <NeobrutalistLoaderMark
+                  size="sm"
+                  className="mx-auto text-[var(--treaty-ink)]"
+                />
                 <p className="text-2xl font-black uppercase leading-tight tracking-[0.08em] text-[var(--treaty-ink)] sm:text-3xl">
                   Saving your vote.
                 </p>

--- a/packages/web/src/components/landing/TreatyVoteFlow.tsx
+++ b/packages/web/src/components/landing/TreatyVoteFlow.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/retroui/Button";
 import { ParameterValue } from "@/components/shared/ParameterValue";
 import { useState, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
-import { Square, CheckSquare } from "lucide-react";
+import { CheckSquare, Hand, Square } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
 import { storage } from "@/lib/storage";
@@ -118,13 +118,8 @@ export function TreatyVoteFlow({
   const { data: session, status } = useSession();
   const shareCardRef = useRef<HTMLDivElement>(null);
   const sliderSectionRef = useRef<HTMLDivElement>(null);
-  const choiceCardRef = useRef<HTMLDivElement>(null);
   const animationFrameRef = useRef<number | null>(null);
   const postVoteRedirectStartedRef = useRef(false);
-  // True only when the user submits the slider in this session. Prevents the
-  // scroll-to-choice effect from firing when sliderSubmitted is restored from
-  // localStorage on page load (which would auto-scroll past the document).
-  const userSubmittedSliderRef = useRef(false);
   const initialVoteShellClassName = compactInitialScreen
     ? "min-h-0 overflow-visible px-0 py-0 sm:px-0 sm:py-0"
     : undefined;
@@ -135,27 +130,6 @@ export function TreatyVoteFlow({
   useEffect(() => {
     setIsMounted(true);
   }, []);
-
-  // When the slider submits, scroll the reality-check / yes-no card into
-  // view in the middle of the viewport. `block: "center"` keeps the question
-  // header visible above the YES/NO buttons; `block: "start"` cut it off.
-  // Without this, the previous slider shell (min-h-screen) leaves the user
-  // scrolled mid-page when the new shell mounts, so the choice card lands
-  // in the bottom half of the viewport with empty whitespace above it.
-  useEffect(() => {
-    if (!sliderSubmitted) return;
-    if (!userSubmittedSliderRef.current) return;
-    const node = choiceCardRef.current;
-    if (!node) return;
-    /// Two ticks: one for AnimatePresence to mount the new node, one for
-    /// the layout to settle so scrollIntoView positions correctly.
-    const id = window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => {
-        node.scrollIntoView({ behavior: "smooth", block: "center" });
-      });
-    });
-    return () => window.cancelAnimationFrame(id);
-  }, [sliderSubmitted]);
 
   useEffect(() => {
     const requestedVariant =
@@ -368,7 +342,6 @@ export function TreatyVoteFlow({
       flowVariant,
       militaryAllocationPercent: militaryAllocation,
     });
-    userSubmittedSliderRef.current = true;
     setSliderSubmitted(true);
     setShowSlider(false);
 
@@ -712,7 +685,7 @@ export function TreatyVoteFlow({
                 </div>
 
                 {/* Slider with Animation */}
-                <div className="relative px-2 pt-3">
+                <div className="relative px-2 pb-10 pt-3">
                   <AnimatePresence>
                     {showAnimation && !userHasDragged && (
                       <>
@@ -735,14 +708,29 @@ export function TreatyVoteFlow({
                         </motion.div>
 
                         <motion.div
-                          className="absolute z-20 pointer-events-none"
+                          aria-hidden="true"
+                          className="pointer-events-none absolute z-20"
+                          initial={{ opacity: 0 }}
+                          animate={{ opacity: 1 }}
+                          exit={{ opacity: 0 }}
+                          transition={{ duration: 0.2 }}
                           style={{
                             left: `${animatedValue}%`,
                             transform: "translateX(-50%)",
-                            top: "16px",
+                            top: "30px",
                           }}
                         >
-                          <div className="h-8 w-px bg-[var(--treaty-ink)]" />
+                          <motion.div
+                            animate={{ rotate: [-12, -18, -12], y: [0, 2, 0] }}
+                            className="flex h-8 w-8 items-center justify-center text-[var(--treaty-ink)]"
+                            transition={{
+                              duration: 0.8,
+                              ease: "easeInOut",
+                              repeat: Infinity,
+                            }}
+                          >
+                            <Hand className="h-7 w-7" strokeWidth={2.5} />
+                          </motion.div>
                         </motion.div>
                       </>
                     )}
@@ -795,7 +783,6 @@ export function TreatyVoteFlow({
       <AnimatePresence>
         {sliderSubmitted && (
           <motion.div
-            ref={choiceCardRef}
             initial={{ opacity: 0, y: 50 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.2 }}

--- a/packages/web/src/components/landing/TreatyVoteFlow.tsx
+++ b/packages/web/src/components/landing/TreatyVoteFlow.tsx
@@ -582,8 +582,8 @@ export function TreatyVoteFlow({
         >
           {isWaitingForAuth ? (
             <TreatyFlowShell
-              className="py-2 sm:py-4"
-              contentClassName="max-w-2xl justify-start pt-0 pb-6 sm:pt-0 sm:pb-12"
+              className="py-6 sm:py-10"
+              contentClassName="max-w-2xl justify-center py-10 sm:py-12"
             >
               <div className="space-y-6 text-center">
                 <NeobrutalistLoaderMark
@@ -597,8 +597,8 @@ export function TreatyVoteFlow({
             </TreatyFlowShell>
           ) : (
             <TreatyFlowShell
-              className="py-2 sm:py-4"
-              contentClassName="max-w-2xl justify-start pt-0 pb-6 sm:pt-0 sm:pb-12"
+              className="py-6 sm:py-10"
+              contentClassName="max-w-2xl justify-center py-10 sm:py-12"
             >
               <div className="space-y-4">
                 <p className="text-center text-2xl font-black uppercase leading-tight tracking-[0.08em] text-[var(--treaty-ink)] sm:text-3xl">
@@ -705,8 +705,8 @@ export function TreatyVoteFlow({
                             transform: "translateX(-50%)",
                           }}
                         >
-                          <div className="border border-[var(--treaty-ink)] bg-[#fffdf8] px-4 py-2">
-                            <p className="whitespace-nowrap text-xs font-black uppercase tracking-[0.22em] text-[var(--treaty-ink)]">
+                          <div className="border border-black bg-white px-4 py-2">
+                            <p className="whitespace-nowrap text-xs font-black uppercase tracking-[0.22em] text-black">
                               Slide me
                             </p>
                           </div>
@@ -727,7 +727,7 @@ export function TreatyVoteFlow({
                         >
                           <motion.div
                             animate={{ rotate: [-12, -18, -12], y: [0, 2, 0] }}
-                            className="flex h-8 w-8 items-center justify-center text-[var(--treaty-ink)]"
+                            className="flex h-8 w-8 items-center justify-center text-black"
                             transition={{
                               duration: 0.8,
                               ease: "easeInOut",
@@ -749,10 +749,10 @@ export function TreatyVoteFlow({
                     onChange={(e) =>
                       handleSliderChange(100 - Number(e.target.value))
                     }
-                    className="h-3 w-full cursor-pointer appearance-none rounded-none border border-[var(--treaty-ink)] bg-[var(--treaty-paper)] slider-treaty"
+                    className="h-3 w-full cursor-pointer appearance-none rounded-none border border-black bg-white slider-treaty"
                     style={{
-                      background: `linear-gradient(to right, var(--treaty-ink) ${militaryAllocation}%, #d8c7a4 ${militaryAllocation}%)`,
-                      accentColor: "var(--treaty-ink)",
+                      background: `linear-gradient(to right, #000 ${militaryAllocation}%, #fff ${militaryAllocation}%)`,
+                      accentColor: "#000",
                     }}
                   />
                 </div>
@@ -795,13 +795,8 @@ export function TreatyVoteFlow({
             <TreatyFlowShell
               data-screen="choice"
               data-testid="treaty-vote-choice-card"
-              // justify-start beats the shell default (justify-center) via
-              // twMerge so the heading lands near the top of the viewport
-              // instead of centered, which previously left a half-empty
-              // viewport above the dropcap copy. Tight pt-0 because the
-              // section already has its own (reduced) py via className.
-              className="py-2 sm:py-4"
-              contentClassName="max-w-4xl justify-start space-y-5 pt-0 pb-6 sm:space-y-8 sm:pt-0 sm:pb-12"
+              className="overflow-y-auto py-6 sm:py-10"
+              contentClassName="max-w-4xl justify-center space-y-6 py-8 sm:space-y-8 sm:py-12"
             >
               {copyMode === "neutral" ? (
                 <TreatyFlowParagraph dropCap className="text-lg leading-8 sm:text-2xl sm:leading-10">
@@ -871,18 +866,7 @@ export function TreatyVoteFlow({
                   : VOTE_SECTION.theQuestion}
               </div>
 
-              <div className="grid gap-4 sm:grid-cols-2">
-                <Button
-                  onClick={() => void handleAnswer("yes")}
-                  className={`${treatyPrimaryButtonClass} h-14 w-full text-lg sm:h-16 sm:text-xl`}
-                >
-                  {answer === "yes" ? (
-                    <CheckSquare className="h-6 w-6" />
-                  ) : (
-                    <Square className="h-6 w-6" />
-                  )}
-                  YES
-                </Button>
+              <div className="grid grid-cols-2 gap-3 sm:gap-4">
                 <Button
                   onClick={() => void handleAnswer("no")}
                   className={`${treatySecondaryButtonClass} h-14 w-full text-lg sm:h-16 sm:text-xl`}
@@ -893,6 +877,17 @@ export function TreatyVoteFlow({
                     <Square className="h-6 w-6" />
                   )}
                   NO
+                </Button>
+                <Button
+                  onClick={() => void handleAnswer("yes")}
+                  className={`${treatyPrimaryButtonClass} h-14 w-full text-lg sm:h-16 sm:text-xl`}
+                >
+                  {answer === "yes" ? (
+                    <CheckSquare className="h-6 w-6" />
+                  ) : (
+                    <Square className="h-6 w-6" />
+                  )}
+                  YES
                 </Button>
               </div>
             </TreatyFlowShell>
@@ -1001,7 +996,7 @@ export function TreatyVoteFlow({
       <style jsx global>{`
         input.slider-treaty {
           appearance: none;
-          accent-color: var(--treaty-ink);
+          accent-color: #000;
         }
 
         .slider-treaty::-webkit-slider-thumb {

--- a/packages/web/src/components/ui/neobrutalist-loader.tsx
+++ b/packages/web/src/components/ui/neobrutalist-loader.tsx
@@ -1,38 +1,105 @@
 "use client";
 
-import React from 'react';
-
 interface NeobrutalistLoaderProps {
   message?: string;
   submessage?: string;
   size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+interface NeobrutalistLoaderMarkProps {
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+export function NeobrutalistLoaderMark({
+  size = 'md',
+  className = '',
+}: NeobrutalistLoaderMarkProps) {
+  const sizeClasses = {
+    sm: 'h-16 w-16',
+    md: 'h-24 w-24',
+    lg: 'h-32 w-32',
+  };
+
+  const cargoClasses = {
+    sm: 'h-3 w-3',
+    md: 'h-4 w-4',
+    lg: 'h-5 w-5',
+  };
+
+  return (
+    <div
+      aria-label="Loading Earth Optimization System"
+      className={`relative ${sizeClasses[size]} ${className}`}
+      role="status"
+    >
+      <div className="absolute inset-0 border-4 border-foreground bg-background shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+        <div className="absolute inset-[18%] rounded-full border-2 border-foreground" />
+        <div className="absolute left-1/2 top-[18%] h-[64%] w-[2px] -translate-x-1/2 bg-foreground/70" />
+        <div className="absolute left-[18%] top-1/2 h-[2px] w-[64%] -translate-y-1/2 bg-foreground/70" />
+        <div className="absolute left-[28%] top-[18%] h-[64%] w-[18%] rounded-full border-l-2 border-r-2 border-foreground/70" />
+        <div className="absolute right-[28%] top-[18%] h-[64%] w-[18%] rounded-full border-l-2 border-r-2 border-foreground/70" />
+
+        <div className="earth-os-orbit absolute inset-2">
+          <div
+            className={`absolute left-1/2 top-0 -translate-x-1/2 border-2 border-foreground bg-brutal-cyan shadow-[3px_3px_0px_0px_rgba(0,0,0,1)] ${cargoClasses[size]}`}
+          />
+        </div>
+
+        <div className="absolute bottom-2 left-2 right-2 h-2 border-2 border-foreground bg-background">
+          <div className="earth-os-packet h-full w-1/3 bg-foreground" />
+        </div>
+      </div>
+
+      <style jsx>{`
+        .earth-os-orbit {
+          animation: earth-os-orbit 1.8s linear infinite;
+          transform-origin: center;
+        }
+
+        .earth-os-packet {
+          animation: earth-os-packet 1.2s steps(5, end) infinite;
+        }
+
+        @keyframes earth-os-orbit {
+          to {
+            transform: rotate(360deg);
+          }
+        }
+
+        @keyframes earth-os-packet {
+          0% {
+            transform: translateX(0);
+          }
+          50% {
+            transform: translateX(200%);
+          }
+          100% {
+            transform: translateX(0);
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .earth-os-orbit,
+          .earth-os-packet {
+            animation: none;
+          }
+        }
+      `}</style>
+    </div>
+  );
 }
 
 export function NeobrutalistLoader({
   message = 'Booting Earth Optimization System',
   submessage = 'Thank you for your patience. Your civilization is very important to us.',
   size = 'md',
+  className = '',
 }: NeobrutalistLoaderProps) {
-  const sizeClasses = {
-    sm: 'w-8 h-8',
-    md: 'w-12 h-12',
-    lg: 'w-16 h-16',
-  };
-
   return (
-    <div className="flex flex-col items-center justify-center py-12 gap-6">
-      {/* Animated Neobrutalist Squares */}
-      <div className="relative flex gap-2">
-        {[0, 1, 2].map((i) => (
-          <div
-            key={i}
-            className={`${sizeClasses[size]} border-4 border-foreground bg-brutal-pink rounded-sm shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]`}
-            style={{
-              animation: `bounce 1.4s ease-in-out ${i * 0.16}s infinite`,
-            }}
-          />
-        ))}
-      </div>
+    <div className={`flex flex-col items-center justify-center gap-6 py-12 ${className}`}>
+      <NeobrutalistLoaderMark size={size} />
 
       {/* Loading Message */}
       {message && (
@@ -48,23 +115,6 @@ export function NeobrutalistLoader({
           {submessage}
         </p>
       )}
-
-      <style jsx>{`
-        @keyframes bounce {
-          0%, 100% {
-            transform: translateY(0) rotate(0deg);
-          }
-          25% {
-            transform: translateY(-20px) rotate(-5deg);
-          }
-          50% {
-            transform: translateY(0) rotate(0deg);
-          }
-          75% {
-            transform: translateY(-10px) rotate(5deg);
-          }
-        }
-      `}</style>
     </div>
   );
 }

--- a/packages/web/src/config/__tests__/site-variant-ui.test.ts
+++ b/packages/web/src/config/__tests__/site-variant-ui.test.ts
@@ -1,181 +1,73 @@
 import { describe, expect, it } from "vitest";
-import { getSiteVariantUiConfig } from "@/config/site-variant-ui";
-import {
-  coalitionLink,
-  endorseLink,
-  legalLink,
-  peopleLink,
-  privacyLink,
-  readTreatyLink,
-  termsLink,
-  trialEmbedLink,
-  trialSurveyLink,
-  treatyDashboardLink,
-  treatyTasksLink,
-  treatyVoteLink,
-  whyLink,
-} from "@/lib/routes";
-import { getSiteConfig } from "@/lib/site";
-import type { SiteKey } from "@/lib/site";
 
-function labelsFor(siteKey: SiteKey) {
-  return getSiteVariantUiConfig(siteKey).nav.sections.flatMap((section) =>
-    section.items.map((item) => item.label),
-  );
+import { getSiteVariantUiConfig } from "@/config/site-variant-ui";
+import { getAllSiteConfigs } from "@/lib/site";
+import type { NavItem } from "@/lib/routes";
+
+function expectValidChromeItem(item: NavItem) {
+  expect(item.href.trim()).not.toBe("");
+  expect(item.label.trim()).not.toBe("");
+  expect(item.description.trim()).not.toBe("");
+  expect(item.cta.trim()).not.toBe("");
+  expect(item.emoji.trim()).not.toBe("");
 }
 
-function chromeItemsFor(siteKey: SiteKey) {
-  const config = getSiteVariantUiConfig(siteKey);
-
-  return [
-    ...config.nav.sections.flatMap((section) => section.items),
-    ...config.footer.columns.flatMap((column) => column.items),
-  ];
+function expectNoDuplicateHrefs(items: NavItem[]) {
+  const hrefs = items.map((item) => item.href);
+  expect(new Set(hrefs).size).toBe(hrefs.length);
 }
 
 describe("site variant UI config", () => {
   it("reads variant chrome from the centralized site config", () => {
-    expect(getSiteVariantUiConfig("onePercentTreaty")).toBe(
-      getSiteConfig("onePercentTreaty").ui,
-    );
-    expect(getSiteVariantUiConfig("dfda")).toBe(
-      getSiteConfig("dfda").ui,
-    );
-  });
-
-  it("gives the treaty site campaign-specific navigation", () => {
-    const config = getSiteVariantUiConfig("onePercentTreaty");
-
-    expect(config.nav.brandLabel).toBe("1% Treaty");
-    expect(config.nav.searchEnabled).toBe(false);
-    expect(labelsFor("onePercentTreaty")).toEqual(
-      expect.arrayContaining([
-        "Vote",
-        "Dashboard",
-        "President Management System",
-        "Read the Treaty",
-      ]),
-    );
-  });
-
-  it("keeps Optimitron on the full platform navigation", () => {
-    const config = getSiteVariantUiConfig("optimitron");
-
-    expect(config.nav.brandLabel).toBe("Optimitron");
-    expect(config.nav.searchEnabled).toBe(true);
-    expect(labelsFor("optimitron")).toEqual(
-      expect.arrayContaining(["Prize", "Tasks", "Dashboard"]),
-    );
-  });
-
-  it("defines footer columns per variant", () => {
-    const treatyFooter = getSiteVariantUiConfig("onePercentTreaty").footer;
-    const warFooter = getSiteVariantUiConfig("warOnDisease").footer;
-
-    expect(treatyFooter.columns.map((column) => column.title)).toEqual([
-      "Campaign",
-      "Proof",
-    ]);
-    expect(
-      treatyFooter.columns.flatMap((column) =>
-        column.items.map((item) => item.label),
-      ),
-    ).toContain("President Management System");
-
-    expect(warFooter.columns.map((column) => column.title)).toEqual([
-      "Campaign",
-      "Reference",
-    ]);
-    expect(
-      warFooter.columns.flatMap((column) =>
-        column.items.map((item) => item.label),
-      ),
-    ).toEqual([
-      "Vote",
-      "Read the Treaty",
-      "Dashboard",
-      peopleLink.label,
-      "Organizational Signatories",
-      "Sign as Organization",
-      "Donate",
-      "Why",
-      "Court of Humanity",
-      "Legal",
-      "Privacy",
-      "Terms",
-    ]);
-  });
-
-  it("defines restrained navigation for the neutral survey site", () => {
-    const config = getSiteVariantUiConfig("trialAbundanceSurvey");
-
-    expect(config.nav.brandLabel).toBe("Trial Abundance Survey");
-    expect(config.nav.searchEnabled).toBe(false);
-    expect(labelsFor("trialAbundanceSurvey")).toEqual(
-      expect.arrayContaining(["Take Survey", "Embed Survey"]),
-    );
-    expect(labelsFor("trialAbundanceSurvey")).not.toContain(
-      "President Management System",
-    );
-  });
-
-  it("assembles campaign chrome from route-level nav items", () => {
-    const treatyItems = chromeItemsFor("onePercentTreaty");
-    const warOnDiseaseItems = chromeItemsFor("warOnDisease");
-    const surveyItems = chromeItemsFor("trialAbundanceSurvey");
-
-    for (const item of [
-      treatyVoteLink,
-      treatyDashboardLink,
-      treatyTasksLink,
-      readTreatyLink,
-      whyLink,
-      coalitionLink,
-      endorseLink,
-      legalLink,
-    ]) {
-      expect(treatyItems).toContain(item);
+    for (const site of getAllSiteConfigs()) {
+      expect(getSiteVariantUiConfig(site.key)).toBe(site.ui);
     }
+  });
 
-    for (const item of [
-      treatyVoteLink,
-      treatyDashboardLink,
-      peopleLink,
-      readTreatyLink,
-      coalitionLink,
-      endorseLink,
-      whyLink,
-      legalLink,
-      privacyLink,
-      termsLink,
-    ]) {
-      expect(warOnDiseaseItems).toContain(item);
+  it("builds structurally valid nav and footer chrome for every variant", () => {
+    for (const site of getAllSiteConfigs()) {
+      const config = getSiteVariantUiConfig(site.key);
+
+      expect(config.nav.brandHref.trim()).not.toBe("");
+      expect(config.nav.brandLabel.trim()).not.toBe("");
+      expect(config.nav.desktopBrandLabel.trim()).not.toBe("");
+      expect(config.nav.menuTitle.trim()).not.toBe("");
+      expect(config.nav.signInCallbackUrl.trim()).not.toBe("");
+      expect(config.nav.sections.length).toBeGreaterThan(0);
+
+      for (const section of config.nav.sections) {
+        expect(section.id.trim()).not.toBe("");
+        expect(section.label.trim()).not.toBe("");
+        expect(section.items.length).toBeGreaterThan(0);
+        expectNoDuplicateHrefs(section.items);
+
+        for (const item of section.items) {
+          expectValidChromeItem(item);
+        }
+      }
+
+      if (config.nav.quickAction) {
+        expectValidChromeItem(config.nav.quickAction);
+      }
+
+      expect(config.footer.brandHref.trim()).not.toBe("");
+      expect(config.footer.brandLabel.trim()).not.toBe("");
+      expect(config.footer.brandDescription.trim()).not.toBe("");
+
+      for (const column of config.footer.columns) {
+        expect(column.title.trim()).not.toBe("");
+        expect(column.items.length).toBeGreaterThan(0);
+        expectNoDuplicateHrefs(column.items);
+
+        for (const item of column.items) {
+          expectValidChromeItem(item);
+        }
+      }
+
+      if (config.footer.sourceLink) {
+        expectValidChromeItem(config.footer.sourceLink);
+      }
     }
-
-    expect(surveyItems).toContain(trialSurveyLink);
-    expect(surveyItems).toContain(trialEmbedLink);
-  });
-
-  it("defines medical navigation for the DFDA site", () => {
-    const config = getSiteVariantUiConfig("dfda");
-
-    expect(config.nav.brandLabel).toBe("DFDA");
-    expect(labelsFor("dfda")).toEqual(
-      expect.arrayContaining(["Conditions", "Treatments"]),
-    );
-  });
-
-  it("separates War on Disease campaign navigation from the legal treaty site", () => {
-    const config = getSiteVariantUiConfig("warOnDisease");
-
-    expect(config.nav.brandLabel).toBe("War on Disease");
-    expect(labelsFor("warOnDisease")).toEqual([
-      "Vote",
-      "Share",
-      peopleLink.label,
-      "Read the Treaty",
-      "Why",
-    ]);
   });
 
   it("keeps partner and medical variant chrome free of internal architecture jargon", () => {
@@ -187,25 +79,20 @@ describe("site variant UI config", () => {
       "program graph",
     ];
 
-    for (const siteKey of [
-      "dfda",
-      "dih",
-      "warOnDisease",
-      "trialAbundanceSurvey",
-    ] satisfies SiteKey[]) {
-      const config = getSiteVariantUiConfig(siteKey);
+    for (const site of getAllSiteConfigs()) {
+      const config = getSiteVariantUiConfig(site.key);
       const copy = [
         config.footer.brandDescription,
         config.footer.bottomText,
         ...config.footer.columns.flatMap((column) =>
           column.items.flatMap((item) => [
-            item.description ?? "",
+            item.description,
             item.tagline ?? "",
           ]),
         ),
         ...config.nav.sections.flatMap((section) =>
           section.items.flatMap((item) => [
-            item.description ?? "",
+            item.description,
             item.tagline ?? "",
           ]),
         ),

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -756,6 +756,30 @@ describe("MCP server tool dispatch", () => {
       );
     });
 
+    it.each([
+      ["organizationId", 123],
+      ["name", { value: "Renamed Org" }],
+      ["type", 7],
+      ["status", ["APPROVED"]],
+      ["slug", { value: "renamed-org" }],
+      ["website", 42],
+      ["description", false],
+      ["logo", ["https://example.org/logo.png"]],
+      ["contactEmail", { email: "hello@example.org" }],
+      ["jurisdictionId", 99],
+    ])("updateOrganization rejects non-string %s values", async (field, value) => {
+      const client = await setup("user-1", [McpScope.EARTHDATA_WRITE]);
+
+      const result = await client.callTool({
+        name: "updateOrganization",
+        arguments: { organizationId: "org-1", [field]: value },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result)).toEqual({ error: `${field} must be a string` });
+      expect(mocks.updateOrganizationServer).not.toHaveBeenCalled();
+    });
+
     it("updateOrganization returns a clean error when the caller cannot manage the org", async () => {
       mocks.updateOrganizationServer.mockRejectedValueOnce(
         new ForbiddenError("You do not have permission to manage this organization"),

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -53,6 +53,12 @@ const mocks = vi.hoisted(() => ({
   getProfileIdentityData: vi.fn(),
   updateUserProfile: vi.fn(),
   createOrganizationWithOwner: vi.fn(),
+  updateOrganizationServer: vi.fn(),
+  addOrganizationMember: vi.fn(),
+  removeOrganizationMember: vi.fn(),
+  updateOrganizationMemberRole: vi.fn(),
+  listOrganizationMembers: vi.fn(),
+  softDeleteOrganization: vi.fn(),
   taskFindUnique: vi.fn(),
   upsertSignerReminderTask: vi.fn(),
   createTaskTrigger: vi.fn(),
@@ -164,8 +170,33 @@ vi.mock("../court-data.server", () => ({
   upsertCourtCase: mocks.upsertCourtCase,
 }));
 
+class ForbiddenError extends Error {
+  constructor(message = "Forbidden") {
+    super(message);
+    this.name = "ForbiddenError";
+  }
+}
+
+class LastOwnerError extends Error {
+  constructor(message = "Cannot remove or demote the last owner of the organization") {
+    super(message);
+    this.name = "LastOwnerError";
+  }
+}
+
+const VALID_MEMBER_ROLES = new Set(["owner", "admin", "member", "viewer"]);
+
 vi.mock("../organization.server", () => ({
   createOrganizationWithOwner: mocks.createOrganizationWithOwner,
+  updateOrganization: mocks.updateOrganizationServer,
+  addOrganizationMember: mocks.addOrganizationMember,
+  removeOrganizationMember: mocks.removeOrganizationMember,
+  updateOrganizationMemberRole: mocks.updateOrganizationMemberRole,
+  listOrganizationMembers: mocks.listOrganizationMembers,
+  softDeleteOrganization: mocks.softDeleteOrganization,
+  isOrganizationMemberRole: (value: string) => VALID_MEMBER_ROLES.has(value),
+  ForbiddenError,
+  LastOwnerError,
 }));
 
 vi.mock("../prisma", () => ({
@@ -654,6 +685,266 @@ describe("MCP server tool dispatch", () => {
         }),
       }),
     );
+  });
+
+  describe("organization management tools", () => {
+    it("updateOrganization patches basic fields and returns the updated org", async () => {
+      mocks.updateOrganizationServer.mockResolvedValueOnce({
+        contactEmail: "hello@example.org",
+        description: "Updated mission",
+        id: "org-1",
+        jurisdictionId: null,
+        logo: null,
+        name: "Renamed Org",
+        slug: "renamed-org",
+        status: OrgStatus.APPROVED,
+        type: OrgType.NONPROFIT,
+        website: "https://example.org",
+      });
+      const client = await setup("user-1", [McpScope.EARTHDATA_WRITE]);
+
+      const result = await client.callTool({
+        name: "updateOrganization",
+        arguments: {
+          organizationId: "org-1",
+          name: "Renamed Org",
+          website: "https://example.org",
+          description: "Updated mission",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.updateOrganizationServer).toHaveBeenCalledWith(
+        "org-1",
+        "user-1",
+        expect.objectContaining({
+          name: "Renamed Org",
+          website: "https://example.org",
+          description: "Updated mission",
+        }),
+        { allowStatusChange: false },
+      );
+      const body = parseToolBody(result);
+      expect((body.organization as Record<string, unknown>)?.slug).toBe("renamed-org");
+    });
+
+    it("updateOrganization passes allowStatusChange=true when caller has admin scope", async () => {
+      mocks.updateOrganizationServer.mockResolvedValueOnce({
+        contactEmail: null,
+        description: null,
+        id: "org-1",
+        jurisdictionId: null,
+        logo: null,
+        name: "Org",
+        slug: "org",
+        status: OrgStatus.APPROVED,
+        type: OrgType.NONPROFIT,
+        website: null,
+      });
+      const client = await setup("admin-1", ALL_SCOPES, { isAdmin: true });
+
+      await client.callTool({
+        name: "updateOrganization",
+        arguments: { organizationId: "org-1", status: "APPROVED" },
+      });
+
+      expect(mocks.updateOrganizationServer).toHaveBeenCalledWith(
+        "org-1",
+        "admin-1",
+        expect.objectContaining({ status: OrgStatus.APPROVED }),
+        { allowStatusChange: true },
+      );
+    });
+
+    it("updateOrganization returns a clean error when the caller cannot manage the org", async () => {
+      mocks.updateOrganizationServer.mockRejectedValueOnce(
+        new ForbiddenError("You do not have permission to manage this organization"),
+      );
+      const client = await setup("user-1", [McpScope.EARTHDATA_WRITE]);
+
+      const result = await client.callTool({
+        name: "updateOrganization",
+        arguments: { organizationId: "org-1", name: "New name" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result)).toEqual({
+        error: "You do not have permission to manage this organization",
+      });
+    });
+
+    it("addOrganizationMember defaults role to member and forwards the call", async () => {
+      mocks.addOrganizationMember.mockResolvedValueOnce({
+        organizationId: "org-1",
+        userId: "user-2",
+        role: "member",
+        joinedAt: new Date("2026-05-03T00:00:00.000Z"),
+      });
+      const client = await setup("user-1", [McpScope.EARTHDATA_WRITE]);
+
+      const result = await client.callTool({
+        name: "addOrganizationMember",
+        arguments: { organizationId: "org-1", userId: "user-2" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.addOrganizationMember).toHaveBeenCalledWith(
+        "org-1",
+        "user-1",
+        "user-2",
+        "member",
+      );
+    });
+
+    it("addOrganizationMember rejects unknown roles before hitting the server", async () => {
+      const client = await setup("user-1", [McpScope.EARTHDATA_WRITE]);
+
+      const result = await client.callTool({
+        name: "addOrganizationMember",
+        arguments: { organizationId: "org-1", userId: "user-2", role: "wizard" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(mocks.addOrganizationMember).not.toHaveBeenCalled();
+    });
+
+    it("removeOrganizationMember surfaces the LastOwnerError as a clean error", async () => {
+      mocks.removeOrganizationMember.mockRejectedValueOnce(
+        new LastOwnerError("Cannot remove or demote the last owner of the organization"),
+      );
+      const client = await setup("user-1", [McpScope.EARTHDATA_WRITE]);
+
+      const result = await client.callTool({
+        name: "removeOrganizationMember",
+        arguments: { organizationId: "org-1", userId: "user-1" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result)).toEqual({
+        error: "Cannot remove or demote the last owner of the organization",
+      });
+    });
+
+    it("removeOrganizationMember allows self-removal even when the caller cannot manage the org", async () => {
+      mocks.removeOrganizationMember.mockResolvedValueOnce(undefined);
+      const client = await setup("user-2", [McpScope.EARTHDATA_WRITE]);
+
+      const result = await client.callTool({
+        name: "removeOrganizationMember",
+        arguments: { organizationId: "org-1", userId: "user-2" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.removeOrganizationMember).toHaveBeenCalledWith(
+        "org-1",
+        "user-2",
+        "user-2",
+      );
+    });
+
+    it("updateOrganizationMemberRole forwards role changes", async () => {
+      mocks.updateOrganizationMemberRole.mockResolvedValueOnce({
+        organizationId: "org-1",
+        userId: "user-2",
+        role: "admin",
+        joinedAt: new Date("2026-05-03T00:00:00.000Z"),
+      });
+      const client = await setup("user-1", [McpScope.EARTHDATA_WRITE]);
+
+      const result = await client.callTool({
+        name: "updateOrganizationMemberRole",
+        arguments: { organizationId: "org-1", userId: "user-2", role: "admin" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.updateOrganizationMemberRole).toHaveBeenCalledWith(
+        "org-1",
+        "user-1",
+        "user-2",
+        "admin",
+      );
+    });
+
+    it("listOrganizationMembers returns a flattened member shape", async () => {
+      mocks.listOrganizationMembers.mockResolvedValueOnce([
+        {
+          role: "owner",
+          joinedAt: new Date("2026-04-01T00:00:00.000Z"),
+          user: {
+            id: "user-1",
+            email: "owner@example.org",
+            person: { displayName: "Owner Person", handle: "owner-person" },
+          },
+        },
+      ]);
+      const client = await setup("user-1", [McpScope.EARTHDATA_WRITE]);
+
+      const result = await client.callTool({
+        name: "listOrganizationMembers",
+        arguments: { organizationId: "org-1" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const body = parseToolBody(result);
+      expect(body.members).toEqual([
+        {
+          userId: "user-1",
+          email: "owner@example.org",
+          displayName: "Owner Person",
+          handle: "owner-person",
+          role: "owner",
+          joinedAt: "2026-04-01T00:00:00.000Z",
+        },
+      ]);
+    });
+
+    it("deleteOrganization soft-deletes when caller is platform admin and org owner", async () => {
+      mocks.softDeleteOrganization.mockResolvedValueOnce(undefined);
+      const client = await setup("admin-1", ALL_SCOPES, { isAdmin: true });
+
+      const result = await client.callTool({
+        name: "deleteOrganization",
+        arguments: { organizationId: "org-1" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.softDeleteOrganization).toHaveBeenCalledWith("org-1", "admin-1");
+      expect(parseToolBody(result)).toMatchObject({
+        organizationId: "org-1",
+        deleted: true,
+      });
+    });
+
+    it("deleteOrganization returns a clean error when the caller is not the owner", async () => {
+      mocks.softDeleteOrganization.mockRejectedValueOnce(
+        new ForbiddenError("Only an organization owner can delete it"),
+      );
+      const client = await setup("admin-1", ALL_SCOPES, { isAdmin: true });
+
+      const result = await client.callTool({
+        name: "deleteOrganization",
+        arguments: { organizationId: "org-1" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result)).toEqual({
+        error: "Only an organization owner can delete it",
+      });
+    });
+
+    it("organization management tools require an authenticated user", async () => {
+      const client = await setup(undefined, [McpScope.EARTHDATA_WRITE]);
+
+      const result = await client.callTool({
+        name: "addOrganizationMember",
+        arguments: { organizationId: "org-1", userId: "user-2" },
+      });
+
+      expect(result.isError).toBe(true);
+      const body = parseToolBody(result);
+      expect(body.error).toBe("authentication_required");
+      expect(mocks.addOrganizationMember).not.toHaveBeenCalled();
+    });
   });
 
   describe("task read tools", () => {

--- a/packages/web/src/lib/__tests__/routes.test.ts
+++ b/packages/web/src/lib/__tests__/routes.test.ts
@@ -4,7 +4,6 @@ import { readFileSync } from "node:fs";
 import {
   ROUTES,
   exploreLinks,
-  footerAppLinks,
   getSignInPath,
   isNavItemActive,
   navSections,
@@ -23,27 +22,6 @@ function requireLink<T extends { href: string }>(href: string, links: T[]): T {
 }
 
 describe("navigation routes", () => {
-  it("surfaces key pages in nav sections", () => {
-    const allNavHrefs = navSections.flatMap((s) => s.items.map((i) => i.href));
-
-    expect(allNavHrefs).toEqual(
-      expect.arrayContaining([
-        ROUTES.treaty,
-        ROUTES.wishocracy,
-        ROUTES.alignment,
-        ROUTES.tasks,
-        ROUTES.prize,
-        ROUTES.fund,
-        ROUTES.dtreasury,
-        ROUTES.efficiency,
-        ROUTES.legislation,
-        ROUTES.tools,
-        ROUTES.dgao,
-        ROUTES.governments,
-      ]),
-    );
-  });
-
   it("keeps route metadata off the root data barrel", () => {
     const source = readFileSync(new URL("../routes.ts", import.meta.url), "utf8");
 
@@ -52,18 +30,6 @@ describe("navigation routes", () => {
 
   it("uses intent-based navigation buckets instead of the old generic fund section", () => {
     expect(navSections.map((section) => section.id)).not.toContain("fund");
-  });
-
-  it("surfaces the core evidence explorers in the explore links", () => {
-    const hrefs = exploreLinks.map((link) => link.href);
-
-    expect(hrefs).toEqual(
-      expect.arrayContaining([
-        ROUTES.referendum,
-        ROUTES.opg,
-        ROUTES.obg,
-      ]),
-    );
   });
 
   it("keeps nested routes highlighted under the correct parent nav item", () => {
@@ -86,22 +52,6 @@ describe("navigation routes", () => {
       }),
     ).toBe(
       `/auth/signin?callbackUrl=${encodeURIComponent(ROUTES.wishocracy)}&ref=friend-123`,
-    );
-  });
-
-  it("footer includes key user-facing links", () => {
-    const footerHrefs = footerAppLinks.map((link) => link.href);
-
-    expect(footerHrefs).toEqual(
-      expect.arrayContaining([
-        ROUTES.wishocracy,
-        ROUTES.alignment,
-        ROUTES.dashboard,
-        ROUTES.profile,
-        ROUTES.census,
-        ROUTES.settings,
-        ROUTES.about,
-      ]),
     );
   });
 });

--- a/packages/web/src/lib/__tests__/site-structured-data.test.ts
+++ b/packages/web/src/lib/__tests__/site-structured-data.test.ts
@@ -15,7 +15,9 @@ describe("buildSiteStructuredData", () => {
     const website = graph.find((node) => node["@type"] === "WebSite");
 
     expect(organization).toMatchObject({
-      name: "Earth Optimization Services LLC",
+      // The 1% Treaty site shares the campaign brand with WoD; the legal
+      // entity (Earth Optimization Services LLC) lives on legalEntityName.
+      name: "International Campaign to End War and Disease",
       url: "https://optimitron.com",
       email: "hello@warondisease.org",
     });

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -5191,30 +5191,44 @@ export function createMcpServer(
         case "updateOrganization": {
           if (!userId) return authRequired(name, "This tool edits an existing organization.");
           const orgServer = await import("./organization.server");
-          const organizationId = (a.organizationId as string) ?? "";
+          if (typeof a.organizationId !== "string") return err("organizationId must be a string");
+          const organizationId = a.organizationId;
           if (!organizationId.trim()) return err("organizationId is required");
 
           const patch: Parameters<typeof orgServer.updateOrganization>[2] = {};
-          const nullable = (raw: unknown) => (raw === "" ? null : (raw as string));
-          if (typeof a.name === "string") patch.name = a.name;
-          if (a.slug !== undefined) {
-            patch.slug = a.slug === "" ? null : (a.slug as string);
+          if (a.name !== undefined) {
+            if (typeof a.name !== "string") return err("name must be a string");
+            patch.name = a.name;
+          }
+          if (a.type !== undefined && typeof a.type !== "string") {
+            return err("type must be a string");
           }
           if (typeof a.type === "string") {
             const orgType = OrgType[a.type as keyof typeof OrgType];
             if (!orgType) return err(`type must be one of: ${Object.keys(OrgType).join(", ")}`);
             patch.type = orgType;
           }
+          if (a.status !== undefined && typeof a.status !== "string") {
+            return err("status must be a string");
+          }
           if (typeof a.status === "string" && a.status !== "") {
             const orgStatus = OrgStatus[a.status as keyof typeof OrgStatus];
             if (!orgStatus) return err(`status must be one of: ${Object.keys(OrgStatus).join(", ")}`);
             patch.status = orgStatus;
           }
-          if (a.website !== undefined) patch.website = nullable(a.website);
-          if (a.description !== undefined) patch.description = nullable(a.description);
-          if (a.logo !== undefined) patch.logo = nullable(a.logo);
-          if (a.contactEmail !== undefined) patch.contactEmail = nullable(a.contactEmail);
-          if (a.jurisdictionId !== undefined) patch.jurisdictionId = nullable(a.jurisdictionId);
+          for (const fieldName of [
+            "slug",
+            "website",
+            "description",
+            "logo",
+            "contactEmail",
+            "jurisdictionId",
+          ] as const) {
+            const raw = a[fieldName];
+            if (raw === undefined) continue;
+            if (typeof raw !== "string") return err(`${fieldName} must be a string`);
+            patch[fieldName] = raw === "" ? null : raw;
+          }
 
           try {
             return await runAuditedEarthDataTool(

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -67,6 +67,12 @@ const TOOL_SCOPES: Record<string, McpScope[]> = {
   createReferendum: [McpScope.TASKS_ADMIN],
   createPerson: [McpScope.TASKS_ADMIN],
   upsertOrganization: [McpScope.EARTHDATA_ADMIN, McpScope.TASKS_ADMIN],
+  updateOrganization: [McpScope.EARTHDATA_WRITE, McpScope.TASKS_ADMIN],
+  deleteOrganization: [McpScope.EARTHDATA_ADMIN, McpScope.TASKS_ADMIN],
+  addOrganizationMember: [McpScope.EARTHDATA_WRITE, McpScope.TASKS_ADMIN],
+  removeOrganizationMember: [McpScope.EARTHDATA_WRITE, McpScope.TASKS_ADMIN],
+  updateOrganizationMemberRole: [McpScope.EARTHDATA_WRITE, McpScope.TASKS_ADMIN],
+  listOrganizationMembers: [McpScope.EARTHDATA_WRITE],
   castReferendumVote: [McpScope.EARTHDATA_WRITE],
   recordRepresentedReferendumVote: [McpScope.EARTHDATA_WRITE],
   searchPeople: [McpScope.EARTHDATA_WRITE],
@@ -132,6 +138,7 @@ const ADMIN_ONLY_TOOLS = new Set([
   "createReferendum",
   "createPerson",
   "upsertOrganization",
+  "deleteOrganization",
   "logAgentRun",
   "acquireLease",
   "heartbeatLease",
@@ -217,6 +224,11 @@ function getMcpBaseUrl(): string {
 const AUDITED_EARTH_DATA_TOOLS = new Set([
   "createOrganization",
   "upsertOrganization",
+  "updateOrganization",
+  "deleteOrganization",
+  "addOrganizationMember",
+  "removeOrganizationMember",
+  "updateOrganizationMemberRole",
   "castReferendumVote",
   "recordRepresentedReferendumVote",
   "signReferendumAsOrganization",
@@ -3071,6 +3083,130 @@ const TASK_TOOL_DEFINITIONS = [
     },
   },
   {
+    name: "updateOrganization",
+    description:
+      "Edit an existing Organization. Caller must be an owner/admin of the org (or its legacy creator). status and jurisdictionId changes additionally require platform-admin privileges.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        organizationId: { type: "string", description: "Organization ID to update" },
+        name: { type: "string", description: "New name" },
+        slug: {
+          type: "string",
+          description:
+            "New URL slug. Pass empty string to regenerate from the (possibly updated) name. Slug collisions auto-disambiguate with -2, -3, etc.",
+        },
+        type: {
+          type: "string",
+          enum: [
+            "UNIVERSITY",
+            "RESEARCH_CENTER",
+            "NONPROFIT",
+            "DAO",
+            "GOVERNMENT",
+            "GOVERNMENT_AGENCY",
+            "HOSPITAL",
+            "BIOTECH",
+            "COMPANY",
+            "FOUNDATION",
+            "INTERGOVERNMENTAL",
+            "MEDIA",
+            "POLITICAL_PARTY",
+            "ADVOCACY",
+            "OTHER",
+          ],
+        },
+        status: {
+          type: "string",
+          enum: ["PENDING", "APPROVED", "REJECTED"],
+          description: "Approval status. Platform-admin only.",
+        },
+        website: { type: "string", description: "Website URL (empty string clears)" },
+        description: { type: "string", description: "Mission or provenance note (empty string clears)" },
+        logo: { type: "string", description: "Logo image URL (empty string clears)" },
+        contactEmail: { type: "string", description: "Primary contact email (empty string clears)" },
+        jurisdictionId: {
+          type: "string",
+          description: "Jurisdiction ID (empty string clears). Platform-admin only.",
+        },
+      },
+      required: ["organizationId"],
+    },
+  },
+  {
+    name: "deleteOrganization",
+    description:
+      "Soft-delete an Organization (sets deletedAt). Caller must be an owner of the org AND a platform admin. Tasks previously assigned to this org keep their assigneeOrganizationId — orphan visibility is intentional for accountability.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        organizationId: { type: "string", description: "Organization ID to soft-delete" },
+      },
+      required: ["organizationId"],
+    },
+  },
+  {
+    name: "addOrganizationMember",
+    description:
+      "Add a user to an Organization with a given role, or update an existing member's role to that value. Caller must be an owner/admin of the org. Accepts only userId (no email lookup — that would expose User-account enumeration).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        organizationId: { type: "string", description: "Organization ID" },
+        userId: { type: "string", description: "User ID to add as a member" },
+        role: {
+          type: "string",
+          enum: ["owner", "admin", "member", "viewer"],
+          description: "Role within the organization. Default: member.",
+        },
+      },
+      required: ["organizationId", "userId"],
+    },
+  },
+  {
+    name: "removeOrganizationMember",
+    description:
+      "Remove a user from an Organization. Caller must be an owner/admin of the org, OR be removing themselves. Cannot remove the last remaining owner — transfer ownership first by adding another owner.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        organizationId: { type: "string", description: "Organization ID" },
+        userId: { type: "string", description: "User ID to remove" },
+      },
+      required: ["organizationId", "userId"],
+    },
+  },
+  {
+    name: "updateOrganizationMemberRole",
+    description:
+      "Change a member's role within an Organization. Caller must be an owner/admin. Cannot demote the last remaining owner.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        organizationId: { type: "string", description: "Organization ID" },
+        userId: { type: "string", description: "User ID whose role to change" },
+        role: {
+          type: "string",
+          enum: ["owner", "admin", "member", "viewer"],
+          description: "New role.",
+        },
+      },
+      required: ["organizationId", "userId", "role"],
+    },
+  },
+  {
+    name: "listOrganizationMembers",
+    description:
+      "List members of an Organization with their roles, emails, and display names. Caller must be an owner/admin of the org.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        organizationId: { type: "string", description: "Organization ID" },
+      },
+      required: ["organizationId"],
+    },
+  },
+  {
     name: "proposeTaskBundle",
     description: "Propose a bundle of tasks for review. Creates each as DRAFT, runs validation, returns review decisions. Does NOT auto-promote.",
     inputSchema: {
@@ -3125,7 +3261,7 @@ const TASK_TOOL_DEFINITIONS = [
   },
   {
     name: "updateTask",
-    description: "Update a private task's estimates, dependencies, deadline metadata, executor, or status. Mark work done with status='VERIFIED'. Passing depends_on replaces the blocker set idempotently, so keep it complete.",
+    description: "Update a private task's estimates, dependencies, deadline metadata, executor, or status. Mark work done with status='VERIFIED'. Passing depends_on replaces the blocker set idempotently, so keep it complete. To re-assign a task to an organization or person, set assigneeOrganizationId or assigneePersonId. Pass an empty string to clear an assignment.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -5050,6 +5186,217 @@ export function createMcpServer(
               };
             },
           );
+        }
+
+        case "updateOrganization": {
+          if (!userId) return authRequired(name, "This tool edits an existing organization.");
+          const orgServer = await import("./organization.server");
+          const organizationId = (a.organizationId as string) ?? "";
+          if (!organizationId.trim()) return err("organizationId is required");
+
+          const patch: Parameters<typeof orgServer.updateOrganization>[2] = {};
+          const nullable = (raw: unknown) => (raw === "" ? null : (raw as string));
+          if (typeof a.name === "string") patch.name = a.name;
+          if (a.slug !== undefined) {
+            patch.slug = a.slug === "" ? null : (a.slug as string);
+          }
+          if (typeof a.type === "string") {
+            const orgType = OrgType[a.type as keyof typeof OrgType];
+            if (!orgType) return err(`type must be one of: ${Object.keys(OrgType).join(", ")}`);
+            patch.type = orgType;
+          }
+          if (typeof a.status === "string" && a.status !== "") {
+            const orgStatus = OrgStatus[a.status as keyof typeof OrgStatus];
+            if (!orgStatus) return err(`status must be one of: ${Object.keys(OrgStatus).join(", ")}`);
+            patch.status = orgStatus;
+          }
+          if (a.website !== undefined) patch.website = nullable(a.website);
+          if (a.description !== undefined) patch.description = nullable(a.description);
+          if (a.logo !== undefined) patch.logo = nullable(a.logo);
+          if (a.contactEmail !== undefined) patch.contactEmail = nullable(a.contactEmail);
+          if (a.jurisdictionId !== undefined) patch.jurisdictionId = nullable(a.jurisdictionId);
+
+          try {
+            return await runAuditedEarthDataTool(
+              name,
+              a,
+              { clientId: options.clientId, oauthGrantId: options.oauthGrantId, userId },
+              async () => {
+                const organization = await orgServer.updateOrganization(
+                  organizationId,
+                  userId,
+                  patch,
+                  { allowStatusChange: hasAdminTaskWriteAccess(scopes, isAdmin) },
+                );
+                return {
+                  organization: {
+                    contactEmail: organization.contactEmail,
+                    description: organization.description,
+                    id: organization.id,
+                    jurisdictionId: organization.jurisdictionId,
+                    logo: organization.logo,
+                    name: organization.name,
+                    slug: organization.slug,
+                    status: organization.status,
+                    type: organization.type,
+                    website: organization.website,
+                  },
+                };
+              },
+            );
+          } catch (error) {
+            if (error instanceof Error) return err(error.message);
+            throw error;
+          }
+        }
+
+        case "deleteOrganization": {
+          if (!userId) return authRequired(name, "This tool soft-deletes an organization.");
+          const orgServer = await import("./organization.server");
+          const organizationId = (a.organizationId as string) ?? "";
+          if (!organizationId.trim()) return err("organizationId is required");
+
+          try {
+            return await runAuditedEarthDataTool(
+              name,
+              a,
+              { clientId: options.clientId, oauthGrantId: options.oauthGrantId, userId },
+              async () => {
+                await orgServer.softDeleteOrganization(organizationId, userId);
+                return { organizationId, deleted: true };
+              },
+            );
+          } catch (error) {
+            if (error instanceof Error) return err(error.message);
+            throw error;
+          }
+        }
+
+        case "addOrganizationMember": {
+          if (!userId) return authRequired(name, "This tool adds a member to an organization.");
+          const orgServer = await import("./organization.server");
+          const organizationId = (a.organizationId as string) ?? "";
+          const targetUserId = (a.userId as string) ?? "";
+          if (!organizationId.trim()) return err("organizationId is required");
+          if (!targetUserId.trim()) return err("userId is required");
+          const roleInput = (typeof a.role === "string" && a.role) || "member";
+          if (!orgServer.isOrganizationMemberRole(roleInput)) {
+            return err(`role must be one of: owner, admin, member, viewer`);
+          }
+
+          try {
+            return await runAuditedEarthDataTool(
+              name,
+              a,
+              { clientId: options.clientId, oauthGrantId: options.oauthGrantId, userId },
+              async () => {
+                const membership = await orgServer.addOrganizationMember(
+                  organizationId,
+                  userId,
+                  targetUserId,
+                  roleInput,
+                );
+                return {
+                  membership: {
+                    organizationId: membership.organizationId,
+                    userId: membership.userId,
+                    role: membership.role,
+                    joinedAt: membership.joinedAt,
+                  },
+                };
+              },
+            );
+          } catch (error) {
+            if (error instanceof Error) return err(error.message);
+            throw error;
+          }
+        }
+
+        case "removeOrganizationMember": {
+          if (!userId) return authRequired(name, "This tool removes a member from an organization.");
+          const orgServer = await import("./organization.server");
+          const organizationId = (a.organizationId as string) ?? "";
+          const targetUserId = (a.userId as string) ?? "";
+          if (!organizationId.trim()) return err("organizationId is required");
+          if (!targetUserId.trim()) return err("userId is required");
+
+          try {
+            return await runAuditedEarthDataTool(
+              name,
+              a,
+              { clientId: options.clientId, oauthGrantId: options.oauthGrantId, userId },
+              async () => {
+                await orgServer.removeOrganizationMember(organizationId, userId, targetUserId);
+                return { organizationId, userId: targetUserId, removed: true };
+              },
+            );
+          } catch (error) {
+            if (error instanceof Error) return err(error.message);
+            throw error;
+          }
+        }
+
+        case "updateOrganizationMemberRole": {
+          if (!userId) return authRequired(name, "This tool changes an organization member's role.");
+          const orgServer = await import("./organization.server");
+          const organizationId = (a.organizationId as string) ?? "";
+          const targetUserId = (a.userId as string) ?? "";
+          const roleInput = (a.role as string) ?? "";
+          if (!organizationId.trim()) return err("organizationId is required");
+          if (!targetUserId.trim()) return err("userId is required");
+          if (!orgServer.isOrganizationMemberRole(roleInput)) {
+            return err(`role must be one of: owner, admin, member, viewer`);
+          }
+
+          try {
+            return await runAuditedEarthDataTool(
+              name,
+              a,
+              { clientId: options.clientId, oauthGrantId: options.oauthGrantId, userId },
+              async () => {
+                const membership = await orgServer.updateOrganizationMemberRole(
+                  organizationId,
+                  userId,
+                  targetUserId,
+                  roleInput,
+                );
+                return {
+                  membership: {
+                    organizationId: membership.organizationId,
+                    userId: membership.userId,
+                    role: membership.role,
+                    joinedAt: membership.joinedAt,
+                  },
+                };
+              },
+            );
+          } catch (error) {
+            if (error instanceof Error) return err(error.message);
+            throw error;
+          }
+        }
+
+        case "listOrganizationMembers": {
+          if (!userId) return authRequired(name, "This tool lists members of an organization.");
+          const orgServer = await import("./organization.server");
+          const organizationId = (a.organizationId as string) ?? "";
+          if (!organizationId.trim()) return err("organizationId is required");
+          try {
+            const members = await orgServer.listOrganizationMembers(organizationId, userId);
+            return ok({
+              members: members.map((m) => ({
+                userId: m.user.id,
+                email: m.user.email,
+                displayName: m.user.person?.displayName ?? null,
+                handle: m.user.person?.handle ?? null,
+                role: m.role,
+                joinedAt: m.joinedAt,
+              })),
+            });
+          } catch (error) {
+            if (error instanceof Error) return err(error.message);
+            throw error;
+          }
         }
 
         case "createPerson": {

--- a/packages/web/src/lib/organization.server.ts
+++ b/packages/web/src/lib/organization.server.ts
@@ -343,3 +343,246 @@ export async function getApprovedOrganizationSurveyContext(slug: string) {
     orgContextToken: issueOrgContextToken(organization.id).encoded,
   };
 }
+
+export class ForbiddenError extends Error {
+  constructor(message = "Forbidden") {
+    super(message);
+    this.name = "ForbiddenError";
+  }
+}
+
+export class LastOwnerError extends Error {
+  constructor(message = "Cannot remove or demote the last owner of the organization") {
+    super(message);
+    this.name = "LastOwnerError";
+  }
+}
+
+export type OrganizationMemberRole = "owner" | "admin" | "member" | "viewer";
+
+const ORGANIZATION_MEMBER_ROLES: ReadonlySet<OrganizationMemberRole> = new Set([
+  "owner",
+  "admin",
+  "member",
+  "viewer",
+]);
+
+export function isOrganizationMemberRole(value: string): value is OrganizationMemberRole {
+  return ORGANIZATION_MEMBER_ROLES.has(value as OrganizationMemberRole);
+}
+
+async function isOrgOwner(userId: string, organizationId: string): Promise<boolean> {
+  const membership = await prisma.organizationMember.findUnique({
+    where: { organizationId_userId: { organizationId, userId } },
+    select: { role: true },
+  });
+  return membership?.role === "owner";
+}
+
+async function assertNotLastOwner(
+  tx: Prisma.TransactionClient,
+  organizationId: string,
+  userIdBeingChanged: string,
+) {
+  const ownerCount = await tx.organizationMember.count({
+    where: { organizationId, role: "owner" },
+  });
+  if (ownerCount <= 1) {
+    const targetMembership = await tx.organizationMember.findUnique({
+      where: { organizationId_userId: { organizationId, userId: userIdBeingChanged } },
+      select: { role: true },
+    });
+    if (targetMembership?.role === "owner") {
+      throw new LastOwnerError();
+    }
+  }
+}
+
+interface UpdateOrganizationInput {
+  name?: string;
+  slug?: string | null;
+  type?: OrgType;
+  status?: OrgStatus;
+  website?: string | null;
+  description?: string | null;
+  logo?: string | null;
+  contactEmail?: string | null;
+  jurisdictionId?: string | null;
+}
+
+interface UpdateOrganizationOptions {
+  allowStatusChange?: boolean;
+}
+
+export async function updateOrganization(
+  organizationId: string,
+  callerUserId: string,
+  patch: UpdateOrganizationInput,
+  options: UpdateOrganizationOptions = {},
+) {
+  if (!(await canManageOrganization(callerUserId, organizationId))) {
+    throw new ForbiddenError("You do not have permission to manage this organization");
+  }
+
+  if (
+    !options.allowStatusChange &&
+    (patch.status !== undefined || patch.jurisdictionId !== undefined)
+  ) {
+    throw new ForbiddenError(
+      "Changing status or jurisdictionId requires platform-admin privileges",
+    );
+  }
+
+  const existing = await prisma.organization.findUnique({
+    where: { id: organizationId },
+    select: { id: true, name: true, slug: true, deletedAt: true },
+  });
+  if (!existing || existing.deletedAt) {
+    throw new Error("Organization not found");
+  }
+
+  const data: Prisma.OrganizationUpdateInput = {};
+
+  if (patch.name !== undefined) {
+    const nextName = patch.name.trim();
+    if (!nextName) throw new Error("Organization name cannot be empty");
+    data.name = nextName;
+  }
+
+  if (patch.slug !== undefined) {
+    const baseSource =
+      patch.slug && patch.slug.trim()
+        ? patch.slug.trim()
+        : (data.name as string | undefined) ?? existing.name;
+    const nextSlug = await getAvailableSlug(prisma, slugify(baseSource), existing.id);
+    data.slug = nextSlug;
+  }
+
+  if (patch.type !== undefined) data.type = patch.type;
+  if (patch.status !== undefined) data.status = patch.status;
+  if (patch.website !== undefined) data.website = patch.website;
+  if (patch.description !== undefined) data.description = patch.description;
+  if (patch.logo !== undefined) data.logo = patch.logo;
+  if (patch.contactEmail !== undefined) data.contactEmail = patch.contactEmail;
+  if (patch.jurisdictionId !== undefined) {
+    data.jurisdiction = patch.jurisdictionId
+      ? { connect: { id: patch.jurisdictionId } }
+      : { disconnect: true };
+  }
+
+  return prisma.organization.update({
+    where: { id: organizationId },
+    data,
+  });
+}
+
+export async function addOrganizationMember(
+  organizationId: string,
+  callerUserId: string,
+  targetUserId: string,
+  role: OrganizationMemberRole,
+) {
+  if (!isOrganizationMemberRole(role)) {
+    throw new Error(`Invalid role: ${role}`);
+  }
+  if (!(await canManageOrganization(callerUserId, organizationId))) {
+    throw new ForbiddenError("You do not have permission to manage this organization");
+  }
+
+  const targetUser = await prisma.user.findUnique({
+    where: { id: targetUserId },
+    select: { id: true },
+  });
+  if (!targetUser) {
+    throw new Error("Target user not found");
+  }
+
+  return prisma.$transaction(async (tx) => {
+    return tx.organizationMember.upsert({
+      where: { organizationId_userId: { organizationId, userId: targetUserId } },
+      update: { role },
+      create: { organizationId, userId: targetUserId, role },
+    });
+  });
+}
+
+export async function removeOrganizationMember(
+  organizationId: string,
+  callerUserId: string,
+  targetUserId: string,
+) {
+  const isSelfRemoval = callerUserId === targetUserId;
+  if (!isSelfRemoval && !(await canManageOrganization(callerUserId, organizationId))) {
+    throw new ForbiddenError("You do not have permission to manage this organization");
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await assertNotLastOwner(tx, organizationId, targetUserId);
+    await tx.organizationMember.delete({
+      where: { organizationId_userId: { organizationId, userId: targetUserId } },
+    });
+  });
+}
+
+export async function updateOrganizationMemberRole(
+  organizationId: string,
+  callerUserId: string,
+  targetUserId: string,
+  role: OrganizationMemberRole,
+) {
+  if (!isOrganizationMemberRole(role)) {
+    throw new Error(`Invalid role: ${role}`);
+  }
+  if (!(await canManageOrganization(callerUserId, organizationId))) {
+    throw new ForbiddenError("You do not have permission to manage this organization");
+  }
+
+  return prisma.$transaction(async (tx) => {
+    if (role !== "owner") {
+      await assertNotLastOwner(tx, organizationId, targetUserId);
+    }
+    return tx.organizationMember.update({
+      where: { organizationId_userId: { organizationId, userId: targetUserId } },
+      data: { role },
+    });
+  });
+}
+
+export async function listOrganizationMembers(
+  organizationId: string,
+  callerUserId: string,
+) {
+  if (!(await canManageOrganization(callerUserId, organizationId))) {
+    throw new ForbiddenError("You do not have permission to view this organization's members");
+  }
+
+  return prisma.organizationMember.findMany({
+    where: { organizationId },
+    select: {
+      role: true,
+      joinedAt: true,
+      user: {
+        select: {
+          id: true,
+          email: true,
+          person: { select: { displayName: true, handle: true } },
+        },
+      },
+    },
+    orderBy: { joinedAt: "asc" },
+  });
+}
+
+export async function softDeleteOrganization(
+  organizationId: string,
+  callerUserId: string,
+) {
+  if (!(await isOrgOwner(callerUserId, organizationId))) {
+    throw new ForbiddenError("Only an organization owner can delete it");
+  }
+
+  await prisma.organization.update({
+    where: { id: organizationId },
+    data: { deletedAt: new Date() },
+  });
+}

--- a/packages/web/src/lib/site.ts
+++ b/packages/web/src/lib/site.ts
@@ -1,5 +1,6 @@
 import {
   DFDA_QUEUE_CLEARANCE_YEARS,
+  DFDA_TRIAL_CAPACITY_MULTIPLIER,
   GLOBAL_WARHEAD_COUNT,
   NUCLEAR_WINTER_OVERKILL_FACTOR,
   NUCLEAR_WINTER_WARHEAD_THRESHOLD,
@@ -51,6 +52,7 @@ const apocalypseCount = Math.round(NUCLEAR_WINTER_OVERKILL_FACTOR.value);
 const apocalypseSlice = (NUCLEAR_WINTER_OVERKILL_FACTOR.value * TREATY_FRACTION).toFixed(2);
 const statusQuoYears = Math.round(STATUS_QUO_QUEUE_CLEARANCE_YEARS.value);
 const dfdaYears = Math.round(DFDA_QUEUE_CLEARANCE_YEARS.value);
+const trialCapacityMultiplier = Math.round(DFDA_TRIAL_CAPACITY_MULTIPLIER.value);
 
 export const OPTIMITRON_CANONICAL_ORIGIN = "https://optimitron.com";
 export const OPTIMITRON_LOCAL_ORIGIN = "http://localhost:3001";
@@ -248,6 +250,13 @@ const PUBLIC_CONTACT_URL = `${OPTIMITRON_CANONICAL_ORIGIN}/about`;
 const ORGANIZATION_SAME_AS = ["https://github.com/mikepsinn/optimitron"];
 const EARTH_OPTIMIZATION_SERVICES_LLC = "Earth Optimization Services LLC";
 const NO_FOOTER_COMPLIANCE_NOTICE = null;
+
+/// Public-facing campaign brand for the WoD + 1pt sites. Distinct from
+/// `EARTH_OPTIMIZATION_SERVICES_LLC` (the legal entity, used in compliance
+/// surfaces). Both campaign sites point `organizationName` at this so SEO
+/// + footer attribution carry the campaign brand instead of the LLC name.
+const INTERNATIONAL_CAMPAIGN_ORG_NAME =
+  "International Campaign to End War and Disease";
 
 function siteAssetPath(directory: string, filename: string) {
   return `/site-assets/${directory}/${filename}`;
@@ -512,9 +521,8 @@ const WAR_ON_DISEASE_UI: SiteVariantUiConfig = {
     brandHref: ROUTES.home,
     brandLabel: "War on Disease",
     brandDescription:
-      `Trade ${apocalypseSlice} of your ${apocalypseCount} apocalypses for disease eradication in ${dfdaYears} years instead of ${statusQuoYears}.`,
-    bottomText:
-      "Building a nuclear bomb requires mass spectrometers and centrifuge cascades. Not building one requires nothing. Rocks do it daily.",
+      `Is it OK if we trade ${apocalypseSlice} of our ${apocalypseCount} apocalypses for disease eradication in ${dfdaYears} years instead of ${statusQuoYears}?`,
+    bottomText: "",
     columns: [
       {
         title: "Campaign",
@@ -530,7 +538,7 @@ const WAR_ON_DISEASE_UI: SiteVariantUiConfig = {
       },
       {
         title: "Reference",
-        items: [whyLink, courtLink, legalLink, privacyLink, termsLink],
+        items: [whyLink, courtLink],
       },
     ],
   },
@@ -967,7 +975,10 @@ const WAR_ON_DISEASE_CONFIG: SiteConfig = {
   ogImage: "/site-assets/warondisease/war-on-disease-og-1200x630.png",
   analyticsId: process.env.NEXT_PUBLIC_GA_WAR_ON_DISEASE_ID,
   contentKey: "onePercentTreaty",
-  organizationName: ORGANIZATION_NAME,
+  // Public-facing campaign brand on WoD; the legal entity (Earth
+  // Optimization Services LLC) stays in `legalEntityName` for compliance
+  // surfaces. SEO + footer attribution show the campaign name.
+  organizationName: INTERNATIONAL_CAMPAIGN_ORG_NAME,
   organizationUrl: ORGANIZATION_URL,
   organizationLogoPath: ORGANIZATION_LOGO_PATH,
   publicContactEmail: PUBLIC_CONTACT_EMAIL,
@@ -1093,7 +1104,9 @@ const ONE_PERCENT_TREATY_CONFIG: SiteConfig = {
   ogImage: "/site-assets/treaty/treaty-og-1200x630.png",
   analyticsId: process.env.NEXT_PUBLIC_GA_ONE_PERCENT_TREATY_ID,
   contentKey: "onePercentTreaty",
-  organizationName: ORGANIZATION_NAME,
+  // Same campaign brand as warondisease.org. Legal entity stays in
+  // legalEntityName for compliance surfaces.
+  organizationName: INTERNATIONAL_CAMPAIGN_ORG_NAME,
   organizationUrl: ORGANIZATION_URL,
   organizationLogoPath: ORGANIZATION_LOGO_PATH,
   publicContactEmail: PUBLIC_CONTACT_EMAIL,

--- a/packages/web/src/lib/site.ts
+++ b/packages/web/src/lib/site.ts
@@ -1,6 +1,5 @@
 import {
   DFDA_QUEUE_CLEARANCE_YEARS,
-  DFDA_TRIAL_CAPACITY_MULTIPLIER,
   GLOBAL_WARHEAD_COUNT,
   NUCLEAR_WINTER_OVERKILL_FACTOR,
   NUCLEAR_WINTER_WARHEAD_THRESHOLD,
@@ -52,7 +51,6 @@ const apocalypseCount = Math.round(NUCLEAR_WINTER_OVERKILL_FACTOR.value);
 const apocalypseSlice = (NUCLEAR_WINTER_OVERKILL_FACTOR.value * TREATY_FRACTION).toFixed(2);
 const statusQuoYears = Math.round(STATUS_QUO_QUEUE_CLEARANCE_YEARS.value);
 const dfdaYears = Math.round(DFDA_QUEUE_CLEARANCE_YEARS.value);
-const trialCapacityMultiplier = Math.round(DFDA_TRIAL_CAPACITY_MULTIPLIER.value);
 
 export const OPTIMITRON_CANONICAL_ORIGIN = "https://optimitron.com";
 export const OPTIMITRON_LOCAL_ORIGIN = "http://localhost:3001";
@@ -251,10 +249,13 @@ const ORGANIZATION_SAME_AS = ["https://github.com/mikepsinn/optimitron"];
 const EARTH_OPTIMIZATION_SERVICES_LLC = "Earth Optimization Services LLC";
 const NO_FOOTER_COMPLIANCE_NOTICE = null;
 
-/// Public-facing campaign brand for the WoD + 1pt sites. Distinct from
-/// `EARTH_OPTIMIZATION_SERVICES_LLC` (the legal entity, used in compliance
-/// surfaces). Both campaign sites point `organizationName` at this so SEO
-/// + footer attribution carry the campaign brand instead of the LLC name.
+/// Public-facing campaign brand for sites operated by the campaign.
+/// Distinct from `EARTH_OPTIMIZATION_SERVICES_LLC` (the legal entity, used
+/// in compliance surfaces). Used by WoD, 1pt, and the Trial Abundance
+/// Survey — all three point `organizationName` at this so SEO + footer
+/// attribution carry the campaign brand instead of the LLC name. The
+/// survey's neutral UX (no campaign branding in the embedded form) is a
+/// separate concern from operator-metadata disclosure to crawlers.
 const INTERNATIONAL_CAMPAIGN_ORG_NAME =
   "International Campaign to End War and Disease";
 
@@ -1242,7 +1243,11 @@ const TRIAL_ABUNDANCE_SURVEY_CONFIG: SiteConfig = {
   ogImage: "/site-assets/survey/survey-og-1200x630.png",
   analyticsId: process.env.NEXT_PUBLIC_GA_TRIAL_ABUNDANCE_SURVEY_ID,
   contentKey: null,
-  organizationName: ORGANIZATION_NAME,
+  // The trial-abundance survey is operated by the same campaign — neutral
+  // SURVEY UX (intentional, so partners can embed it without political
+  // branding) is distinct from operator-metadata disclosure. Crawlers,
+  // journalists, and due-diligence-doing partners get truthful attribution.
+  organizationName: INTERNATIONAL_CAMPAIGN_ORG_NAME,
   organizationUrl: ORGANIZATION_URL,
   organizationLogoPath: ORGANIZATION_LOGO_PATH,
   publicContactEmail: PUBLIC_CONTACT_EMAIL,


### PR DESCRIPTION
## Summary
- add MCP tools and server helpers for organization updates, member management, member listing, and soft deletion
- remove brittle exact menu-content assertions while keeping chrome shape and jargon guardrail tests
- polish War on Disease footer/site metadata and structured-data expectations
- stop the treaty slider submit from auto-scrolling and replace the animated guide line with a hand cue

## Verification
- pnpm --filter @optimitron/web run typecheck:fast
- pnpm --filter @optimitron/web exec vitest run src/config/__tests__/site-variant-ui.test.ts src/lib/__tests__/routes.test.ts src/lib/__tests__/mcp-server.test.ts src/lib/__tests__/treaty-post-vote-flow-mounts.test.ts
- pnpm --filter @optimitron/web exec vitest run src/lib/__tests__/site-structured-data.test.ts src/config/__tests__/site-variant-ui.test.ts src/lib/__tests__/routes.test.ts
- BASE_URL=http://127.0.0.1:3002 SKIP_SERVER=1 pnpm --filter @optimitron/web exec playwright test e2e/treaty-vote-click.spec.ts --project=default --reporter=list
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Redesigned loader animation with new Earth/orbit visual style

* **Style**
  - Updated button styling with refined color scheme
  - Enhanced voting flow interface and layout
  - Improved footer display with conditional content
  - Refreshed campaign branding across site pages

* **Bug Fixes**
  - Improved vote submission stability and scroll behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->