### PR TITLE
Fix people OG image source URLs

### DIFF
--- a/packages/web/src/app/people/[id]/opengraph-image.tsx
+++ b/packages/web/src/app/people/[id]/opengraph-image.tsx
@@ -1,6 +1,9 @@
 import { ImageResponse } from "next/og";
 import { PersonLifeStatus } from "@optimitron/db/enums";
+import { headers } from "next/headers";
+import { toAbsoluteOgImageSrc } from "@/lib/og-image";
 import { getRepresentedPersonProfileData } from "@/lib/represented-people.server";
+import { getRequestSiteOrigin } from "@/lib/site";
 
 export const runtime = "nodejs";
 export const revalidate = 3600;
@@ -80,6 +83,13 @@ export default async function OGImage({
   const condition = data.memorial?.conditionLabel ?? null;
   const lag = data.memorial?.efficacyLag ?? null;
   const country = data.memorial?.deathCountryCode ?? null;
+  const requestHeaders = await headers();
+  const imageBaseOrigin = getRequestSiteOrigin({
+    forwardedHost: requestHeaders.get("x-forwarded-host"),
+    forwardedProto: requestHeaders.get("x-forwarded-proto"),
+    host: requestHeaders.get("host"),
+  });
+  const personImageSrc = toAbsoluteOgImageSrc(data.person.image, imageBaseOrigin);
 
   return new ImageResponse(
     <div
@@ -107,11 +117,11 @@ export default async function OGImage({
           backgroundColor: "#1a1a1a",
         }}
       >
-        {data.person.image ? (
+        {personImageSrc ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img
             alt={data.person.displayName}
-            src={data.person.image}
+            src={personImageSrc}
             style={{ width: "100%", height: "100%", objectFit: "cover" }}
           />
         ) : (

--- a/packages/web/src/lib/__tests__/og-image.test.ts
+++ b/packages/web/src/lib/__tests__/og-image.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { toAbsoluteOgImageSrc } from "../og-image";
+
+describe("toAbsoluteOgImageSrc", () => {
+  it("passes through absolute http(s) URLs", () => {
+    expect(toAbsoluteOgImageSrc("https://cdn.example.com/a.jpg")).toBe(
+      "https://cdn.example.com/a.jpg",
+    );
+    expect(toAbsoluteOgImageSrc("http://cdn.example.com/a.jpg")).toBe(
+      "http://cdn.example.com/a.jpg",
+    );
+  });
+
+  it("prefixes local asset paths with the request origin", () => {
+    expect(
+      toAbsoluteOgImageSrc("/img/grandma.jpg", "https://1percenttreaty.org"),
+    ).toBe("https://1percenttreaty.org/img/grandma.jpg");
+  });
+
+  it("upgrades protocol-relative URLs to https", () => {
+    expect(toAbsoluteOgImageSrc("//cdn.example.com/a.jpg")).toBe(
+      "https://cdn.example.com/a.jpg",
+    );
+  });
+
+  it("drops unsafe or empty sources", () => {
+    expect(toAbsoluteOgImageSrc(null)).toBeNull();
+    expect(toAbsoluteOgImageSrc("   ")).toBeNull();
+    expect(toAbsoluteOgImageSrc("javascript:alert(1)")).toBeNull();
+  });
+});

--- a/packages/web/src/lib/og-image.ts
+++ b/packages/web/src/lib/og-image.ts
@@ -1,0 +1,21 @@
+import { getConfiguredSiteOrigin } from "@/lib/site";
+
+const HTTP_URL_PATTERN = /^https?:\/\//i;
+
+export function toAbsoluteOgImageSrc(
+  src: string | null | undefined,
+  baseOrigin: string = getConfiguredSiteOrigin({ allowLocalFallback: true }),
+): string | null {
+  const trimmed = src?.trim();
+  if (!trimmed) return null;
+
+  if (HTTP_URL_PATTERN.test(trimmed)) return trimmed;
+  if (trimmed.startsWith("//")) return `https:${trimmed}`;
+
+  try {
+    const url = new URL(trimmed, baseOrigin);
+    return HTTP_URL_PATTERN.test(url.toString()) ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Convert represented-person OG image sources to absolute URLs before passing them to next/og
- Use the request origin for site-local assets like /img/grandma.jpg
- Add focused coverage for OG image source normalization

## Tests
- pnpm --filter @optimitron/web exec vitest run src/lib/__tests__/og-image.test.ts
- pnpm --filter @optimitron/web run typecheck:fast