### PR TITLE
Speed up PR visual review gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,18 +241,108 @@ jobs:
         id: visual_regression
         run: pnpm --filter @optimitron/web run e2e -- visual
 
+      - name: Upload PR visual screenshots for review publishing
+        if: ${{ github.event_name == 'pull_request' && steps.visual_regression.outcome == 'success' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: web-pr-visual-screenshots
+          path: packages/web/screenshots
+          if-no-files-found: error
+
+      - name: Build visual review index
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          VISUAL_REVIEW_COMMIT_SHA: ${{ github.sha }}
+          VISUAL_REVIEW_BASE_URL: ""
+          VISUAL_REVIEW_PR_NUMBER: ""
+          VISUAL_REVIEW_HEAD_BRANCH: ${{ github.ref_name }}
+          VISUAL_REVIEW_REPO: ${{ github.repository }}
+        run: pnpm --filter @optimitron/web run visual:review
+
+      - name: Summarize visual review
+        if: ${{ github.event_name != 'pull_request' }}
+        shell: bash
+        run: |
+          {
+            echo "## Visual review"
+            echo
+            echo "- Open the \`web-visual-review\` artifact from this run."
+            echo "- Start with \`packages/web/output/playwright/review/latest.html\` for the compact before/after screenshot gallery."
+            echo "- Use the generated gallery for before/after diffs and changed-only review."
+            echo "- Captured routes are defined in \`packages/web/e2e/visual-regression.spec.ts\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Playwright visual review
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: web-visual-review
+          path: |
+            packages/web/output/playwright/review
+            packages/web/screenshots
+            packages/web/playwright-report
+            packages/web/test-results
+          if-no-files-found: ignore
+
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: web-playwright-artifacts
+          path: |
+            packages/web/playwright-report
+            packages/web/screenshots
+            packages/web/public/img/screenshots
+            packages/web/test-results
+          if-no-files-found: ignore
+
+  web-visual-review:
+    name: web-visual-review
+    if: ${{ github.event_name == 'pull_request' && needs.web-e2e-validate.result == 'success' }}
+    needs: web-e2e-validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: write
+      deployments: write
+      issues: write
+      pull-requests: write
+      statuses: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@8.14.0 --activate
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download PR visual screenshots
+        uses: actions/download-artifact@v6
+        with:
+          name: web-pr-visual-screenshots
+          path: packages/web/screenshots
+
       - name: Preserve PR visual screenshots
-        if: always() && github.event_name == 'pull_request'
         shell: bash
         run: |
           rm -rf packages/web/output/playwright/pr-screenshots
-          if [ -d packages/web/screenshots ]; then
-            mkdir -p packages/web/output/playwright
-            cp -R packages/web/screenshots packages/web/output/playwright/pr-screenshots
-          fi
+          mkdir -p packages/web/output/playwright
+          cp -R packages/web/screenshots packages/web/output/playwright/pr-screenshots
 
       - name: Resolve main visual baseline
-        if: always() && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -262,10 +352,6 @@ jobs:
           rm -rf "$baseline_root"
           mkdir -p "$baseline_root"
 
-          # `--limit 5` instead of 20: the previous successful main run
-          # virtually always has the artifact. Iterating 20 deep mostly
-          # burned API calls + network setup time without finding anything
-          # the first 5 didn't.
           mapfile -t run_ids < <(gh run list \
             --workflow CI \
             --branch main \
@@ -287,9 +373,7 @@ jobs:
                   echo "VISUAL_BEFORE_ROOT=$GITHUB_WORKSPACE/$screenshots_dir" >> "$GITHUB_ENV"
                   echo "Downloaded visual baseline from main run $run_id."
                   rm -rf packages/web/screenshots
-                  if [ -d "$pr_screenshots" ]; then
-                    cp -R "$pr_screenshots" packages/web/screenshots
-                  fi
+                  cp -R "$pr_screenshots" packages/web/screenshots
                   exit 0
                 fi
               done
@@ -300,12 +384,9 @@ jobs:
 
           echo "No usable main web-visual-review artifact found; visual review will show after screenshots only."
           rm -rf packages/web/screenshots
-          if [ -d "$pr_screenshots" ]; then
-            cp -R "$pr_screenshots" packages/web/screenshots
-          fi
+          cp -R "$pr_screenshots" packages/web/screenshots
 
       - name: Resolve PR preview URL
-        if: always() && github.event_name == 'pull_request'
         id: pr_preview_url
         uses: actions/github-script@v8
         with:
@@ -321,10 +402,6 @@ jobs:
             });
 
             for (const deployment of deployments) {
-              // Skip our own visual-review deployments — we set up
-              // `visual-review/pr-N` to drive the inline timeline annotation
-              // for the gh-pages review URL, but here we want the *app*
-              // preview URL (Vercel) to feed VISUAL_REVIEW_BASE_URL.
               const env = deployment.environment || '';
               if (env.startsWith('visual-review')) continue;
 
@@ -347,7 +424,7 @@ jobs:
             return '';
 
       - name: Post PR preview links comment
-        if: ${{ !cancelled() && github.event_name == 'pull_request' && steps.pr_preview_url.outputs.result != '' }}
+        if: ${{ !cancelled() && steps.pr_preview_url.outputs.result != '' }}
         uses: actions/github-script@v8
         env:
           PREVIEW_URL: ${{ steps.pr_preview_url.outputs.result }}
@@ -357,8 +434,6 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
 
-            // Pull changed files from the PR API (works with depth-1 checkout).
-            // Filter out deletions so the table doesn't link to 404s.
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner, repo, pull_number: issue_number, per_page: 100,
             });
@@ -398,13 +473,10 @@ jobs:
       - name: Build visual review index
         if: always()
         env:
-          VISUAL_REVIEW_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          VISUAL_REVIEW_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           VISUAL_REVIEW_BASE_URL: ${{ steps.pr_preview_url.outputs.result }}
-          # Feeds the per-route "Copy context" button on latest.html so the
-          # generated clipboard payload includes the right PR/branch/repo
-          # identifiers for whoever the reviewer is pasting it to.
           VISUAL_REVIEW_PR_NUMBER: ${{ github.event.pull_request.number }}
-          VISUAL_REVIEW_HEAD_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          VISUAL_REVIEW_HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
           VISUAL_REVIEW_REPO: ${{ github.repository }}
         run: pnpm --filter @optimitron/web run visual:review
 
@@ -433,26 +505,7 @@ jobs:
             packages/web/test-results
           if-no-files-found: ignore
 
-      # Publish the per-PR visual review to the long-lived `gh-pages` branch
-      # so reviews from different PRs don't clobber each other. The previous
-      # setup used `actions/deploy-pages`, which atomically REPLACES the
-      # entire Pages site each deploy — so whenever any PR's CI finished,
-      # every other PR's review URL went 404 until that PR's CI ran again.
-      #
-      # `peaceiris/actions-gh-pages` with `keep_files: true` writes only the
-      # current PR's directory and preserves everything else on `gh-pages`.
-      #
-      # One-time repo setup: Settings → Pages → Source must be set to
-      # "Deploy from a branch" with branch `gh-pages` (root). The action
-      # creates the branch on its first push.
-      # Gate the publish chain on the visual-regression step succeeding,
-      # not just on `!cancelled()`. A test failure produces incomplete
-      # screenshots ("62 missing pairs"); publishing that to gh-pages
-      # gives reviewers a misleading review URL. Real test breakage
-      # already surfaces as the web-validate job failing — the artifact
-      # upload still runs `always()` so debugging info isn't lost.
       - name: Prepare per-PR visual review directory
-        if: ${{ steps.visual_regression.outcome == 'success' && github.event_name == 'pull_request' }}
         id: prepare_pages
         shell: bash
         run: |
@@ -465,20 +518,12 @@ jobs:
           mkdir -p "$commit_dir" "$latest_dir"
           cp -R packages/web/output/playwright/review/. "$commit_dir/"
           cp -R packages/web/output/playwright/review/. "$latest_dir/"
-          # `latest.html` is the entry point the build script writes. Also
-          # publish it as `index.html` so bare `pr-N/latest/` and
-          # `pr-N/<sha>/` directory URLs (no filename) resolve to the review
-          # page instead of returning 404.
           if [ -f "$commit_dir/latest.html" ]; then
             cp "$commit_dir/latest.html" "$commit_dir/index.html"
           fi
           if [ -f "$latest_dir/latest.html" ]; then
             cp "$latest_dir/latest.html" "$latest_dir/index.html"
           fi
-          # Seed `.nojekyll` and a root `index.html` at the publish root so the
-          # gh-pages site doesn't try to render through Jekyll and so the
-          # bare https://<user>.github.io/<repo>/ URL renders something
-          # meaningful. `keep_files: true` preserves these across deploys.
           publish_root="packages/web/output/playwright/pages-per-pr"
           touch "$publish_root/.nojekyll"
           cat > "$publish_root/index.html" <<'HTML'
@@ -499,7 +544,6 @@ jobs:
           echo "publish_dir=packages/web/output/playwright/pages-per-pr" >> "$GITHUB_OUTPUT"
 
       - name: Publish visual review to gh-pages
-        if: ${{ steps.visual_regression.outcome == 'success' && github.event_name == 'pull_request' }}
         id: visual_review_pages
         uses: peaceiris/actions-gh-pages@v4
         with:
@@ -512,13 +556,8 @@ jobs:
           user_name: github-actions[bot]
           user_email: github-actions[bot]@users.noreply.github.com
 
-      # Only post the status link AFTER peaceiris/actions-gh-pages
-      # actually succeeded — otherwise reviewers click through to a
-      # 404 (publish skipped or failed but status URL already pointed
-      # there). `steps.visual_review_pages.outcome == 'success'` ensures
-      # gh-pages has the path before we advertise it.
       - name: Post Visual review commit status
-        if: ${{ !cancelled() && github.event_name == 'pull_request' && steps.visual_review_pages.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.visual_review_pages.outcome == 'success' }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -537,18 +576,8 @@ jobs:
               target_url,
             });
 
