### PR TITLE
Clean up plaintiff workflow and footer UI

### DIFF
--- a/packages/web/AGENTS.md
+++ b/packages/web/AGENTS.md
@@ -40,6 +40,25 @@ Imports from ALL `@optimitron/*` packages. This is the integration layer.
 - **If screenshot verification is blocked, say why.** Do not commit UI changes without screenshots unless the human explicitly accepts the limitation.
 - **Do not freeze long-form copy in E2E.** Browser tests should assert behavior, route transitions, data contracts, analytics-critical parameters, accessibility roles, and the presence/absence of coarse UI states. Avoid exact prose, magic-number, or paragraph-level assertions unless the wording itself is the contract being tested. Put exact copy parity in focused unit/doc tests, seeded-template tests, or screenshot review instead.
 
+## Mike UI Complaint Checklist
+
+Before calling a public or authenticated UI "done," inspect it as if the human is about to open the page and ask why it is making the desired action harder.
+
+- **Goal first.** Identify the one action the page should maximize. Put that action before browsing, explanation, counters, filters, dashboards, FAQs, or legal framing.
+- **No useless top clutter.** Remove or demote counters, filter boxes, sort controls, explanatory cards, "older" buttons, and status text that do not help the next user action.
+- **Do not require auth to understand or start.** Let anonymous visitors fill the conversion form first when possible; persist the draft and ask for auth only when the action must be verified.
+- **Do not leak our planning conversation into copy.** Avoid phrases like "details can come later," "add details now," "record," "manage people," or other internal narration unless the user explicitly asks for that wording.
+- **Use the user's frame, not generic product mush.** If the page is about plaintiffs, court evidence, Humanity v. Government, or the 1% Treaty, say that. Do not retreat to vague labels like "humans on the record" or "people already represented" when the stronger frame is known.
+- **Preserve sharp copy.** When moving existing/user-provided language into another place such as an FAQ, keep it as close to exact as grammar allows. Do not blandly paraphrase it.
+- **Cite loaded numbers.** Use parameter/citation components for major numeric claims wherever available instead of hardcoded unsupported numbers.
+- **One click should do the obvious thing.** Post-submit CTAs should deep-link to the specific thing just created. Photo boxes should open photo upload/crop. Do not send users to an index where they must find and click the same item again.
+- **Use normal app language.** Buttons and dialog labels should sound like the familiar control they are: "Upload photo," "Crop photo," "Cancel," "Save," "Delete." Avoid awkward labels like "Crop square photo."
+- **Do not show giant forms by default.** Use tables/cards for scanning and dialogs or expansion for editing. Forms should appear when the user chooses to edit a specific item.
+- **Mobile is not optional.** Tables must not clip off-screen. Use responsive cards or a proven responsive table primitive. Pagination belongs where users expect it, usually below the list.
+- **Remove columns nobody cares about.** Do not include evidence counts, implementation fields, or other low-value columns just because the data exists.
+- **Use proven UI libraries for tricky interactions.** Cropping, dragging, zooming, sliders, dialogs, and tables should rely on established primitives before hand-rolled behavior.
+- **Test-looking data is a design problem.** If fake/test records appear in screenshots or production-like views, either clean them up safely or design the list so low-quality records do not dominate the first impression.
+
 ## Off-Limits
 
 - Library package internals (`packages/optimizer/src/*`, `packages/wishocracy/src/*`, etc.)

