### PR TITLE
Add MCP image URL imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@
 - If a tool, skill, or generated workflow suggests `codex/...` branches or `[codex]` pull request titles, ignore that convention in this repository and use the `feature/...` branch plus a plain feature/fix title.
 - If work starts on `main`, create the `feature/...` branch before editing. If already on a non-main branch, continue there unless the human asks to rename or split the work.
 - When implementation is done and checks pass, commit the intended changes, push the branch, and open or update the pull request unless the human explicitly asked not to commit or push.
+- Do not create draft pull requests unless the human explicitly asks for a draft. Open normal pull requests so CI and review automation run immediately.
 - After every push, watch GitHub Actions, deployment checks, and pull request review comments. Fix valid failures or comments, push again, and watch again.
 - If a review comment is mistaken, stale, or non-actionable, mark it resolved when tooling allows. Do not make unnecessary code changes just to satisfy an invalid comment.
 - Once checks are green and there are no unresolved valid review complaints, merge the pull request when the human has asked you to finish or merge the work.

--- a/packages/web/src/app/api/uploads/images/route.ts
+++ b/packages/web/src/app/api/uploads/images/route.ts
@@ -5,19 +5,17 @@ import {
   buildImageUploadKey,
   normalizeImageUpload,
 } from "@/lib/image-upload.server";
-import type { ImageUploadKind } from "@/lib/image-upload-types";
+import {
+  IMAGE_UPLOAD_KINDS,
+  type ImageUploadKind,
+} from "@/lib/image-upload-types";
 import {
   ObjectStorageNotConfiguredError,
   uploadObject,
 } from "@/lib/object-storage.server";
 
 const uploadImageSchema = z.object({
-  kind: z.enum([
-    "memorial-evidence-image",
-    "organization-square-logo",
-    "organization-wordmark-logo",
-    "person-photo",
-  ]),
+  kind: z.enum(IMAGE_UPLOAD_KINDS),
 });
 
 export async function POST(request: Request) {

--- a/packages/web/src/lib/__tests__/image-upload-from-url.server.test.ts
+++ b/packages/web/src/lib/__tests__/image-upload-from-url.server.test.ts
@@ -1,0 +1,148 @@
+import sharp from "sharp";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  lookup: vi.fn(),
+  uploadObject: vi.fn(),
+}));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: mocks.lookup,
+}));
+
+vi.mock("../object-storage.server", () => ({
+  uploadObject: mocks.uploadObject,
+}));
+
+import { uploadImageFromUrl } from "../image-upload-from-url.server";
+
+beforeEach(() => {
+  mocks.lookup.mockReset();
+  mocks.uploadObject.mockReset();
+  vi.unstubAllGlobals();
+  mocks.lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  mocks.uploadObject.mockResolvedValue({
+    publicUrl: "https://assets.example.org/organizations/logos/logo.webp",
+  });
+});
+
+async function tinyPng() {
+  return sharp({
+    create: {
+      width: 120,
+      height: 80,
+      channels: 4,
+      background: { r: 255, g: 255, b: 255, alpha: 0 },
+    },
+  })
+    .png()
+    .toBuffer();
+}
+
+describe("uploadImageFromUrl", () => {
+  it("fetches, normalizes, and uploads public organization images", async () => {
+    const image = await tinyPng();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(image, {
+          headers: {
+            "content-length": String(image.byteLength),
+            "content-type": "image/png",
+          },
+          status: 200,
+        }),
+      ),
+    );
+
+    const result = await uploadImageFromUrl({
+      filename: "Institute logo.png",
+      kind: "organization-square-logo",
+      url: "https://example.org/assets/logo.png",
+    });
+
+    expect(result).toEqual({
+      contentType: "image/webp",
+      key: expect.stringMatching(
+        /^organizations\/logos\/\d{4}-\d{2}-\d{2}\/.+-Institute-logo\.webp$/,
+      ),
+      publicUrl: "https://assets.example.org/organizations/logos/logo.webp",
+      sizeBytes: expect.any(Number),
+      sourceUrl: "https://example.org/assets/logo.png",
+    });
+    expect(mocks.lookup).toHaveBeenCalledWith("example.org", { all: true });
+    expect(mocks.uploadObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contentType: "image/webp",
+        key: result.key,
+      }),
+    );
+  });
+
+  it("rejects local/private hosts before fetching", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      uploadImageFromUrl({
+        kind: "organization-square-logo",
+        url: "http://127.0.0.1/logo.png",
+      }),
+    ).rejects.toThrow("Image URL host is not allowed");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.uploadObject).not.toHaveBeenCalled();
+  });
+
+  it("rejects bracketed IPv6 loopback URLs before fetching", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      uploadImageFromUrl({
+        kind: "person-photo",
+        url: "http://[::1]/logo.png",
+      }),
+    ).rejects.toThrow("Image URL host is not allowed");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.uploadObject).not.toHaveBeenCalled();
+  });
+
+  it("rejects hostnames that resolve to private addresses", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    mocks.lookup.mockResolvedValueOnce([{ address: "10.0.0.4", family: 4 }]);
+
+    await expect(
+      uploadImageFromUrl({
+        kind: "organization-wordmark-logo",
+        url: "https://images.example.org/logo.png",
+      }),
+    ).rejects.toThrow("Image URL host is not allowed");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.uploadObject).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-image responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("hello", {
+          headers: { "content-type": "text/html" },
+          status: 200,
+        }),
+      ),
+    );
+
+    await expect(
+      uploadImageFromUrl({
+        kind: "organization-square-logo",
+        url: "https://example.org/logo",
+      }),
+    ).rejects.toThrow("Remote URL must return a supported image type");
+
+    expect(mocks.uploadObject).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/lib/__tests__/image-upload-from-url.server.test.ts
+++ b/packages/web/src/lib/__tests__/image-upload-from-url.server.test.ts
@@ -1,5 +1,12 @@
 import sharp from "sharp";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ImageUploadKind } from "../image-upload-types";