-      # Create a GitHub Deployment + DeploymentStatus per commit so the PR
-      # timeline shows an inline "deployed to visual-review X minutes ago"
-      # annotation under each commit, the way Vercel's bot does. Each commit
-      # gets its own annotation linking to the per-commit gh-pages URL,
-      # which is immutable thanks to keep_files: true on the gh-pages
-      # publish step. transient_environment: true tells GitHub to retire
-      # older deployments for this environment automatically.
-      # Same publish-succeeded gate as the commit status above — the
-      # inline timeline annotation points to the same URL, no point
-      # posting it if gh-pages doesn't have the path yet.
       - name: Create Visual review deployment
-        if: ${{ !cancelled() && github.event_name == 'pull_request' && steps.visual_review_pages.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.visual_review_pages.outcome == 'success' }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -581,16 +610,6 @@ jobs:
               log_url: target_url,
               description: 'Visual review ready',
             });
-
-      - name: Upload Playwright artifacts
-        if: failure()
-        uses: actions/upload-artifact@v6
-        with:
-          name: web-playwright-artifacts
-          path: |
-            packages/web/playwright-report
-            packages/web/public/img/screenshots
-          if-no-files-found: ignore
 
   web-validate:
     name: web-validate

--- a/.github/workflows/smoke-deploy.yml
+++ b/.github/workflows/smoke-deploy.yml
@@ -15,7 +15,7 @@ permissions:
 #    Deployment Protection -> Protection Bypass for Automation.
 # 3. Add the same secret to Production if you want production smoke to hit the
 #    exact protected *.vercel.app deployment URL. Without it, production smoke
