### PR TITLE
Add Humanity v Government route link

### DIFF
--- a/packages/web/src/app/humanity-v-government/page.test.ts
+++ b/packages/web/src/app/humanity-v-government/page.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { HUMANITY_V_GOVERNMENT_MANUAL_URL } from "@/lib/routes";
+
+const mocks = vi.hoisted(() => ({
+  permanentRedirect: vi.fn((target: string) => {
+    throw new Error(`redirect:${target}`);
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  permanentRedirect: mocks.permanentRedirect,
+}));
+
+import HumanityVGovernmentPage from "./page";
+
+describe("HumanityVGovernmentPage", () => {
+  it("redirects to the manual appendix", () => {
+    expect(() => HumanityVGovernmentPage()).toThrow(
+      `redirect:${HUMANITY_V_GOVERNMENT_MANUAL_URL}`,
+    );
+  });
+});

--- a/packages/web/src/app/humanity-v-government/page.tsx
+++ b/packages/web/src/app/humanity-v-government/page.tsx
@@ -1,0 +1,6 @@
+import { permanentRedirect } from "next/navigation";
+import { HUMANITY_V_GOVERNMENT_MANUAL_URL } from "@/lib/routes";
+
+export default function HumanityVGovernmentPage() {
+  permanentRedirect(HUMANITY_V_GOVERNMENT_MANUAL_URL);
+}

--- a/packages/web/src/app/people/[id]/page.tsx
+++ b/packages/web/src/app/people/[id]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 import { PersonLifeStatus } from "@optimitron/db/enums";
 import { headers } from "next/headers";
 import Link from "next/link";
@@ -17,7 +18,12 @@ import {
 import { getPersonTaskProfileData } from "@/lib/tasks.server";
 import { authOptions } from "@/lib/auth";
 import { getRepresentedLifeStatusLabel } from "@/lib/represented-life-status";
-import { peopleLink, plaintiffsLink, ROUTES } from "@/lib/routes";
+import {
+  humanityVGovernmentLink,
+  peopleLink,
+  plaintiffsLink,
+  ROUTES,
+} from "@/lib/routes";
 import {
   getRepresentedPersonProfileData,
   type RepresentedPersonProfileData,
@@ -142,8 +148,18 @@ function RepresentedPersonProfile({
   const summaryCards = [
     { label: "Registered by", value: representedBy },
     relationship ? { label: "Relationship", value: relationship } : null,
-    { label: "Case", value: "Humanity v. Government" },
-  ].filter(Boolean) as Array<{ label: string; value: string }>;
+    {
+      label: "Case",
+      value: (
+        <Link
+          className="underline underline-offset-4"
+          href={ROUTES.humanityVGovernment}
+        >
+          {humanityVGovernmentLink.label}
+        </Link>
+      ),
+    },
+  ].filter(Boolean) as Array<{ label: string; value: ReactNode }>;
 
   return (
     <main className="min-h-screen bg-background pb-20 text-foreground [font-family:var(--v0-font-libre-baskerville)]">
@@ -272,7 +288,14 @@ function RepresentedPersonProfile({
             </h2>
             <p className="font-bold leading-7 text-muted-foreground">
               At least one submitter has consented to use this plaintiff as
-              evidence in Humanity v. Government or a future legal proceeding.
+              evidence in{" "}
+              <Link
+                className="underline underline-offset-4"
+                href={ROUTES.humanityVGovernment}
+              >
+                {humanityVGovernmentLink.label}
+              </Link>{" "}
+              or a future legal proceeding.
             </p>
             <a
               className="inline-block border border-foreground bg-foreground px-5 py-3 text-sm font-black uppercase tracking-[0.14em] text-background"
@@ -286,8 +309,14 @@ function RepresentedPersonProfile({
 
         <section className="border border-border bg-card p-5 text-card-foreground">
           <p className="font-bold leading-7 text-muted-foreground">
-            This plaintiff was registered as evidence in Humanity v. Government.
-            The claim is simple: governments were hired to promote the general
+            This plaintiff was registered as evidence in{" "}
+            <Link
+              className="underline underline-offset-4"
+              href={ROUTES.humanityVGovernment}
+            >
+              {humanityVGovernmentLink.label}
+            </Link>
+            . The claim is simple: governments were hired to promote the general
             welfare and spent the repair money on war.
           </p>
           <Link

--- a/packages/web/src/app/plaintiffs/manage/page.tsx
+++ b/packages/web/src/app/plaintiffs/manage/page.tsx
@@ -15,7 +15,12 @@ import { authOptions } from "@/lib/auth";
 import { getSiteMetadata } from "@/lib/metadata";
 import { GOVERNMENTS_PAID_TO_PROMOTE_WELFARE } from "@/lib/people-parameters";
 import { prisma } from "@/lib/prisma";
-import { getSignInPath, plaintiffsManageLink, ROUTES } from "@/lib/routes";
+import {
+  getSignInPath,
+  humanityVGovernmentLink,
+  plaintiffsManageLink,
+  ROUTES,
+} from "@/lib/routes";
 import { getSiteFromHeaders } from "@/lib/site";
 import { TREATY_REFERENDUM_SLUG } from "@/lib/treaty";
 
@@ -250,7 +255,12 @@ export default async function ManagePeoplePage({
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div className="space-y-2">
               <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-                Humanity v. Government
+                <Link
+                  className="underline underline-offset-4"
+                  href={ROUTES.humanityVGovernment}
+                >
+                  {humanityVGovernmentLink.label}
+                </Link>
               </p>
               <h1 className="text-4xl font-black uppercase leading-none sm:text-5xl">
                 Your Plaintiffs
@@ -265,8 +275,14 @@ export default async function ManagePeoplePage({
           </div>
           <div className="space-y-4 border border-foreground bg-background p-5 text-lg font-bold leading-8 text-foreground">
             <p>
-              These are the plaintiffs you registered for Humanity v.
-              Government, the Court of Humanity class action.
+              These are the plaintiffs you registered for{" "}
+              <Link
+                className="underline underline-offset-4"
+                href={ROUTES.humanityVGovernment}
+              >
+                {humanityVGovernmentLink.label}
+              </Link>
+              , the Court of Humanity class action.
             </p>
             <p>
               Humanity pays governments{" "}

--- a/packages/web/src/app/plaintiffs/page.tsx
+++ b/packages/web/src/app/plaintiffs/page.tsx
@@ -17,7 +17,7 @@ import {
   getRepresentedPeopleGalleryData,
   type RepresentedPeopleSortKey,
 } from "@/lib/represented-people.server";
-import { plaintiffsLink, ROUTES } from "@/lib/routes";
+import { humanityVGovernmentLink, plaintiffsLink, ROUTES } from "@/lib/routes";
 import { getSiteFromHeaders } from "@/lib/site";
 
 const VALID_SORT_KEYS: RepresentedPeopleSortKey[] = [
@@ -168,7 +168,14 @@ export default async function PlaintiffsPage({
           <p className="max-w-5xl text-lg font-bold leading-8 text-muted-foreground sm:text-2xl sm:leading-10">
             Please list everyone you love who can no longer sign the 1% Treaty
             because of death, disease, or both, so they may be presented as
-            evidence in the class action lawsuit Humanity v. Government.
+            evidence in the class action lawsuit{" "}
+            <Link
+              className="underline underline-offset-4"
+              href={ROUTES.humanityVGovernment}
+            >
+              {humanityVGovernmentLink.label}
+            </Link>
+            .
           </p>
         </header>
 
@@ -226,7 +233,13 @@ export default async function PlaintiffsPage({
                 Public plaintiffs
               </p>
               <h2 className="text-3xl font-black uppercase leading-tight">
-                Plaintiffs in Humanity v. Government
+                Plaintiffs in{" "}
+                <Link
+                  className="underline underline-offset-4"
+                  href={ROUTES.humanityVGovernment}
+                >
+                  {humanityVGovernmentLink.label}
+                </Link>
               </h2>
             </div>
           </div>
@@ -329,9 +342,15 @@ export default async function PlaintiffsPage({
               Know a victim of war or disease?
             </summary>
             <p className="mt-3 max-w-4xl font-bold leading-7 text-muted-foreground">
-              Add them to the plaintiff list for Humanity v. Government, the
-              class action against the governments of Earth. Governments were
-              hired to promote the general welfare. They spent{" "}
+              Add them to the plaintiff list for{" "}
+              <Link
+                className="underline underline-offset-4"
+                href={ROUTES.humanityVGovernment}
+              >
+                {humanityVGovernmentLink.label}
+              </Link>
+              , the class action against the governments of Earth. Governments
+              were hired to promote the general welfare. They spent{" "}
               <ParameterValue
                 className="font-black"
                 param={CUMULATIVE_MILITARY_SPENDING_FED_ERA}

--- a/packages/web/src/lib/__tests__/site.test.ts
+++ b/packages/web/src/lib/__tests__/site.test.ts
@@ -49,9 +49,7 @@ describe("site variant registry", () => {
     );
     expect(getSiteFromHost("dfda.earth").key).toBe("dfda");
     expect(getSiteFromHost("dih.earth").key).toBe("dih");
-    expect(getSiteFromHost("acceleratedmedicine.org").key).toBe(
-      "warOnDisease",
-    );
+    expect(getSiteFromHost("acceleratedmedicine.org").key).toBe("warOnDisease");
     expect(getSiteFromHost("optimitron.com").key).toBe("optimitron");
   });
 
@@ -148,10 +146,13 @@ describe("site variant registry", () => {
     expect(warSite.description).toBe(WAR_ON_DISEASE_APOCALYPSE_DESCRIPTION);
     expect(warSite.ui.footer.brandDescription).toBe(warSite.description);
     expect(warSite.rootMetadata.description).toBe(warSite.description);
-    expect(warSite.rootMetadata.openGraphDescription).toBe(
-      warSite.description,
-    );
+    expect(warSite.rootMetadata.openGraphDescription).toBe(warSite.description);
     expect(warSite.rootMetadata.twitterDescription).toBe(warSite.description);
+    expect(
+      warSite.ui.footer.columns
+        .flatMap((column) => column.items)
+        .some((item) => item.href === ROUTES.humanityVGovernment),
+    ).toBe(true);
     expect(warSite.domains).toEqual(
       expect.arrayContaining([
         "1percenttreaty.org",
@@ -251,6 +252,7 @@ describe("site variant registry", () => {
     expect(isSiteRouteAllowed(warSite, ROUTES.signatories)).toBe(true);
     expect(isSiteRouteAllowed(warSite, ROUTES.campaign)).toBe(true);
     expect(isSiteRouteAllowed(warSite, ROUTES.coalition)).toBe(true);
+    expect(isSiteRouteAllowed(warSite, ROUTES.humanityVGovernment)).toBe(true);
     expect(isSiteRouteAllowed(warSite, ROUTES.endorse)).toBe(true);
     expect(isSiteRouteAllowed(warSite, ROUTES.privacy)).toBe(true);
     expect(isSiteRouteAllowed(warSite, ROUTES.terms)).toBe(true);
@@ -293,10 +295,7 @@ describe("site variant registry", () => {
       getEnabledStaticPathsForSite(getSiteConfig("optimitron"), candidates),
     ).toEqual([ROUTES.donate, ROUTES.treaty]);
     expect(
-      getEnabledStaticPathsForSite(
-        getSiteConfig("warOnDisease"),
-        candidates,
-      ),
+      getEnabledStaticPathsForSite(getSiteConfig("warOnDisease"), candidates),
     ).toEqual(expect.arrayContaining(candidates));
   });
 

--- a/packages/web/src/lib/represented-life-status.ts
+++ b/packages/web/src/lib/represented-life-status.ts
@@ -9,5 +9,5 @@ export function getRepresentedLifeStatusLabel(
   if (status === PersonLifeStatus.LIVING) {
     return "Plaintiff represented by another human";
   }
-  return "Plaintiff in Humanity v. Government";
+  return "Plaintiff in the case";
 }

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -56,6 +56,7 @@ export const ROUTES = {
   // The Treaty
   treaty: "/treaty",
   court: "/court",
+  humanityVGovernment: "/humanity-v-government",
   vote: "/vote",
   why: "/why",
   legal: "/legal",
@@ -624,6 +625,19 @@ export const courtLink: NavItem = {
   cta: "Join the Court",
 };
 
+export const HUMANITY_V_GOVERNMENT_MANUAL_URL =
+  "https://manual.warondisease.org/knowledge/appendix/humanity-v-government.html";
+
+export const humanityVGovernmentLink: NavItem = {
+  href: ROUTES.humanityVGovernment,
+  label: "Humanity v. Government",
+  emoji: "⚖️",
+  description:
+    "Governments were hired to promote the general welfare. They chose war instead. Now there's a legal theory for that.",
+  tagline: "The case against government harm",
+  cta: "Read the Case",
+};
+
 export const readTreatyLink: NavItem = {
   ...treatyLink,
   label: "Read the Treaty",
@@ -660,8 +674,7 @@ export const plaintiffsLink: NavItem = {
   href: ROUTES.plaintiffs,
   label: "Plaintiffs",
   emoji: "👥",
-  description:
-    "Sign the 1% Treaty for someone who can no longer sign it themselves, so they can be listed as a plaintiff in Humanity v. Government.",
+  description: `Sign the 1% Treaty for someone who can no longer sign it themselves, so they can be listed as a plaintiff in ${humanityVGovernmentLink.label}.`,
   tagline: "Sign for someone who can't",
   cta: "Sign for Them",
 };
@@ -670,7 +683,7 @@ export const plaintiffsManageLink: NavItem = {
   ...plaintiffsLink,
   href: ROUTES.plaintiffsManage,
   label: "Your Plaintiffs",
-  description: "Edit the plaintiffs you registered for Humanity v. Government.",
+  description: `Edit the plaintiffs you registered for ${humanityVGovernmentLink.label}.`,
   tagline: "Edit your plaintiffs",
   cta: "Your Plaintiffs",
 };

--- a/packages/web/src/lib/site.ts
+++ b/packages/web/src/lib/site.ts
@@ -21,6 +21,7 @@ import {
   endorseLink,
   exploreLinks,
   footerAppLinks,
+  humanityVGovernmentLink,
   inviteVoterLink,
   legalLink,
   navSections,
@@ -64,11 +65,7 @@ export const SITE_VARIANT_OVERRIDE_QUERY_PARAM = "site";
 // Per-host site configuration (generic Site* / referendum-microsite layer)
 // ---------------------------------------------------------------------------
 
-export type SiteKey =
-  | "optimitron"
-  | "dfda"
-  | "dih"
-  | "warOnDisease";
+export type SiteKey = "optimitron" | "dfda" | "dih" | "warOnDisease";
 
 export const SITE_VARIANT_OVERRIDE_HEADER = "x-optimitron-site-key";
 
@@ -493,7 +490,7 @@ const WAR_ON_DISEASE_UI: SiteVariantUiConfig = {
       },
       {
         title: "Reference",
-        items: [whyLink, courtLink],
+        items: [whyLink, courtLink, humanityVGovernmentLink],
       },
     ],
   },
@@ -728,11 +725,7 @@ const DIH_CONFIG: SiteConfig = {
   chromeVariant: "platform",
   userFraming: "voter",
   canonicalOrigin: "https://dih.earth",
-  domains: [
-    "dih.earth",
-    "www.dih.earth",
-    "dih.local",
-  ],
+  domains: ["dih.earth", "www.dih.earth", "dih.local"],
   name: "DIH",
   shortName: "DIH",
   alternateSiteNames: [
@@ -925,6 +918,7 @@ const WAR_ON_DISEASE_CONFIG: SiteConfig = {
     canonicalPrefixes: [
       ROUTES.treaty,
       ROUTES.court,
+      ROUTES.humanityVGovernment,
       ROUTES.tasks,
       ROUTES.people,
       ROUTES.plaintiffs,
@@ -950,6 +944,7 @@ const WAR_ON_DISEASE_CONFIG: SiteConfig = {
     publicPrefixes: [
       ROUTES.treaty,
       ROUTES.court,
+      ROUTES.humanityVGovernment,
       ROUTES.tasks,
       ROUTES.people,
       ROUTES.plaintiffs,
@@ -984,11 +979,7 @@ const WAR_ON_DISEASE_CONFIG: SiteConfig = {
       ROUTES.profile,
       ROUTES.settings,
     ],
-    minimalChromePrefixes: [
-      ROUTES.vote,
-      ROUTES.questions,
-      ROUTES.survey,
-    ],
+    minimalChromePrefixes: [ROUTES.vote, ROUTES.questions, ROUTES.survey],
   },
   assets: WAR_ON_DISEASE_ASSETS,
   sitemap: {


### PR DESCRIPTION
## Summary
- add `/humanity-v-government` as a local redirect to the manual appendix
- add the route to the War on Disease footer Reference column and route allowlist
- link visible `Humanity v. Government` mentions on plaintiff/person pages through the local route

## Verification
- `pnpm --filter @optimitron/web exec vitest run src/app/humanity-v-government/page.test.ts src/lib/__tests__/site.test.ts`
- `pnpm --filter @optimitron/web exec prettier --check src/lib/routes.ts src/lib/site.ts src/lib/__tests__/site.test.ts src/lib/represented-life-status.ts src/app/humanity-v-government/page.tsx src/app/humanity-v-government/page.test.ts src/app/plaintiffs/page.tsx src/app/plaintiffs/manage/page.tsx 'src/app/people/[id]/page.tsx'`
- `pnpm --filter @optimitron/web exec tsc --noEmit`
- `git diff --check`

## Screenshot Review
Local only, not uploaded because screenshots can contain production-derived data.

- Review page: `E:\code\optimitron\packages\web\output\playwright\review\latest.html`
- Covered `/plaintiffs?site=warOnDisease` desktop/mobile top content and footer Reference links, including expanded mobile footer.
- Verified `/humanity-v-government` redirects to `https://manual.warondisease.org/knowledge/appendix/humanity-v-government.html`.