### PR TITLE
Clean up plaintiff management flow

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -114,6 +114,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^9.14.0",
     "react-dom": "^18.3.1",
+    "react-easy-crop": "^5.5.7",
     "react-icons": "^5.6.0",
     "react-katex": "^3.1.0",
     "react-markdown": "^10.1.0",

--- a/packages/web/src/app/api/people/[id]/route.test.ts
+++ b/packages/web/src/app/api/people/[id]/route.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   conditionCreate: vi.fn(),
   conditionUpdate: vi.fn(),
+  conditionUpdateMany: vi.fn(),
   ensurePersonForUser: vi.fn(),
   globalVariableFindFirst: vi.fn(),
   memorialEvidenceCreate: vi.fn(),
@@ -23,11 +24,13 @@ const mocks = vi.hoisted(() => ({
   relationshipCreate: vi.fn(),
   relationshipFindFirst: vi.fn(),
   relationshipUpdate: vi.fn(),
+  relationshipUpdateMany: vi.fn(),
   requireAuth: vi.fn(),
   subjectUpsert: vi.fn(),
   transaction: vi.fn(),
   voteFindFirst: vi.fn(),
   voteUpdate: vi.fn(),
+  voteUpdateMany: vi.fn(),
 }));
 
 vi.mock("@/lib/auth-utils", () => ({
@@ -51,12 +54,18 @@ vi.mock("@/lib/subject.server", () => ({
   ensureSubjectForPerson: mocks.subjectUpsert,
 }));
 
-import { PATCH } from "./route";
+import { DELETE, PATCH } from "./route";
 
 function request(body: Record<string, unknown>) {
   return new Request("http://localhost/api/people/person_1", {
     method: "PATCH",
     body: JSON.stringify(body),
+  });
+}
+
+function deleteRequest() {
+  return new Request("http://localhost/api/people/person_1", {
+    method: "DELETE",
   });
 }
 
@@ -78,6 +87,7 @@ function tx() {
     personCondition: {
       create: mocks.conditionCreate,
       update: mocks.conditionUpdate,
+      updateMany: mocks.conditionUpdateMany,
     },
     personMemorial: {
       findUnique: mocks.memorialFindUnique,
@@ -103,8 +113,12 @@ function tx() {
       create: mocks.relationshipCreate,
       findFirst: mocks.relationshipFindFirst,
       update: mocks.relationshipUpdate,
+      updateMany: mocks.relationshipUpdateMany,
     },
-    referendumVote: { update: mocks.voteUpdate },
+    referendumVote: {
+      update: mocks.voteUpdate,
+      updateMany: mocks.voteUpdateMany,
+    },
     subject: { upsert: mocks.subjectUpsert },
   };
 }
@@ -373,6 +387,145 @@ describe("PATCH /api/people/[id]", () => {
         consentPublicDisplay: true,
         consentPublicDisplayAt: new Date("2024-01-02T00:00:00.000Z"),
       }),
+    });
+  });
+});
+
+describe("DELETE /api/people/[id]", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.requireAuth.mockResolvedValue({ userId: "user_1" });
+    mocks.personFindUnique.mockResolvedValue({
+      createdByUserId: "user_1",
+      deletedAt: null,
+      id: "person_1",
+      memorial: { id: "memorial_1" },
+    });
+    mocks.voteFindFirst.mockResolvedValue({ id: "vote_1" });
+    mocks.transaction.mockImplementation(async (callback) => callback(tx()));
+  });
+
+  it("returns 401 when not signed in", async () => {
+    mocks.requireAuth.mockRejectedValue(new Error("Unauthorized"));
+
+    const res = await DELETE(deleteRequest(), params());
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(mocks.transaction).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the person is not owned by the user", async () => {
+    mocks.personFindUnique.mockResolvedValue({
+      createdByUserId: "user_2",
+      deletedAt: null,
+      id: "person_1",
+      memorial: null,
+    });
+
+    const res = await DELETE(deleteRequest(), params());
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Person not found" });
+    expect(mocks.voteFindFirst).not.toHaveBeenCalled();
+    expect(mocks.transaction).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the represented vote is not owned by the user", async () => {
+    mocks.voteFindFirst.mockResolvedValue(null);
+
+    const res = await DELETE(deleteRequest(), params());
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({
+      error: "Only the original representative can delete this person.",
+    });
+    expect(mocks.transaction).not.toHaveBeenCalled();
+  });
+
+  it("soft-deletes the represented plaintiff and owned related rows", async () => {
+    const res = await DELETE(deleteRequest(), params());
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      deleted: true,
+      personId: "person_1",
+    });
+    expect(mocks.personUpdate).toHaveBeenCalledWith({
+      where: { id: "person_1" },
+      data: {
+        deletedAt: expect.any(Date),
+        isPublic: false,
+      },
+    });
+    expect(mocks.voteUpdateMany).toHaveBeenCalledWith({
+      where: {
+        deletedAt: null,
+        personId: "person_1",
+        userId: "user_1",
+        voteSource: "REPRESENTED",
+      },
+      data: {
+        deletedAt: expect.any(Date),
+        isPublic: false,
+      },
+    });
+    expect(mocks.conditionUpdateMany).toHaveBeenCalledWith({
+      where: { deletedAt: null, personId: "person_1" },
+      data: {
+        deletedAt: expect.any(Date),
+        isPublic: false,
+      },
+    });
+    expect(mocks.relationshipUpdateMany).toHaveBeenCalledWith({
+      where: {
+        deletedAt: null,
+        OR: [
+          { createdByUserId: "user_1", objectPersonId: "person_1" },
+          { createdByUserId: "user_1", subjectPersonId: "person_1" },
+        ],
+      },
+      data: {
+        deletedAt: expect.any(Date),
+        isPublic: false,
+      },
+    });
+    expect(mocks.memorialUpdate).toHaveBeenCalledWith({
+      where: { id: "memorial_1" },
+      data: {
+        deletedAt: expect.any(Date),
+        isPublic: false,
+      },
+    });
+    expect(mocks.memorialSubmissionUpdateMany).toHaveBeenCalledWith({
+      where: {
+        deletedAt: null,
+        memorialId: "memorial_1",
+        submittedByUserId: "user_1",
+      },
+      data: {
+        consentPublicDisplay: false,
+        deletedAt: expect.any(Date),
+        isPublic: false,
+      },
+    });
+    expect(mocks.memorialEvidenceUpdateMany).toHaveBeenCalledWith({
+      where: {
+        deletedAt: null,
+        memorialId: "memorial_1",
+        submittedByUserId: "user_1",
+      },
+      data: {
+        deletedAt: expect.any(Date),
+        isPublic: false,
+      },
+    });
+    expect(mocks.memorialResponsiblePartyUpdateMany).toHaveBeenCalledWith({
+      where: { deletedAt: null, memorialId: "memorial_1" },
+      data: {
+        deletedAt: expect.any(Date),
+        isPublic: false,
+      },
     });
   });
 });

