### PR TITLE
Improve people directory and MCP task guard

### DIFF
--- a/packages/web/src/app/people/page.tsx
+++ b/packages/web/src/app/people/page.tsx
@@ -81,94 +81,103 @@ export async function generateMetadata() {
   );
 }
 
-function PersonDirectoryCard({ person }: { person: PeopleDirectoryPerson }) {
+function PersonDirectoryRow({ person }: { person: PeopleDirectoryPerson }) {
   const topTask = person.openTaskPreview[0] ?? null;
   const verifiedTask = person.verifiedTaskPreview[0] ?? null;
-  const tags: string[] = [];
-  if (person.isPublicFigure) tags.push("Public official");
-  if (person.countryCode) tags.push(person.countryCode);
-  tags.push(
-    `${person.publicTaskCount} task${person.publicTaskCount === 1 ? "" : "s"}`,
-  );
+  const roleText = [
+    person.isPublicFigure ? "Public official" : null,
+    person.countryCode,
+  ]
+    .filter(Boolean)
+    .join(" / ");
+  const taskCount = `${person.publicTaskCount.toLocaleString()} task${
+    person.publicTaskCount === 1 ? "" : "s"
+  }`;
+  const metadata = [roleText || "Person", taskCount];
+  const taskHref = topTask
+    ? `${ROUTES.tasks}/${topTask.id}`
+    : verifiedTask
+      ? `${ROUTES.tasks}/${verifiedTask.id}`
+      : null;
+  const taskLabel = topTask ? "Next task" : verifiedTask ? "Verified work" : "";
+  const task = topTask ?? verifiedTask;
 
   return (
-    <article className="border border-border bg-card p-4 text-card-foreground">
-      <div className="flex items-start gap-4">
-        <Avatar className="h-16 w-16 shrink-0 border border-border bg-background">
-          <Avatar.Image
-            alt={person.displayName}
-            src={person.image ?? undefined}
-          />
-          <Avatar.Fallback className="bg-background text-lg font-black">
-            {getFallbackInitials(person.displayName)}
-          </Avatar.Fallback>
-        </Avatar>
-        <div className="min-w-0 flex-1 space-y-2">
-          <div>
-            <h2 className="break-words text-xl font-black leading-tight">
-              <Link
-                className="underline-offset-4 hover:underline"
-                href={person.href}
-              >
-                {person.displayName}
-              </Link>
-            </h2>
-            {person.headline || person.affiliation ? (
-              <p className="mt-1 break-words text-sm font-bold leading-6 text-muted-foreground">
-                {person.headline ?? person.affiliation}
-              </p>
-            ) : null}
-          </div>
-          {tags.length > 0 ? (
-            <p className="text-xs font-black uppercase tracking-[0.14em] text-muted-foreground">
-              {tags.join(" / ")}
+    <article className="grid gap-4 border-b border-border bg-background px-4 py-4 text-foreground lg:grid-cols-[minmax(240px,1.35fr)_minmax(140px,0.65fr)_minmax(260px,1.35fr)_minmax(104px,auto)] lg:items-center">
+      <div className="flex min-w-0 items-start gap-3">
+        <Link className="shrink-0" href={person.href}>
+          <Avatar className="h-12 w-12 border border-border bg-background">
+            <Avatar.Image
+              alt={person.displayName}
+              src={person.image ?? undefined}
+            />
+            <Avatar.Fallback className="bg-background text-sm font-black">
+              {getFallbackInitials(person.displayName)}
+            </Avatar.Fallback>
+          </Avatar>
+        </Link>
+        <div className="min-w-0">
+          <h2 className="break-words text-base font-black leading-6">
+            <Link
+              className="underline-offset-4 hover:underline"
+              href={person.href}
+            >
+              {person.displayName}
+            </Link>
+          </h2>
+          {person.headline || person.affiliation ? (
+            <p className="mt-1 break-words text-sm font-bold leading-6 text-muted-foreground">
+              {person.headline ?? person.affiliation}
             </p>
           ) : null}
         </div>
       </div>
 
-      {topTask ? (
-        <section className="mt-4 border-t border-border pt-4">
-          <p className="text-xs font-black uppercase tracking-[0.14em] text-muted-foreground">
-            Next task
-          </p>
-          <Link
-            className="mt-2 block font-black leading-6 underline-offset-4 hover:underline"
-            href={`${ROUTES.tasks}/${topTask.id}`}
-          >
-            {topTask.title}
-          </Link>
-          <p className="mt-2 text-xs font-black uppercase tracking-[0.12em] text-muted-foreground">
-            {formatCategory(topTask.category)}
-          </p>
-        </section>
-      ) : verifiedTask ? (
-        <section className="mt-4 border-t border-border pt-4">
-          <p className="text-xs font-black uppercase tracking-[0.14em] text-muted-foreground">
-            Verified work
-          </p>
-          <Link
-            className="mt-2 block font-black leading-6 underline-offset-4 hover:underline"
-            href={`${ROUTES.tasks}/${verifiedTask.id}`}
-          >
-            {verifiedTask.title}
-          </Link>
-        </section>
-      ) : null}
+      <div className="text-xs font-black uppercase tracking-[0.12em] text-muted-foreground lg:text-sm lg:font-bold lg:normal-case lg:tracking-normal">
+        <p className="lg:hidden">{metadata.join(" / ")}</p>
+        <div className="hidden lg:block">
+          {metadata.map((item) => (
+            <p key={item}>{item}</p>
+          ))}
+        </div>
+      </div>
 
-      <div className="mt-5 flex flex-wrap gap-3">
+      <div className="min-w-0">
+        {task && taskHref ? (
+          <>
+            <p className="text-xs font-black uppercase tracking-[0.14em] text-muted-foreground">
+              {taskLabel}
+            </p>
+            <Link
+              className="mt-1 block break-words text-sm font-black leading-6 underline-offset-4 hover:underline"
+              href={taskHref}
+            >
+              {task.title}
+            </Link>
+            <p className="mt-1 text-xs font-black uppercase tracking-[0.12em] text-muted-foreground">
+              {formatCategory(task.category)}
+            </p>
+          </>
+        ) : (
+          <p className="text-sm font-bold text-muted-foreground">
+            No public task preview.
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2 lg:justify-end">
         <Link
-          className="inline-flex min-h-11 items-center border border-foreground bg-foreground px-4 text-xs font-black uppercase tracking-[0.14em] text-background"
+          className="inline-flex min-h-10 items-center border border-foreground bg-background px-3 text-xs font-black uppercase tracking-[0.14em] text-foreground"
           href={person.href}
         >
-          Open profile
+          Profile
         </Link>
-        {topTask ? (
+        {taskHref ? (
           <Link
-            className="inline-flex min-h-11 items-center border border-foreground bg-background px-4 text-xs font-black uppercase tracking-[0.14em] text-foreground"
-            href={`${ROUTES.tasks}/${topTask.id}`}
+            className="inline-flex min-h-10 items-center border border-foreground bg-foreground px-3 text-xs font-black uppercase tracking-[0.14em] text-background"
+            href={taskHref}
           >
-            Open task
+            Task
           </Link>
         ) : null}
       </div>
@@ -201,13 +210,12 @@ export default async function PeoplePage({
               Decentralized to-do list for humanity
             </p>
             <h1 className="max-w-4xl text-4xl font-black uppercase leading-none tracking-tight sm:text-6xl">
-              Find people who can move work forward.
+              Coordinate the humans who can end war and disease.
             </h1>
             <p className="max-w-4xl text-lg font-bold leading-8 text-muted-foreground">
-              Search for officials, lawyers, clinical researchers, organizers,
-              funders, and other humans with tasks. Open a profile, see the work
-              assigned to them, and remind the right person to do the right
-              thing.
+              Find officials, lawyers, clinical researchers, organizers,
+              funders, and other people with public tasks. Open a profile, see
+              what they were asked to do, and remind them.
             </p>
           </div>
 
@@ -236,7 +244,7 @@ export default async function PeoplePage({
               <input name="role" type="hidden" value={role} />
             ) : null}
             <Input
-              className="min-h-12 border-border bg-background text-base font-bold"
+              className="min-h-12 border-foreground bg-background text-base font-bold text-foreground placeholder:text-muted-foreground"
               defaultValue={data.query}
               name="q"
               placeholder="Name, role, skill, organization, jurisdiction, or task"
@@ -277,17 +285,23 @@ export default async function PeoplePage({
                 Directory
               </p>
               <h2 className="mt-1 text-2xl font-black uppercase">
-                {data.totalCount.toLocaleString()} useful human
-                {data.totalCount === 1 ? "" : "s"}
+                {data.totalCount.toLocaleString()}{" "}
+                {data.totalCount === 1 ? "person" : "people"} with tasks
               </h2>
             </div>
           </div>
 
           {data.people.length > 0 ? (
             <>
-              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <div className="overflow-hidden border border-border bg-background">
+                <div className="hidden border-b border-border px-4 py-3 text-xs font-black uppercase tracking-[0.14em] text-muted-foreground lg:grid lg:grid-cols-[minmax(240px,1.35fr)_minmax(140px,0.65fr)_minmax(260px,1.35fr)_minmax(104px,auto)]">
+                  <span>Person</span>
+                  <span>Role</span>
+                  <span>Task</span>
+                  <span className="text-right">Open</span>
+                </div>
                 {data.people.map((person) => (
-                  <PersonDirectoryCard key={person.id} person={person} />
+                  <PersonDirectoryRow key={person.id} person={person} />
                 ))}
               </div>
               {data.totalPages > 1 ? (
@@ -339,10 +353,8 @@ export default async function PeoplePage({
               ) : null}
             </>
           ) : (
-            <article className="border border-border bg-card p-6 text-card-foreground">
-              <p className="text-lg font-black uppercase">
-                No useful humans found.
-              </p>
+            <article className="border border-border bg-background p-6 text-foreground">
+              <p className="text-lg font-black uppercase">No people found.</p>
               <p className="mt-3 max-w-3xl font-bold leading-7 text-muted-foreground">
                 Try a broader search, pick another role, or open the task list
                 and find work that needs an assignee.

--- a/packages/web/src/components/retroui/Input.tsx
+++ b/packages/web/src/components/retroui/Input.tsx
@@ -14,10 +14,8 @@ export const Input: React.FC<InputProps> = ({
     <input
       type={type}
       placeholder={placeholder}
-      className={`px-4 py-2 w-full rounded-none border-2 shadow-xs transition focus:outline-hidden focus:shadow-none ${
-        props["aria-invalid"]
-          ? "border-destructive text-destructive shadow-xs shadow-destructive"
-          : ""
+      className={`px-4 py-2 w-full rounded-none border-2 transition focus:outline-hidden ${
+        props["aria-invalid"] ? "border-destructive text-destructive" : ""
       } ${className}`}
       {...props}
     />

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -1136,6 +1136,20 @@ describe("MCP server tool dispatch", () => {
       });
     });
 
+    it("returns a clean getTask error when taskId is missing", async () => {
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "getTask",
+        arguments: {},
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result)).toMatchObject({
+        error: expect.stringContaining("taskId is required"),
+      });
+      expect(mocks.getTaskDetailData).not.toHaveBeenCalled();
+    });
+
     it("getBlockers ignores soft-deleted dependency edges so it agrees with getTask visibility", async () => {
       const client = await setup("user-1", ALL_SCOPES);
       await client.callTool({

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -561,6 +561,15 @@ function optionalString(value: unknown) {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+function requiredString(value: unknown, fieldName: string) {
+  return (
+    optionalString(value) ??
+    err(
+      `${fieldName} is required. Use searchTasks, listTasks, getMyQueue, or getNextAction to find a task id, then call this tool with {"${fieldName}":"<task-id>"}.`,
+    )
+  );
+}
+
 function mergeTaskContextJson(input: {
   baseContextJson?: unknown;
   patchContextJson?: unknown;
@@ -3257,7 +3266,7 @@ const TASK_TOOL_DEFINITIONS = [
   {
     name: "getTask",
     description:
-      "Get full details for a single task including impact estimates, milestones, dependencies, and evidence.",
+      "Get full details for one task by taskId. If you do not have a taskId yet, call searchTasks, listTasks, getMyQueue, or getNextAction first.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -6304,8 +6313,10 @@ export function createMcpServer(
           // ── getTask ────────────────────────────────────────────
           case "getTask": {
             const { tasks } = await getTaskFunctions();
+            const taskId = requiredString(a.taskId, "taskId");
+            if (typeof taskId !== "string") return taskId;
             const result = await tasks.getTaskDetailData(
-              a.taskId as string,
+              taskId,
               userId ?? null,
             );
             if (!result) return err("Task not found");

--- a/packages/web/src/lib/people-directory.server.ts
+++ b/packages/web/src/lib/people-directory.server.ts
@@ -54,8 +54,6 @@ const ACTIVE_TASK_PREVIEW_LIMIT = 3;
 const DEFAULT_PAGE_SIZE = 10;
 const MAX_PAGE_SIZE = 20;
 const VERIFIED_TASK_PREVIEW_LIMIT = 2;
-const TASK_PREVIEW_LIMIT =
-  ACTIVE_TASK_PREVIEW_LIMIT + VERIFIED_TASK_PREVIEW_LIMIT;
 
 const ROLE_FILTERS = {
   all: null,
@@ -78,6 +76,46 @@ const publicDirectoryTaskWhere = {
   ...publicAssignedTaskWhere,
   status: { in: [TaskStatus.ACTIVE, TaskStatus.VERIFIED] },
 } satisfies Prisma.TaskWhereInput;
+
+type TaskPreview = {
+  category: TaskCategory;
+  id: string;
+  skillTags: string[];
+  title: string;
+};
+
+async function getTaskPreviewsByPerson(
+  personIds: string[],
+  status: TaskStatus,
+  limit: number,
+) {
+  if (personIds.length === 0) {
+    return new Map<string, TaskPreview[]>();
+  }
+
+  const entries = await Promise.all(
+    personIds.map(async (personId) => {
+      const tasks = await prisma.task.findMany({
+        orderBy: { createdAt: "desc" },
+        select: {
+          category: true,
+          id: true,
+          skillTags: true,
+          title: true,
+        },
+        take: limit,
+        where: {
+          ...publicAssignedTaskWhere,
+          assigneePersonId: personId,
+          status,
+        },
+      });
+      return [personId, tasks] as const;
+    }),
+  );
+
+  return new Map(entries);
+}
 
 function buildRoleWhere(
   role: PeopleDirectoryRole,
@@ -183,18 +221,6 @@ export async function getPeopleDirectoryData({
           assignedTasks: { where: publicDirectoryTaskWhere },
         },
       },
-      assignedTasks: {
-        orderBy: [{ status: "asc" }, { createdAt: "desc" }],
-        select: {
-          category: true,
-          id: true,
-          skillTags: true,
-          status: true,
-          title: true,
-        },
-        take: TASK_PREVIEW_LIMIT,
-        where: publicDirectoryTaskWhere,
-      },
       countryCode: true,
       currentAffiliation: true,
       displayName: true,
@@ -209,6 +235,19 @@ export async function getPeopleDirectoryData({
     take,
     where,
   });
+  const personIds = people.map((person) => person.id);
+  const [activeTasksByPerson, verifiedTasksByPerson] = await Promise.all([
+    getTaskPreviewsByPerson(
+      personIds,
+      TaskStatus.ACTIVE,
+      ACTIVE_TASK_PREVIEW_LIMIT,
+    ),
+    getTaskPreviewsByPerson(
+      personIds,
+      TaskStatus.VERIFIED,
+      VERIFIED_TASK_PREVIEW_LIMIT,
+    ),
+  ]);
 
   return {
     page: currentPage,
@@ -222,25 +261,23 @@ export async function getPeopleDirectoryData({
       id: person.id,
       image: person.image,
       isPublicFigure: person.isPublicFigure,
-      openTaskPreview: person.assignedTasks
-        .filter((task) => task.status === TaskStatus.ACTIVE)
-        .slice(0, ACTIVE_TASK_PREVIEW_LIMIT)
-        .map((task) => ({
+      openTaskPreview: (activeTasksByPerson.get(person.id) ?? []).map(
+        (task) => ({
           category: task.category,
           id: task.id,
           skillTags: task.skillTags,
           title: task.title,
-        })),
+        }),
+      ),
       publicTaskCount: person._count.assignedTasks,
       sourceUrl: person.sourceUrl,
-      verifiedTaskPreview: person.assignedTasks
-        .filter((task) => task.status === TaskStatus.VERIFIED)
-        .slice(0, VERIFIED_TASK_PREVIEW_LIMIT)
-        .map((task) => ({
+      verifiedTaskPreview: (verifiedTasksByPerson.get(person.id) ?? []).map(
+        (task) => ({
           category: task.category,
           id: task.id,
           title: task.title,
-        })),
+        }),
+      ),
     })),
     query: query.trim(),
     role,

--- a/packages/web/src/lib/people-directory.server.ts
+++ b/packages/web/src/lib/people-directory.server.ts
@@ -51,9 +51,11 @@ export interface PeopleDirectoryData {
 }
 
 const ACTIVE_TASK_PREVIEW_LIMIT = 3;
-const DEFAULT_PAGE_SIZE = 36;
-const MAX_PAGE_SIZE = 60;
+const DEFAULT_PAGE_SIZE = 10;
+const MAX_PAGE_SIZE = 20;
 const VERIFIED_TASK_PREVIEW_LIMIT = 2;
+const TASK_PREVIEW_LIMIT =
+  ACTIVE_TASK_PREVIEW_LIMIT + VERIFIED_TASK_PREVIEW_LIMIT;
 
 const ROLE_FILTERS = {
   all: null,
@@ -72,46 +74,10 @@ const publicAssignedTaskWhere = {
   isPublic: true,
 } satisfies Prisma.TaskWhereInput;
 
-async function getTaskPreviewsByPerson(
-  personIds: string[],
-  status: TaskStatus,
-  limit: number,
-) {
-  if (personIds.length === 0) {
-    return new Map<
-      string,
-      Array<{
-        category: TaskCategory;
-        id: string;
-        skillTags: string[];
-        title: string;
-      }>
-    >();
-  }
-
-  const entries = await Promise.all(
-    personIds.map(async (personId) => {
-      const tasks = await prisma.task.findMany({
-        orderBy: { createdAt: "desc" },
-        select: {
-          category: true,
-          id: true,
-          skillTags: true,
-          title: true,
-        },
-        take: limit,
-        where: {
-          ...publicAssignedTaskWhere,
-          assigneePersonId: personId,
-          status,
-        },
-      });
-      return [personId, tasks] as const;
-    }),
-  );
-
-  return new Map(entries);
-}
+const publicDirectoryTaskWhere = {
+  ...publicAssignedTaskWhere,
+  status: { in: [TaskStatus.ACTIVE, TaskStatus.VERIFIED] },
+} satisfies Prisma.TaskWhereInput;
 
 function buildRoleWhere(
   role: PeopleDirectoryRole,
@@ -126,7 +92,7 @@ function buildRoleWhere(
     ? {
         assignedTasks: {
           some: {
-            ...publicAssignedTaskWhere,
+            ...publicDirectoryTaskWhere,
             category: { in: [...categories] },
           },
         },
@@ -148,7 +114,7 @@ function buildSearchWhere(query: string): Prisma.PersonWhereInput | null {
       {
         assignedTasks: {
           some: {
-            ...publicAssignedTaskWhere,
+            ...publicDirectoryTaskWhere,
             OR: [
               { title: { contains: q, mode: "insensitive" } },
               { description: { contains: q, mode: "insensitive" } },
@@ -194,12 +160,7 @@ export async function getPeopleDirectoryData({
   const clauses: Prisma.PersonWhereInput[] = [
     { deletedAt: null },
     { lifeStatus: { not: PersonLifeStatus.DECEASED } },
-    {
-      OR: [
-        { isPublicFigure: true },
-        { assignedTasks: { some: publicAssignedTaskWhere } },
-      ],
-    },
+    { assignedTasks: { some: publicDirectoryTaskWhere } },
   ];
 
   const searchWhere = buildSearchWhere(query);
@@ -215,16 +176,24 @@ export async function getPeopleDirectoryData({
   const currentPage = Math.min(Math.max(page, 1), totalPages);
 
   const people = await prisma.person.findMany({
-    orderBy: [
-      { isPublicFigure: "desc" },
-      { assignedTasks: { _count: "desc" } },
-      { displayName: "asc" },
-    ],
+    orderBy: [{ isPublicFigure: "desc" }, { displayName: "asc" }],
     select: {
       _count: {
         select: {
-          assignedTasks: { where: publicAssignedTaskWhere },
+          assignedTasks: { where: publicDirectoryTaskWhere },
         },
+      },
+      assignedTasks: {
+        orderBy: [{ status: "asc" }, { createdAt: "desc" }],
+        select: {
+          category: true,
+          id: true,
+          skillTags: true,
+          status: true,
+          title: true,
+        },
+        take: TASK_PREVIEW_LIMIT,
+        where: publicDirectoryTaskWhere,
       },
       countryCode: true,
       currentAffiliation: true,
@@ -240,19 +209,6 @@ export async function getPeopleDirectoryData({
     take,
     where,
   });
-  const personIds = people.map((person) => person.id);
-  const [activeTasksByPerson, verifiedTasksByPerson] = await Promise.all([
-    getTaskPreviewsByPerson(
-      personIds,
-      TaskStatus.ACTIVE,
-      ACTIVE_TASK_PREVIEW_LIMIT,
-    ),
-    getTaskPreviewsByPerson(
-      personIds,
-      TaskStatus.VERIFIED,
-      VERIFIED_TASK_PREVIEW_LIMIT,
-    ),
-  ]);
 
   return {
     page: currentPage,
@@ -266,23 +222,25 @@ export async function getPeopleDirectoryData({
       id: person.id,
       image: person.image,
       isPublicFigure: person.isPublicFigure,
-      openTaskPreview: (activeTasksByPerson.get(person.id) ?? []).map(
-        (task) => ({
+      openTaskPreview: person.assignedTasks
+        .filter((task) => task.status === TaskStatus.ACTIVE)
+        .slice(0, ACTIVE_TASK_PREVIEW_LIMIT)
+        .map((task) => ({
           category: task.category,
           id: task.id,
           skillTags: task.skillTags,
           title: task.title,
-        }),
-      ),
+        })),
       publicTaskCount: person._count.assignedTasks,
       sourceUrl: person.sourceUrl,
-      verifiedTaskPreview: (verifiedTasksByPerson.get(person.id) ?? []).map(
-        (task) => ({
+      verifiedTaskPreview: person.assignedTasks
+        .filter((task) => task.status === TaskStatus.VERIFIED)
+        .slice(0, VERIFIED_TASK_PREVIEW_LIMIT)
+        .map((task) => ({
           category: task.category,
           id: task.id,
           title: task.title,
-        }),
-      ),
+        })),
     })),
     query: query.trim(),
     role,

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -650,9 +650,8 @@ export const peopleLink: NavItem = {
   href: ROUTES.people,
   label: "People",
   emoji: "👥",
-  description:
-    "Find the humans who can move tasks forward, remind them, and see the work assigned to them.",
-  tagline: "Find humans with tasks",
+  description: "Coordinate with the people who can help end war and disease.",
+  tagline: "Coordinate people with tasks",
   cta: "Find People",
 };
 

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -650,8 +650,9 @@ export const peopleLink: NavItem = {
   href: ROUTES.people,
   label: "People",
   emoji: "👥",
-  description: "Coordinate with the people who can help end war and disease.",
-  tagline: "Coordinate people with tasks",
+  description:
+    "1% Treaty work needs actual humans. Find people with public tasks and remind the right one.",
+  tagline: "1% Treaty task coordination",
   cta: "Find People",
 };
 

--- a/packages/web/src/lib/tasks.server.ts
+++ b/packages/web/src/lib/tasks.server.ts
@@ -974,9 +974,7 @@ function getTaskVisibilityWhere(input?: {
     if (!input?.userId) {
       return { ...baseWhere, createdByUserId: "__unreachable__" };
     }
-    const ors: Prisma.TaskWhereInput[] = [
-      { createdByUserId: input.userId },
-    ];
+    const ors: Prisma.TaskWhereInput[] = [{ createdByUserId: input.userId }];
     if (input.personId) {
       ors.push({ assigneePersonId: input.personId });
     }
@@ -1108,23 +1106,28 @@ export async function getTasksPageData(
 }
 
 export async function getTaskDetailData(
-  taskId: string,
+  taskId: string | null | undefined,
   userId?: string | null,
   options?: {
     frameKey?: TaskImpactFrameKey | string | null;
   },
 ) {
+  const normalizedTaskId = typeof taskId === "string" ? taskId.trim() : "";
+  if (!normalizedTaskId) {
+    return null;
+  }
+
   const [task, viewer, taskCommunicationCount] = await Promise.all([
     prisma.task.findFirst({
       where: getTaskVisibilityWhere({
-        taskId,
+        taskId: normalizedTaskId,
         userId,
         visibility: "accessible",
       }),
       select: taskDetailSelect,
     }),
     userId ? getTaskViewer(userId) : Promise.resolve(null),
-    countTaskCommunications(taskId),
+    countTaskCommunications(normalizedTaskId),
   ]);
 
   if (!task) {
@@ -1137,7 +1140,7 @@ export async function getTaskDetailData(
       : await prisma.taskClaim.findUnique({
           where: {
             taskId_userId: {
-              taskId,
+              taskId: normalizedTaskId,
               userId,
             },
           },


### PR DESCRIPTION
## What changed
- Made `/people` a compact, paginated people directory instead of a tall card wall.
- Reduced the people directory query shape: 10 rows by default, no relation-count sorting, only people with active/verified public tasks, and bounded task previews.
- Removed the default shadow from the shared `Input` primitive.
- Added defensive MCP validation so `getTask` returns a clean `taskId is required` error instead of allowing a missing ID to reach Prisma.

## Why
- `/people` was too tall on mobile and too expensive for Vercel, with production reporting memory exhaustion.
- MCP clients can call tools incorrectly; the server should return useful instructions instead of Prisma validation errors.

## Validation
- `pnpm --filter @optimitron/web run typecheck:fast`
- `pnpm --filter @optimitron/web exec vitest run src/lib/__tests__/mcp-server.test.ts`
- Playwright screenshots reviewed: `packages/web/output/playwright/people-directory-copy/review.html`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Directory header now displays total count of people with available tasks

* **Style**
  * Redesigned people directory with new row-based layout
  * Updated People page copy, tagline, and search input styling
  * Simplified input component styling for improved clarity

* **Bug Fixes**
  * Enhanced error handling and messaging for missing task information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->