### PR TITLE
ci: gate web lint + fix entity errors; docs: voice north-star

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,12 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=8192
 
+      - name: Lint web app
+        # The web package was previously never linted in CI (core-validate
+        # filters it out with '!@optimitron/web'), so ESLint errors such as
+        # react/no-unescaped-entities rode through green CI. Gate on them here.
+        run: pnpm --filter @optimitron/web run lint
+
       - name: Run web unit tests
         run: pnpm --filter @optimitron/web run test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,8 @@ Everything user-facing is narrated by **Wishonia** — _World Integrated System 
 - **Criticise the system, never a party.** The data does the work.
 - **In-world artifacts** (EOS pamphlet, certificates, application forms) may go full 1950s brochure — they're documents Wishonia hands you.
 
+**North star.** The bar is two existing pages: `app/joke/page.tsx` and `app/love/page.tsx`. Benchmark line: _"Humanity still has about 121 spare apocalypses. That is enough murder capacity."_ — earnest setup, a specific number, then a flat deadpan aside. Full voice on campaign/marketing/share surfaces; plain-Vonnegut (no forced jokes) on utility (dashboards, settings, dev docs). Judge a rewrite by whether it reaches that bar, not just whether it removed slop.
+
 **No startup-bro copy.** No infrastructure metaphors (stack, rails, off-ramp, primitive, substrate, surface area), empty mechanism vocabulary (incentive layer, the protocol that, this converts it, fundamentally), or corporate openers (We're building, Let's take a moment). If a sentence could appear unchanged in a Stripe keynote, rewrite.
 
 **"Military contractor", never "defense contractor."** "Defense" is the industry's own euphemism. Code identifiers (`DEFENSE_LOBBYING_ANNUAL`) keep their names.

--- a/packages/web/src/app/people/[id]/opengraph-image.tsx
+++ b/packages/web/src/app/people/[id]/opengraph-image.tsx
@@ -66,7 +66,7 @@ export default async function OGImage({
           fontWeight: 900,
         }}
       >
-        Sign for someone who can't
+        {"Sign for someone who can't"}
       </div>,
       { ...size },
     );

