### PR TITLE
Fix production build validation

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -37,6 +37,20 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   webpack: (config, { isServer }) => {
+    // wagmi/connectors re-exports optional wallet connectors whose peer
+    // packages are intentionally not installed. WalletConnect and injected
+    // wallets are the only connectors configured in this app.
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@base-org/account": false,
+      "@coinbase/wallet-sdk": false,
+      "@metamask/connect-evm": false,
+      "@safe-global/safe-apps-provider": false,
+      "@safe-global/safe-apps-sdk": false,
+      porto: false,
+      "porto/internal": false,
+    };
+
     // MetaMask SDK bundles React Native code that references this package.
     config.resolve.fallback = {
       ...config.resolve.fallback,

--- a/packages/web/src/lib/__tests__/env.test.ts
+++ b/packages/web/src/lib/__tests__/env.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function setRequiredEnv() {
+  process.env.NEXTAUTH_SECRET = "test-secret";
+  process.env.DATABASE_URL = "postgresql://user:password@localhost:5432/test";
+}
+
+async function loadServerEnv() {
+  vi.resetModules();
+  const { getServerEnv } = await import("@/lib/env");
+  return getServerEnv();
+}
+
+describe("server env validation", () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("treats blank optional R2 URL variables as unset", async () => {
+    process.env = { ...ORIGINAL_ENV };
+    setRequiredEnv();
+    process.env.R2_ENDPOINT = "";
+    process.env.R2_PUBLIC_URL = "   ";
+
+    const env = await loadServerEnv();
+
+    expect(env.R2_ENDPOINT).toBeUndefined();
+    expect(env.R2_PUBLIC_URL).toBeUndefined();
+  });
+
+  it("rejects malformed non-blank R2_ENDPOINT values", async () => {
+    process.env = { ...ORIGINAL_ENV };
+    setRequiredEnv();
+    process.env.R2_ENDPOINT = "not-a-url";
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(loadServerEnv()).rejects.toThrow(/R2_ENDPOINT: Invalid url/);
+  });
+
+  it("rejects malformed non-blank R2_PUBLIC_URL values", async () => {
+    process.env = { ...ORIGINAL_ENV };
+    setRequiredEnv();
+    process.env.R2_PUBLIC_URL = "not-a-url";
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(loadServerEnv()).rejects.toThrow(/R2_PUBLIC_URL: Invalid url/);
+  });
+});

--- a/packages/web/src/lib/env.ts
+++ b/packages/web/src/lib/env.ts
@@ -15,14 +15,23 @@ import { z } from "zod";
 /*  Schema                                                             */
 /* ------------------------------------------------------------------ */
 
+const blankToUndefined = (value: unknown): unknown =>
+  typeof value === "string" && value.trim() === "" ? undefined : value;
+
 const optionalNonEmptyString = z.preprocess(
-  (value) =>
-    typeof value === "string" && value.trim() === "" ? undefined : value,
+  blankToUndefined,
   z.string().trim().min(1).optional(),
 );
 
+const optionalUrl = z.preprocess(
+  blankToUndefined,
+  z.string().trim().url().optional(),
+);
+
 const serverSchema = z.object({
-  NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+  NODE_ENV: z
+    .enum(["development", "production", "test"])
+    .default("development"),
 
   // ── Auth ──────────────────────────────────────────────────────────
   NEXTAUTH_SECRET: z.string().min(1, "NEXTAUTH_SECRET is required"),
@@ -106,9 +115,9 @@ const serverSchema = z.object({
   // The runtime presign route reads these to issue PUT URLs scoped to the
   // bucket; the bucket's public hostname is served from R2_PUBLIC_URL.
   // For dev-only media uploads (legacy), see also CLOUDFLARE_TOKEN above.
-  R2_ENDPOINT: z.string().url().optional(),
+  R2_ENDPOINT: optionalUrl,
   R2_BUCKET: z.string().optional(),
-  R2_PUBLIC_URL: z.string().url().optional(),
+  R2_PUBLIC_URL: optionalUrl,
   R2_ACCESS_KEY_ID: z.string().optional(),
   R2_SECRET_ACCESS_KEY: z.string().optional(),
 });
@@ -146,7 +155,9 @@ export function getServerEnv(): ServerEnv {
     const formatted = parsed.error.flatten().fieldErrors;
     console.error("Invalid server environment variables:", formatted);
     throw new Error(
-      `Missing or invalid server environment variables:\n${Object.entries(formatted)
+      `Missing or invalid server environment variables:\n${Object.entries(
+        formatted,
+      )
         .map(([k, v]) => `  ${k}: ${(v ?? []).join(", ")}`)
         .join("\n")}`,
     );
@@ -162,15 +173,19 @@ export function getClientEnv(): ClientEnv {
 
   const parsed = clientSchema.safeParse({
     NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,
-    NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID,
+    NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID:
+      process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID,
     NEXT_PUBLIC_WORLD_ID_ENABLED: process.env.NEXT_PUBLIC_WORLD_ID_ENABLED,
-    NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
+    NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
+      process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
   });
   if (!parsed.success) {
     const formatted = parsed.error.flatten().fieldErrors;
     console.error("Invalid client environment variables:", formatted);
     throw new Error(
-      `Missing or invalid client environment variables:\n${Object.entries(formatted)
+      `Missing or invalid client environment variables:\n${Object.entries(
+        formatted,
+      )
         .map(([k, v]) => `  ${k}: ${(v ?? []).join(", ")}`)
         .join("\n")}`,
     );


### PR DESCRIPTION
## Summary
- Treat blank optional R2 URL env vars as unset while still rejecting malformed non-blank URLs
- Stub unused optional Wagmi connector peer packages so production builds with WalletConnect enabled do not emit module resolution warnings
- Add focused env validation tests for blank and malformed R2 URL values

## Verification
- pnpm --filter @optimitron/web exec vitest run src/lib/__tests__/env.test.ts
- pnpm --filter @optimitron/web exec prettier --check next.config.js src/lib/env.ts src/lib/__tests__/env.test.ts
- node --check packages/web/next.config.js
- pnpm --filter @optimitron/web run typecheck:fast
- next build --experimental-build-mode compile --no-lint with NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID set and blank R2_ENDPOINT/R2_PUBLIC_URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved environment variable validation with clearer, multi-line error messages for easier debugging

* **Chores**
  * Optimized client bundle by removing unused modules
  * Added comprehensive tests for environment variable handling and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->