-#    uses the public warondisease.org alias, which is the user-facing surface.
+#    uses the public production aliases so host-specific outages stay visible.
 
 jobs:
   smoke:
@@ -48,6 +48,7 @@ jobs:
           DEPLOYMENT_JSON: ${{ toJSON(github.event.deployment) }}
           DEPLOYMENT_STATUS_JSON: ${{ toJSON(github.event.deployment_status) }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          PUBLIC_PRODUCTION_SMOKE_URLS: ${{ vars.PUBLIC_PRODUCTION_SMOKE_URLS || 'https://warondisease.org,https://optimitron.com' }}
         run: |
           node <<'NODE'
           const fs = require("node:fs");
@@ -82,21 +83,39 @@ jobs:
             environment === "Production" &&
             parsedUrl.hostname.endsWith(".vercel.app") &&
             !bypassSecret;
-          const smokeUrl = isProtectedVercelDeploymentUrl
-            ? "https://warondisease.org"
-            : targetUrl;
+          const publicProductionSmokeUrls = parseUrlList(
+            process.env.PUBLIC_PRODUCTION_SMOKE_URLS,
+          );
+          const smokeUrls = isProtectedVercelDeploymentUrl
+            ? publicProductionSmokeUrls
+            : [targetUrl];
+
+          if (isProtectedVercelDeploymentUrl && smokeUrls.length === 0) {
+            throw new Error(
+              "PUBLIC_PRODUCTION_SMOKE_URLS must include at least one public production URL when Production deployment protection is enabled without a bypass secret.",
+            );
+          }
 
           if (isProtectedVercelDeploymentUrl) {
             console.log(
-              "Production deployment URL is Vercel-protected and no Production bypass secret is configured; smoking the public production domain instead.",
+              "Production deployment URL is Vercel-protected and no Production bypass secret is configured; smoking the public production domains instead.",
             );
           }
 
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
-            `environment=${environment}\nurl=${smokeUrl}\nsource_url=${targetUrl}\n`,
+            `environment=${environment}\nurl=${smokeUrls[0]}\nurls=${smokeUrls.join(",")}\nsource_url=${targetUrl}\n`,
           );