--- a/packages/web/src/app/people/[id]/page.tsx
+++ b/packages/web/src/app/people/[id]/page.tsx
@@ -86,9 +86,13 @@ function getFallbackInitials(value: string) {
 }
 
 function getRepresentedLifeStatusLabel(status: PersonLifeStatus) {
-  if (status === PersonLifeStatus.DECEASED) return "Added for someone deceased";
-  if (status === PersonLifeStatus.LIVING) return "Added for someone living";
-  return "Status unknown";
+  if (status === PersonLifeStatus.DECEASED) {
+    return "Plaintiff who can no longer sign";
+  }
+  if (status === PersonLifeStatus.LIVING) {
+    return "Plaintiff represented by another human";
+  }
+  return "Plaintiff in Humanity v. Government";
 }
 
 function formatRelationship(value: string | null) {
@@ -127,6 +131,11 @@ function RepresentedPersonProfile({
     vote.publicComment && vote.publicComment !== memorial?.memorialMessage
       ? vote.publicComment
       : null;
+  const summaryCards = [
+    { label: "Registered by", value: representedBy },
+    relationship ? { label: "Relationship", value: relationship } : null,
+    { label: "Case", value: "Humanity v. Government" },
+  ].filter(Boolean) as Array<{ label: string; value: string }>;
 
   return (
     <main className="min-h-screen bg-background pb-20 text-foreground [font-family:var(--v0-font-libre-baskerville)]">
@@ -175,30 +184,17 @@ function RepresentedPersonProfile({
         </header>
 
         <section className="grid gap-5 md:grid-cols-3">
-          <div className="border border-border bg-card p-5 text-card-foreground">
-            <p className="text-xs font-black uppercase tracking-[0.16em] text-muted-foreground">
-              Added by
-            </p>
-            <p className="mt-2 text-2xl font-black">{representedBy}</p>
-          </div>
-          <div className="border border-border bg-card p-5 text-card-foreground">
-            <p className="text-xs font-black uppercase tracking-[0.16em] text-muted-foreground">
-              Relationship
-            </p>
-            <p className="mt-2 text-2xl font-black">
-              {relationship ?? "Not specified"}
-            </p>
-          </div>
-          <div className="border border-border bg-card p-5 text-card-foreground">
-            <p className="text-xs font-black uppercase tracking-[0.16em] text-muted-foreground">
-              Signature type
-            </p>
-            <p className="mt-2 text-2xl font-black">
-              {person.lifeStatus === PersonLifeStatus.DECEASED
-                ? "Memorial"
-                : "Represented"}
-            </p>
-          </div>
+          {summaryCards.map((card) => (
+            <div
+              className="border border-border bg-card p-5 text-card-foreground"
+              key={card.label}
+            >
+              <p className="text-xs font-black uppercase tracking-[0.16em] text-muted-foreground">
+                {card.label}
+              </p>
+              <p className="mt-2 text-2xl font-black">{card.value}</p>
+            </div>
+          ))}
         </section>
 
         {conditions.length > 0 ? (
@@ -264,26 +260,31 @@ function RepresentedPersonProfile({
               Evidence package
             </h2>
             <p className="font-bold leading-7 text-muted-foreground">
-              At least one submitter has consented to court-evidence use of this
-              memorial. The evidence package is available as JSON for the Court
-              of Humanity or any future legal proceeding.
+              At least one submitter has consented to use this plaintiff as
+              evidence in Humanity v. Government or a future legal proceeding.
             </p>
             <a
               className="inline-block border border-foreground bg-foreground px-5 py-3 text-sm font-black uppercase tracking-[0.14em] text-background"
               download={`${person.handle ?? person.id}-evidence-package.json`}
               href={`/api/people/${person.handle ?? person.id}/evidence-package`}
             >
-              Download evidence package (JSON)
+              Download evidence package
             </a>
           </section>
         ) : null}
 
         <section className="border border-border bg-card p-5 text-card-foreground">
           <p className="font-bold leading-7 text-muted-foreground">
-            This is not a direct treaty signature. Direct counts only include
-            living people signing for themselves. This page is for someone
-            represented by another person.
+            This plaintiff was registered as evidence in Humanity v. Government.
+            The claim is simple: governments were hired to promote the general
+            welfare and spent the repair money on war.
           </p>
+          <Link
+            className="mt-4 inline-flex min-h-12 items-center border border-foreground bg-foreground px-5 text-sm font-black uppercase tracking-[0.14em] text-background"
+            href={ROUTES.people}
+          >
+            Register another plaintiff
+          </Link>
         </section>
       </div>
     </main>

--- a/packages/web/src/app/people/[id]/page.tsx
+++ b/packages/web/src/app/people/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/tasks/accountability";
 import { getPersonTaskProfileData } from "@/lib/tasks.server";
 import { authOptions } from "@/lib/auth";
+import { getRepresentedLifeStatusLabel } from "@/lib/represented-life-status";
 import { peopleLink, ROUTES } from "@/lib/routes";
 import {
   getRepresentedPersonProfileData,
@@ -83,16 +84,6 @@ function getFallbackInitials(value: string) {
     .slice(0, 2)
     .map((part) => part[0]?.toUpperCase() ?? "")
     .join("");
-}
-
-function getRepresentedLifeStatusLabel(status: PersonLifeStatus) {
-  if (status === PersonLifeStatus.DECEASED) {
-    return "Plaintiff who can no longer sign";
-  }
-  if (status === PersonLifeStatus.LIVING) {
-    return "Plaintiff represented by another human";
-  }
-  return "Plaintiff in Humanity v. Government";
 }
 
 function formatRelationship(value: string | null) {

--- a/packages/web/src/app/people/manage/page.tsx
+++ b/packages/web/src/app/people/manage/page.tsx
@@ -109,9 +109,7 @@ export default async function ManagePeoplePage({
   const requestedPage = parsePage(params.page);
   const editParam = Array.isArray(params.edit) ? params.edit[0] : params.edit;
   const initialEditingId =
-    typeof editParam === "string" && editParam.trim()
-      ? editParam.trim()
-      : null;
+    typeof editParam === "string" && editParam.trim() ? editParam.trim() : null;
   const representedPeopleWhere = {
     createdByUserId: userId,
     deletedAt: null,
@@ -138,10 +136,7 @@ export default async function ManagePeoplePage({
       birthDate: true,
       conditions: {
         where: { deletedAt: null },
-        orderBy: [
-          { status: "desc" as const },
-          { createdAt: "asc" as const },
-        ],
+        orderBy: [{ status: "desc" as const }, { createdAt: "asc" as const }],
         select: { conditionName: true, status: true },
         take: 3,
       },
@@ -200,7 +195,8 @@ export default async function ManagePeoplePage({
   const editablePeople = people.map((person) => {
     const primaryCondition =
       person.conditions.find(
-        (condition) => condition.status === PersonConditionStatus.CAUSE_OF_DEATH,
+        (condition) =>
+          condition.status === PersonConditionStatus.CAUSE_OF_DEATH,
       ) ??
       person.conditions[0] ??
       null;
@@ -253,8 +249,8 @@ export default async function ManagePeoplePage({
           </div>
           <div className="space-y-4 border border-foreground bg-background p-5 text-lg font-bold leading-8 text-foreground">
             <p>
-              These are the plaintiffs you registered for the Court of Humanity
-              class action against the governments of Earth.
+              These are the plaintiffs you registered for Humanity v.
+              Government, the Court of Humanity class action.
             </p>
             <p>
               Humanity pays governments{" "}
@@ -263,8 +259,8 @@ export default async function ManagePeoplePage({
                 figures={2}
                 param={GOVERNMENTS_PAID_TO_PROMOTE_WELFARE}
               />{" "}
-              a year to promote the general welfare. Over the last century,
-              they spent{" "}
+              a year to promote the general welfare. Over the last century, they
+              spent{" "}
               <ParameterValue
                 className="font-black"
                 figures={2}
@@ -285,8 +281,8 @@ export default async function ManagePeoplePage({
               years of clinical trials at current government spending.
             </p>
             <p>
-              Edit each plaintiff so the complaint has names, evidence, and
-              consent instead of spreadsheet fog.
+              Open a plaintiff to add the photo, disease or cause, relationship,
+              public note, or evidence.
             </p>
           </div>
         </header>

--- a/packages/web/src/app/people/page.tsx
+++ b/packages/web/src/app/people/page.tsx
@@ -112,6 +112,7 @@ export default async function PeoplePage({
           efficacyLagOnly,
         },
         page,
+        pageSize: 24,
         sort,
       })
     : null;
@@ -121,12 +122,12 @@ export default async function PeoplePage({
   const currentPage = data?.page ?? 1;
   const hasActiveBrowseState = Boolean(
     causeCategory ||
-      conditionGlobalVariableId ||
-      conflictId ||
-      countryCode ||
-      efficacyLagOnly ||
-      sort !== "recent" ||
-      currentPage > 1,
+    conditionGlobalVariableId ||
+    conflictId ||
+    countryCode ||
+    efficacyLagOnly ||
+    sort !== "recent" ||
+    currentPage > 1,
   );
   const showBrowseTools = hasActiveBrowseState || filteredCount >= 24;
   const filterParams = new URLSearchParams();
@@ -153,7 +154,7 @@ export default async function PeoplePage({
           <p className="max-w-5xl text-lg font-bold leading-8 text-muted-foreground sm:text-2xl sm:leading-10">
             Please list everyone you love who can no longer sign the 1% Treaty
             because of death, disease, or both, so they may be presented as
-            evidence in the Court of Humanity.
+            evidence in the class action lawsuit Humanity v. Government.
           </p>
         </header>
 
@@ -208,10 +209,10 @@ export default async function PeoplePage({
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div className="space-y-2">
               <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-                Names entered as evidence
+                Public plaintiffs
               </p>
               <h2 className="text-3xl font-black uppercase leading-tight">
-                Plaintiffs in the Court of Humanity
+                Plaintiffs in Humanity v. Government
               </h2>
             </div>
           </div>
@@ -219,10 +220,12 @@ export default async function PeoplePage({
           {showBrowseTools ? (
             <>
               <PeopleFilterBar />
-              <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-                Showing {formatCount(people.length)} of{" "}
-                {formatCount(filteredCount)}
-              </p>
+              {hasActiveBrowseState ? (
+                <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+                  Showing {formatCount(people.length)} of{" "}
+                  {formatCount(filteredCount)}
+                </p>
+              ) : null}
             </>
           ) : null}
 
@@ -241,10 +244,10 @@ export default async function PeoplePage({
             ) : (
               <article className="col-span-3 border border-border bg-card p-8 text-card-foreground sm:col-span-4 md:col-span-6 lg:col-span-7 xl:col-span-8">
                 <p className="text-xs font-black uppercase tracking-[0.16em] text-muted-foreground">
-                  No names yet
+                  No public plaintiffs yet
                 </p>
                 <p className="mt-4 text-lg font-bold leading-8">
-                  Add the first person above.
+                  Add the first plaintiff above.
                 </p>
               </article>
             )}
@@ -303,26 +306,8 @@ export default async function PeoplePage({
               The Invisible Graveyard
             </summary>
             <p className="mt-3 max-w-4xl font-bold leading-7 text-muted-foreground">
-              <strong>{formatCount(data?.deadPersonVoteCount ?? 0)}</strong>{" "}
-              humans are no longer alive.{" "}
-              <strong>{formatCount(data?.representedHumanCount ?? 0)}</strong>{" "}
-              more are alive but could not sign it themselves.{" "}
-              <strong>{formatCount(data?.officialVoteCount ?? 0)}</strong>{" "}
-              humans signed directly.
-            </p>
-            <p className="mt-3 max-w-4xl font-bold leading-7 text-muted-foreground">
-              Dead humans do not count toward direct signature totals. They
-              count toward making preventable death harder to hide.
-            </p>
-          </details>
-          <details className="border border-border bg-card p-4 text-card-foreground">
-            <summary className="cursor-pointer text-lg font-black uppercase">
-              Why is this separate from treaty signatures?
-            </summary>
-            <p className="mt-3 max-w-4xl font-bold leading-7 text-muted-foreground">
-              Direct treaty signatures stay separate. Represented humans become
-              public evidence that the treaty is for actual people, not
-              spreadsheet fog.
+              Dead humans cannot click a treaty button. Their names still count
+              toward making preventable death harder to hide.
             </p>
           </details>
           <details className="border border-border bg-card p-4 text-card-foreground">
@@ -330,9 +315,9 @@ export default async function PeoplePage({
               Know a victim of war or disease?
             </summary>
             <p className="mt-3 max-w-4xl font-bold leading-7 text-muted-foreground">
-              Add them to the plaintiff list for the Court of Humanity class
-              action against the governments of Earth. Governments were hired to
-              promote the general welfare. They spent{" "}
+              Add them to the plaintiff list for Humanity v. Government, the
+              class action against the governments of Earth. Governments were
+              hired to promote the general welfare. They spent{" "}
               <ParameterValue
                 className="font-black"
                 param={CUMULATIVE_MILITARY_SPENDING_FED_ERA}

--- a/packages/web/src/components/Footer.tsx
+++ b/packages/web/src/components/Footer.tsx
@@ -2,23 +2,43 @@ import Link from "next/link";
 import { NavItemLink } from "@/components/navigation/NavItemLink";
 import { getSiteVariantUiConfig } from "@/config/site-variant-ui";
 import { ROUTES } from "@/lib/routes";
-import { getSiteConfig, type SiteKey } from "@/lib/site";
+import { getSiteConfig, type SiteFooterColumn, type SiteKey } from "@/lib/site";
 
 interface FooterProps {
   siteKey?: SiteKey;
 }
 
+function FooterColumnLinks({ column }: { column: SiteFooterColumn }) {
+  return (
+    <ul className="space-y-2">
+      {column.items.map((link) => (
+        <li key={link.href}>
+          <NavItemLink item={link} variant="footer" external={link.external} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 export default function Footer({ siteKey = "optimitron" }: FooterProps) {
   const site = getSiteConfig(siteKey);
   const config = getSiteVariantUiConfig(siteKey).footer;
+  const year = new Date().getFullYear();
+  const bottomText =
+    config.bottomText.trim().length > 0
+      ? config.bottomText.replace("{year}", String(year))
+      : `© ${year} ${site.organizationName}.`;
 
   return (
     <footer className="border-t-2 border-foreground bg-background text-foreground">
       <div className="max-w-7xl mx-auto px-4 py-10 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8">
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-5">
           {/* Brand */}
           <div className="sm:col-span-2 lg:col-span-1">
-            <Link href={config.brandHref} className="text-lg font-black uppercase tracking-tight transition-colors hover:text-muted-foreground">
+            <Link
+              href={config.brandHref}
+              className="text-lg font-black uppercase tracking-tight transition-colors hover:text-muted-foreground"
+            >
               {config.brandLabel}
             </Link>
             <p className="mt-3 text-sm font-bold leading-relaxed text-muted-foreground">
@@ -26,49 +46,40 @@ export default function Footer({ siteKey = "optimitron" }: FooterProps) {
             </p>
           </div>
 
+          <div className="space-y-0 sm:hidden">
+            {config.columns.map((column) => (
+              <details
+                className="border-t border-border py-3 last:border-b"
+                key={column.title}
+              >
+                <summary className="cursor-pointer list-none text-xs font-black uppercase tracking-[0.14em] text-foreground [&::-webkit-details-marker]:hidden">
+                  {column.title}
+                </summary>
+                <div className="mt-3">
+                  <FooterColumnLinks column={column} />
+                </div>
+              </details>
+            ))}
+          </div>
+
           {config.columns.map((column) => (
-            <div key={column.title}>
+            <div className="hidden sm:block" key={column.title}>
               <h4 className="mb-3 text-xs font-black uppercase tracking-[0.14em] text-foreground">
                 {column.title}
               </h4>
-              <ul className="space-y-2">
-                {column.items.map((link) => (
-                  <li key={link.href}>
-                    <NavItemLink
-                      item={link}
-                      variant="footer"
-                      external={link.external}
-                    />
-                  </li>
-                ))}
-              </ul>
+              <FooterColumnLinks column={column} />
             </div>
           ))}
         </div>
 
         <div className="mt-10 border-t border-border pt-6 text-center text-sm font-bold text-muted-foreground">
-          {config.bottomText || config.sourceLink ? (
-            <p>
-              {config.bottomText}
-              {config.sourceLink ? (
-                <>
-                  {" "}
-                  <NavItemLink
-                    item={config.sourceLink}
-                    variant="custom"
-                    external
-                    className="font-bold text-foreground hover:underline"
-                  >
-                    Source code
-                  </NavItemLink>{" "}
-                  open for inspection by any sufficiently curious primate.
-                </>
-              ) : null}
-            </p>
-          ) : null}
-          <p className="text-xs">
-            {site.organizationName}. Contact{" "}
-            <a href={`mailto:${site.publicContactEmail}`} className="underline hover:no-underline">
+          <p>{bottomText}</p>
+          <p className="mt-2 text-xs">
+            Contact{" "}
+            <a
+              href={`mailto:${site.publicContactEmail}`}
+              className="underline hover:no-underline"
+            >
               {site.publicContactEmail}
             </a>
             .
@@ -77,7 +88,10 @@ export default function Footer({ siteKey = "optimitron" }: FooterProps) {
             aria-label="Legal"
             className="mt-3 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-xs"
           >
-            <Link href={ROUTES.privacy} className="underline hover:no-underline">
+            <Link
+              href={ROUTES.privacy}
+              className="underline hover:no-underline"
+            >
               Privacy
             </Link>
             <span aria-hidden="true">·</span>

--- a/packages/web/src/components/Footer.tsx
+++ b/packages/web/src/components/Footer.tsx
@@ -13,7 +13,9 @@ function FooterColumnLinks({ column }: { column: SiteFooterColumn }) {
     <ul className="space-y-2">
       {column.items.map((link) => (
         <li key={link.href}>
-          <NavItemLink item={link} variant="footer" external={link.external} />
+          <NavItemLink item={link} variant="footer" external={link.external}>
+            {link.label}
+          </NavItemLink>
         </li>
       ))}
     </ul>
@@ -26,8 +28,8 @@ export default function Footer({ siteKey = "optimitron" }: FooterProps) {
   const year = new Date().getFullYear();
   const bottomText =
     config.bottomText.trim().length > 0
-      ? config.bottomText.replace("{year}", String(year))
-      : `© ${year} ${site.organizationName}.`;
+      ? config.bottomText.replaceAll("{year}", String(year))
+      : `\u00a9 ${year} ${site.organizationName}.`;
 
   return (
     <footer className="border-t-2 border-foreground bg-background text-foreground">
@@ -94,11 +96,11 @@ export default function Footer({ siteKey = "optimitron" }: FooterProps) {
             >
               Privacy
             </Link>
-            <span aria-hidden="true">·</span>
+            <span aria-hidden="true">{"\u00b7"}</span>
             <Link href={ROUTES.terms} className="underline hover:no-underline">
               Terms
             </Link>
-            <span aria-hidden="true">·</span>
+            <span aria-hidden="true">{"\u00b7"}</span>
             <Link href={ROUTES.legal} className="underline hover:no-underline">
               Legal
             </Link>

--- a/packages/web/src/components/people/ManageRepresentedPeopleClient.tsx
+++ b/packages/web/src/components/people/ManageRepresentedPeopleClient.tsx
@@ -160,10 +160,10 @@ export function ManageRepresentedPeopleClient({
   }, [initialEditingId]);
 
   const editingPerson = editingId
-    ? rows.find((person) => person.id === editingId) ?? null
+    ? (rows.find((person) => person.id === editingId) ?? null)
     : null;
   const deleteCandidate = deleteCandidateId
-    ? rows.find((person) => person.id === deleteCandidateId) ?? null
+    ? (rows.find((person) => person.id === deleteCandidateId) ?? null)
     : null;
 
   useEffect(() => {
@@ -174,7 +174,9 @@ export function ManageRepresentedPeopleClient({
 
   function updatePerson(id: string, patch: Partial<EditableRepresentedPerson>) {
     setRows((prev) =>
-      prev.map((person) => (person.id === id ? patchPerson(person, patch) : person)),
+      prev.map((person) =>
+        person.id === id ? patchPerson(person, patch) : person,
+      ),
     );
   }
 
@@ -229,7 +231,9 @@ export function ManageRepresentedPeopleClient({
       setErrorById((prev) => ({
         ...prev,
         [person.id]:
-          caught instanceof Error ? caught.message : "Could not save this person.",
+          caught instanceof Error
+            ? caught.message
+            : "Could not save this person.",
       }));
     } finally {
       setSavingId(null);
@@ -351,7 +355,9 @@ export function ManageRepresentedPeopleClient({
       setErrorById((prev) => ({
         ...prev,
         [person.id]:
-          caught instanceof Error ? caught.message : "Could not upload evidence.",
+          caught instanceof Error
+            ? caught.message
+            : "Could not upload evidence.",
       }));
     } finally {
       setUploadingId(null);
@@ -427,7 +433,10 @@ export function ManageRepresentedPeopleClient({
             </thead>
             <tbody>
               {rows.map((person) => (
-                <tr className="border-b border-border last:border-b-0" key={person.id}>
+                <tr
+                  className="border-b border-border last:border-b-0"
+                  key={person.id}
+                >
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-3">
                       <PersonThumb person={person} />
@@ -515,19 +524,17 @@ export function ManageRepresentedPeopleClient({
                           src={editingPerson.imageUrl}
                         />
                       ) : (
-                        <div className="flex h-full w-full items-center justify-center p-4 text-center text-2xl font-black uppercase">
-                          Upload photo
+                        <div className="flex h-full w-full items-center justify-center p-4 text-center text-5xl font-black uppercase">
+                          {initials(editingPerson.displayName)}
                         </div>
                       )}
-                    </button>
-                    <button
-                      className="inline-flex min-h-11 cursor-pointer items-center border border-foreground bg-background px-3 text-xs font-black uppercase tracking-[0.14em] disabled:opacity-40"
-                      disabled={uploadingId === editingPerson.id}
-                      onClick={openPhotoPicker}
-                      type="button"
-                    >
-                      <Upload className="mr-2 h-4 w-4" aria-hidden="true" />
-                      {uploadingId === editingPerson.id ? "Uploading" : "Upload photo"}
+                      <span className="absolute inset-x-0 bottom-0 bg-foreground px-3 py-2 text-center text-xs font-black uppercase tracking-[0.14em] text-background">
+                        {uploadingId === editingPerson.id
+                          ? "Uploading"
+                          : editingPerson.imageUrl
+                            ? "Change photo"
+                            : "Upload photo"}
+                      </span>
                     </button>
                     <input
                       accept="image/jpeg,image/png,image/webp,image/gif"
@@ -569,13 +576,18 @@ export function ManageRepresentedPeopleClient({
                           className="min-h-12 w-full border border-border bg-background px-3 font-bold text-foreground"
                           onChange={(event) =>
                             updatePerson(editingPerson.id, {
-                              lifeStatus: event.target.value as PersonLifeStatus,
+                              lifeStatus: event.target
+                                .value as PersonLifeStatus,
                             })
                           }
                           value={editingPerson.lifeStatus}
                         >
-                          <option value={PersonLifeStatus.UNKNOWN}>Unknown</option>
-                          <option value={PersonLifeStatus.LIVING}>Living</option>
+                          <option value={PersonLifeStatus.UNKNOWN}>
+                            Unknown
+                          </option>
+                          <option value={PersonLifeStatus.LIVING}>
+                            Living
+                          </option>
                           <option value={PersonLifeStatus.DECEASED}>
                             No longer alive
                           </option>
@@ -583,7 +595,7 @@ export function ManageRepresentedPeopleClient({
                       </div>
                       <div className="space-y-2">
                         <Label className="text-xs font-black uppercase">
-                          Birth date optional
+                          Birth date
                         </Label>
                         <Input
                           className="border-border bg-background font-bold"
@@ -628,7 +640,7 @@ export function ManageRepresentedPeopleClient({
                       </div>
                       <div className="space-y-2">
                         <Label className="text-xs font-black uppercase">
-                          Cause kind
+                          Cause category
                         </Label>
                         <select
                           className="min-h-12 w-full border border-border bg-background px-3 font-bold text-foreground"
@@ -646,16 +658,22 @@ export function ManageRepresentedPeopleClient({
                           <option value={PersonDeathCauseCategory.DISEASE}>
                             Disease
                           </option>
-                          <option value={PersonDeathCauseCategory.ARMED_CONFLICT}>
+                          <option
+                            value={PersonDeathCauseCategory.ARMED_CONFLICT}
+                          >
                             Armed conflict
                           </option>
-                          <option value={PersonDeathCauseCategory.STATE_VIOLENCE}>
+                          <option
+                            value={PersonDeathCauseCategory.STATE_VIOLENCE}
+                          >
                             State violence
                           </option>
                           <option value={PersonDeathCauseCategory.TERRORISM}>
                             Terrorism
                           </option>
-                          <option value={PersonDeathCauseCategory.OTHER_PREVENTABLE}>
+                          <option
+                            value={PersonDeathCauseCategory.OTHER_PREVENTABLE}
+                          >
                             Other preventable
                           </option>
                           <option value={PersonDeathCauseCategory.OTHER}>
@@ -669,7 +687,7 @@ export function ManageRepresentedPeopleClient({
                       <div className="grid gap-3 border border-border bg-background p-4 sm:grid-cols-2">
                         <div className="space-y-2">
                           <Label className="text-xs font-black uppercase">
-                            Date of death optional
+                            Date of death
                           </Label>
                           <Input
                             className="border-border bg-background font-bold"
@@ -684,7 +702,7 @@ export function ManageRepresentedPeopleClient({
                         </div>
                         <div className="space-y-2">
                           <Label className="text-xs font-black uppercase">
-                            Country of death optional
+                            Country of death
                           </Label>
                           <Input
                             className="border-border bg-background font-bold uppercase"
@@ -723,13 +741,16 @@ export function ManageRepresentedPeopleClient({
                             }
                           />
                           <span>
-                            This can be used as evidence in future accountability
-                            work.
+                            This can be used as evidence in future
+                            accountability work.
                           </span>
                         </label>
                         <div className="space-y-3 sm:col-span-2">
                           <label className="inline-flex min-h-11 cursor-pointer items-center border border-foreground bg-background px-3 text-xs font-black uppercase tracking-[0.14em]">
-                            <Upload className="mr-2 h-4 w-4" aria-hidden="true" />
+                            <Upload
+                              className="mr-2 h-4 w-4"
+                              aria-hidden="true"
+                            />
                             {uploadingId === editingPerson.id
                               ? "Uploading"
                               : "Add evidence file"}
@@ -739,7 +760,8 @@ export function ManageRepresentedPeopleClient({
                               disabled={uploadingId === editingPerson.id}
                               onChange={(event) => {
                                 const file = event.target.files?.[0];
-                                if (file) void uploadEvidence(editingPerson, file);
+                                if (file)
+                                  void uploadEvidence(editingPerson, file);
                                 event.target.value = "";
                               }}
                               type="file"
@@ -762,23 +784,35 @@ export function ManageRepresentedPeopleClient({
                                     }
                                     value={evidence.evidenceKind}
                                   >
-                                    <option value={PersonMemorialEvidenceKind.PHOTO}>
+                                    <option
+                                      value={PersonMemorialEvidenceKind.PHOTO}
+                                    >
                                       Photo
                                     </option>
-                                    <option value={PersonMemorialEvidenceKind.DOCUMENT}>
+                                    <option
+                                      value={
+                                        PersonMemorialEvidenceKind.DOCUMENT
+                                      }
+                                    >
                                       Document
                                     </option>
                                     <option
-                                      value={PersonMemorialEvidenceKind.NEWS_ARTICLE}
+                                      value={
+                                        PersonMemorialEvidenceKind.NEWS_ARTICLE
+                                      }
                                     >
                                       News article
                                     </option>
                                     <option
-                                      value={PersonMemorialEvidenceKind.DEATH_RECORD}
+                                      value={
+                                        PersonMemorialEvidenceKind.DEATH_RECORD
+                                      }
                                     >
                                       Death record
                                     </option>
-                                    <option value={PersonMemorialEvidenceKind.OTHER}>
+                                    <option
+                                      value={PersonMemorialEvidenceKind.OTHER}
+                                    >
                                       Other
                                     </option>
                                   </select>
@@ -872,7 +906,9 @@ export function ManageRepresentedPeopleClient({
                         type="button"
                       >
                         <Trash2 className="mr-2 h-4 w-4" aria-hidden="true" />
-                        {deletingId === editingPerson.id ? "Deleting" : "Delete"}
+                        {deletingId === editingPerson.id
+                          ? "Deleting"
+                          : "Delete"}
                       </button>
                       {savedId === editingPerson.id ? (
                         <p className="text-sm font-black uppercase tracking-[0.14em]">

--- a/packages/web/src/components/people/PeopleFilterBar.tsx
+++ b/packages/web/src/components/people/PeopleFilterBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PersonDeathCauseCategory } from "@optimitron/db/enums";
+import { SlidersHorizontal } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState, useTransition } from "react";
 import { Button } from "@/components/retroui/Button";
@@ -132,16 +133,20 @@ export function PeopleFilterBar() {
     ) || selectedSort !== "recent";
 
   return (
-    <section className="border border-border bg-card p-4 text-card-foreground">
-      <details className="group" {...(hasFilter ? { open: true } : {})}>
-        <summary className="inline-flex min-h-9 cursor-pointer list-none items-center gap-2 border border-border bg-background px-3 text-xs font-black uppercase tracking-[0.14em] text-foreground marker:hidden hover:bg-muted">
-          <span>Filter and sort</span>
+    <section className="flex justify-end text-card-foreground">
+      <details
+        className="group relative w-full sm:w-auto"
+        {...(hasFilter ? { open: true } : {})}
+      >
+        <summary className="ml-auto inline-flex min-h-10 cursor-pointer list-none items-center gap-2 border border-border bg-background px-3 text-xs font-black uppercase tracking-[0.14em] text-foreground hover:bg-muted [&::-webkit-details-marker]:hidden">
+          <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
+          <span>Filter</span>
           {hasFilter ? (
             <span className="text-muted-foreground">Active</span>
           ) : null}
         </summary>
 
-        <div className="mt-4 space-y-4">
+        <div className="mt-3 space-y-4 border border-border bg-card p-4 sm:absolute sm:right-0 sm:z-20 sm:w-[min(44rem,calc(100vw-2rem))]">
           <div className="flex items-baseline justify-between gap-3">
             <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
               Find a human

--- a/packages/web/src/components/people/PeopleFilterBar.tsx
+++ b/packages/web/src/components/people/PeopleFilterBar.tsx
@@ -52,6 +52,22 @@ export function PeopleFilterBar() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [, startTransition] = useTransition();
+  const selectedSort =
+    (searchParams.get("sort") as RepresentedPeopleSortKey | null) ?? "recent";
+  const selectedCause = searchParams.get("cause") ?? "";
+  const selectedCondition = searchParams.get("conditionId") ?? "";
+  const selectedConflict = searchParams.get("conflictId") ?? "";
+  const selectedCountry = searchParams.get("country") ?? "";
+  const efficacyOnly = searchParams.get("efficacyLag") === "1";
+  const hasFilter =
+    Boolean(
+      selectedCause ||
+      selectedCondition ||
+      selectedConflict ||
+      selectedCountry ||
+      efficacyOnly,
+    ) || selectedSort !== "recent";
+  const [isOpen, setIsOpen] = useState(hasFilter);
 
   const [conditionOptions, setConditionOptions] = useState<ConditionOption[]>(
     [],
@@ -100,6 +116,12 @@ export function PeopleFilterBar() {
     };
   }, []);
 
+  useEffect(() => {
+    if (hasFilter) {
+      setIsOpen(true);
+    }
+  }, [hasFilter]);
+
   function applyFilter(name: string, value: string) {
     const next = new URLSearchParams(searchParams.toString());
     if (value) next.set(name, value);
@@ -116,27 +138,12 @@ export function PeopleFilterBar() {
     });
   }
 
-  const selectedSort =
-    (searchParams.get("sort") as RepresentedPeopleSortKey | null) ?? "recent";
-  const selectedCause = searchParams.get("cause") ?? "";
-  const selectedCondition = searchParams.get("conditionId") ?? "";
-  const selectedConflict = searchParams.get("conflictId") ?? "";
-  const selectedCountry = searchParams.get("country") ?? "";
-  const efficacyOnly = searchParams.get("efficacyLag") === "1";
-  const hasFilter =
-    Boolean(
-      selectedCause ||
-      selectedCondition ||
-      selectedConflict ||
-      selectedCountry ||
-      efficacyOnly,
-    ) || selectedSort !== "recent";
-
   return (
     <section className="flex justify-end text-card-foreground">
       <details
         className="group relative w-full sm:w-auto"
-        {...(hasFilter ? { open: true } : {})}
+        onToggle={(event) => setIsOpen(event.currentTarget.open)}
+        open={isOpen}
       >
         <summary className="ml-auto inline-flex min-h-10 cursor-pointer list-none items-center gap-2 border border-border bg-background px-3 text-xs font-black uppercase tracking-[0.14em] text-foreground hover:bg-muted [&::-webkit-details-marker]:hidden">
           <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
@@ -286,7 +293,7 @@ export function PeopleFilterBar() {
                   }
                   type="checkbox"
                 />
-                Only show efficacy-lag flagged 👻
+                Only show efficacy-lag evidence
               </label>
             </div>
           </div>

--- a/packages/web/src/components/people/PersonFaceTile.tsx
+++ b/packages/web/src/components/people/PersonFaceTile.tsx
@@ -1,21 +1,11 @@
 import Link from "next/link";
-import { PersonLifeStatus } from "@optimitron/db/enums";
+import { getRepresentedLifeStatusLabel } from "@/lib/represented-life-status";
 import { ROUTES } from "@/lib/routes";
 import type { RepresentedPersonCard } from "@/lib/represented-people.server";
 
 interface PersonFaceTileProps {
   index: number;
   person: RepresentedPersonCard;
-}
-
-function lifeStatusBadge(status: PersonLifeStatus): string {
-  if (status === PersonLifeStatus.DECEASED) {
-    return "Plaintiff who can no longer sign";
-  }
-  if (status === PersonLifeStatus.LIVING) {
-    return "Plaintiff represented by another human";
-  }
-  return "Plaintiff in Humanity v. Government";
 }
 
 export function PersonFaceTile({ person }: PersonFaceTileProps) {
@@ -32,7 +22,7 @@ export function PersonFaceTile({ person }: PersonFaceTileProps) {
   return (
     <Wrapper
       {...wrapperProps}
-      aria-label={`${person.displayName} - ${lifeStatusBadge(person.lifeStatus)}`}
+      aria-label={`${person.displayName} - ${getRepresentedLifeStatusLabel(person.lifeStatus)}`}
       className="group relative block aspect-square overflow-hidden border border-border bg-muted text-card-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground"
     >
       {person.image ? (
@@ -53,7 +43,7 @@ export function PersonFaceTile({ person }: PersonFaceTileProps) {
         className="pointer-events-none absolute inset-0 flex translate-y-full flex-col justify-end gap-1 bg-foreground/90 p-3 text-background opacity-0 transition-all duration-150 group-hover:translate-y-0 group-hover:opacity-100 group-focus-visible:translate-y-0 group-focus-visible:opacity-100"
       >
         <p className="text-[0.65rem] font-black uppercase tracking-[0.16em]">
-          {lifeStatusBadge(person.lifeStatus)}
+          {getRepresentedLifeStatusLabel(person.lifeStatus)}
         </p>
         <p className="line-clamp-2 text-base font-black uppercase leading-tight">
           {person.displayName}

--- a/packages/web/src/components/people/PersonFaceTile.tsx
+++ b/packages/web/src/components/people/PersonFaceTile.tsx
@@ -9,9 +9,13 @@ interface PersonFaceTileProps {
 }
 
 function lifeStatusBadge(status: PersonLifeStatus): string {
-  if (status === PersonLifeStatus.DECEASED) return "Added for someone deceased";
-  if (status === PersonLifeStatus.LIVING) return "Added for someone living";
-  return "Status unknown";
+  if (status === PersonLifeStatus.DECEASED) {
+    return "Plaintiff who can no longer sign";
+  }
+  if (status === PersonLifeStatus.LIVING) {
+    return "Plaintiff represented by another human";
+  }
+  return "Plaintiff in Humanity v. Government";
 }
 
 export function PersonFaceTile({ person }: PersonFaceTileProps) {

--- a/packages/web/src/config/__tests__/site-variant-ui.test.ts
+++ b/packages/web/src/config/__tests__/site-variant-ui.test.ts
@@ -63,10 +63,6 @@ describe("site variant UI config", () => {
           expectValidChromeItem(item);
         }
       }
-
-      if (config.footer.sourceLink) {
-        expectValidChromeItem(config.footer.sourceLink);
-      }
     }
   });
 

--- a/packages/web/src/lib/represented-life-status.ts
+++ b/packages/web/src/lib/represented-life-status.ts
@@ -1,0 +1,13 @@
+import { PersonLifeStatus } from "@optimitron/db/enums";
+
+export function getRepresentedLifeStatusLabel(
+  status: PersonLifeStatus,
+): string {
+  if (status === PersonLifeStatus.DECEASED) {
+    return "Plaintiff who can no longer sign";
+  }
+  if (status === PersonLifeStatus.LIVING) {
+    return "Plaintiff represented by another human";
+  }
+  return "Plaintiff in Humanity v. Government";
+}

--- a/packages/web/src/lib/represented-people.server.ts
+++ b/packages/web/src/lib/represented-people.server.ts
@@ -235,7 +235,9 @@ export async function getRepresentedPeopleGalleryData(
   if (!referendum) return null;
 
   const personFilterWhere = buildPersonFilterWhere(filters);
-  const personWhereForVote = personFilterWhere ? { person: personFilterWhere } : {};
+  const personWhereForVote = personFilterWhere
+    ? { person: personFilterWhere }
+    : {};
 
   const publicRepresentedWhere: Prisma.ReferendumVoteWhereInput = {
     ...buildRepresentedReferendumVoteWhere({
@@ -271,7 +273,14 @@ export async function getRepresentedPeopleGalleryData(
       case "oldest":
         return { createdAt: "asc" as const };
       case "recent":
-        return { createdAt: "desc" as const };
+        return [
+          {
+            person: {
+              image: { sort: "desc" as const, nulls: "last" as const },
+            },
+          },
+          { createdAt: "desc" as const },
+        ];
       case "died-closest-to-cure":
         return { createdAt: "desc" as const }; // overridden by in-memory sort
     }
@@ -338,7 +347,8 @@ export async function getRepresentedPeopleGalleryData(
       lifeStatus: vote.person.lifeStatus,
       personId: vote.person.id,
       publicComment:
-        vote.person.memorial?.submissions[0]?.memorialMessage ?? vote.publicComment,
+        vote.person.memorial?.submissions[0]?.memorialMessage ??
+        vote.publicComment,
       representedBy: getUserDisplayName(vote.user),
       voteId: vote.id,
     })),
@@ -421,7 +431,10 @@ export async function getRepresentedPersonProfileData(
           id: true,
           responsibleParties: {
             where: { deletedAt: null, isPublic: true },
-            orderBy: [{ isPrimary: "desc" as const }, { createdAt: "asc" as const }],
+            orderBy: [
+              { isPrimary: "desc" as const },
+              { createdAt: "asc" as const },
+            ],
             select: { name: true },
             take: 3,
           },
@@ -458,7 +471,9 @@ export async function getRepresentedPersonProfileData(
   const relationship =
     person.relationshipsAsObject.find(
       (candidate) => candidate.createdByUserId === vote.user.id,
-    ) ?? person.relationshipsAsObject[0] ?? null;
+    ) ??
+    person.relationshipsAsObject[0] ??
+    null;
 
   return {
     conditions: person.conditions,
@@ -475,15 +490,19 @@ export async function getRepresentedPersonProfileData(
     memorial: person.memorial
       ? (() => {
           const topCondition =
-            person.conditions.find((c) => c.status === PersonConditionStatusEnum.CAUSE_OF_DEATH)
-              ?.conditionName ?? person.conditions[0]?.conditionName ?? null;
+            person.conditions.find(
+              (c) => c.status === PersonConditionStatusEnum.CAUSE_OF_DEATH,
+            )?.conditionName ??
+            person.conditions[0]?.conditionName ??
+            null;
           const lag = person.memorial.efficacyLagEvidence[0];
           const lagTimeline = lag?.interventionApprovalTimeline ?? null;
           const publicSubmission = person.memorial.submissions.find(
             (s) => s.consentPublicDisplay && s.isPublic,
           );
           const hasCourtEvidenceConsent = person.memorial.submissions.some(
-            (s) => s.consentCourtEvidence && s.consentPublicDisplay && s.isPublic,
+            (s) =>
+              s.consentCourtEvidence && s.consentPublicDisplay && s.isPublic,
           );
           return {
             causeCategory: person.memorial.causeCategory,

--- a/packages/web/src/lib/represented-people.server.ts
+++ b/packages/web/src/lib/represented-people.server.ts
@@ -177,6 +177,7 @@ function buildPersonFilterWhere(
 }
 
 const galleryVoteSelect = {
+  createdAt: true,
   id: true,
   publicComment: true,
   person: {
@@ -262,10 +263,10 @@ export async function getRepresentedPeopleGalleryData(
     ],
   };
 
-  // Sort handling. The "died-closest-to-cure" sort is a nested aggregation
-  // Prisma can't express in orderBy, so we hydrate the filtered rows, sort
-  // in-memory, and then paginate. For other sorts we let Prisma do the work.
-  const isSpecialSort = sort === "died-closest-to-cure";
+  // Sort handling. Prisma can't express the efficacy-lag aggregation or a
+  // relation-field nulls-last order, so those sorts hydrate the filtered rows,
+  // sort in-memory, and then paginate.
+  const isInMemorySort = sort === "died-closest-to-cure" || sort === "recent";
   const orderBy = (() => {
     switch (sort) {
       case "alphabetical":
@@ -273,14 +274,7 @@ export async function getRepresentedPeopleGalleryData(
       case "oldest":
         return { createdAt: "asc" as const };
       case "recent":
-        return [
-          {
-            person: {
-              image: { sort: "desc" as const, nulls: "last" as const },
-            },
-          },
-          { createdAt: "desc" as const },
-        ];
+        return { createdAt: "desc" as const };
       case "died-closest-to-cure":
         return { createdAt: "desc" as const }; // overridden by in-memory sort
     }
@@ -310,14 +304,20 @@ export async function getRepresentedPeopleGalleryData(
     prisma.referendumVote.findMany({
       where: filteredVoteWhere,
       orderBy,
-      ...(isSpecialSort ? {} : { skip: gallerySkip, take: pageSize }),
+      ...(isInMemorySort ? {} : { skip: gallerySkip, take: pageSize }),
       select: galleryVoteSelect,
     }),
   ]);
 
-  const sortedVotes = isSpecialSort
+  const sortedVotes = isInMemorySort
     ? [...rawVotes]
         .sort((a, b) => {
+          if (sort === "recent") {
+            const imagePresence =
+              Number(Boolean(b.person.image)) - Number(Boolean(a.person.image));
+            if (imagePresence !== 0) return imagePresence;
+            return b.createdAt.getTime() - a.createdAt.getTime();
+          }
           const aDays =
             a.person.memorial?.efficacyLagEvidence[0]?.diedBeforeApprovalDays ??
             Number.POSITIVE_INFINITY;

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -646,10 +646,10 @@ export const treatyVoteLink: NavItem = {
 
 export const peopleLink: NavItem = {
   href: ROUTES.people,
-  label: "Sign for Someone Who Can't",
+  label: "Plaintiffs",
   emoji: "👥",
   description:
-    "Sign the 1% Treaty for someone who can no longer sign it themselves.",
+    "Sign the 1% Treaty for someone who can no longer sign it themselves, so they can be listed as a plaintiff in Humanity v. Government.",
   tagline: "Sign for someone who can't",
   cta: "Sign for Them",
 };
@@ -657,11 +657,10 @@ export const peopleLink: NavItem = {
 export const peopleManageLink: NavItem = {
   ...peopleLink,
   href: ROUTES.peopleManage,
-  label: "Manage Plaintiffs",
-  description:
-    "Edit the people you signed for: photos, dates, evidence, and what to say at the trial.",
-  tagline: "Edit the people you signed for",
-  cta: "Manage Plaintiffs",
+  label: "Your Plaintiffs",
+  description: "Edit the plaintiffs you registered for Humanity v. Government.",
+  tagline: "Edit your plaintiffs",
+  cta: "Your Plaintiffs",
 };
 
 export const questionsLink: NavItem = {

--- a/packages/web/src/lib/site.ts
+++ b/packages/web/src/lib/site.ts
@@ -23,7 +23,6 @@ import {
   endorseLink,
   exploreLinks,
   footerAppLinks,
-  githubLink,
   inviteVoterLink,
   legalLink,
   navSections,
@@ -193,7 +192,6 @@ export interface SiteFooterConfig {
   brandHref: string;
   brandLabel: string;
   columns: SiteFooterColumn[];
-  sourceLink?: NavItem;
 }
 
 export interface SiteVariantUiConfig {
@@ -476,7 +474,6 @@ const OPTIMITRON_UI: SiteVariantUiConfig = {
     brandDescription: "The Earth Optimization Machine.",
     bottomText:
       "© 4237 Wishonia. All rights reserved in this and 6,412 adjacent timelines. Unauthorized reproduction of the general welfare is encouraged and, frankly, overdue.",
-    sourceLink: githubLink,
     columns: [
       { title: "App", items: footerAppLinks },
       { title: "Analysis", items: exploreLinks },
@@ -550,8 +547,9 @@ const WAR_ON_DISEASE_UI: SiteVariantUiConfig = {
   footer: {
     brandHref: ROUTES.home,
     brandLabel: INTERNATIONAL_CAMPAIGN_ORG_NAME,
-    brandDescription: `Is it OK if we trade ${apocalypseSlice} of our ${apocalypseCount} apocalypses for disease eradication in ${dfdaYears} years instead of ${statusQuoYears}?`,
-    bottomText: "",
+    brandDescription:
+      "The campaign behind Humanity v. Government and the 1% Treaty.",
+    bottomText: `© {year} ${INTERNATIONAL_CAMPAIGN_ORG_NAME}.`,
     columns: [
       {
         title: "Campaign",
@@ -590,8 +588,7 @@ const ONE_PERCENT_TREATY_UI: SiteVariantUiConfig = {
     brandLabel: "1% Treaty",
     brandDescription:
       "Move one percent of the murder budget to the medicine budget. Your species will find this controversial.",
-    bottomText:
-      "© 4237 Wishonia. Reproduction of the general welfare is encouraged and, at this point, somewhat urgent.",
+    bottomText: `© {year} ${INTERNATIONAL_CAMPAIGN_ORG_NAME}.`,
     columns: [
       {
         title: "Campaign",


### PR DESCRIPTION
## Summary
- reframes the `/people` conversion surface around plaintiffs and Humanity v. Government while keeping the public path stable
- removes distracting top-level counters/FAQ copy, simplifies the footer, and drops the source-code sentence from the footer baseline
- makes plaintiff browsing less noisy with photo-first ordering, smaller pagination, a subtle filter control, and cleaner plaintiff detail/manage copy
- keeps the AGENTS checklist documenting the UI complaint pattern for future work

## Verification
- `pnpm --filter @optimitron/web run typecheck:fast`
- `pnpm --filter @optimitron/web exec vitest run src/config/__tests__/site-variant-ui.test.ts`
- `pnpm --filter @optimitron/web exec prettier --check ...`
- `git diff --check`
- Playwright screenshot audit: `packages/web/output/playwright/people-audit/review.html`

## Route note
I did not rename `/people` to `/plaintiffs` in this PR. `/people` is still the broader person/profile namespace; a later PR can add `/plaintiffs` as a focused conversion/gallery route once `/people` has a true general directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a UI design and review checklist to AGENTS.md for public and authenticated interfaces.

* **UI / Content Updates**
  * Updated site copy to reference "Humanity v. Government" across people flows, profile pages, and empty states.
  * Renamed navigation and management labels to "Plaintiffs" and "Your Plaintiffs".

* **Profile & Evidence**
  * Unified profile summary cards, clarified evidence messaging, and updated evidence package download text.

* **Footer & Layout**
  * Modernized footer with a responsive column layout and simplified bottom section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->