### PR TITLE
Protect public detail routes

### DIFF
--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -3,6 +3,33 @@
   "git": {
     "deploymentEnabled": false
   },
+  "routes": [
+    {
+      "src": "^/(people|tasks)/[^/]+/?$",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": "(?i)(curl|wget|python|scrapy|go-http-client|httpclient|java/|okhttp|libwww-perl|perl|php|ruby|axios|node-fetch|undici)"
+        }
+      ],
+      "mitigate": {
+        "action": "challenge"
+      }
+    },
+    {
+      "src": "^/(people|tasks)/[^/]+/?$",
+      "missing": [
+        {
+          "type": "header",
+          "key": "user-agent"
+        }
+      ],
+      "mitigate": {
+        "action": "challenge"
+      }
+    }
+  ],
   "crons": [
     {
       "path": "/api/cron/run-due-triggers",

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -5,7 +5,7 @@
   },
   "routes": [
     {
-      "src": "^/(people|tasks)/[^/]+/?$",
+      "src": "^/(?:people/(?!manage(?:/|$))[^/]+|tasks/[^/]+)(?:/opengraph-image)?/?$",
       "has": [
         {
           "type": "header",
@@ -18,7 +18,20 @@
       }
     },
     {
-      "src": "^/(people|tasks)/[^/]+/?$",
+      "src": "^/(?:people/(?!manage(?:/|$))[^/]+|tasks/[^/]+)(?:/opengraph-image)?/?$",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": "^\\s*$"
+        }
+      ],
+      "mitigate": {
+        "action": "challenge"
+      }
+    },
+    {
+      "src": "^/(?:people/(?!manage(?:/|$))[^/]+|tasks/[^/]+)(?:/opengraph-image)?/?$",
       "missing": [
         {
           "type": "header",


### PR DESCRIPTION
## Summary
- Add Vercel Firewall route mitigation for exact `/people/[id]` and `/tasks/[id]` page requests.
- Challenge obvious non-browser automation and requests without a user agent before they reach the Next.js app.

## Why
The May 6 Vercel anomaly appears to involve expensive public dynamic detail pages. Firewall mitigation is the smallest effective protection because it runs before middleware, SSR, and database work. Middleware rate limiting would still invoke app code and needs shared storage; caching is riskier here because these pages can include viewer-specific state and high-cardinality IDs.

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('packages/web/vercel.json','utf8')); console.log('vercel.json OK')"`

## Notes
- Local Vercel CLI anomaly/config validation was blocked by an invalid configured Vercel token.