--- a/packages/web/src/app/api/people/[id]/route.ts
+++ b/packages/web/src/app/api/people/[id]/route.ts
@@ -779,3 +779,137 @@ export async function PATCH(
     );
   }
 }
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { userId } = await requireAuth();
+    const { id } = await params;
+
+    const existingPerson = await prisma.person.findUnique({
+      where: { id },
+      select: {
+        createdByUserId: true,
+        deletedAt: true,
+        id: true,
+        memorial: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+    if (
+      !existingPerson ||
+      existingPerson.deletedAt ||
+      existingPerson.createdByUserId !== userId
+    ) {
+      return NextResponse.json({ error: "Person not found" }, { status: 404 });
+    }
+
+    const representedVote = await prisma.referendumVote.findFirst({
+      where: {
+        deletedAt: null,
+        personId: id,
+        userId,
+        voteSource: ReferendumVoteSource.REPRESENTED,
+      },
+      select: { id: true },
+    });
+    if (!representedVote) {
+      return NextResponse.json(
+        { error: "Only the original representative can delete this person." },
+        { status: 403 },
+      );
+    }
+
+    await prisma.$transaction(async (tx) => {
+      const now = new Date();
+      await tx.person.update({
+        where: { id },
+        data: {
+          deletedAt: now,
+          isPublic: false,
+        },
+      });
+      await tx.referendumVote.updateMany({
+        where: {
+          deletedAt: null,
+          personId: id,
+          userId,
+          voteSource: ReferendumVoteSource.REPRESENTED,
+        },
+        data: {
+          deletedAt: now,
+          isPublic: false,
+        },
+      });
+      await tx.personCondition.updateMany({
+        where: { deletedAt: null, personId: id },
+        data: {
+          deletedAt: now,
+          isPublic: false,
+        },
+      });
+      await tx.personRelationship.updateMany({
+        where: {
+          deletedAt: null,
+          OR: [
+            { createdByUserId: userId, objectPersonId: id },
+            { createdByUserId: userId, subjectPersonId: id },
+          ],
+        },
+        data: {
+          deletedAt: now,
+          isPublic: false,
+        },
+      });
+
+      const memorialId = existingPerson.memorial?.id ?? null;
+      if (memorialId) {
+        await tx.personMemorial.update({
+          where: { id: memorialId },
+          data: {
+            deletedAt: now,
+            isPublic: false,
+          },
+        });
+        await tx.personMemorialSubmission.updateMany({
+          where: { deletedAt: null, memorialId, submittedByUserId: userId },
+          data: {
+            consentPublicDisplay: false,
+            deletedAt: now,
+            isPublic: false,
+          },
+        });
+        await tx.personMemorialEvidence.updateMany({
+          where: { deletedAt: null, memorialId, submittedByUserId: userId },
+          data: {
+            deletedAt: now,
+            isPublic: false,
+          },
+        });
+        await tx.personMemorialResponsibleParty.updateMany({
+          where: { deletedAt: null, memorialId },
+          data: {
+            deletedAt: now,
+            isPublic: false,
+          },
+        });
+      }
+    });
+
+    return NextResponse.json({ deleted: true, personId: id });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    console.error("Failed to delete represented person", error);
+    return NextResponse.json(
+      { error: "Failed to delete represented person" },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/src/app/people/manage/page.tsx
+++ b/packages/web/src/app/people/manage/page.tsx
@@ -107,6 +107,11 @@ export default async function ManagePeoplePage({
   const referendumSlug = TREATY_REFERENDUM_SLUG;
   const params = (await searchParams) ?? {};
   const requestedPage = parsePage(params.page);
+  const editParam = Array.isArray(params.edit) ? params.edit[0] : params.edit;
+  const initialEditingId =
+    typeof editParam === "string" && editParam.trim()
+      ? editParam.trim()
+      : null;
   const representedPeopleWhere = {
     createdByUserId: userId,
     deletedAt: null,
@@ -287,6 +292,7 @@ export default async function ManagePeoplePage({
         </header>
 
         <ManageRepresentedPeopleClient
+          initialEditingId={initialEditingId}
           people={editablePeople}
           referendumSlug={referendumSlug}
         />

--- a/packages/web/src/components/people/ManageRepresentedPeopleClient.tsx
+++ b/packages/web/src/components/people/ManageRepresentedPeopleClient.tsx
@@ -7,8 +7,8 @@ import {
   PersonLifeStatus,
   PersonMemorialEvidenceKind,
 } from "@optimitron/db/enums";
-import { Upload, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Trash2, Upload, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/retroui/Button";
 import { Checkbox } from "@/components/retroui/Checkbox";
 import { Input } from "@/components/retroui/Input";
@@ -46,6 +46,7 @@ export interface EditableRepresentedPerson {
 }
 
 interface ManageRepresentedPeopleClientProps {
+  initialEditingId?: string | null;
   people: EditableRepresentedPerson[];
   referendumSlug: string;
 }
@@ -107,24 +108,50 @@ function initials(name: string) {
   return letters.toUpperCase() || "??";
 }
 
+function PersonThumb({ person }: { person: EditableRepresentedPerson }) {
+  return (
+    <div className="flex h-12 w-12 shrink-0 items-center justify-center border border-border bg-background text-sm font-black uppercase">
+      {person.imageUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          alt=""
+          className="h-full w-full object-cover"
+          src={person.imageUrl}
+        />
+      ) : (
+        initials(person.displayName)
+      )}
+    </div>
+  );
+}
+
 export function ManageRepresentedPeopleClient({
+  initialEditingId = null,
   people,
   referendumSlug,
 }: ManageRepresentedPeopleClientProps) {
   const [rows, setRows] = useState(people);
   const [savingId, setSavingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   const [uploadingId, setUploadingId] = useState<string | null>(null);
   const [savedId, setSavedId] = useState<string | null>(null);
-  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(initialEditingId);
   const [errorById, setErrorById] = useState<Record<string, string>>({});
   const [photoCropDraft, setPhotoCropDraft] = useState<{
     file: File;
     personId: string;
   } | null>(null);
+  const photoInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setRows(people);
   }, [people]);
+
+  useEffect(() => {
+    if (initialEditingId) {
+      setEditingId(initialEditingId);
+    }
+  }, [initialEditingId]);
 
   const editingPerson = editingId
     ? rows.find((person) => person.id === editingId) ?? null
@@ -200,6 +227,41 @@ export function ManageRepresentedPeopleClient({
     }
   }
 
+  async function deletePerson(person: EditableRepresentedPerson) {
+    if (deletingId) return;
+    const confirmed = window.confirm(
+      `Delete "${person.displayName}"? This removes the plaintiff from your list.`,
+    );
+    if (!confirmed) return;
+
+    setDeletingId(person.id);
+    setSavedId(null);
+    setErrorById((prev) => ({ ...prev, [person.id]: "" }));
+    try {
+      const response = await fetch(`/api/people/${person.id}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(payload.error ?? "Could not delete this plaintiff.");
+      }
+      setRows((prev) => prev.filter((row) => row.id !== person.id));
+      setEditingId(null);
+    } catch (caught) {
+      setErrorById((prev) => ({
+        ...prev,
+        [person.id]:
+          caught instanceof Error
+            ? caught.message
+            : "Could not delete this plaintiff.",
+      }));
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
   async function uploadPhoto(person: EditableRepresentedPerson, file: File) {
     setUploadingId(person.id);
     setErrorById((prev) => ({ ...prev, [person.id]: "" }));
@@ -220,6 +282,15 @@ export function ManageRepresentedPeopleClient({
     } finally {
       setUploadingId(null);
     }
+  }
+
+  function openPhotoPicker() {
+    photoInputRef.current?.click();
+  }
+
+  function selectPhotoFile(personId: string, file: File | undefined) {
+    if (!file) return;
+    setPhotoCropDraft({ file, personId });
   }
 
   async function uploadCroppedPhoto(file: File) {
@@ -293,7 +364,45 @@ export function ManageRepresentedPeopleClient({
 
   return (
     <section className="space-y-4">
-      <div className="overflow-hidden border border-border bg-card text-card-foreground">
+      <div className="space-y-3 md:hidden">
+        {rows.map((person) => (
+          <article
+            className="border border-border bg-card p-4 text-card-foreground"
+            key={person.id}
+          >
+            <div className="flex items-start gap-3">
+              <PersonThumb person={person} />
+              <div className="min-w-0 flex-1">
+                <p className="break-words font-black">{person.displayName}</p>
+                {person.conditionName ? (
+                  <p className="mt-1 break-words text-sm font-bold text-muted-foreground">
+                    {person.conditionName}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+            <dl className="mt-4 grid grid-cols-2 gap-2 text-xs font-black uppercase tracking-[0.12em]">
+              <div>
+                <dt className="text-muted-foreground">Status</dt>
+                <dd className="mt-1">{lifeStatusLabel(person.lifeStatus)}</dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">Public</dt>
+                <dd className="mt-1">{person.isPublic ? "Yes" : "No"}</dd>
+              </div>
+            </dl>
+            <Button
+              className="mt-4 min-h-11 w-full border border-foreground bg-background px-4 text-xs font-black uppercase tracking-[0.14em] text-foreground shadow-none hover:translate-x-0 hover:translate-y-0"
+              onClick={() => setEditingId(person.id)}
+              type="button"
+            >
+              Edit
+            </Button>
+          </article>
+        ))}
+      </div>
+
+      <div className="hidden overflow-hidden border border-border bg-card text-card-foreground md:block">
         <div className="overflow-x-auto">
           <table className="w-full min-w-[720px] border-collapse text-left">
             <thead>
@@ -301,7 +410,6 @@ export function ManageRepresentedPeopleClient({
                 <th className="px-4 py-3">Plaintiff</th>
                 <th className="px-4 py-3">Status</th>
                 <th className="px-4 py-3">Public</th>
-                <th className="px-4 py-3">Evidence</th>
                 <th className="px-4 py-3 text-right">Edit</th>
               </tr>
             </thead>
@@ -310,18 +418,7 @@ export function ManageRepresentedPeopleClient({
                 <tr className="border-b border-border last:border-b-0" key={person.id}>
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-3">
-                      <div className="flex h-12 w-12 shrink-0 items-center justify-center border border-border bg-background text-sm font-black uppercase">
-                        {person.imageUrl ? (
-                          // eslint-disable-next-line @next/next/no-img-element
-                          <img
-                            alt=""
-                            className="h-full w-full object-cover"
-                            src={person.imageUrl}
-                          />
-                        ) : (
-                          initials(person.displayName)
-                        )}
-                      </div>
+                      <PersonThumb person={person} />
                       <div>
                         <p className="font-black">{person.displayName}</p>
                         {person.conditionName ? (
@@ -337,9 +434,6 @@ export function ManageRepresentedPeopleClient({
                   </td>
                   <td className="px-4 py-3 text-sm font-black uppercase tracking-[0.12em]">
                     {person.isPublic ? "Yes" : "No"}
-                  </td>
-                  <td className="px-4 py-3 text-sm font-black uppercase tracking-[0.12em]">
-                    {person.evidence.length}
                   </td>
                   <td className="px-4 py-3 text-right">
                     <Button
@@ -392,7 +486,15 @@ export function ManageRepresentedPeopleClient({
 
                 <div className="grid gap-6 lg:grid-cols-[220px_1fr]">
                   <div className="space-y-3">
-                    <div className="aspect-square border border-border bg-background">
+                    <button
+                      aria-label={
+                        editingPerson.imageUrl ? "Change photo" : "Upload photo"
+                      }
+                      className="group relative aspect-square w-full cursor-pointer overflow-hidden border border-border bg-background text-foreground"
+                      disabled={uploadingId === editingPerson.id}
+                      onClick={openPhotoPicker}
+                      type="button"
+                    >
                       {editingPerson.imageUrl ? (
                         // eslint-disable-next-line @next/next/no-img-element
                         <img
@@ -401,31 +503,34 @@ export function ManageRepresentedPeopleClient({
                           src={editingPerson.imageUrl}
                         />
                       ) : (
-                        <div className="flex h-full w-full items-center justify-center p-4 text-center text-3xl font-black uppercase">
-                          No photo
+                        <div className="flex h-full w-full items-center justify-center p-4 text-center text-2xl font-black uppercase">
+                          Upload photo
                         </div>
                       )}
-                    </div>
-                    <label className="inline-flex min-h-11 cursor-pointer items-center border border-foreground bg-background px-3 text-xs font-black uppercase tracking-[0.14em]">
+                    </button>
+                    <button
+                      className="inline-flex min-h-11 cursor-pointer items-center border border-foreground bg-background px-3 text-xs font-black uppercase tracking-[0.14em] disabled:opacity-40"
+                      disabled={uploadingId === editingPerson.id}
+                      onClick={openPhotoPicker}
+                      type="button"
+                    >
                       <Upload className="mr-2 h-4 w-4" aria-hidden="true" />
                       {uploadingId === editingPerson.id ? "Uploading" : "Upload photo"}
-                      <input
-                        accept="image/jpeg,image/png,image/webp,image/gif"
-                        className="hidden"
-                        disabled={uploadingId === editingPerson.id}
-                        onChange={(event) => {
-                          const file = event.target.files?.[0];
-                          if (file) {
-                            setPhotoCropDraft({
-                              file,
-                              personId: editingPerson.id,
-                            });
-                          }
-                          event.target.value = "";
-                        }}
-                        type="file"
-                      />
-                    </label>
+                    </button>
+                    <input
+                      accept="image/jpeg,image/png,image/webp,image/gif"
+                      className="hidden"
+                      disabled={uploadingId === editingPerson.id}
+                      onChange={(event) => {
+                        selectPhotoFile(
+                          editingPerson.id,
+                          event.target.files?.[0],
+                        );
+                        event.target.value = "";
+                      }}
+                      ref={photoInputRef}
+                      type="file"
+                    />
                   </div>
 
                   <div className="space-y-4">
@@ -735,6 +840,7 @@ export function ManageRepresentedPeopleClient({
                         className="min-h-12 border border-foreground bg-foreground px-5 font-black uppercase tracking-[0.12em] text-background shadow-none hover:translate-x-0 hover:translate-y-0 disabled:opacity-40"
                         disabled={
                           savingId === editingPerson.id ||
+                          deletingId === editingPerson.id ||
                           !editingPerson.displayName.trim()
                         }
                         onClick={() => void savePerson(editingPerson)}
@@ -744,6 +850,18 @@ export function ManageRepresentedPeopleClient({
                           ? "Saving..."
                           : "Save changes"}
                       </Button>
+                      <button
+                        className="inline-flex min-h-12 items-center border border-foreground bg-background px-5 text-sm font-black uppercase tracking-[0.12em] text-foreground disabled:opacity-40"
+                        disabled={
+                          savingId === editingPerson.id ||
+                          deletingId === editingPerson.id
+                        }
+                        onClick={() => void deletePerson(editingPerson)}
+                        type="button"
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" aria-hidden="true" />
+                        {deletingId === editingPerson.id ? "Deleting" : "Delete"}
+                      </button>
                       {savedId === editingPerson.id ? (
                         <p className="text-sm font-black uppercase tracking-[0.14em]">
                           Saved

--- a/packages/web/src/components/people/RepresentedPersonConversionForm.tsx
+++ b/packages/web/src/components/people/RepresentedPersonConversionForm.tsx
@@ -8,7 +8,11 @@ import { AuthForm } from "@/components/auth/AuthForm";
 import { Button } from "@/components/retroui/Button";
 import { Input } from "@/components/retroui/Input";
 import { Label } from "@/components/retroui/Label";
-import { postRepresentedPersonDraft, syncPendingRepresentedPeople } from "@/lib/represented-person-sync";
+import {
+  postRepresentedPersonDraft,
+  syncPendingRepresentedPeople,
+  type SyncedRepresentedPerson,
+} from "@/lib/represented-person-sync";
 import { ROUTES } from "@/lib/routes";
 import { storage, type PendingRepresentedPersonDraft } from "@/lib/storage";
 import { TREATY_REFERENDUM_SLUG } from "@/lib/treaty";
@@ -16,11 +20,25 @@ import { cn } from "@/lib/utils";
 
 type FormMode = "idle" | "auth" | "saving" | "saved" | "syncing" | "error";
 
+interface SavedRepresentedPerson {
+  displayName: string;
+  personId?: string;
+}
+
 function createDraftId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
   }
   return `represented-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function savedPersonFromSync(
+  person: SyncedRepresentedPerson,
+): SavedRepresentedPerson {
+  return {
+    displayName: person.displayName,
+    personId: person.personId,
+  };
 }
 
 interface RepresentedPersonConversionFormProps {
@@ -37,7 +55,7 @@ export function RepresentedPersonConversionForm({
   const [displayName, setDisplayName] = useState("");
   const [mode, setMode] = useState<FormMode>("idle");
   const [error, setError] = useState<string | null>(null);
-  const [savedNames, setSavedNames] = useState<string[]>([]);
+  const [savedPeople, setSavedPeople] = useState<SavedRepresentedPerson[]>([]);
   const [syncAttempt, setSyncAttempt] = useState(0);
   const syncStartedRef = useRef(false);
 
@@ -75,8 +93,8 @@ export function RepresentedPersonConversionForm({
           return;
         }
 
-        if (result.syncedDrafts.length > 0) {
-          setSavedNames(result.syncedDrafts.map((draft) => draft.displayName));
+        if (result.syncedPeople.length > 0) {
+          setSavedPeople(result.syncedPeople.map(savedPersonFromSync));
         }
 
         if (result.failedDrafts.length > 0) {
@@ -127,18 +145,18 @@ export function RepresentedPersonConversionForm({
 
     if (!isAuthenticated) {
       storage.addPendingRepresentedPerson(draft);
-      setSavedNames([draft.displayName]);
+      setSavedPeople([{ displayName: draft.displayName }]);
       setMode("auth");
       resetForm();
       return;
     }
 
     try {
-      const ok = await postRepresentedPersonDraft(draft);
-      if (!ok) {
+      const person = await postRepresentedPersonDraft(draft);
+      if (!person) {
         throw new Error("Could not save this person.");
       }
-      setSavedNames([draft.displayName]);
+      setSavedPeople([savedPersonFromSync(person)]);
       router.refresh();
       setMode("saved");
       resetForm();
@@ -163,7 +181,7 @@ export function RepresentedPersonConversionForm({
               Name saved
             </p>
             <h2 className="text-3xl font-black uppercase leading-tight">
-              Verify to sign for {savedNames[0] ?? "them"}.
+              Verify to sign for {savedPeople[0]?.displayName ?? "them"}.
             </h2>
             <p className="font-bold leading-7 text-muted-foreground">
               We saved the name in this browser. Verify once to finish the
@@ -204,7 +222,10 @@ export function RepresentedPersonConversionForm({
   }
 
   if (mode === "saved") {
-    const names = savedNames.join(", ");
+    const names = savedPeople.map((person) => person.displayName).join(", ");
+    const addDetailsHref = savedPeople[0]?.personId
+      ? `${ROUTES.peopleManage}?edit=${encodeURIComponent(savedPeople[0].personId)}`
+      : ROUTES.peopleManage;
     return (
       <section className={shellClass} data-testid="represented-person-saved">
         <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
@@ -217,7 +238,7 @@ export function RepresentedPersonConversionForm({
           <Button
             className="border border-foreground bg-foreground px-5 py-3 text-sm font-black uppercase tracking-[0.14em] text-background shadow-none hover:translate-x-0 hover:translate-y-0"
             onClick={() => {
-              setSavedNames([]);
+              setSavedPeople([]);
               setMode("idle");
             }}
             type="button"
@@ -226,9 +247,9 @@ export function RepresentedPersonConversionForm({
           </Button>
           <Link
             className="inline-flex min-h-12 items-center border border-foreground bg-background px-5 py-3 text-sm font-black uppercase tracking-[0.14em] text-foreground"
-            href={ROUTES.peopleManage}
+            href={addDetailsHref}
           >
-            Edit record
+            Add details
           </Link>
         </div>
       </section>

--- a/packages/web/src/components/people/SquarePhotoCropper.tsx
+++ b/packages/web/src/components/people/SquarePhotoCropper.tsx
@@ -2,11 +2,8 @@
 
 import * as ReactDialog from "@radix-ui/react-dialog";
 import { Check, X } from "lucide-react";
-import type {
-  ChangeEvent,
-  PointerEvent as ReactPointerEvent,
-} from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import Cropper, { type Area, type Point } from "react-easy-crop";
 
 const OUTPUT_SIZE = 1024;
 const MIN_ZOOM = 1;
@@ -19,20 +16,6 @@ interface SquarePhotoCropperProps {
   title?: string;
 }
 
-interface Point {
-  x: number;
-  y: number;
-}
-
-interface Size {
-  height: number;
-  width: number;
-}
-
-function clamp(value: number, min: number, max: number) {
-  return Math.min(Math.max(value, min), max);
-}
-
 function croppedFileName(fileName: string) {
   const dotIndex = fileName.lastIndexOf(".");
   const baseName =
@@ -40,25 +23,63 @@ function croppedFileName(fileName: string) {
   return `${baseName}-square.jpg`;
 }
 
-function getFit(naturalSize: Size, frameSize: number, zoom: number) {
-  const baseScale = Math.max(
-    frameSize / naturalSize.width,
-    frameSize / naturalSize.height,
-  );
-  const scale = baseScale * zoom;
-  return {
-    height: naturalSize.height * scale,
-    scale,
-    width: naturalSize.width * scale,
-  };
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener("load", () => resolve(image));
+    image.addEventListener("error", () =>
+      reject(new Error("Could not read this image.")),
+    );
+    image.src = src;
+  });
 }
 
-function getMaxOffset(naturalSize: Size, frameSize: number, zoom: number) {
-  const fit = getFit(naturalSize, frameSize, zoom);
-  return {
-    x: Math.max(0, (fit.width - frameSize) / 2),
-    y: Math.max(0, (fit.height - frameSize) / 2),
-  };
+async function cropImageToFile(input: {
+  area: Area;
+  fileName: string;
+  imageUrl: string;
+}): Promise<File> {
+  const image = await loadImage(input.imageUrl);
+  const canvas = document.createElement("canvas");
+  canvas.width = OUTPUT_SIZE;
+  canvas.height = OUTPUT_SIZE;
+  const context = canvas.getContext("2d");
+  if (!context) throw new Error("Could not crop this image.");
+
+  context.fillStyle = "#fff";
+  context.fillRect(0, 0, OUTPUT_SIZE, OUTPUT_SIZE);
+  context.imageSmoothingEnabled = true;
+  context.imageSmoothingQuality = "high";
+  context.drawImage(
+    image,
+    input.area.x,
+    input.area.y,
+    input.area.width,
+    input.area.height,
+    0,
+    0,
+    OUTPUT_SIZE,
+    OUTPUT_SIZE,
+  );
+
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (result) => {
+        if (result) {
+          resolve(result);
+        } else {
+          reject(new Error("Could not crop this image."));
+        }
+      },
+      "image/jpeg",
+      0.92,
+    );
+  });
+
+  return new File([blob], croppedFileName(input.fileName), {
+    lastModified: Date.now(),
+    type: "image/jpeg",
+  });
 }
 
 export function SquarePhotoCropper({
@@ -67,97 +88,32 @@ export function SquarePhotoCropper({
   onCrop,
   title = "Crop photo",
 }: SquarePhotoCropperProps) {
-  const frameRef = useRef<HTMLDivElement>(null);
-  const imageRef = useRef<HTMLImageElement>(null);
-  const dragRef = useRef<{
-    pointerId: number;
-    start: Point;
-    startPosition: Point;
-  } | null>(null);
   const [imageUrl, setImageUrl] = useState("");
-  const [naturalSize, setNaturalSize] = useState<Size | null>(null);
-  const [frameSize, setFrameSize] = useState(0);
-  const [position, setPosition] = useState<Point>({ x: 0, y: 0 });
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(MIN_ZOOM);
-  const [isDragging, setIsDragging] = useState(false);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
   const [isCropping, setIsCropping] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const url = URL.createObjectURL(file);
     setImageUrl(url);
-    setNaturalSize(null);
-    setPosition({ x: 0, y: 0 });
+    setCrop({ x: 0, y: 0 });
     setZoom(MIN_ZOOM);
+    setCroppedAreaPixels(null);
     setError(null);
     return () => URL.revokeObjectURL(url);
   }, [file]);
 
-  useEffect(() => {
-    const frame = frameRef.current;
-    if (!frame) return;
-
-    const measure = () => {
-      setFrameSize(frame.getBoundingClientRect().width);
-    };
-    measure();
-
-    const observer = new ResizeObserver(measure);
-    observer.observe(frame);
-    return () => observer.disconnect();
-  }, []);
-
-  function clampPosition(nextPosition: Point, nextZoom = zoom) {
-    if (!naturalSize || frameSize <= 0) return { x: 0, y: 0 };
-    const maxOffset = getMaxOffset(naturalSize, frameSize, nextZoom);
-    return {
-      x: clamp(nextPosition.x, -maxOffset.x, maxOffset.x),
-      y: clamp(nextPosition.y, -maxOffset.y, maxOffset.y),
-    };
-  }
-
-  function handlePointerDown(event: ReactPointerEvent<HTMLDivElement>) {
-    if (!naturalSize || isCropping) return;
-    event.currentTarget.setPointerCapture(event.pointerId);
-    dragRef.current = {
-      pointerId: event.pointerId,
-      start: { x: event.clientX, y: event.clientY },
-      startPosition: position,
-    };
-    setIsDragging(true);
-  }
-
-  function handlePointerMove(event: ReactPointerEvent<HTMLDivElement>) {
-    const drag = dragRef.current;
-    if (!drag || drag.pointerId !== event.pointerId) return;
-    const nextPosition = {
-      x: drag.startPosition.x + event.clientX - drag.start.x,
-      y: drag.startPosition.y + event.clientY - drag.start.y,
-    };
-    setPosition(clampPosition(nextPosition));
-  }
-
-  function endDrag(event: ReactPointerEvent<HTMLDivElement>) {
-    if (dragRef.current?.pointerId === event.pointerId) {
-      dragRef.current = null;
-      setIsDragging(false);
-      try {
-        event.currentTarget.releasePointerCapture(event.pointerId);
-      } catch {
-        // The pointer may already be released if the browser cancelled it.
-      }
-    }
-  }
-
-  function handleZoomChange(event: ChangeEvent<HTMLInputElement>) {
-    const nextZoom = Number(event.currentTarget.value);
-    setZoom(nextZoom);
-    setPosition((current) => clampPosition(current, nextZoom));
-  }
+  const handleCropComplete = useCallback(
+    (_croppedArea: Area, nextCroppedAreaPixels: Area) => {
+      setCroppedAreaPixels(nextCroppedAreaPixels);
+    },
+    [],
+  );
 
   async function handleCrop() {
-    const image = imageRef.current;
-    if (!image || !naturalSize || frameSize <= 0) {
+    if (!imageUrl || !croppedAreaPixels) {
       setError("Could not read this image.");
       return;
     }
@@ -165,63 +121,11 @@ export function SquarePhotoCropper({
     setIsCropping(true);
     setError(null);
     try {
-      const fit = getFit(naturalSize, frameSize, zoom);
-      const imageLeft = frameSize / 2 + position.x - fit.width / 2;
-      const imageTop = frameSize / 2 + position.y - fit.height / 2;
-      const sourceSize = Math.min(
-        frameSize / fit.scale,
-        naturalSize.width,
-        naturalSize.height,
-      );
-      const sx = clamp(
-        -imageLeft / fit.scale,
-        0,
-        Math.max(0, naturalSize.width - sourceSize),
-      );
-      const sy = clamp(
-        -imageTop / fit.scale,
-        0,
-        Math.max(0, naturalSize.height - sourceSize),
-      );
-      const canvas = document.createElement("canvas");
-      canvas.width = OUTPUT_SIZE;
-      canvas.height = OUTPUT_SIZE;
-      const context = canvas.getContext("2d");
-      if (!context) throw new Error("Could not crop this image.");
-
-      context.fillStyle = "#fff";
-      context.fillRect(0, 0, OUTPUT_SIZE, OUTPUT_SIZE);
-      context.imageSmoothingEnabled = true;
-      context.imageSmoothingQuality = "high";
-      context.drawImage(
-        image,
-        sx,
-        sy,
-        sourceSize,
-        sourceSize,
-        0,
-        0,
-        OUTPUT_SIZE,
-        OUTPUT_SIZE,
-      );
-
-      const blob = await new Promise<Blob>((resolve, reject) => {
-        canvas.toBlob(
-          (result) => {
-            if (result) {
-              resolve(result);
-            } else {
-              reject(new Error("Could not crop this image."));
-            }
-          },
-          "image/jpeg",
-          0.92,
-        );
-      });
       await onCrop(
-        new File([blob], croppedFileName(file.name), {
-          lastModified: Date.now(),
-          type: "image/jpeg",
+        await cropImageToFile({
+          area: croppedAreaPixels,
+          fileName: file.name,
+          imageUrl,
         }),
       );
     } catch (caught) {
@@ -233,9 +137,6 @@ export function SquarePhotoCropper({
     }
   }
 
-  const fit =
-    naturalSize && frameSize > 0 ? getFit(naturalSize, frameSize, zoom) : null;
-
   return (
     <ReactDialog.Root
       open
@@ -246,100 +147,90 @@ export function SquarePhotoCropper({
       <ReactDialog.Portal>
         <ReactDialog.Overlay className="fixed inset-0 z-[120] bg-foreground/80" />
         <ReactDialog.Content className="fixed left-1/2 top-1/2 z-[121] max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-auto border border-foreground bg-background p-5 text-foreground shadow-none sm:p-6">
-        <div className="flex items-start justify-between gap-4">
-          <ReactDialog.Title
-            asChild
-            className="text-2xl font-black uppercase leading-tight"
-            id="square-photo-cropper-title"
-          >
-            <h2>{title}</h2>
-          </ReactDialog.Title>
-          <button
-            aria-label="Cancel crop"
-            className="inline-flex min-h-10 items-center border border-foreground bg-background px-3 text-foreground disabled:opacity-40"
-            disabled={isCropping}
-            onClick={onCancel}
-            type="button"
-          >
-            <X className="h-4 w-4" aria-hidden="true" />
-          </button>
-        </div>
+          <div className="flex items-start justify-between gap-4">
+            <ReactDialog.Title
+              asChild
+              className="text-2xl font-black uppercase leading-tight"
+              id="square-photo-cropper-title"
+            >
+              <h2>{title}</h2>
+            </ReactDialog.Title>
+            <button
+              aria-label="Cancel crop"
+              className="inline-flex min-h-10 items-center border border-foreground bg-background px-3 text-foreground disabled:opacity-40"
+              disabled={isCropping}
+              onClick={onCancel}
+              type="button"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
 
-        <div
-          className="relative mt-5 aspect-square w-full touch-none overflow-hidden border border-foreground bg-card"
-          onPointerCancel={endDrag}
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={endDrag}
-          ref={frameRef}
-          style={{ cursor: isDragging ? "grabbing" : "grab" }}
-        >
-          {imageUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              alt=""
-              className="absolute left-1/2 top-1/2 max-w-none select-none"
-              draggable={false}
-              onError={() => setError("Could not read this image.")}
-              onLoad={(event) =>
-                setNaturalSize({
-                  height: event.currentTarget.naturalHeight,
-                  width: event.currentTarget.naturalWidth,
-                })
-              }
-              ref={imageRef}
-              src={imageUrl}
-              style={
-                fit
-                  ? {
-                      height: `${fit.height}px`,
-                      transform: `translate(-50%, -50%) translate(${position.x}px, ${position.y}px)`,
-                      width: `${fit.width}px`,
-                    }
-                  : undefined
-              }
+          <div className="relative mt-5 aspect-square w-full overflow-hidden border border-foreground bg-card">
+            {imageUrl ? (
+              <Cropper
+                aspect={1}
+                crop={crop}
+                cropShape="rect"
+                image={imageUrl}
+                maxZoom={MAX_ZOOM}
+                minZoom={MIN_ZOOM}
+                objectFit="cover"
+                onCropChange={setCrop}
+                onCropComplete={handleCropComplete}
+                onZoomChange={setZoom}
+                restrictPosition
+                showGrid={false}
+                style={{
+                  cropAreaStyle: {
+                    border: "1px solid #000",
+                    boxShadow: "0 0 0 9999px rgb(0 0 0 / 0.35)",
+                  },
+                }}
+                zoom={zoom}
+              />
+            ) : null}
+          </div>
+
+          <label className="mt-4 block text-xs font-black uppercase tracking-[0.14em]">
+            Zoom
+            <input
+              className="mt-2 block w-full accent-foreground"
+              disabled={!imageUrl || isCropping}
+              max={MAX_ZOOM}
+              min={MIN_ZOOM}
+              onChange={(event) => setZoom(Number(event.currentTarget.value))}
+              step={0.01}
+              type="range"
+              value={zoom}
             />
-          ) : null}
-        </div>
+          </label>
 
-        <label className="mt-4 block text-xs font-black uppercase tracking-[0.14em]">
-          Zoom
-          <input
-            className="mt-2 block w-full accent-foreground"
-            disabled={!naturalSize || isCropping}
-            max={MAX_ZOOM}
-            min={MIN_ZOOM}
-            onChange={handleZoomChange}
-            step={0.01}
-            type="range"
-            value={zoom}
-          />
-        </label>
+          <p className="mt-3 text-sm font-bold text-muted-foreground">
+            Drag the photo to position it. Use the slider, mouse wheel, or pinch
+            to zoom.
+          </p>
+          {error ? <p className="mt-3 text-sm font-black">{error}</p> : null}
 
-        <p className="mt-3 text-sm font-bold text-muted-foreground">
-          Drag to reposition. Use the slider to zoom.
-        </p>
-        {error ? <p className="mt-3 text-sm font-black">{error}</p> : null}
-
-        <div className="mt-5 flex flex-wrap items-center gap-3">
-          <button
-            className="inline-flex min-h-12 items-center border border-foreground bg-background px-5 font-black uppercase tracking-[0.12em] text-foreground disabled:opacity-40"
-            disabled={isCropping}
-            onClick={onCancel}
-            type="button"
-          >
-            Cancel
-          </button>
-          <button
-            className="inline-flex min-h-12 items-center border border-foreground bg-foreground px-5 font-black uppercase tracking-[0.12em] text-background disabled:opacity-40"
-            disabled={!naturalSize || isCropping}
-            onClick={() => void handleCrop()}
-            type="button"
-          >
-            <Check className="mr-2 h-4 w-4" aria-hidden="true" />
-            {isCropping ? "Saving" : "Save"}
-          </button>
-        </div>
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <button
+              className="inline-flex min-h-12 items-center border border-foreground bg-background px-5 font-black uppercase tracking-[0.12em] text-foreground disabled:opacity-40"
+              disabled={isCropping}
+              onClick={onCancel}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="inline-flex min-h-12 items-center border border-foreground bg-foreground px-5 font-black uppercase tracking-[0.12em] text-background disabled:opacity-40"
+              disabled={!croppedAreaPixels || isCropping}
+              onClick={() => void handleCrop()}
+              type="button"
+            >
+              <Check className="mr-2 h-4 w-4" aria-hidden="true" />
+              {isCropping ? "Saving" : "Save"}
+            </button>
+          </div>
         </ReactDialog.Content>
       </ReactDialog.Portal>
     </ReactDialog.Root>

--- a/packages/web/src/lib/__tests__/represented-person-sync.test.ts
+++ b/packages/web/src/lib/__tests__/represented-person-sync.test.ts
@@ -21,7 +21,10 @@ vi.mock("@/lib/storage", () => ({
   },
 }));
 
-import { syncPendingRepresentedPeople } from "../represented-person-sync";
+import {
+  postRepresentedPersonDraft,
+  syncPendingRepresentedPeople,
+} from "../represented-person-sync";
 
 const draft = {
   clientDraftId: "draft_1",
@@ -57,12 +60,20 @@ describe("represented person sync", () => {
 
   it("posts and clears successful drafts", async () => {
     mocks.getPendingRepresentedPeople.mockReturnValue([draft]);
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        person: { displayName: "Grandma Kay", id: "person_1" },
+      }),
+      ok: true,
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await syncPendingRepresentedPeople();
 
     expect(result.syncedDrafts).toEqual([draft]);
+    expect(result.syncedPeople).toEqual([
+      { displayName: "Grandma Kay", draft, personId: "person_1" },
+    ]);
     expect(result.failedDrafts).toEqual([]);
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/referendums/one-percent-treaty/represented-people",
@@ -84,8 +95,25 @@ describe("represented person sync", () => {
     const result = await syncPendingRepresentedPeople();
 
     expect(result.syncedDrafts).toEqual([]);
+    expect(result.syncedPeople).toEqual([]);
     expect(result.failedDrafts).toEqual([draft]);
     expect(mocks.removePendingRepresentedPeople).not.toHaveBeenCalled();
+  });
+
+  it("returns the created person id from a successful post", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        person: { displayName: "Grandma Kay", id: "person_1" },
+      }),
+      ok: true,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(postRepresentedPersonDraft(draft)).resolves.toEqual({
+      displayName: "Grandma Kay",
+      draft,
+      personId: "person_1",
+    });
   });
 
   it("skips sync when another tab owns an active lock", async () => {
@@ -101,6 +129,7 @@ describe("represented person sync", () => {
     const result = await syncPendingRepresentedPeople();
 
     expect(result.skippedBecauseLocked).toBe(true);
+    expect(result.syncedPeople).toEqual([]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/lib/represented-person-sync.ts
+++ b/packages/web/src/lib/represented-person-sync.ts
@@ -11,6 +11,13 @@ export interface RepresentedPersonSyncResult {
   failedDrafts: PendingRepresentedPersonDraft[];
   skippedBecauseLocked: boolean;
   syncedDrafts: PendingRepresentedPersonDraft[];
+  syncedPeople: SyncedRepresentedPerson[];
+}
+
+export interface SyncedRepresentedPerson {
+  displayName: string;
+  draft: PendingRepresentedPersonDraft;
+  personId: string;
 }
 
 function createOwnerId(): string {
@@ -56,7 +63,7 @@ function draftPayload(draft: PendingRepresentedPersonDraft) {
 
 export async function postRepresentedPersonDraft(
   draft: PendingRepresentedPersonDraft,
-): Promise<boolean> {
+): Promise<SyncedRepresentedPerson | null> {
   const response = await fetch(
     `/api/referendums/${draft.referendumSlug}/represented-people`,
     {
@@ -65,7 +72,17 @@ export async function postRepresentedPersonDraft(
       body: JSON.stringify(draftPayload(draft)),
     },
   );
-  return response.ok;
+  if (!response.ok) return null;
+  const payload = (await response.json().catch(() => null)) as {
+    person?: { displayName?: string; id?: string };
+  } | null;
+  const personId = payload?.person?.id;
+  if (!personId) return null;
+  return {
+    displayName: payload?.person?.displayName ?? draft.displayName,
+    draft,
+    personId,
+  };
 }
 
 export async function syncPendingRepresentedPeople(): Promise<RepresentedPersonSyncResult> {
@@ -75,19 +92,22 @@ export async function syncPendingRepresentedPeople(): Promise<RepresentedPersonS
       failedDrafts: [],
       skippedBecauseLocked: true,
       syncedDrafts: [],
+      syncedPeople: [],
     };
   }
 
   const syncedDrafts: PendingRepresentedPersonDraft[] = [];
+  const syncedPeople: SyncedRepresentedPerson[] = [];
   const failedDrafts: PendingRepresentedPersonDraft[] = [];
 
   try {
     const drafts = storage.getPendingRepresentedPeople();
     for (const draft of drafts) {
       try {
-        const ok = await postRepresentedPersonDraft(draft);
-        if (ok) {
+        const person = await postRepresentedPersonDraft(draft);
+        if (person) {
           syncedDrafts.push(draft);
+          syncedPeople.push(person);
         } else {
           failedDrafts.push(draft);
         }
@@ -106,6 +126,7 @@ export async function syncPendingRepresentedPeople(): Promise<RepresentedPersonS
       failedDrafts,
       skippedBecauseLocked: false,
       syncedDrafts,
+      syncedPeople,
     };
   } finally {
     releaseLock(ownerId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,6 +589,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-easy-crop:
+        specifier: ^5.5.7
+        version: 5.5.7(react-dom@18.3.1)(react@18.3.1)
       react-icons:
         specifier: ^5.6.0
         version: 5.6.0(react@18.3.1)
@@ -17430,6 +17433,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  /normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+    dev: false
+
   /npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -18570,6 +18577,18 @@ packages:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  /react-easy-crop@5.5.7(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+    dev: false
 
   /react-email@5.2.10:
     resolution: {integrity: sha512-Ys8yR5/a0nXf5u2GlT2UV93PJHC3ZnuMnNebEn7I5UE9XfMFPtlpgDs02mPJOJn49fhJjDTWIUlZD1vmQPDgJg==}


### PR DESCRIPTION
## Summary
- replace the custom plaintiff photo cropper with `react-easy-crop` and make the photo box itself open upload/crop
- return created represented-person IDs so the success CTA opens that plaintiff directly in the editor
- add creator-owned soft delete for represented plaintiffs
- make Your Plaintiffs responsive: mobile cards, desktop table, no evidence-count column

## Validation
- `pnpm --filter @optimitron/web run typecheck:fast`
- `pnpm --filter @optimitron/web exec vitest run 'src/app/api/people/[id]/route.test.ts' src/lib/__tests__/represented-person-sync.test.ts`
- `git diff --check`
- UI screenshots inspected locally:
  - `packages/web/output/playwright/people-manage-responsive/review.html`
  - `packages/web/output/playwright/people-photo-picker/review.html`
  - `packages/web/output/playwright/people-cropper/review.html`
  - `packages/web/output/playwright/people-delete/review.html`

## Note
- Local `pnpm --filter @optimitron/web run build:fast` was attempted but the running dev server appears to hold `.next/trace`, causing `EPERM: operation not permitted, open '.next/trace'`. I left the dev server alone and am relying on clean PR CI for the production build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to delete represented people from the management interface.
  * Improved photo upload and cropping experience with enhanced tools.
  * Direct links now open to edit specific people without extra navigation.

* **Improvements**
  * Enhanced avatar display throughout the people management interface.
  * Refined layout and navigation on mobile and desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->