+
+const ORG_SQUARE_LOGO_KIND =
+  "organization-square-logo" satisfies ImageUploadKind;
+const ORG_WORDMARK_LOGO_KIND =
+  "organization-wordmark-logo" satisfies ImageUploadKind;
+const PERSON_PHOTO_KIND = "person-photo" satisfies ImageUploadKind;
 
 const mocks = vi.hoisted(() => ({
   lookup: vi.fn(),
@@ -57,7 +64,7 @@ describe("uploadImageFromUrl", () => {
 
     const result = await uploadImageFromUrl({
       filename: "Institute logo.png",
-      kind: "organization-square-logo",
+      kind: ORG_SQUARE_LOGO_KIND,
       url: "https://example.org/assets/logo.png",
     });
 
@@ -85,7 +92,7 @@ describe("uploadImageFromUrl", () => {
 
     await expect(
       uploadImageFromUrl({
-        kind: "organization-square-logo",
+        kind: ORG_SQUARE_LOGO_KIND,
         url: "http://127.0.0.1/logo.png",
       }),
     ).rejects.toThrow("Image URL host is not allowed");
@@ -100,8 +107,23 @@ describe("uploadImageFromUrl", () => {
 
     await expect(
       uploadImageFromUrl({
-        kind: "person-photo",
+        kind: PERSON_PHOTO_KIND,
         url: "http://[::1]/logo.png",
+      }),
+    ).rejects.toThrow("Image URL host is not allowed");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.uploadObject).not.toHaveBeenCalled();
+  });
+
+  it("rejects IPv6 documentation-range URLs before fetching", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      uploadImageFromUrl({
+        kind: PERSON_PHOTO_KIND,
+        url: "http://[2001:db8::1]/logo.png",
       }),
     ).rejects.toThrow("Image URL host is not allowed");
 
@@ -116,7 +138,7 @@ describe("uploadImageFromUrl", () => {
 
     await expect(
       uploadImageFromUrl({
-        kind: "organization-wordmark-logo",
+        kind: ORG_WORDMARK_LOGO_KIND,
         url: "https://images.example.org/logo.png",
       }),
     ).rejects.toThrow("Image URL host is not allowed");
@@ -138,10 +160,47 @@ describe("uploadImageFromUrl", () => {
 
     await expect(
       uploadImageFromUrl({
-        kind: "organization-square-logo",
+        kind: ORG_SQUARE_LOGO_KIND,
         url: "https://example.org/logo",
       }),
     ).rejects.toThrow("Remote URL must return a supported image type");
+
+    expect(mocks.uploadObject).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-OK HTTP responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(null, {
+          headers: { "content-type": "image/png" },
+          status: 404,
+        }),
+      ),
+    );
+
+    await expect(
+      uploadImageFromUrl({
+        kind: ORG_SQUARE_LOGO_KIND,
+        url: "https://example.org/missing-logo.png",
+      }),
+    ).rejects.toThrow("Image URL returned HTTP 404");
+
+    expect(mocks.uploadObject).not.toHaveBeenCalled();
+  });
+
+  it("propagates fetch network errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new TypeError("network error")),
+    );
+
+    await expect(
+      uploadImageFromUrl({
+        kind: ORG_SQUARE_LOGO_KIND,
+        url: "https://example.org/logo.png",
+      }),
+    ).rejects.toThrow("network error");
 
     expect(mocks.uploadObject).not.toHaveBeenCalled();
   });

--- a/packages/web/src/lib/__tests__/image-upload-from-url.server.test.ts
+++ b/packages/web/src/lib/__tests__/image-upload-from-url.server.test.ts
@@ -1,3 +1,6 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage } from "node:http";
+import { Readable } from "node:stream";
 import sharp from "sharp";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ImageUploadKind } from "../image-upload-types";
@@ -9,6 +12,8 @@ const ORG_WORDMARK_LOGO_KIND =
 const PERSON_PHOTO_KIND = "person-photo" satisfies ImageUploadKind;
 
 const mocks = vi.hoisted(() => ({
+  httpRequest: vi.fn(),
+  httpsRequest: vi.fn(),
   lookup: vi.fn(),
   uploadObject: vi.fn(),
 }));
@@ -17,6 +22,23 @@ vi.mock("node:dns/promises", () => ({
   lookup: mocks.lookup,
 }));
 
+vi.mock("node:http", async () => {
+  const actual = await vi.importActual<typeof import("node:http")>("node:http");
+  return {
+    ...actual,
+    request: mocks.httpRequest,
+  };
+});
+
+vi.mock("node:https", async () => {
+  const actual =
+    await vi.importActual<typeof import("node:https")>("node:https");
+  return {
+    ...actual,
+    request: mocks.httpsRequest,
+  };
+});
+
 vi.mock("../object-storage.server", () => ({
   uploadObject: mocks.uploadObject,
 }));
@@ -24,9 +46,10 @@ vi.mock("../object-storage.server", () => ({
 import { uploadImageFromUrl } from "../image-upload-from-url.server";
 
 beforeEach(() => {
+  mocks.httpRequest.mockReset();
+  mocks.httpsRequest.mockReset();
   mocks.lookup.mockReset();
   mocks.uploadObject.mockReset();
-  vi.unstubAllGlobals();
   mocks.lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
   mocks.uploadObject.mockResolvedValue({
     publicUrl: "https://assets.example.org/organizations/logos/logo.webp",
@@ -46,20 +69,63 @@ async function tinyPng() {
     .toBuffer();
 }
 
+function responseFromBody(
+  body: Buffer | string | null,
+  {
+    headers = {},
+    status = 200,
+  }: { headers?: Record<string, string>; status?: number } = {},
+) {
+  const stream = Readable.from(body === null ? [] : [body]) as IncomingMessage;
+  stream.statusCode = status;
+  stream.headers = headers;
+  return stream;
+}
+
+type StubRequest = EventEmitter & {
+  destroy(error?: Error): void;
+  end(): void;
+  setTimeout(timeout: number, callback: () => void): void;
+};
+
+function requestStub(onEnd: (request: StubRequest) => void) {
+  const request = new EventEmitter() as StubRequest;
+  request.destroy = (error?: Error) => {
+    if (error) request.emit("error", error);
+  };
+  request.end = () => {
+    onEnd(request);
+  };
+  request.setTimeout = () => undefined;
+  return request;
+}
+
+function mockHttpsResponse(response: IncomingMessage) {
+  mocks.httpsRequest.mockImplementationOnce((_options, responseHandler) =>
+    requestStub(() => {
+      responseHandler(response);
+    }),
+  );
+}
+
+function mockHttpsError(error: Error) {
+  mocks.httpsRequest.mockImplementationOnce(() =>
+    requestStub((request) => {
+      request.emit("error", error);
+    }),
+  );
+}
+
 describe("uploadImageFromUrl", () => {
   it("fetches, normalizes, and uploads public organization images", async () => {
     const image = await tinyPng();
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        new Response(image, {
-          headers: {
-            "content-length": String(image.byteLength),
-            "content-type": "image/png",
-          },
-          status: 200,
-        }),
-      ),
+    mockHttpsResponse(
+      responseFromBody(image, {
+        headers: {
+          "content-length": String(image.byteLength),
+          "content-type": "image/png",
+        },
+      }),
     );
 
     const result = await uploadImageFromUrl({
@@ -78,6 +144,18 @@ describe("uploadImageFromUrl", () => {
       sourceUrl: "https://example.org/assets/logo.png",
     });
     expect(mocks.lookup).toHaveBeenCalledWith("example.org", { all: true });
+    expect(mocks.httpsRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: "image/webp,image/png,image/jpeg,image/gif,*/*;q=0.8",
+          Host: "example.org",
+        }),
+        hostname: "93.184.216.34",
+        path: "/assets/logo.png",
+        servername: "example.org",
+      }),
+      expect.any(Function),
+    );
     expect(mocks.uploadObject).toHaveBeenCalledWith(
       expect.objectContaining({
         contentType: "image/webp",
@@ -87,9 +165,6 @@ describe("uploadImageFromUrl", () => {
   });
 
   it("rejects local/private hosts before fetching", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-
     await expect(
       uploadImageFromUrl({
         kind: ORG_SQUARE_LOGO_KIND,
@@ -97,14 +172,12 @@ describe("uploadImageFromUrl", () => {
       }),
     ).rejects.toThrow("Image URL host is not allowed");
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.httpRequest).not.toHaveBeenCalled();
+    expect(mocks.httpsRequest).not.toHaveBeenCalled();
     expect(mocks.uploadObject).not.toHaveBeenCalled();
   });
 
   it("rejects bracketed IPv6 loopback URLs before fetching", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-
     await expect(
       uploadImageFromUrl({
         kind: PERSON_PHOTO_KIND,
@@ -112,14 +185,12 @@ describe("uploadImageFromUrl", () => {
       }),
     ).rejects.toThrow("Image URL host is not allowed");
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.httpRequest).not.toHaveBeenCalled();
+    expect(mocks.httpsRequest).not.toHaveBeenCalled();
     expect(mocks.uploadObject).not.toHaveBeenCalled();
   });
 
   it("rejects IPv6 documentation-range URLs before fetching", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-
     await expect(
       uploadImageFromUrl({
         kind: PERSON_PHOTO_KIND,
@@ -127,13 +198,12 @@ describe("uploadImageFromUrl", () => {
       }),
     ).rejects.toThrow("Image URL host is not allowed");
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.httpRequest).not.toHaveBeenCalled();
+    expect(mocks.httpsRequest).not.toHaveBeenCalled();
     expect(mocks.uploadObject).not.toHaveBeenCalled();
   });
 
   it("rejects hostnames that resolve to private addresses", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
     mocks.lookup.mockResolvedValueOnce([{ address: "10.0.0.4", family: 4 }]);
 
     await expect(
@@ -143,19 +213,16 @@ describe("uploadImageFromUrl", () => {
       }),
     ).rejects.toThrow("Image URL host is not allowed");
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.httpRequest).not.toHaveBeenCalled();
+    expect(mocks.httpsRequest).not.toHaveBeenCalled();
     expect(mocks.uploadObject).not.toHaveBeenCalled();
   });
 
   it("rejects non-image responses", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        new Response("hello", {
-          headers: { "content-type": "text/html" },
-          status: 200,
-        }),
-      ),
+    mockHttpsResponse(
+      responseFromBody("hello", {
+        headers: { "content-type": "text/html" },
+      }),
     );
 
     await expect(
@@ -169,14 +236,11 @@ describe("uploadImageFromUrl", () => {
   });
 
   it("rejects non-OK HTTP responses", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        new Response(null, {
-          headers: { "content-type": "image/png" },
-          status: 404,
-        }),
-      ),
+    mockHttpsResponse(
+      responseFromBody(null, {
+        headers: { "content-type": "image/png" },
+        status: 404,
+      }),
     );
 
     await expect(
@@ -189,11 +253,8 @@ describe("uploadImageFromUrl", () => {
     expect(mocks.uploadObject).not.toHaveBeenCalled();
   });
 
-  it("propagates fetch network errors", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockRejectedValue(new TypeError("network error")),
-    );
+  it("propagates request network errors", async () => {
+    mockHttpsError(new TypeError("network error"));
 
     await expect(
       uploadImageFromUrl({

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -53,6 +53,7 @@ const mocks = vi.hoisted(() => ({
   getProfileIdentityData: vi.fn(),
   updateUserProfile: vi.fn(),
   createOrganizationWithOwner: vi.fn(),
+  uploadImageFromUrl: vi.fn(),
   updateOrganizationServer: vi.fn(),
   addOrganizationMember: vi.fn(),
   removeOrganizationMember: vi.fn(),
@@ -205,6 +206,10 @@ vi.mock("../organization.server", () => ({
   isOrganizationMemberRole: (value: string) => VALID_MEMBER_ROLES.has(value),
   ForbiddenError,
   LastOwnerError,
+}));
+
+vi.mock("../image-upload-from-url.server", () => ({
+  uploadImageFromUrl: mocks.uploadImageFromUrl,
 }));
 
 vi.mock("../prisma", () => ({
@@ -571,6 +576,7 @@ describe("MCP server tool dispatch", () => {
     expect(writerNames).toEqual(
       expect.arrayContaining([
         "createOrganization",
+        "uploadImageFromUrl",
         "upsertMemorialPerson",
         "addMemorialEvidence",
         "recordInterventionExperience",
@@ -707,6 +713,49 @@ describe("MCP server tool dispatch", () => {
     expect(parseToolBody(result)).toEqual({
       error: "Organization name already exists: Open Philanthropy",
     });
+  });
+
+  it("uploadImageFromUrl imports a remote organization logo through MCP", async () => {
+    mocks.uploadImageFromUrl.mockResolvedValueOnce({
+      contentType: "image/webp",
+      key: "organizations/logos/2026-05-07/logo.webp",
+      publicUrl: "https://assets.example.org/organizations/logos/logo.webp",
+      sizeBytes: 1234,
+      sourceUrl: "https://example.org/logo.png",
+    });
+    const client = await setup("user-1", [McpScope.EARTHDATA_WRITE]);
+
+    const result = await client.callTool({
+      name: "uploadImageFromUrl",
+      arguments: {
+        filename: "institute-logo.png",
+        kind: "organization-square-logo",
+        url: "https://example.org/logo.png",
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mocks.uploadImageFromUrl).toHaveBeenCalledWith({
+      filename: "institute-logo.png",
+      kind: "organization-square-logo",
+      url: "https://example.org/logo.png",
+    });
+    expect(parseToolBody(result)).toEqual({
+      contentType: "image/webp",
+      key: "organizations/logos/2026-05-07/logo.webp",
+      publicUrl: "https://assets.example.org/organizations/logos/logo.webp",
+      sizeBytes: 1234,
+      sourceUrl: "https://example.org/logo.png",
+    });
+    expect(mocks.mcpToolCallAuditCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: "SUCCEEDED",
+          toolName: "uploadImageFromUrl",
+          userId: "user-1",
+        }),
+      }),
+    );
   });
 
   it("audits successful Earth-data MCP writes without storing raw payloads", async () => {

--- a/packages/web/src/lib/image-upload-from-url.server.ts
+++ b/packages/web/src/lib/image-upload-from-url.server.ts
@@ -1,4 +1,7 @@
 import { lookup } from "node:dns/promises";
+import * as http from "node:http";
+import type { IncomingHttpHeaders, IncomingMessage } from "node:http";
+import * as https from "node:https";
 import net from "node:net";
 import {
   buildImageUploadKey,
@@ -52,11 +55,14 @@ function extensionForContentType(contentType: string) {
 }
 
 function filenameFromUrl(url: URL, contentType: string) {
-  const pathnameName = decodeURIComponent(
-    url.pathname.split("/").filter(Boolean).pop() ?? "",
-  )
-    .replace(/[?#].*$/, "")
-    .trim();
+  const rawName = url.pathname.split("/").filter(Boolean).pop() ?? "";
+  let decodedName = rawName;
+  try {
+    decodedName = decodeURIComponent(rawName);
+  } catch {
+    decodedName = rawName;
+  }
+  const pathnameName = decodedName.replace(/[?#].*$/, "").trim();
   if (/\.[a-z0-9]{2,5}$/i.test(pathnameName)) return pathnameName;
   return `remote-image.${extensionForContentType(contentType)}`;
 }
@@ -118,7 +124,14 @@ function isPrivateIp(address: string) {
   return false;
 }
 
-async function assertPublicImageUrl(url: URL) {
+interface PublicImageTarget {
+  address: string;
+  family?: number;
+  hostHeader: string;
+  servername?: string;
+}
+
+async function assertPublicImageUrl(url: URL): Promise<PublicImageTarget> {
   const hostname = validationHostname(url.hostname);
   if (url.protocol !== "http:" && url.protocol !== "https:") {
     throw new Error("Image URL must use http or https.");
@@ -134,7 +147,11 @@ async function assertPublicImageUrl(url: URL) {
     if (isPrivateIp(hostname)) {
       throw new Error("Image URL host is not allowed.");
     }
-    return;
+    return {
+      address: hostname,
+      family: net.isIP(hostname),
+      hostHeader: url.host,
+    };
   }
 
   const addresses = await lookup(hostname, { all: true });
@@ -144,10 +161,57 @@ async function assertPublicImageUrl(url: URL) {
   ) {
     throw new Error("Image URL host is not allowed.");
   }
+  const target = addresses[0];
+  return {
+    address: target.address,
+    family: target.family,
+    hostHeader: url.host,
+    servername: hostname,
+  };
+}
+
+function headerValue(headers: IncomingHttpHeaders, name: string) {
+  const value = headers[name.toLowerCase()];
+  if (Array.isArray(value)) return value[0] ?? null;
+  return typeof value === "string" ? value : null;
+}
+
+function requestPinnedUrl(
+  url: URL,
+  target: PublicImageTarget,
+): Promise<IncomingMessage> {
+  const isHttps = url.protocol === "https:";
+  const commonOptions: http.RequestOptions = {
+    family: target.family,
+    headers: {
+      Accept: "image/webp,image/png,image/jpeg,image/gif,*/*;q=0.8",
+      Host: target.hostHeader,
+      "User-Agent": "Optimitron image importer",
+    },
+    hostname: target.address,
+    method: "GET",
+    path: `${url.pathname}${url.search}`,
+    port: url.port ? Number(url.port) : isHttps ? 443 : 80,
+    protocol: url.protocol,
+  };
+
+  return new Promise((resolve, reject) => {
+    const request = isHttps
+      ? https.request(
+          { ...commonOptions, servername: target.servername },
+          resolve,
+        )
+      : http.request(commonOptions, resolve);
+    request.setTimeout(FETCH_TIMEOUT_MS, () => {
+      request.destroy(new Error("Image URL request timed out."));
+    });
+    request.on("error", reject);
+    request.end();
+  });
 }
 
 async function fetchWithRedirects(startUrl: URL): Promise<{
-  response: Response;
+  response: IncomingMessage;
   sourceUrl: URL;
 }> {
   let currentUrl = startUrl;
@@ -156,31 +220,14 @@ async function fetchWithRedirects(startUrl: URL): Promise<{
     redirectCount <= MAX_REDIRECTS;
     redirectCount += 1
   ) {
-    await assertPublicImageUrl(currentUrl);
+    const target = await assertPublicImageUrl(currentUrl);
+    const response = await requestPinnedUrl(currentUrl, target);
+    const status = response.statusCode ?? 0;
+    const location = headerValue(response.headers, "location");
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-    let response: Response;
-    try {
-      response = await fetch(currentUrl, {
-        headers: {
-          Accept:
-            "image/avif,image/webp,image/png,image/jpeg,image/gif,*/*;q=0.8",
-          "User-Agent": "Optimitron image importer",
-        },
-        redirect: "manual",
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeout);
-    }
-
-    if (
-      response.status >= 300 &&
-      response.status < 400 &&
-      response.headers.has("location")
-    ) {
-      currentUrl = new URL(response.headers.get("location") ?? "", currentUrl);
+    if (status >= 300 && status < 400 && location) {
+      response.resume();
+      currentUrl = new URL(location, currentUrl);
       continue;
     }
 
@@ -190,40 +237,48 @@ async function fetchWithRedirects(startUrl: URL): Promise<{
   throw new Error("Image URL redirected too many times.");
 }
 
-async function readResponseBuffer(response: Response, maxBytes: number) {
-  const contentLength = Number(response.headers.get("content-length") ?? 0);
+async function readResponseBuffer(
+  response: IncomingMessage,
+  maxBytes: number,
+) {
+  const contentLength = Number(
+    headerValue(response.headers, "content-length") ?? 0,
+  );
   if (Number.isFinite(contentLength) && contentLength > maxBytes) {
     throw new Error(
       `Image must be ${Math.round(maxBytes / 1024 / 1024)} MB or smaller.`,
     );
   }
 
-  const reader = response.body?.getReader();
-  if (!reader) {
-    const buffer = Buffer.from(await response.arrayBuffer());
-    if (buffer.byteLength > maxBytes) {
-      throw new Error(
-        `Image must be ${Math.round(maxBytes / 1024 / 1024)} MB or smaller.`,
-      );
-    }
-    return buffer;
-  }
+  return new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    let sizeError: Error | null = null;
+    const timeout = setTimeout(() => {
+      response.destroy(new Error("Image URL response timed out."));
+    }, FETCH_TIMEOUT_MS);
 
-  const chunks: Buffer[] = [];
-  let totalBytes = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    const chunk = Buffer.from(value);
-    totalBytes += chunk.byteLength;
-    if (totalBytes > maxBytes) {
-      throw new Error(
-        `Image must be ${Math.round(maxBytes / 1024 / 1024)} MB or smaller.`,
-      );
-    }
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks);
+    response.on("data", (value: Buffer | string) => {
+      const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+      totalBytes += chunk.byteLength;
+      if (totalBytes > maxBytes) {
+        sizeError = new Error(
+          `Image must be ${Math.round(maxBytes / 1024 / 1024)} MB or smaller.`,
+        );
+        response.destroy(sizeError);
+        return;
+      }
+      chunks.push(chunk);
+    });
+    response.on("end", () => {
+      clearTimeout(timeout);
+      resolve(Buffer.concat(chunks));
+    });
+    response.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(sizeError ?? error);
+    });
+  });
 }
 
 export async function uploadImageFromUrl({
@@ -239,14 +294,17 @@ export async function uploadImageFromUrl({
   }
 
   const { response, sourceUrl } = await fetchWithRedirects(parsedUrl);
-  if (!response.ok) {
-    throw new Error(`Image URL returned HTTP ${response.status}.`);
+  const status = response.statusCode ?? 0;
+  if (status < 200 || status >= 300) {
+    response.resume();
+    throw new Error(`Image URL returned HTTP ${status}.`);
   }
 
   const remoteContentType = contentTypeBase(
-    response.headers.get("content-type"),
+    headerValue(response.headers, "content-type"),
   );
   if (!ALLOWED_REMOTE_IMAGE_TYPES.has(remoteContentType)) {
+    response.resume();
     throw new Error("Remote URL must return a supported image type.");
   }
 

--- a/packages/web/src/lib/image-upload-from-url.server.ts
+++ b/packages/web/src/lib/image-upload-from-url.server.ts
@@ -1,0 +1,274 @@
+import { lookup } from "node:dns/promises";
+import net from "node:net";
+import {
+  buildImageUploadKey,
+  getImageUploadMaxInputBytes,
+  normalizeImageUpload,
+} from "@/lib/image-upload.server";
+import type { ImageUploadKind } from "@/lib/image-upload-types";
+import { uploadObject } from "@/lib/object-storage.server";
+
+const ALLOWED_REMOTE_IMAGE_TYPES = new Set([
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+const MAX_REDIRECTS = 3;
+const FETCH_TIMEOUT_MS = 10_000;
+
+export interface UploadImageFromUrlInput {
+  filename?: string | null;
+  kind: ImageUploadKind;
+  url: string;
+}
+
+export interface UploadImageFromUrlResult {
+  contentType: string;
+  key: string;
+  publicUrl: string;
+  sizeBytes: number;
+  sourceUrl: string;
+}
+
+function contentTypeBase(contentType: string | null) {
+  return contentType?.split(";")[0]?.trim().toLowerCase() ?? "";
+}
+
+function extensionForContentType(contentType: string) {
+  switch (contentType) {
+    case "image/gif":
+      return "gif";
+    case "image/jpeg":
+      return "jpg";
+    case "image/png":
+      return "png";
+    case "image/webp":
+      return "webp";
+    default:
+      return "img";
+  }
+}
+
+function filenameFromUrl(url: URL, contentType: string) {
+  const pathnameName = decodeURIComponent(
+    url.pathname.split("/").filter(Boolean).pop() ?? "",
+  )
+    .replace(/[?#].*$/, "")
+    .trim();
+  if (/\.[a-z0-9]{2,5}$/i.test(pathnameName)) return pathnameName;
+  return `remote-image.${extensionForContentType(contentType)}`;
+}
+
+function isBlockedHostname(hostname: string) {
+  const lower = hostname.toLowerCase();
+  return (
+    lower === "localhost" ||
+    lower === "0.0.0.0" ||
+    lower.endsWith(".localhost") ||
+    lower.endsWith(".local") ||
+    lower.endsWith(".internal")
+  );
+}
+
+function validationHostname(hostname: string) {
+  return hostname.startsWith("[") && hostname.endsWith("]")
+    ? hostname.slice(1, -1)
+    : hostname;
+}
+
+function isPrivateIp(address: string) {
+  const ipVersion = net.isIP(address);
+  if (ipVersion === 4) {
+    const [a = 0, b = 0, c = 0] = address
+      .split(".")
+      .map((part) => Number(part));
+    return (
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 0) ||
+      (a === 192 && b === 168) ||
+      (a === 198 && (b === 18 || b === 19)) ||
+      (a === 198 && b === 51 && c === 100) ||
+      (a === 203 && b === 0 && c === 113) ||
+      a >= 224
+    );
+  }
+  if (ipVersion === 6) {
+    const lower = address.toLowerCase();
+    if (lower.startsWith("::ffff:")) {
+      return isPrivateIp(lower.slice("::ffff:".length));
+    }
+    return (
+      lower === "::" ||
+      lower === "::1" ||
+      lower.startsWith("fc") ||
+      lower.startsWith("fd") ||
+      /^fe[89ab]/.test(lower) ||
+      lower.startsWith("ff")
+    );
+  }
+  return false;
+}
+
+async function assertPublicImageUrl(url: URL) {
+  const hostname = validationHostname(url.hostname);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Image URL must use http or https.");
+  }
+  if (url.username || url.password) {
+    throw new Error("Image URL must not include credentials.");
+  }
+  if (isBlockedHostname(hostname)) {
+    throw new Error("Image URL host is not allowed.");
+  }
+
+  if (net.isIP(hostname)) {
+    if (isPrivateIp(hostname)) {
+      throw new Error("Image URL host is not allowed.");
+    }
+    return;
+  }
+
+  const addresses = await lookup(hostname, { all: true });
+  if (
+    addresses.length === 0 ||
+    addresses.some((item) => isPrivateIp(item.address))
+  ) {
+    throw new Error("Image URL host is not allowed.");
+  }
+}
+
+async function fetchWithRedirects(startUrl: URL): Promise<{
+  response: Response;
+  sourceUrl: URL;
+}> {
+  let currentUrl = startUrl;
+  for (
+    let redirectCount = 0;
+    redirectCount <= MAX_REDIRECTS;
+    redirectCount += 1
+  ) {
+    await assertPublicImageUrl(currentUrl);
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    let response: Response;
+    try {
+      response = await fetch(currentUrl, {
+        headers: {
+          Accept:
+            "image/avif,image/webp,image/png,image/jpeg,image/gif,*/*;q=0.8",
+          "User-Agent": "Optimitron image importer",
+        },
+        redirect: "manual",
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (
+      response.status >= 300 &&
+      response.status < 400 &&
+      response.headers.has("location")
+    ) {
+      currentUrl = new URL(response.headers.get("location") ?? "", currentUrl);
+      continue;
+    }
+
+    return { response, sourceUrl: currentUrl };
+  }
+
+  throw new Error("Image URL redirected too many times.");
+}
+
+async function readResponseBuffer(response: Response, maxBytes: number) {
+  const contentLength = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new Error(
+      `Image must be ${Math.round(maxBytes / 1024 / 1024)} MB or smaller.`,
+    );
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > maxBytes) {
+      throw new Error(
+        `Image must be ${Math.round(maxBytes / 1024 / 1024)} MB or smaller.`,
+      );
+    }
+    return buffer;
+  }
+
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    const chunk = Buffer.from(value);
+    totalBytes += chunk.byteLength;
+    if (totalBytes > maxBytes) {
+      throw new Error(
+        `Image must be ${Math.round(maxBytes / 1024 / 1024)} MB or smaller.`,
+      );
+    }
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+export async function uploadImageFromUrl({
+  filename,
+  kind,
+  url,
+}: UploadImageFromUrlInput): Promise<UploadImageFromUrlResult> {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    throw new Error("Image URL is invalid.");
+  }
+
+  const { response, sourceUrl } = await fetchWithRedirects(parsedUrl);
+  if (!response.ok) {
+    throw new Error(`Image URL returned HTTP ${response.status}.`);
+  }
+
+  const remoteContentType = contentTypeBase(
+    response.headers.get("content-type"),
+  );
+  if (!ALLOWED_REMOTE_IMAGE_TYPES.has(remoteContentType)) {
+    throw new Error("Remote URL must return a supported image type.");
+  }
+
+  const maxBytes = getImageUploadMaxInputBytes(kind);
+  const source = await readResponseBuffer(response, maxBytes);
+  const sourceFile = new File(
+    [source],
+    filename?.trim() || filenameFromUrl(sourceUrl, remoteContentType),
+    { type: remoteContentType },
+  );
+  const normalized = await normalizeImageUpload(sourceFile, { kind });
+  const key = buildImageUploadKey({ filename: normalized.filename, kind });
+  const uploaded = await uploadObject({
+    body: normalized.buffer,
+    contentLength: normalized.buffer.byteLength,
+    contentType: normalized.contentType,
+    key,
+  });
+
+  return {
+    contentType: normalized.contentType,
+    key,
+    publicUrl: uploaded.publicUrl,
+    sizeBytes: normalized.buffer.byteLength,
+    sourceUrl: sourceUrl.toString(),
+  };
+}

--- a/packages/web/src/lib/image-upload-from-url.server.ts
+++ b/packages/web/src/lib/image-upload-from-url.server.ts
@@ -109,6 +109,8 @@ function isPrivateIp(address: string) {
       lower === "::1" ||
       lower.startsWith("fc") ||
       lower.startsWith("fd") ||
+      lower.startsWith("2001:db8") ||
+      lower.startsWith("2001:0db8") ||
       /^fe[89ab]/.test(lower) ||
       lower.startsWith("ff")
     );

--- a/packages/web/src/lib/image-upload-types.ts
+++ b/packages/web/src/lib/image-upload-types.ts
@@ -1,5 +1,15 @@
-export type ImageUploadKind =
-  | "memorial-evidence-image"
-  | "organization-square-logo"
-  | "organization-wordmark-logo"
-  | "person-photo";
+export const IMAGE_UPLOAD_KINDS = [
+  "memorial-evidence-image",
+  "organization-square-logo",
+  "organization-wordmark-logo",
+  "person-photo",
+] as const;
+
+export type ImageUploadKind = (typeof IMAGE_UPLOAD_KINDS)[number];
+
+export function isImageUploadKind(value: unknown): value is ImageUploadKind {
+  return (
+    typeof value === "string" &&
+    (IMAGE_UPLOAD_KINDS as readonly string[]).includes(value)
+  );
+}

--- a/packages/web/src/lib/image-upload.server.ts
+++ b/packages/web/src/lib/image-upload.server.ts
@@ -96,6 +96,10 @@ export function buildImageUploadKey(input: {
   )}.${config.outputExtension}`;
 }
 
+export function getImageUploadMaxInputBytes(kind: ImageUploadKind) {
+  return KIND_CONFIG[kind].maxInputBytes;
+}
+
 export async function normalizeImageUpload(
   file: File,
   { kind }: NormalizeImageUploadInput,

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -49,18 +49,26 @@ import {
   isTaskTriggerToolName,
 } from "./mcp-tools/task-triggers";
 import { slugify } from "./slugify";
+import {
+  IMAGE_UPLOAD_KINDS,
+  isImageUploadKind,
+} from "./image-upload-types";
 import type {
   RankableTask,
   TaskPriorityInput,
   TaskPriorityResult,
 } from "./tasks/rank-tasks";
-import type { ImageUploadKind } from "./image-upload-types";
 
 export { MCP_SCOPE_DESCRIPTIONS, DEFAULT_SCOPES, ALL_SCOPES, McpScope };
 
+const UPLOAD_IMAGE_FROM_URL_TOOL_NAME = "uploadImageFromUrl" as const;
+
 const TOOL_SCOPES: Record<string, McpScope[]> = {
   createOrganization: [McpScope.EARTHDATA_WRITE, McpScope.TASKS_ADMIN],
-  uploadImageFromUrl: [McpScope.EARTHDATA_WRITE, McpScope.TASKS_ADMIN],
+  [UPLOAD_IMAGE_FROM_URL_TOOL_NAME]: [
+    McpScope.EARTHDATA_WRITE,
+    McpScope.TASKS_ADMIN,
+  ],
   createTask: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
   proposeTaskBundle: [McpScope.TASKS_ADMIN],
   promoteTask: [McpScope.TASKS_ADMIN],
@@ -258,7 +266,7 @@ function getMcpBaseUrl(): string {
 
 const AUDITED_EARTH_DATA_TOOLS = new Set([
   "createOrganization",
-  "uploadImageFromUrl",
+  UPLOAD_IMAGE_FROM_URL_TOOL_NAME,
   "upsertOrganization",
   "updateOrganization",
   "deleteOrganization",
@@ -3653,7 +3661,7 @@ const TASK_TOOL_DEFINITIONS = [
     },
   },
   {
-    name: "uploadImageFromUrl",
+    name: UPLOAD_IMAGE_FROM_URL_TOOL_NAME,
     description:
       "Fetch a public image URL, normalize it through the same image pipeline used by the web app, upload it to object storage, and return the canonical public URL. Use this before createOrganization/updateOrganization when you have a remote square logo, wordmark, or person photo URL.",
     inputSchema: {
@@ -3666,12 +3674,7 @@ const TASK_TOOL_DEFINITIONS = [
         },
         kind: {
           type: "string",
-          enum: [
-            "memorial-evidence-image",
-            "organization-square-logo",
-            "organization-wordmark-logo",
-            "person-photo",
-          ],
+          enum: [...IMAGE_UPLOAD_KINDS],
           description:
             "Upload target. Organization logos usually use organization-square-logo and organization-wordmark-logo.",
         },
@@ -7401,7 +7404,7 @@ export function createMcpServer(
             }
           }
 
-          case "uploadImageFromUrl": {
+          case UPLOAD_IMAGE_FROM_URL_TOOL_NAME: {
             if (!userId)
               return authRequired(
                 name,
@@ -7410,16 +7413,9 @@ export function createMcpServer(
             if (typeof a.url !== "string" || !a.url.trim()) {
               return err("url is required");
             }
-            if (typeof a.kind !== "string") {
-              return err("kind is required");
-            }
-            const allowedKinds = new Set<ImageUploadKind>([
-              "memorial-evidence-image",
-              "organization-square-logo",
-              "organization-wordmark-logo",
-              "person-photo",
-            ]);
-            if (!allowedKinds.has(a.kind as ImageUploadKind)) {
+            const url = a.url.trim();
+            const kind = a.kind;
+            if (!isImageUploadKind(kind)) {
               return err(
                 "kind must be one of: memorial-evidence-image, organization-square-logo, organization-wordmark-logo, person-photo",
               );
@@ -7444,8 +7440,8 @@ export function createMcpServer(
                   uploadImageFromUrl({
                     filename:
                       typeof a.filename === "string" ? a.filename : null,
-                    kind: a.kind as ImageUploadKind,
-                    url: a.url as string,
+                    kind,
+                    url,
                   }),
               );
             } catch (error) {

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -54,11 +54,13 @@ import type {
   TaskPriorityInput,
   TaskPriorityResult,
 } from "./tasks/rank-tasks";
+import type { ImageUploadKind } from "./image-upload-types";
 
 export { MCP_SCOPE_DESCRIPTIONS, DEFAULT_SCOPES, ALL_SCOPES, McpScope };
 
 const TOOL_SCOPES: Record<string, McpScope[]> = {
   createOrganization: [McpScope.EARTHDATA_WRITE, McpScope.TASKS_ADMIN],
+  uploadImageFromUrl: [McpScope.EARTHDATA_WRITE, McpScope.TASKS_ADMIN],
   createTask: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
   proposeTaskBundle: [McpScope.TASKS_ADMIN],
   promoteTask: [McpScope.TASKS_ADMIN],
@@ -256,6 +258,7 @@ function getMcpBaseUrl(): string {
 
 const AUDITED_EARTH_DATA_TOOLS = new Set([
   "createOrganization",
+  "uploadImageFromUrl",
   "upsertOrganization",
   "updateOrganization",
   "deleteOrganization",
@@ -2162,8 +2165,16 @@ const EARTH_DATA_TOOL_DEFINITIONS = [
         website: { type: "string" },
         description: { type: "string" },
         donationUrl: { type: "string" },
-        squareLogoUrl: { type: "string" },
-        wordmarkLogoUrl: { type: "string" },
+        squareLogoUrl: {
+          type: "string",
+          description:
+            "Square logo mark URL. Use uploadImageFromUrl with kind=organization-square-logo first when starting from a remote public image URL.",
+        },
+        wordmarkLogoUrl: {
+          type: "string",
+          description:
+            "Horizontal wordmark logo URL. Use uploadImageFromUrl with kind=organization-wordmark-logo first when starting from a remote public image URL.",
+        },
         contactEmail: { type: "string" },
         referendumSlug: { type: "string" },
         position: { type: "string", enum: ["YES", "NO", "ABSTAIN"] },
@@ -3561,7 +3572,11 @@ const TASK_TOOL_DEFINITIONS = [
           description: "Current organization/affiliation.",
         },
         countryCode: { type: "string", description: "ISO-3166 country code." },
-        image: { type: "string", description: "Avatar image URL." },
+        image: {
+          type: "string",
+          description:
+            "Avatar image URL. Use uploadImageFromUrl with kind=person-photo first when starting from a remote public image URL.",
+        },
         isPublicFigure: {
           type: "boolean",
           description: "Marks this person as a public-facing profile.",
@@ -3638,6 +3653,38 @@ const TASK_TOOL_DEFINITIONS = [
     },
   },
   {
+    name: "uploadImageFromUrl",
+    description:
+      "Fetch a public image URL, normalize it through the same image pipeline used by the web app, upload it to object storage, and return the canonical public URL. Use this before createOrganization/updateOrganization when you have a remote square logo, wordmark, or person photo URL.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        url: {
+          type: "string",
+          description:
+            "Public http(s) image URL. Local/private network hosts are rejected.",
+        },
+        kind: {
+          type: "string",
+          enum: [
+            "memorial-evidence-image",
+            "organization-square-logo",
+            "organization-wordmark-logo",
+            "person-photo",
+          ],
+          description:
+            "Upload target. Organization logos usually use organization-square-logo and organization-wordmark-logo.",
+        },
+        filename: {
+          type: "string",
+          description:
+            "Optional filename to use before normalization. Defaults to the URL path filename.",
+        },
+      },
+      required: ["url", "kind"],
+    },
+  },
+  {
     name: "createOrganization",
     description:
       "Create an approved organization for task assignment. Uses post-moderation: create now, reject later if needed.",
@@ -3688,11 +3735,13 @@ const TASK_TOOL_DEFINITIONS = [
         },
         squareLogoUrl: {
           type: "string",
-          description: "Square logo mark URL",
+          description:
+            "Square logo mark URL. Use uploadImageFromUrl with kind=organization-square-logo first when starting from a remote public image URL.",
         },
         wordmarkLogoUrl: {
           type: "string",
-          description: "Horizontal wordmark logo URL",
+          description:
+            "Horizontal wordmark logo URL. Use uploadImageFromUrl with kind=organization-wordmark-logo first when starting from a remote public image URL.",
         },
         jurisdictionId: {
           type: "string",
@@ -3983,11 +4032,13 @@ const TASK_TOOL_DEFINITIONS = [
         },
         squareLogoUrl: {
           type: "string",
-          description: "Square logo mark URL",
+          description:
+            "Square logo mark URL. Use uploadImageFromUrl with kind=organization-square-logo first when starting from a remote public image URL.",
         },
         wordmarkLogoUrl: {
           type: "string",
-          description: "Horizontal wordmark logo URL",
+          description:
+            "Horizontal wordmark logo URL. Use uploadImageFromUrl with kind=organization-wordmark-logo first when starting from a remote public image URL.",
         },
         sourceRef: {
           type: "string",
@@ -4058,11 +4109,13 @@ const TASK_TOOL_DEFINITIONS = [
         },
         squareLogoUrl: {
           type: "string",
-          description: "Square logo mark URL (empty string clears)",
+          description:
+            "Square logo mark URL (empty string clears). Use uploadImageFromUrl with kind=organization-square-logo first when starting from a remote public image URL.",
         },
         wordmarkLogoUrl: {
           type: "string",
-          description: "Horizontal wordmark logo URL (empty string clears)",
+          description:
+            "Horizontal wordmark logo URL (empty string clears). Use uploadImageFromUrl with kind=organization-wordmark-logo first when starting from a remote public image URL.",
         },
         contactEmail: {
           type: "string",
@@ -7345,6 +7398,59 @@ export function createMcpServer(
                 return err(e.message);
               }
               throw e;
+            }
+          }
+
+          case "uploadImageFromUrl": {
+            if (!userId)
+              return authRequired(
+                name,
+                "This tool uploads an image into the site media bucket.",
+              );
+            if (typeof a.url !== "string" || !a.url.trim()) {
+              return err("url is required");
+            }
+            if (typeof a.kind !== "string") {
+              return err("kind is required");
+            }
+            const allowedKinds = new Set<ImageUploadKind>([
+              "memorial-evidence-image",
+              "organization-square-logo",
+              "organization-wordmark-logo",
+              "person-photo",
+            ]);
+            if (!allowedKinds.has(a.kind as ImageUploadKind)) {
+              return err(
+                "kind must be one of: memorial-evidence-image, organization-square-logo, organization-wordmark-logo, person-photo",
+              );
+            }
+            if (a.filename !== undefined && typeof a.filename !== "string") {
+              return err("filename must be a string");
+            }
+
+            const { uploadImageFromUrl } = await import(
+              "./image-upload-from-url.server"
+            );
+            try {
+              return await runAuditedEarthDataTool(
+                name,
+                a,
+                {
+                  clientId: options.clientId,
+                  oauthGrantId: options.oauthGrantId,
+                  userId,
+                },
+                () =>
+                  uploadImageFromUrl({
+                    filename:
+                      typeof a.filename === "string" ? a.filename : null,
+                    kind: a.kind as ImageUploadKind,
+                    url: a.url as string,
+                  }),
+              );
+            } catch (error) {
+              if (error instanceof Error) return err(error.message);
+              throw error;
             }
           }
 


### PR DESCRIPTION
## Summary
- add an MCP tool that fetches a public image URL, rejects local/private hosts, normalizes through the existing image upload pipeline, and uploads to object storage
- teach organization/person MCP image fields to use the importer before setting logo/photo URLs
- add unit coverage for remote image imports and MCP dispatch
- add the AGENTS.md rule to avoid draft PRs unless explicitly requested

## Tests
- pnpm --dir packages/web exec vitest run src/lib/__tests__/image-upload-from-url.server.test.ts src/lib/__tests__/mcp-server.test.ts --testNamePattern "uploadImageFromUrl|exposes Earth-data write tools"
- pnpm --dir packages/web exec vitest run src/lib/__tests__/mcp-server.test.ts
- pnpm --dir packages/web exec tsc --noEmit --pretty false


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

- Added the ability to upload images from external URLs with automatic validation
- Validates hostname and content-type to ensure safe uploads
- Enforces configurable size limits based on image type
- Automatically generates filenames and storage information from URLs when not provided
- Integrated into available tools and workflows for streamlined image handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->