### PR TITLE
Fix smoke deploy + simplify dashboard

### DIFF
--- a/.github/workflows/smoke-deploy.yml
+++ b/.github/workflows/smoke-deploy.yml
@@ -69,9 +69,19 @@ jobs:
             const terminalFailures = new Set(["failure", "error", "inactive"]);
             let lastStatus = "not found";
 
+            function isProductionDeployment(deployment, status) {
+              return /^production$/i.test(
+                String(status.environment || deployment.environment || ""),
+              );
+            }
+
             async function resolveVercelDeployment() {
-              if (eventDeploymentId && eventDeploymentCreator === "vercel[bot]") {
-                return eventDeployment;
+              if (
+                eventDeploymentId &&
+                (eventDeploymentCreator === "vercel[bot]" ||
+                  isProductionDeployment(eventDeployment, initialStatus))
+              ) {
+                return { ...eventDeployment, id: eventDeploymentId };
               }
               const { data } = await github.rest.repos.listDeployments({
                 owner,
@@ -98,7 +108,7 @@ jobs:
             while (Date.now() < deadline) {
               const deployment = await resolveVercelDeployment();
               if (!deployment?.id) {
-                lastStatus = `no Vercel deployment found for ${deploymentSha}`;
+                lastStatus = `no smokeable deployment found for ${deploymentSha}`;
                 core.info(`Deployment status: ${lastStatus}`);
                 await new Promise((resolve) => setTimeout(resolve, intervalMs));
                 continue;

--- a/.github/workflows/smoke-deploy.yml
+++ b/.github/workflows/smoke-deploy.yml
@@ -24,7 +24,16 @@ jobs:
     name: Smoke deployed URL
     if: >-
       !startsWith(github.event.deployment.environment, 'visual-review') &&
-      !startsWith(github.event.deployment_status.environment, 'visual-review')
+      !startsWith(github.event.deployment_status.environment, 'visual-review') &&
+      (github.event.deployment.creator.login == 'vercel[bot]' ||
+        github.event.deployment_status.creator.login == 'vercel[bot]' ||
+        github.event.deployment.environment == 'Production' ||
+        github.event.deployment.environment == 'production' ||
+        github.event.deployment_status.environment == 'Production' ||
+        github.event.deployment_status.environment == 'production' ||
+        contains(github.event.deployment_status.environment_url, 'warondisease.org') ||
+        contains(github.event.deployment_status.environment_url, 'optimitron.com') ||
+        contains(github.event.deployment_status.environment_url, 'onepercenttreaty.org'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment:
@@ -53,7 +62,8 @@ jobs:
               initialStatus.deployment_id ||
               initialStatus.deployment?.id;
             const eventDeploymentCreator = String(
-              eventDeployment.creator?.login ||
+              initialStatus.creator?.login ||
+                eventDeployment.creator?.login ||
                 initialStatus.deployment?.creator?.login ||
                 "",
             );
@@ -69,9 +79,28 @@ jobs:
             const terminalFailures = new Set(["failure", "error", "inactive"]);
             let lastStatus = "not found";
 
+            function isProductionUrl(value) {
+              try {
+                const hostname = new URL(String(value || "")).hostname.toLowerCase();
+                return [
+                  "warondisease.org",
+                  "optimitron.com",
+                  "onepercenttreaty.org",
+                ].some(
+                  (domain) => hostname === domain || hostname.endsWith(`.${domain}`),
+                );
+              } catch {
+                return false;
+              }
+            }
+
             function isProductionDeployment(deployment, status) {
-              return /^production$/i.test(
-                String(status.environment || deployment.environment || ""),
+              const environment = String(
+                status.environment || deployment.environment || "",
+              );
+              return (
+                /^production$/i.test(environment) ||
+                isProductionUrl(status.environment_url)
               );
             }
 
@@ -148,7 +177,7 @@ jobs:
           RESOLVED_DEPLOYMENT_ENVIRONMENT: ${{ steps.deployment_status.outputs.environment }}
           RESOLVED_DEPLOYMENT_URL: ${{ steps.deployment_status.outputs.environment_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          PUBLIC_PRODUCTION_SMOKE_URLS: ${{ vars.PUBLIC_PRODUCTION_SMOKE_URLS || 'https://warondisease.org,https://optimitron.com' }}
+          PUBLIC_PRODUCTION_SMOKE_URLS: ${{ vars.PUBLIC_PRODUCTION_SMOKE_URLS || 'https://warondisease.org,https://optimitron.com,https://onepercenttreaty.org' }}
         run: |
           node <<'NODE'
           const fs = require("node:fs");

--- a/packages/web/src/components/site/TreatyTaskDashboardClient.tsx
+++ b/packages/web/src/components/site/TreatyTaskDashboardClient.tsx
@@ -53,32 +53,23 @@ export function TreatyTaskDashboardClient({
 
         <HumanityManagerStatusPanel status={humanityManagerStatus} />
 
-        <details className="group border border-[var(--treaty-ink)]/30 bg-[var(--treaty-paper)]">
-          <summary className="cursor-pointer list-none px-4 py-3 text-sm font-black uppercase tracking-[0.14em] text-[var(--treaty-ink)] marker:hidden">
-            <span className="inline-block w-4">▸</span>
-            Other ways to help
-          </summary>
-          <ul className="border-t border-[var(--treaty-ink)]/30 px-4 py-3">
-            {OTHER_ACTIONS.map((action) => (
-              <li
-                key={action.href}
-                className="border-b border-[var(--treaty-ink)]/15 py-3 last:border-b-0"
+        <ul className="divide-y divide-[var(--treaty-ink)]/15 border border-[var(--treaty-ink)]/30 bg-[var(--treaty-paper)]">
+          {OTHER_ACTIONS.map((action) => (
+            <li key={action.href}>
+              <Link
+                href={action.href}
+                className="block px-4 py-3 hover:underline"
               >
-                <Link
-                  href={action.href}
-                  className="block hover:underline"
-                >
-                  <p className="text-sm font-black uppercase tracking-[0.08em]">
-                    {action.label}
-                  </p>
-                  <p className="mt-1 text-xs font-bold text-[var(--treaty-ink)]/70">
-                    {action.body}
-                  </p>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </details>
+                <p className="text-sm font-black uppercase tracking-[0.08em]">
+                  {action.label}
+                </p>
+                <p className="mt-1 text-xs font-bold text-[var(--treaty-ink)]/70">
+                  {action.body}
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/packages/web/src/lib/humanity-manager-status-content.tsx
+++ b/packages/web/src/lib/humanity-manager-status-content.tsx
@@ -57,13 +57,18 @@ function formatCount(value: number): string {
   return Math.max(0, value).toLocaleString("en-US");
 }
 
-function buildEmployeeStatus(input: HumanityManagerStatusInput): string {
+function buildHeading(input: HumanityManagerStatusInput): string {
+  if (
+    input.overdueEmployeeCount === 0 &&
+    input.directConversionCount === 0
+  ) {
+    return "None assigned";
+  }
   if (input.overdueEmployeeCount === 0) {
-    return "No employee tasks are waiting right now.";
+    return "All voted";
   }
   const count = formatCount(input.overdueEmployeeCount);
-  const noun = input.overdueEmployeeCount === 1 ? "employee" : "employees";
-  return `${count} ${noun} still need the 30-second vote.`;
+  return `${count} overdue`;
 }
 
 export function createHumanityManagerStatus({
@@ -81,18 +86,13 @@ export function createHumanityManagerStatus({
   }) {
     return (
       <Section>
-        <Eyebrow>Employee tasks</Eyebrow>
-        <Heading>Who still needs the 30-second vote?</Heading>
-        <Text>
-          These are the humans you assigned to vote. Copy a reminder until
-          their vote verifies the task.
-        </Text>
-        <Text>{buildEmployeeStatus(input)}</Text>
+        <Eyebrow>Your employees</Eyebrow>
+        <Heading>{buildHeading(input)}</Heading>
         {input.reminders.length > 0 ? (
           <ReminderBlock reminders={input.reminders} />
         ) : (
           <Text muted>
-            Assign two humans above and their open vote tasks will appear here.
+            Assign employees above. Their status appears here.
           </Text>
         )}
         <CompletedEmployees


### PR DESCRIPTION
## Summary
- **CI smoke:** accept production deployment status from any creator (not just vercel bot), fix URL detection for onepercenttreaty.org
- **Dashboard:** flatten the Other ways to help accordion into a visible list; rewrite the status panel — kill blather heading, replace with dynamic heading (3 overdue / All voted / None assigned); cut redundant text blocks

## Test plan
- [x] HumanityManagerStatusPanel test passes
- [x] TypeScript compiles clean
- [ ] CI green (core-validate, web-static-validate, web-e2e-validate)
- [ ] Visual check on preview deploy