### PR TITLE
[codex] Rename War on Disease 2 IC2EWD

### DIFF
--- a/packages/web/src/lib/__tests__/site-structured-data.test.ts
+++ b/packages/web/src/lib/__tests__/site-structured-data.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import { getSiteConfig } from "@/lib/site";
 import { buildSiteStructuredData } from "@/lib/site-structured-data";
 
+const INTERNATIONAL_CAMPAIGN_NAME =
+  "International Campaign to End War and Disease";
+
 describe("buildSiteStructuredData", () => {
   it("emits organization and website JSON-LD for the site variant", () => {
     const site = getSiteConfig("onePercentTreaty");
@@ -17,7 +20,7 @@ describe("buildSiteStructuredData", () => {
     expect(organization).toMatchObject({
       // The 1% Treaty site shares the campaign brand with WoD; the legal
       // entity (Earth Optimization Services LLC) lives on legalEntityName.
-      name: "International Campaign to End War and Disease",
+      name: INTERNATIONAL_CAMPAIGN_NAME,
       url: "https://optimitron.com",
       email: "hello@warondisease.org",
     });
@@ -25,6 +28,29 @@ describe("buildSiteStructuredData", () => {
       name: "1% Treaty",
       url: "https://1percenttreaty.org",
     });
-    expect(website?.publisher).toEqual({ "@id": "https://optimitron.com#organization" });
+    expect(website?.publisher).toEqual({
+      "@id": "https://optimitron.com#organization",
+    });
+  });
+
+  it("uses the campaign name as the War on Disease website name", () => {
+    const site = getSiteConfig("warOnDisease");
+    const payload = buildSiteStructuredData(site);
+    const graph = payload["@graph"];
+
+    const organization = graph.find((node) => node["@type"] === "Organization");
+    const website = graph.find((node) => node["@type"] === "WebSite");
+
+    expect(organization).toMatchObject({
+      name: INTERNATIONAL_CAMPAIGN_NAME,
+    });
+    expect(website).toMatchObject({
+      name: INTERNATIONAL_CAMPAIGN_NAME,
+      alternateName: expect.arrayContaining([
+        "War on Disease",
+        INTERNATIONAL_CAMPAIGN_NAME,
+      ]),
+      url: "https://warondisease.org",
+    });
   });
 });

--- a/packages/web/src/lib/__tests__/site.test.ts
+++ b/packages/web/src/lib/__tests__/site.test.ts
@@ -17,6 +17,10 @@ import {
 } from "@/lib/site";
 import { DASHBOARD_INVITE_HREF, ROUTES } from "@/lib/routes";
 
+const INTERNATIONAL_CAMPAIGN_NAME =
+  "International Campaign to End War and Disease";
+const INTERNATIONAL_CAMPAIGN_SHORT_NAME = "IC2EWD";
+
 describe("site variant registry", () => {
   it("uses local http origins for .local hosts", () => {
     expect(
@@ -119,8 +123,31 @@ describe("site variant registry", () => {
   });
 
   it("keeps site variant identity, UI, and initiative data in the site config", () => {
+    const warSite = getSiteConfig("warOnDisease");
     const treatySite = getSiteConfig("onePercentTreaty");
     const surveySite = getSiteConfig("trialAbundanceSurvey");
+
+    expect(warSite).toMatchObject({
+      name: INTERNATIONAL_CAMPAIGN_NAME,
+      shortName: INTERNATIONAL_CAMPAIGN_SHORT_NAME,
+      organizationName: INTERNATIONAL_CAMPAIGN_NAME,
+      emailBranding: {
+        fromName: INTERNATIONAL_CAMPAIGN_SHORT_NAME,
+        orgName: INTERNATIONAL_CAMPAIGN_NAME,
+      },
+      initiative: {
+        key: "warOnDisease",
+        name: INTERNATIONAL_CAMPAIGN_NAME,
+        shortName: INTERNATIONAL_CAMPAIGN_SHORT_NAME,
+      },
+    });
+    expect(warSite.alternateSiteNames).toEqual(
+      expect.arrayContaining(["War on Disease", INTERNATIONAL_CAMPAIGN_NAME]),
+    );
+    expect(warSite.ui.nav.brandLabel).toBe(INTERNATIONAL_CAMPAIGN_SHORT_NAME);
+    expect(warSite.ui.nav.desktopBrandLabel).toBe(INTERNATIONAL_CAMPAIGN_NAME);
+    expect(warSite.ui.nav.menuTitle).toBe(INTERNATIONAL_CAMPAIGN_NAME);
+    expect(warSite.ui.footer.brandLabel).toBe(INTERNATIONAL_CAMPAIGN_NAME);
 
     expect(treatySite.domains).toEqual(
       expect.arrayContaining(["1percenttreaty.org", "www.1percenttreaty.org"]),
@@ -355,7 +382,7 @@ describe("site variant registry", () => {
     expect(getSiteConfig("dfda").rootMetadata.title).toContain("DFDA");
     expect(getSiteConfig("dih").rootMetadata.title).toContain("DIH");
     expect(getSiteConfig("warOnDisease").rootMetadata.title).toContain(
-      "War on Disease",
+      INTERNATIONAL_CAMPAIGN_NAME,
     );
   });
 });

--- a/packages/web/src/lib/site.ts
+++ b/packages/web/src/lib/site.ts
@@ -274,6 +274,8 @@ const NO_FOOTER_COMPLIANCE_NOTICE = null;
 /// separate concern from operator-metadata disclosure to crawlers.
 const INTERNATIONAL_CAMPAIGN_ORG_NAME =
   "International Campaign to End War and Disease";
+const INTERNATIONAL_CAMPAIGN_SHORT_NAME = "IC2EWD";
+const WAR_ON_DISEASE_LEGACY_NAME = "War on Disease";
 
 function siteAssetPath(directory: string, filename: string) {
   return `/site-assets/${directory}/${filename}`;
@@ -536,10 +538,10 @@ const DIH_UI: SiteVariantUiConfig = {
 const WAR_ON_DISEASE_UI: SiteVariantUiConfig = {
   nav: {
     brandHref: ROUTES.home,
-    brandLabel: "War on Disease",
-    desktopBrandLabel: "War on Disease",
+    brandLabel: INTERNATIONAL_CAMPAIGN_SHORT_NAME,
+    desktopBrandLabel: INTERNATIONAL_CAMPAIGN_ORG_NAME,
     menuEnabled: true,
-    menuTitle: "War on Disease",
+    menuTitle: INTERNATIONAL_CAMPAIGN_ORG_NAME,
     quickAction: inviteVoterLink,
     searchEnabled: false,
     sections: warOnDiseaseNavSections,
@@ -547,7 +549,7 @@ const WAR_ON_DISEASE_UI: SiteVariantUiConfig = {
   },
   footer: {
     brandHref: ROUTES.home,
-    brandLabel: "War on Disease",
+    brandLabel: INTERNATIONAL_CAMPAIGN_ORG_NAME,
     brandDescription: `Is it OK if we trade ${apocalypseSlice} of our ${apocalypseCount} apocalypses for disease eradication in ${dfdaYears} years instead of ${statusQuoYears}?`,
     bottomText: "",
     columns: [
@@ -991,11 +993,11 @@ const WAR_ON_DISEASE_CONFIG: SiteConfig = {
     `www.${WAR_ON_DISEASE_CANONICAL_DOMAIN}`,
     "warondisease.local",
   ],
-  name: "War on Disease",
-  shortName: "War on Disease",
+  name: INTERNATIONAL_CAMPAIGN_ORG_NAME,
+  shortName: INTERNATIONAL_CAMPAIGN_SHORT_NAME,
   alternateSiteNames: [
-    "War on Disease",
-    "International Campaign to End War and Disease",
+    WAR_ON_DISEASE_LEGACY_NAME,
+    INTERNATIONAL_CAMPAIGN_ORG_NAME,
   ],
   description: `Nuclear winter takes about ${nuclearWinterThreshold} warheads. You have ${warheadCount} — ${apocalypseCount} apocalypses. Sacrifice ${apocalypseSlice} of them to eradicate disease in ${dfdaYears} years instead of ${statusQuoYears}.`,
   ogImage: "/site-assets/warondisease/war-on-disease-og-1200x630.png",
@@ -1011,17 +1013,17 @@ const WAR_ON_DISEASE_CONFIG: SiteConfig = {
   publicContactUrl: PUBLIC_CONTACT_URL,
   legalEntityName: EARTH_OPTIMIZATION_SERVICES_LLC,
   emailBranding: {
-    fromName: "War on Disease",
+    fromName: INTERNATIONAL_CAMPAIGN_SHORT_NAME,
     primaryColor: "#ff6b9d",
     secondaryColor: "#00d4ff",
-    orgName: "War on Disease",
+    orgName: INTERNATIONAL_CAMPAIGN_ORG_NAME,
   },
   footerComplianceNotice: NO_FOOTER_COMPLIANCE_NOTICE,
   sameAs: ORGANIZATION_SAME_AS,
   initiative: {
     key: "warOnDisease",
-    name: "War on Disease",
-    shortName: "War on Disease",
+    name: INTERNATIONAL_CAMPAIGN_ORG_NAME,
+    shortName: INTERNATIONAL_CAMPAIGN_SHORT_NAME,
     description:
       "Your chance of dying from terrorism: 1 in 30 million. Your chance of dying from disease: 100%. The budget does not reflect this.",
     eyebrow: "Disease Eradication",
@@ -1036,22 +1038,22 @@ const WAR_ON_DISEASE_CONFIG: SiteConfig = {
   primaryReferendumSlug: TREATY_REFERENDUM_SLUG,
   primaryTaskKey: null,
   rootMetadata: {
-    title: "War on Disease",
+    title: INTERNATIONAL_CAMPAIGN_ORG_NAME,
     description: `Nuclear winter takes about ${nuclearWinterThreshold} warheads. You have ${warheadCount} — ${apocalypseCount} apocalypses. Sacrifice ${apocalypseSlice} of them to eradicate disease in ${dfdaYears} years instead of ${statusQuoYears}.`,
-    openGraphTitle: "War on Disease",
+    openGraphTitle: INTERNATIONAL_CAMPAIGN_ORG_NAME,
     openGraphDescription: `Trade ${apocalypseSlice} of your ${apocalypseCount} apocalypses for disease eradication in ${dfdaYears} years instead of ${statusQuoYears}. Your species will find this controversial.`,
     openGraphImage: {
       url: "/site-assets/warondisease/war-on-disease-og-1200x630.png",
       width: 1200,
       height: 630,
-      alt: "War on Disease social image",
+      alt: `${INTERNATIONAL_CAMPAIGN_ORG_NAME} social image`,
     },
-    twitterTitle: "War on Disease",
+    twitterTitle: INTERNATIONAL_CAMPAIGN_ORG_NAME,
     twitterDescription: `Nuclear winter takes about ${nuclearWinterThreshold} warheads. You have ${warheadCount}. That is ${apocalypseCount} apocalypses, in case the first ${apocalypseCount - 1} do not take.`,
     twitterImage: "/site-assets/warondisease/war-on-disease-og-1200x630.png",
     keywords: [
-      "War on Disease",
-      "International Campaign to End War and Disease",
+      WAR_ON_DISEASE_LEGACY_NAME,
+      INTERNATIONAL_CAMPAIGN_ORG_NAME,
       "1% Treaty",
       "disease eradication",
       "clinical trials",


### PR DESCRIPTION
## Summary

- Renames the War on Disease site config, desktop header, footer brand, root metadata, initiative identity, and JSON-LD website name to `International Campaign to End War and Disease`.
- Uses `IC2EWD` for short-name/mobile-constrained slots.
- Keeps `War on Disease` as an alternate/legacy site name for search and compatibility.

## Validation

- `pnpm --filter @optimitron/web exec vitest run src/lib/__tests__/site.test.ts src/lib/__tests__/site-structured-data.test.ts`
- `pnpm --filter @optimitron/web run typecheck:fast`
- `pnpm exec prettier --check packages/web/src/lib/site.ts packages/web/src/lib/__tests__/site.test.ts packages/web/src/lib/__tests__/site-structured-data.test.ts`
- `git diff --check`

Screenshots intentionally skipped per user instruction for this simple site-name change.