--- a/packages/web/src/app/privacy/page.tsx
+++ b/packages/web/src/app/privacy/page.tsx
@@ -136,7 +136,7 @@ export default async function PrivacyPage() {
                 public evidence, or share a public referral link, the site may
                 display the details you submitted, related public counts, and
                 referral impact. Public plaintiff and memorial pages may show
-                the person's name, photo, relationship, life or death status,
+                the person&apos;s name, photo, relationship, life or death status,
                 public comments, memorial details, evidence, and
                 responsible-party claims. They may also show a condition or
                 cause when the form asks for public display and you confirm it.

--- a/packages/web/src/app/tasks/page.tsx
+++ b/packages/web/src/app/tasks/page.tsx
@@ -77,7 +77,7 @@ export default async function TasksPage() {
         {root ? (
           <section className="space-y-3">
             <h2 className="text-lg font-black uppercase tracking-tight sm:text-2xl">
-              Humanity's Tasks
+              Humanity&apos;s Tasks
             </h2>
             <SortableTaskList
               tasks={[root]}

--- a/packages/web/src/app/terms/page.tsx
+++ b/packages/web/src/app/terms/page.tsx
@@ -162,7 +162,7 @@ export default async function TermsPage() {
                   to represent them.
                 </li>
                 <li>
-                  Do not publicly disclose a living or unknown-status person's
+                  Do not publicly disclose a living or unknown-status person&apos;s
                   health condition unless you have consent or legal authority to
                   make that disclosure.
                 </li>

--- a/packages/web/src/components/Footer.tsx
+++ b/packages/web/src/components/Footer.tsx
@@ -41,7 +41,7 @@ function FooterBrandDescription({
 
   return (
     <>
-      Let's trade one apocalypse out of humanity's{" "}
+      Let&apos;s trade one apocalypse out of humanity&apos;s{" "}
       <ParameterValue
         className="font-black text-foreground"
         display="integer"

--- a/packages/web/src/components/landing/TreatyPostVoteShareFlow.tsx
+++ b/packages/web/src/components/landing/TreatyPostVoteShareFlow.tsx
@@ -1019,7 +1019,7 @@ export function TreatyPostVoteShareFlow({
           <>
             <div className="space-y-4">
               <FlowParagraph>
-                Thank you for voting. Now: would you like to vote on behalf of someone who can't? Someone who died of a disease that might have been cured, or a war that didn't need to happen? Give them a voice. They would have voted too.
+                Thank you for voting. Now: would you like to vote on behalf of someone who can&apos;t? Someone who died of a disease that might have been cured, or a war that didn&apos;t need to happen? Give them a voice. They would have voted too.
               </FlowParagraph>
             </div>
             <RepresentedPersonForm variant="inline" />

--- a/packages/web/src/components/people/RepresentedPersonForm.tsx
+++ b/packages/web/src/components/people/RepresentedPersonForm.tsx
@@ -781,7 +781,7 @@ export function RepresentedPersonForm({
                         }}
                         value={conflictId}
                       >
-                        <option value="">Select or "Other"</option>
+                        <option value="">Select or &quot;Other&quot;</option>
                         {conflictOptions.map((conflict) => (
                           <option key={conflict.id} value={conflict.id}>
                             {conflict.name}

--- a/packages/web/src/components/profile/PublicProfileOwnerControls.tsx
+++ b/packages/web/src/components/profile/PublicProfileOwnerControls.tsx
@@ -64,7 +64,7 @@ export function PublicProfileOwnerControls({
             Your public to-do list
           </p>
           <p className="mt-2 text-base font-black text-foreground [font-family:var(--v0-font-libre-baskerville)] sm:text-lg">
-            This is how other humans help you figure out the most valuable action you can take to maximize humanity's median income and healthy life expectancy. Make it public to get help from your network and the world, or keep it private if you prefer. You can change this anytime.
+            This is how other humans help you figure out the most valuable action you can take to maximize humanity&apos;s median income and healthy life expectancy. Make it public to get help from your network and the world, or keep it private if you prefer. You can change this anytime.
           </p>
 
           <div className="mt-4">

--- a/packages/web/src/lib/humanity-manager-promotion-content.tsx
+++ b/packages/web/src/lib/humanity-manager-promotion-content.tsx
@@ -37,13 +37,13 @@ export function createHumanityManagerPromotion({
         <PromoEyebrow>Humanity Manager · Assignment 1</PromoEyebrow>
         <PromoBody>
           <PromoText>
-            🥳Congratulations! You've been promoted to Humanity Manager at Earth Optimization Services, LLC. You are responsible for getting{" "}
+            🥳Congratulations! You&apos;ve been promoted to Humanity Manager at Earth Optimization Services, LLC. You are responsible for getting{" "}
             <ParameterValue
               className="font-black"
               figures={1}
               param={GLOBAL_POPULATION_2024}
             />{" "}
-            humans to agree to trade one of Earth's{" "}
+            humans to agree to trade one of Earth&apos;s{" "}
             <ParameterValue
               className="font-black"
               figures={3}


### PR DESCRIPTION
## Why
The web package was **never linted in CI**. `core-validate` runs `lint` with `--filter '!@optimitron/web'`, and the web lanes only typecheck/test/e2e. So `react/no-unescaped-entities` errors sailed through green CI — that's exactly how the voice pass in #91 shipped raw apostrophes (`That's`, `governments'`, `don't`).

## What
- **Add a `Lint web app` step** to the `web-static-validate` CI job so web ESLint errors now gate merges.
- **Fix the 13 pre-existing entity errors** the gate now catches (across 9 files). Escapes are **rendering-invariant** (`&apos;`/`&quot;` render identically); the people OG-image uses a JS expression instead, since Satori doesn't decode HTML entities.
- **Codify the Wishonia voice north-star** in `CLAUDE.md`: `joke`/`love` pages as the bar, the benchmark line, and full-voice-on-campaign vs plain-Vonnegut-on-utility.

## Verified
- `pnpm --filter @optimitron/web run lint` → **0 errors** (18 pre-existing `<img>`-type warnings remain; warnings don't fail lint).
- `typecheck:app` clean.

Warnings are intentionally not gated (would require a separate `<img>`→`next/image` cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI coverage by adding a web app lint check to the validation pipeline.
  * Cleaned up displayed text across the site to render apostrophes and quotes safely in several pages and components.

* **Documentation**
  * Refined contributor guidance with clearer voice-and-tone examples for different product surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->