-          console.log(`Resolved ${environment} smoke target: ${smokeUrl}`);
+          console.log(
+            `Resolved ${environment} smoke target(s): ${smokeUrls.join(", ")}`,
+          );
+
+          function parseUrlList(value) {
+            return String(value || "")
+              .split(/[,\s]+/u)
+              .map((url) => url.trim())
+              .filter(Boolean);
+          }
           NODE
 
       - name: Run deploy smoke
@@ -104,6 +123,7 @@ jobs:
         env:
           PREVIEW_URL: ${{ steps.target.outputs.environment == 'Preview' && steps.target.outputs.url || '' }}
           PROD_URL: ${{ steps.target.outputs.environment == 'Production' && steps.target.outputs.url || '' }}
+          PROD_URLS: ${{ steps.target.outputs.environment == 'Production' && steps.target.outputs.urls || '' }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           SMOKE_DEPLOY_RESULT_FILE: ${{ runner.temp }}/smoke-deploy-result.json
         run: |

--- a/.github/workflows/smoke-deploy.yml
+++ b/.github/workflows/smoke-deploy.yml
@@ -9,10 +9,13 @@ permissions:
   issues: write
   pull-requests: read
 
-# Operator setup for protected Vercel previews:
+# Operator setup for protected Vercel deployments:
 # 1. Open GitHub Settings -> Environments -> Preview -> Environment secrets.
 # 2. Add VERCEL_AUTOMATION_BYPASS_SECRET with the Vercel project secret from
 #    Deployment Protection -> Protection Bypass for Automation.
+# 3. Add the same secret to Production if you want production smoke to hit the
+#    exact protected *.vercel.app deployment URL. Without it, production smoke
+#    uses the public warondisease.org alias, which is the user-facing surface.
 
 jobs:
   smoke:
@@ -44,6 +47,7 @@ jobs:
         env:
           DEPLOYMENT_JSON: ${{ toJSON(github.event.deployment) }}
           DEPLOYMENT_STATUS_JSON: ${{ toJSON(github.event.deployment_status) }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           node <<'NODE'
           const fs = require("node:fs");
@@ -59,6 +63,9 @@ jobs:
           }
 
           const parsedUrl = new URL(targetUrl);
+          const bypassSecret = String(
+            process.env.VERCEL_AUTOMATION_BYPASS_SECRET || "",
+          ).trim();
           const productionHosts = new Set([
             "warondisease.org",
             "www.warondisease.org",
@@ -71,12 +78,25 @@ jobs:
             /^production$/i.test(environmentName) ||
             productionHosts.has(parsedUrl.hostname.toLowerCase());
           const environment = isProduction ? "Production" : "Preview";
+          const isProtectedVercelDeploymentUrl =
+            environment === "Production" &&
+            parsedUrl.hostname.endsWith(".vercel.app") &&
+            !bypassSecret;
+          const smokeUrl = isProtectedVercelDeploymentUrl
+            ? "https://warondisease.org"
+            : targetUrl;
+
+          if (isProtectedVercelDeploymentUrl) {
+            console.log(
+              "Production deployment URL is Vercel-protected and no Production bypass secret is configured; smoking the public production domain instead.",
+            );
+          }
 
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
-            `environment=${environment}\nurl=${targetUrl}\n`,
+            `environment=${environment}\nurl=${smokeUrl}\nsource_url=${targetUrl}\n`,
           );
-          console.log(`Resolved ${environment} smoke target: ${targetUrl}`);
+          console.log(`Resolved ${environment} smoke target: ${smokeUrl}`);
           NODE
 
       - name: Run deploy smoke

--- a/packages/web/scripts/smoke-deploy.mjs
+++ b/packages/web/scripts/smoke-deploy.mjs
@@ -16,7 +16,11 @@ const ROUTES_TO_SMOKE = [
   {
     path: "/",
     expectedH1: "Please Take 30 Seconds to End War and Disease",
-    source: "TreatyVoteFlow default headline",
+    expectedH1ByHost: {
+      "optimitron.com": "Play the Earth Optimization Game!",
+      "www.optimitron.com": "Play the Earth Optimization Game!",
+    },
+    source: "site root heading",
   },
   {
     path: "/treaty",
@@ -106,10 +110,14 @@ const ERROR_MARKERS = [
 
 async function main() {
   const startedAt = new Date();
-  const target = resolveTarget();
-  const bypassSecret = (process.env.VERCEL_AUTOMATION_BYPASS_SECRET ?? "").trim();
+  const targets = resolveTargets();
+  const environment = targets[0]?.environment ?? "Production";
+  const targetUrl = formatTargetUrls(targets);
+  const bypassSecret = (
+    process.env.VERCEL_AUTOMATION_BYPASS_SECRET ?? ""
+  ).trim();
 
-  if (target.environment === "Preview" && !bypassSecret) {
+  if (environment === "Preview" && !bypassSecret) {
     // Fail loud. The previous skip-with-warning was an escape hatch
     // that silently masked smoke for ~24 hours because the secret
     // wasn't set. The secret is retrievable in one curl + jq +
@@ -119,14 +127,12 @@ async function main() {
     console.error(
       "[smoke-deploy] FAIL: VERCEL_AUTOMATION_BYPASS_SECRET is not set in the GitHub Preview environment.",
     );
+    console.error("[smoke-deploy] Retrieve and set in one command:");
     console.error(
-      "[smoke-deploy] Retrieve and set in one command:",
+      '[smoke-deploy]   curl -H "Authorization: Bearer $VERCEL_TOKEN" \\',
     );
     console.error(
-      "[smoke-deploy]   curl -H \"Authorization: Bearer $VERCEL_TOKEN\" \\",
-    );
-    console.error(
-      "[smoke-deploy]     \"https://api.vercel.com/v9/projects/$VERCEL_PROJECT_ID?teamId=$VERCEL_ORG_ID\" \\",
+      '[smoke-deploy]     "https://api.vercel.com/v9/projects/$VERCEL_PROJECT_ID?teamId=$VERCEL_ORG_ID" \\',
     );
     console.error(
       "[smoke-deploy]     | jq -r '.protectionBypass | keys[0]' \\",
@@ -143,17 +149,19 @@ async function main() {
       success: false,
       skipped: false,
       reason: "VERCEL_AUTOMATION_BYPASS_SECRET not configured",
-      environment: target.environment,
-      targetUrl: target.baseUrl.href,
+      environment,
+      targetUrl,
+      targetUrls: targets.map((target) => target.baseUrl.href),
       startedAt: startedAt.toISOString(),
       durationMs: 0,
       routes: [],
       failures: [
         {
           path: "(setup)",
+          targetUrl,
           status: null,
           error:
-            "VERCEL_AUTOMATION_BYPASS_SECRET missing from GitHub Preview environment. Run: curl -H \"Authorization: Bearer $VERCEL_TOKEN\" \"https://api.vercel.com/v9/projects/$VERCEL_PROJECT_ID?teamId=$VERCEL_ORG_ID\" | jq -r '.protectionBypass | keys[0]' | gh secret set VERCEL_AUTOMATION_BYPASS_SECRET --env Preview",
+            'VERCEL_AUTOMATION_BYPASS_SECRET missing from GitHub Preview environment. Run: curl -H "Authorization: Bearer $VERCEL_TOKEN" "https://api.vercel.com/v9/projects/$VERCEL_PROJECT_ID?teamId=$VERCEL_ORG_ID" | jq -r \'.protectionBypass | keys[0]\' | gh secret set VERCEL_AUTOMATION_BYPASS_SECRET --env Preview',
           matchedErrorMarker: null,
         },
       ],
@@ -163,21 +171,26 @@ async function main() {
     process.exit(1);
   }
 
-  console.log(
-    `Smoke testing ${target.environment} deployment ${target.baseUrl.href}`,
-  );
+  for (const target of targets) {
+    console.log(
+      `Smoke testing ${target.environment} deployment ${target.baseUrl.href}`,
+    );
+  }
 
   const routeResults = await Promise.all(
-    ROUTES_TO_SMOKE.map((route) =>
-      smokeRoute({ route, target, bypassSecret }),
+    targets.flatMap((target) =>
+      ROUTES_TO_SMOKE.map((route) =>
+        smokeRoute({ route, target, bypassSecret }),
+      ),
     ),
   );
   const durationMs = Date.now() - startedAt.getTime();
   const failures = routeResults.filter((result) => !result.ok);
   const summary = {
     success: failures.length === 0,
-    environment: target.environment,
-    targetUrl: target.baseUrl.href,
+    environment,
+    targetUrl,
+    targetUrls: targets.map((target) => target.baseUrl.href),
     startedAt: startedAt.toISOString(),
     durationMs,
     routes: routeResults,
@@ -191,25 +204,26 @@ async function main() {
     const label = result.ok ? "PASS" : "FAIL";
     const status = result.status ? `HTTP ${result.status}` : "no response";
     console.log(
-      `${label} ${result.path} ${status} ${result.durationMs}ms after ${result.attempts.length} attempt(s)`,
+      `${label} ${formatResultTarget(result)}${result.path} ${status} ${result.durationMs}ms after ${result.attempts.length} attempt(s)`,
     );
   }
 
   if (failures.length > 0) {
     console.error(
-      `Deploy smoke failed for ${failures.length} of ${routeResults.length} route(s).`,
+      `Deploy smoke failed for ${failures.length} of ${routeResults.length} route check(s).`,
     );
     process.exitCode = 1;
     return;
   }
 
   console.log(
-    `Deploy smoke passed for ${routeResults.length} route(s) in ${durationMs}ms.`,
+    `Deploy smoke passed for ${routeResults.length} route check(s) in ${durationMs}ms.`,
   );
 }
 
 async function smokeRoute({ route, target, bypassSecret }) {
   const url = new URL(route.path, target.baseUrl);
+  const expectedH1 = resolveExpectedH1(route, target.baseUrl.hostname);
   const attempts = [];
   const startedAt = Date.now();
 
@@ -217,6 +231,7 @@ async function smokeRoute({ route, target, bypassSecret }) {
     const attemptResult = await fetchAndAssert({
       route,
       url,
+      expectedH1,
       bypassSecret,
       attempt,
     });
@@ -225,7 +240,9 @@ async function smokeRoute({ route, target, bypassSecret }) {
     if (attemptResult.ok) {
       return summarizeRouteResult({
         route,
+        target,
         url,
+        expectedH1,
         startedAt,
         attempts,
         finalAttempt: attemptResult,
@@ -239,14 +256,22 @@ async function smokeRoute({ route, target, bypassSecret }) {
 
   return summarizeRouteResult({
     route,
+    target,
     url,
+    expectedH1,
     startedAt,
     attempts,
     finalAttempt: attempts.at(-1),
   });
 }
 
-async function fetchAndAssert({ route, url, bypassSecret, attempt }) {
+async function fetchAndAssert({
+  route,
+  url,
+  expectedH1,
+  bypassSecret,
+  attempt,
+}) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   const attemptStartedAt = Date.now();
@@ -269,7 +294,7 @@ async function fetchAndAssert({ route, url, bypassSecret, attempt }) {
     const body = await response.text();
     const h1Texts = extractH1Texts(body);
     const matchedErrorMarker = findErrorMarker(body);
-    const normalizedExpectedH1 = normalizeText(route.expectedH1);
+    const normalizedExpectedH1 = normalizeText(expectedH1);
     const hasExpectedH1 = h1Texts.some(
       (text) => normalizeText(text) === normalizedExpectedH1,
     );
@@ -315,15 +340,24 @@ async function fetchAndAssert({ route, url, bypassSecret, attempt }) {
   }
 }
 
-function summarizeRouteResult({ route, url, startedAt, attempts, finalAttempt }) {
+function summarizeRouteResult({
+  route,
+  target,
+  url,
+  expectedH1,
+  startedAt,
+  attempts,
+  finalAttempt,
+}) {
   return {
     path: route.path,
+    targetUrl: target.baseUrl.href,
     url: url.href,
     source: route.source,
     ok: Boolean(finalAttempt?.ok),
     status: finalAttempt?.status ?? null,
     finalUrl: finalAttempt?.finalUrl ?? url.href,
-    expectedH1: route.expectedH1,
+    expectedH1,
     h1Texts: finalAttempt?.h1Texts ?? [],
     missingExpectedH1: finalAttempt?.missingExpectedH1 ?? true,
     matchedErrorMarker: finalAttempt?.matchedErrorMarker ?? null,
@@ -333,20 +367,48 @@ function summarizeRouteResult({ route, url, startedAt, attempts, finalAttempt })
   };
 }
 
-function resolveTarget() {
+function resolveExpectedH1(route, hostname) {
+  return (
+    route.expectedH1ByHost?.[String(hostname).toLowerCase()] ?? route.expectedH1
+  );
+}
+
+function resolveTargets() {
   const previewUrl = (process.env.PREVIEW_URL ?? "").trim();
   const prodUrl = (process.env.PROD_URL ?? "").trim();
+  const prodUrls = (process.env.PROD_URLS ?? "").trim();
+  const prodTargetValue = prodUrls || prodUrl;
 
-  if (previewUrl && prodUrl) {
-    throw new Error("Set PREVIEW_URL or PROD_URL, not both.");
+  if (previewUrl && prodTargetValue) {
+    throw new Error("Set PREVIEW_URL or PROD_URL/PROD_URLS, not both.");
   }
 
-  if (!previewUrl && !prodUrl) {
-    throw new Error("Set PREVIEW_URL or PROD_URL before running deploy smoke.");
+  if (!previewUrl && !prodTargetValue) {
+    throw new Error(
+      "Set PREVIEW_URL, PROD_URL, or PROD_URLS before running deploy smoke.",
+    );
   }
 
   const environment = previewUrl ? "Preview" : "Production";
-  const rawUrl = previewUrl || prodUrl;
+  const rawUrls = previewUrl ? [previewUrl] : parseTargetUrls(prodTargetValue);
+  if (rawUrls.length === 0) {
+    throw new Error(`${environment} URL list did not contain any URLs.`);
+  }
+
+  return rawUrls.map((rawUrl) => ({
+    environment,
+    baseUrl: normalizeTargetUrl(rawUrl, environment),
+  }));
+}
+
+function parseTargetUrls(value) {
+  return String(value)
+    .split(/[,\s]+/u)
+    .map((url) => url.trim())
+    .filter(Boolean);
+}
+
+function normalizeTargetUrl(rawUrl, environment) {
   let baseUrl;
   try {
     baseUrl = new URL(rawUrl);
@@ -362,7 +424,23 @@ function resolveTarget() {
     baseUrl.pathname = `${baseUrl.pathname}/`;
   }
 
-  return { environment, baseUrl };
+  return baseUrl;
+}
+
+function formatTargetUrls(targets) {
+  return targets.map((target) => target.baseUrl.href).join(", ");
+}
+
+function formatResultTarget(result) {
+  if (!result.targetUrl) {
+    return "";
+  }
+
+  try {
+    return `${new URL(result.targetUrl).hostname} `;
+  } catch {
+    return `${result.targetUrl} `;
+  }
 }
 
 function extractH1Texts(html) {
@@ -438,9 +516,8 @@ function codePointToString(codePoint, fallback) {
 function findErrorMarker(body) {
   const lowerBody = body.toLowerCase();
   return (
-    ERROR_MARKERS.find((marker) =>
-      lowerBody.includes(marker.toLowerCase()),
-    ) ?? null
+    ERROR_MARKERS.find((marker) => lowerBody.includes(marker.toLowerCase())) ??
+    null
   );
 }
 
@@ -507,18 +584,22 @@ function buildMarkdownSummary(summary) {
   ];
 
   if (summary.success) {
-    lines.push(`Checked ${summary.routes.length} route(s).`, "");
+    const targetCount = summary.targetUrls?.length ?? 1;
+    lines.push(
+      `Checked ${summary.routes.length} route check(s) across ${targetCount} target(s).`,
+      "",
+    );
     return `${lines.join("\n")}\n`;
   }
 
   lines.push(
-    "| Route | Status | Missing h1 | Error marker | Details |",
-    "| --- | --- | --- | --- | --- |",
+    "| Target | Route | Status | Missing h1 | Error marker | Details |",
+    "| --- | --- | --- | --- | --- | --- |",
   );
 
   for (const failure of summary.failures) {
     lines.push(
-      `| ${escapeMarkdownTableCell(failure.path)} | ${escapeMarkdownTableCell(
+      `| ${escapeMarkdownTableCell(formatFailureTarget(failure))} | ${escapeMarkdownTableCell(failure.path)} | ${escapeMarkdownTableCell(
         failure.status ? String(failure.status) : "no response",
       )} | ${escapeMarkdownTableCell(
         failure.missingExpectedH1 ? failure.expectedH1 : "no",
@@ -530,6 +611,18 @@ function buildMarkdownSummary(summary) {
 
   lines.push("");
   return `${lines.join("\n")}\n`;
+}
+
+function formatFailureTarget(failure) {
+  if (!failure.targetUrl) {
+    return "n/a";
+  }
+
+  try {
+    return new URL(failure.targetUrl).hostname;
+  } catch {
+    return failure.targetUrl;
+  }
 }
 
 function escapeMarkdownTableCell(value) {
@@ -547,7 +640,11 @@ main().catch(async (error) => {
   const summary = {
     success: false,
     environment: process.env.PREVIEW_URL ? "Preview" : "Production",
-    targetUrl: process.env.PREVIEW_URL || process.env.PROD_URL || "",
+    targetUrl:
+      process.env.PREVIEW_URL ||
+      process.env.PROD_URLS ||
+      process.env.PROD_URL ||
+      "",
     startedAt: new Date().toISOString(),
     durationMs: 0,
     routes: [],


### PR DESCRIPTION
## Summary
- keep the required PR gate running web build, smoke, and visual Playwright validation
- move PR visual-review gallery publishing to a separate advisory job after e2e validation
- make production deploy smoke fall back to the public warondisease.org alias when the generated Vercel deployment URL is protected and Production has no automation bypass secret

## Verification
- pnpm exec prettier --check .github/workflows/ci.yml .github/workflows/smoke-deploy.yml
- git diff --check
- PROD_URL=https://warondisease.org node packages/web/scripts/smoke-deploy.mjs