### PR TITLE
Count only sent overdue reminders

### DIFF
--- a/packages/web/src/app/api/cron/task-overdue-reminders/route.test.ts
+++ b/packages/web/src/app/api/cron/task-overdue-reminders/route.test.ts
@@ -246,7 +246,7 @@ describe("/api/cron/task-overdue-reminders", () => {
     expect(json).toEqual(expect.objectContaining({ sent: 0, skipped: 1 }));
   });
 
-  it("counts reminder comments even when the linked email did not send", async () => {
+  it("only counts sent reminder comments toward the one-reminder cap", async () => {
     mocks.taskCommentAggregate.mockResolvedValue({
       _count: { _all: 1 },
       _max: { createdAt: new Date("2026-04-01T00:00:00.000Z") },
@@ -262,6 +262,7 @@ describe("/api/cron/task-overdue-reminders", () => {
           communications: {
             some: expect.objectContaining({
               purpose: "REMINDER",
+              status: "SENT",
             }),
           },
           taskId: "task_1",

--- a/packages/web/src/app/api/cron/task-overdue-reminders/route.ts
+++ b/packages/web/src/app/api/cron/task-overdue-reminders/route.ts
@@ -5,6 +5,7 @@ import {
   TaskCommunicationAudience,
   TaskCommunicationChannel,
   TaskCommunicationPurpose,
+  TaskCommunicationStatus,
   TaskStatus,
 } from "@optimitron/db/enums";
 import type { Prisma } from "@optimitron/db";
@@ -119,6 +120,7 @@ async function processOverdueReminders(now: Date): Promise<ReminderResult> {
             some: {
               deletedAt: null,
               purpose: TaskCommunicationPurpose.REMINDER,
+              status: TaskCommunicationStatus.SENT,
             },
           },
         },


### PR DESCRIPTION
## What changed

- Count only successfully sent reminder communications toward the one-reminder overdue cap.
- Keeps retry behavior intact if the reminder email provider/config fails before delivery.

## Validation

- `pnpm --filter @optimitron/web exec vitest run src/app/api/cron/task-overdue-reminders/route.test.ts src/lib/tasks/__tests__/task-overdue-reminder.test.ts`
- `pnpm --filter @optimitron/web run typecheck:fast`
- `pnpm exec prettier --check packages/web/src/app/api/cron/task-overdue-reminders/route.ts packages/web/src/app/api/cron/task-overdue-reminders/route.test.ts`
- `git diff --check`