### PR TITLE
feat: EOS landing v2 — the Government of Tomorrow showroom

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Optimitron is an **Earth Optimization Machine** for coordinating 8 billion human
 
 The current public campaign is the **International Campaign to End War and Disease** at `warondisease.org`. Until the 1% Treaty passes, that campaign is the product. `optimitron.com` is the operating system and proof engine behind it.
 
-**Earth Optimization Services (EOS)** is the company form of the machine. Every human on Earth is a president of EOS. It buys controlling shares of the corporations that control governments and redirects their ~$4.4B/yr lobbying (`US_TOTAL_LOBBYING_ANNUAL`; defense-only subset is `DEFENSE_LOBBYING_ANNUAL`, ~$127M — don't conflate) toward maximizing median healthy life expectancy and median real after-tax income.
+**Earth Optimization Services (EOS)** is the company form of the machine. Every human on Earth is a president of EOS. It buys controlling shares of the corporations that control governments and redirects their ~$4.4B/yr lobbying (`US_TOTAL_LOBBYING_ANNUAL`; defense-only subset is `DEFENSE_LOBBYING_ANNUAL`, ~$198M — don't conflate) toward maximizing median healthy life expectancy and median real after-tax income.
 
 Default priority order during campaign mode:
 

--- a/TODO.md
+++ b/TODO.md
@@ -123,7 +123,7 @@ Do not let lower items crowd out higher ones.
   Government of Tomorrow redesign (exact approved sketch shipped as the
   masthead status line). The lobbying-figure rule stands for any future
   lobbying claim on this page: `US_TOTAL_LOBBYING_ANNUAL` (~$4.4B) for the
-  all-corporations claim — NOT `DEFENSE_LOBBYING_ANNUAL` (~$127M).
+  all-corporations claim — NOT `DEFENSE_LOBBYING_ANNUAL` (~$198M).
 - **Task tree: cause-node split + seed ALL 35 missing solution tasks
   (Mike-approved 2026-07-02/03):** full plan + tree diagrams in
   `.claude/plans/task-tree-cause-split.md`; complete manual-vs-tasks audit

--- a/TODO.md
+++ b/TODO.md
@@ -59,13 +59,42 @@ Do not let lower items crowd out higher ones.
   registration, verdict voting, and treaty settlement.
 - Visual review includes email screenshots; preview DB drift and unexplained
   missing screenshots still waste review time.
-- **EOS landing (SHIPPED; copy gate satisfied, Mike 2026-07-03: "it shipped,
-  it's fine"):** optimitron.com `/` is the Earth Optimization Services landing
-  (`eosLanding` variant, `EarthOptimizationServicesLandingPage`); game scroll
-  at `/game`; `TODO(copy)` markers stripped. Still open: `/invest` (Loving
-  Takeover / Fund I) deferred — order ladder links to `/fund` with
-  `TODO(invest)` until securities/legal copy is reviewed. Plans:
-  `.claude/plans/eos-landing.md`, `docs/eos-landing-plan.md`.
+- **EOS landing v2: Government of Tomorrow showroom (Mike-approved direction +
+  copy gate 2026-07-03, branch `feature/eos-government-of-tomorrow`):**
+  investor pitch replaced by product catalog — masthead "your application was
+  accepted at birth" (closes the 2026-06-09 masthead item), IN STOCK hero,
+  departments grid (Optimitron, dFDA, DIH, Court of Humanity, Department of
+  Peace, Automated Revenue Service, Universal Security Administration,
+  Aligned Election Commission — all priced by generated params), service
+  counter (curated managed tasks + escrow funding via `EosServiceCounter` /
+  shared `FundingTaskCard`), investor content (calculator/terms/data-room
+  CTAs/legal gate) moved to `/fund`, one shareholder footer strip on `/`.
+  "Decentralized Federal Reserve" card deliberately dropped — ARS + USA cover
+  it without $WISH adjacency. Still open: `/invest` (Loving Takeover / Fund I)
+  deferred until securities/legal copy is reviewed. Known flake:
+  `pledges.server.test.ts` threshold-event race fails under full-suite
+  parallelism (P2034 serialization), passes isolated — pre-existing from
+  PR #98. Follow-ups needing the manual-repo parameter pipeline
+  (`manual/dih_models/parameters.py` — the TS file is generated, do not
+  hand-add): (1) `AUTOMATED_REVENUE_SERVICE_TX_TAX_RATE` (0.5%) so the ARS
+  card's rate is a ParameterValue; (2) `US_TAX_CODE_PAGES` (74,000) behind
+  the "17.5 Harry Potters" line; (3) params for the drug-war thermostat
+  panel stats ($1T, 6,000→107,000 overdose deaths, 53 years) which are
+  manual-verbatim but uncited on the panel. Cold-stranger follow-ups
+  (2026-07-03 run, screenshots `packages/web/output/cold-stranger/`):
+  (a) ParameterValue citation-dialog LaTeX clips off-screen on mobile
+  (pre-existing, site-wide); (b) AUDIT: treaty task renders "Task value
+  $84,787T" — implausible (>5,000x annual peace dividend), check
+  selectedImpactFrame EV computation/units; (c) /fund calculator shows
+  fail-pays-more ($64k vs $35k) with the military-contractor-stock
+  explanation two screens below the numbers — move into same viewport;
+  (d) cross-domain vote CTA (optimitron.com → warondisease.org) reads as
+  brand whiplash to strangers — partially mitigated by naming the treaty
+  in the hero; consider an interstitial or shared brand cue. (e) DoP
+  manual page (`department-of-peace.qmd`) upgrade queued: buy-order robot
+  framing + Megatons-to-Megawatts params (20k warheads → ~10% US
+  electricity 1993–2013) so the card's lightbulbs line gets citations.
+  Plans: `.claude/plans/eos-landing.md`, chat copy doc 2026-07-03.
 - **Earth Optimization Machine page (Mike-approved 2026-07-03, queue after
   MCP-fix + cause-split):** one canonical "what is the machine" page — the
   appliance tour: inputs (census, transmit, what 10,000 jurisdictions tried)
@@ -90,14 +119,11 @@ Do not let lower items crowd out higher ones.
   `TODO(param)` marker in the seed; (3) IABs deliberately deferred (Phase 2,
   gated on prize success); (4) a site route for the Loving Takeover so the
   endpoint stops pointing at the manual. Needs its own branch/PR after #88.
-- **EOS landing: "every president" masthead copy (Mike-approved framing,
-  2026-06-09):** work "every human on Earth is a president of EOS" into the
-  masthead/offer (sketch: "Correction: your application was accepted at birth.
-  You are one of 8,000,000,000 presidents."). Canonical framing now in
-  CLAUDE.md `## What This Is`. Lobbying figure on this page must use
-  `US_TOTAL_LOBBYING_ANNUAL` (~$4.4B, all corporate) for the
-  all-corporations claim — NOT `DEFENSE_LOBBYING_ANNUAL` (~$127M). Own
-  branch after PR #88; manual-search + verbatim copy gate before shipping.
+- **EOS landing: "every president" masthead copy — DONE 2026-07-03** in the
+  Government of Tomorrow redesign (exact approved sketch shipped as the
+  masthead status line). The lobbying-figure rule stands for any future
+  lobbying claim on this page: `US_TOTAL_LOBBYING_ANNUAL` (~$4.4B) for the
+  all-corporations claim — NOT `DEFENSE_LOBBYING_ANNUAL` (~$127M).
 - **Task tree: cause-node split + seed ALL 35 missing solution tasks
   (Mike-approved 2026-07-02/03):** full plan + tree diagrams in
   `.claude/plans/task-tree-cause-split.md`; complete manual-vs-tasks audit

--- a/packages/data/src/parameters/parameters-calculations-citations.ts
+++ b/packages/data/src/parameters/parameters-calculations-citations.ts
@@ -3843,22 +3843,6 @@ export const AI_DIPLOMATIC_CORPS_ANNUAL_COST: Parameter = {
   manualPageTitle: "Department of Peace",
 };
 
-export const ALIGNED_ELECTION_COMMISSION_ANNUAL_OPEX: Parameter = {
-  value: 10000000.0,
-  parameterName: "ALIGNED_ELECTION_COMMISSION_ANNUAL_OPEX",
-  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-aligned_election_commission_annual_opex",
-  unit: "USD",
-  displayName: "Aligned Election Commission Annual Operating Cost",
-  description: "Bottom-up annual operating cost of the Aligned Election Commission: the arithmetic is simple enough that engineers are the whole budget. Uncertainty propagates from the component distributions via Monte Carlo.",
-  sourceType: "calculated",
-  confidence: "high",
-  formula: "ENGINEERS × COST_PER_ENGINEER",
-  latex: "\\begin{gathered}\nCost_{opex,ann} \\\\\n= Aligned \\times Cost_{ann} \\\\\n= 20 \\times \\$500K \\\\\n= \\$10M\n\\end{gathered}",
-  confidenceInterval: [3740425.850699416, 22999358.211654056],
-  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/aligned-election-commission.html",
-  manualPageTitle: "The Aligned Election Commission",
-};
-
 export const APOCALYPSE_MARKUP: Parameter = {
   value: 2719248427416.0605,
   parameterName: "APOCALYPSE_MARKUP",
@@ -3891,23 +3875,23 @@ export const APOCALYPSE_MARKUP_MULTIPLIER: Parameter = {
 };
 
 export const AUTOMATED_REVENUE_SERVICE_ANNUAL_OPEX: Parameter = {
-  value: 200000000.0,
+  value: 150000000.0,
   parameterName: "AUTOMATED_REVENUE_SERVICE_ANNUAL_OPEX",
   calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-automated_revenue_service_annual_opex",
   unit: "USD",
   displayName: "Automated Revenue Service Annual Operating Cost",
-  description: "Bottom-up annual operating cost of the Automated Revenue Service: engineers plus per-transaction infrastructure plus security. Uncertainty propagates from the component distributions via Monte Carlo.",
+  description: "Annual operating cost of the Automated Revenue Service: design transaction volume times the all-in comparator-anchored cost per settlement. Uncertainty propagates from the component distributions via Monte Carlo.",
   sourceType: "calculated",
   confidence: "high",
-  formula: "ENGINEERS × COST_PER_ENGINEER + TRANSACTIONS × COST_PER_TRANSACTION + SECURITY",
-  latex: "\\begin{gathered}\nCost_{opex,ann} \\\\\n= \\text{ENGINEERS} \\times \\text{COST\\_PER\\_ENGINEER} \\\\\n+ \\text{TRANSACTIONS} \\times \\text{COST\\_PER\\_TRANSACTION} \\\\\n+ \\text{SECURITY}\n\\end{gathered}",
-  confidenceInterval: [106578571.31340095, 340477778.8185683],
+  formula: "TRANSACTIONS × ALL_IN_COST_PER_TRANSACTION",
+  latex: "\\begin{gathered}\nCost_{opex,ann} \\\\\n= Automated_{annual} \\times Cost_{all} \\\\\n= 500B \\times \\$0.0003 \\\\\n= \\$150M\n\\end{gathered}",
+  confidenceInterval: [50000000.0, 364641188.53458035],
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
   manualPageTitle: "The Automated Revenue Service",
 };
 
 export const AUTOMATED_REVENUE_SERVICE_SAVINGS_PER_AMERICAN_ANNUAL: Parameter = {
-  value: 1666.0298507462687,
+  value: 1666.1791044776119,
   parameterName: "AUTOMATED_REVENUE_SERVICE_SAVINGS_PER_AMERICAN_ANNUAL",
   calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-automated_revenue_service_savings_per_american_annual",
   unit: "USD",
@@ -3916,8 +3900,8 @@ export const AUTOMATED_REVENUE_SERVICE_SAVINGS_PER_AMERICAN_ANNUAL: Parameter = 
   sourceType: "calculated",
   confidence: "high",
   formula: "(TAX_COMPLIANCE_BURDEN + IRS_BUDGET − ARS_BUDGET) / US_POPULATION",
-  latex: "\\begin{gathered}\nSavings_{ann} = (\\text{TAX\\_COMPLIANCE\\_BURDEN} + \\text{IRS\\_BUDGET} − \\text{ARS\\_BUDGET}) / \\text{US\\_POPULATION}\n\\\\[0.5em]\n\\text{where } Cost_{opex,ann} = \\text{ENGINEERS} \\times \\text{COST\\_PER\\_ENGINEER} + \\text{TRANSACTIONS} \\times \\text{COST\\_PER\\_TRANSACTION} + \\text{SECURITY}\n\\end{gathered}",
-  confidenceInterval: [1418.2020471537328, 1917.2744588047267],
+  latex: "\\begin{gathered}\nSavings_{ann} = (\\text{TAX\\_COMPLIANCE\\_BURDEN} + \\text{IRS\\_BUDGET} − \\text{ARS\\_BUDGET}) / \\text{US\\_POPULATION}\n\\\\[0.5em]\n\\text{where } Cost_{opex,ann} = Automated_{annual} \\times Cost_{all} = 500B \\times \\$0.0003 = \\$150M\n\\end{gathered}",
+  confidenceInterval: [1418.398731450049, 1917.2332431165862],
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
   manualPageTitle: "The Automated Revenue Service",
 };
@@ -9511,17 +9495,17 @@ export const UNEXPLORED_RATIO: Parameter = {
 };
 
 export const UNIVERSAL_SECURITY_ADMIN_ANNUAL_OPEX: Parameter = {
-  value: 99705000.0,
+  value: 100500000.0,
   parameterName: "UNIVERSAL_SECURITY_ADMIN_ANNUAL_OPEX",
   calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-universal_security_admin_annual_opex",
   unit: "USD",
   displayName: "Universal Security Administration Annual Operating Cost",
-  description: "Bottom-up annual operating cost of the Universal Security Administration: identity layer plus 365 daily deposits per citizen plus engineers. Uncertainty propagates from the component distributions via Monte Carlo.",
+  description: "Annual operating cost of the Universal Security Administration: population times the all-in comparator-anchored cost per citizen. Uncertainty propagates from the component distributions via Monte Carlo.",
   sourceType: "calculated",
   confidence: "high",
-  formula: "POPULATION × IDENTITY_COST + POPULATION × 365 × DEPOSIT_COST + ENGINEERS × COST_PER_ENGINEER",
-  latex: "\\begin{gathered}\nCost_{opex,ann} \\\\\n= \\text{POPULATION} \\times \\text{IDENTITY\\_COST} \\\\\n+ \\text{POPULATION} \\times 365 \\times \\text{DEPOSIT\\_COST} \\\\\n+ \\text{ENGINEERS} \\times \\text{COST\\_PER\\_ENGINEER}\n\\end{gathered}",
-  confidenceInterval: [43271726.39325468, 198663200.1746349],
+  formula: "POPULATION × ALL_IN_COST_PER_CITIZEN",
+  latex: "\\begin{gathered}\nCost_{opex,ann} \\\\\n= Pop_{US} \\times Cost_{ann} \\\\\n= 335M \\times \\$0.3 \\\\\n= \\$100M\n\\end{gathered}",
+  confidenceInterval: [33502610.72389832, 250250471.63982713],
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/universal-security-administration.html",
   manualPageTitle: "The Universal Security Administration",
 };
@@ -10829,16 +10813,30 @@ export const AI_NEGOTIATOR_COST_PER_AGENT_HOUR: Parameter = {
   manualPageTitle: "Department of Peace",
 };
 
-export const ALIGNED_ELECTION_COMMISSION_ENGINEER_HEADCOUNT: Parameter = {
-  value: 20.0,
-  parameterName: "ALIGNED_ELECTION_COMMISSION_ENGINEER_HEADCOUNT",
-  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-aligned_election_commission_engineer_headcount",
-  unit: "engineers",
-  displayName: "Aligned Election Commission Engineer Headcount",
-  description: "Engineering headcount assumed for alignment-score computation, public data pipelines, and campaign-fund routing.",
+export const ALGORITHMIC_MONETARY_AUTHORITY_ANNUAL_OPEX: Parameter = {
+  value: 7500000.0,
+  parameterName: "ALGORITHMIC_MONETARY_AUTHORITY_ANNUAL_OPEX",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-algorithmic_monetary_authority_annual_opex",
+  unit: "USD",
+  displayName: "Algorithmic Monetary Authority Annual Operating Cost",
+  description: "All-in annual operating cost of the Algorithmic Monetary Authority: basket monitoring, rule execution, continuous public verification, and the humans who hold the pager. Sized as a small monitoring operation; the rule itself is one formula and requires no committee.",
   sourceType: "definition",
   confidence: "high",
-  confidenceInterval: [10.0, 60.0],
+  confidenceInterval: [3000000.0, 20000000.0],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/algorithmic-monetary-authority.html",
+  manualPageTitle: "The Algorithmic Monetary Authority",
+};
+
+export const ALIGNED_ELECTION_COMMISSION_ANNUAL_OPEX: Parameter = {
+  value: 7000000.0,
+  parameterName: "ALIGNED_ELECTION_COMMISSION_ANNUAL_OPEX",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-aligned_election_commission_annual_opex",
+  unit: "USD",
+  displayName: "Aligned Election Commission Annual Operating Cost",
+  description: "All-in annual operating cost of the Aligned Election Commission: alignment-score computation, public data pipelines, and fund routing. Sized as a small data-engineering operation; the most similar existing system is the NRA's politician scorecard, which runs on a budget that rounds to zero.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [2000000.0, 20000000.0],
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/aligned-election-commission.html",
   manualPageTitle: "The Aligned Election Commission",
 };
@@ -10884,6 +10882,20 @@ export const APPROVED_DRUG_DISEASE_PAIRINGS: Parameter = {
   manualPageTitle: "The Untapped Therapeutic Frontier",
 };
 
+export const AUTOMATED_REVENUE_SERVICE_ALL_IN_COST_PER_TRANSACTION: Parameter = {
+  value: 0.0003,
+  parameterName: "AUTOMATED_REVENUE_SERVICE_ALL_IN_COST_PER_TRANSACTION",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-automated_revenue_service_all_in_cost_per_transaction",
+  unit: "USD",
+  displayName: "All-In Cost per Settlement Transaction",
+  description: "All-in cost per settlement (three hundredths of a cent): compute, storage, security audits, and the mostly-AI workforce, amortized per transaction. Anchored to the most similar systems that exist: card networks clear transactions for internal costs in this range, and public blockchain rails settle transfers for fractions of a cent.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [0.0001, 0.001],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
+  manualPageTitle: "The Automated Revenue Service",
+};
+
 export const AUTOMATED_REVENUE_SERVICE_ANNUAL_TRANSACTION_VOLUME: Parameter = {
   value: 500000000000.0,
   parameterName: "AUTOMATED_REVENUE_SERVICE_ANNUAL_TRANSACTION_VOLUME",
@@ -10893,48 +10905,6 @@ export const AUTOMATED_REVENUE_SERVICE_ANNUAL_TRANSACTION_VOLUME: Parameter = {
   description: "Design capacity: annual final-consumption settlements processed by the protocol, set well above current US card-network transaction volume.",
   sourceType: "definition",
   confidence: "high",
-  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
-  manualPageTitle: "The Automated Revenue Service",
-};
-
-export const AUTOMATED_REVENUE_SERVICE_ENGINEER_HEADCOUNT: Parameter = {
-  value: 200.0,
-  parameterName: "AUTOMATED_REVENUE_SERVICE_ENGINEER_HEADCOUNT",
-  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-automated_revenue_service_engineer_headcount",
-  unit: "engineers",
-  displayName: "Automated Revenue Service Engineer Headcount",
-  description: "Engineering, security, and operations headcount assumed for running the settlement-tax protocol at national scale.",
-  sourceType: "definition",
-  confidence: "high",
-  confidenceInterval: [100.0, 400.0],
-  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
-  manualPageTitle: "The Automated Revenue Service",
-};
-
-export const AUTOMATED_REVENUE_SERVICE_INFRA_COST_PER_TRANSACTION: Parameter = {
-  value: 0.0001,
-  parameterName: "AUTOMATED_REVENUE_SERVICE_INFRA_COST_PER_TRANSACTION",
-  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-automated_revenue_service_infra_cost_per_transaction",
-  unit: "USD",
-  displayName: "Infrastructure Cost per Settlement Transaction",
-  description: "Assumed compute, storage, and bandwidth cost per settlement (a hundredth of a cent), generous against modern payment-rail marginal costs.",
-  sourceType: "definition",
-  confidence: "high",
-  confidenceInterval: [3e-05, 0.0005],
-  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
-  manualPageTitle: "The Automated Revenue Service",
-};
-
-export const AUTOMATED_REVENUE_SERVICE_SECURITY_ANNUAL_COST: Parameter = {
-  value: 50000000.0,
-  parameterName: "AUTOMATED_REVENUE_SERVICE_SECURITY_ANNUAL_COST",
-  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-automated_revenue_service_security_annual_cost",
-  unit: "USD",
-  displayName: "Automated Revenue Service Annual Security Budget",
-  description: "Annual budget for security audits, red teams, and bug bounties on the settlement-tax protocol.",
-  sourceType: "definition",
-  confidence: "high",
-  confidenceInterval: [20000000.0, 150000000.0],
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
   manualPageTitle: "The Automated Revenue Service",
 };
@@ -11551,6 +11521,20 @@ export const DCT_PLATFORM_FUNDING_MEDIUM: Parameter = {
   manualPageTitle: "A Decentralized FDA",
 };
 
+export const DECENTRALIZED_CENSUS_BUREAU_ANNUAL_OPEX: Parameter = {
+  value: 15000000.0,
+  parameterName: "DECENTRALIZED_CENSUS_BUREAU_ANNUAL_OPEX",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-decentralized_census_bureau_annual_opex",
+  unit: "USD",
+  displayName: "Decentralized Census Bureau Annual Operating Cost",
+  description: "All-in annual operating cost of the sensor array: continuously computing, cross-checking, and integrity-auditing the statistics the machine steers by (median after-tax income aggregates, healthy-life-expectancy estimation from dFDA outcome data, data-poisoning detection). Sized as a mid-sized analytics operation; roughly 1% of what the decennial census costs per year amortized. The citizen count itself is a free byproduct of the identity layer.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [5000000.0, 40000000.0],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/decentralized-census-bureau.html",
+  manualPageTitle: "The Decentralized Census Bureau",
+};
+
 export const DEFENSE_SECTOR_RETENTION_PCT: Parameter = {
   value: 0.99,
   parameterName: "DEFENSE_SECTOR_RETENTION_PCT",
@@ -12094,20 +12078,6 @@ export const GLOBAL_TO_US_POLITICAL_COST_RATIO: Parameter = {
   confidenceInterval: [3.0, 8.0],
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/appendix/cost-of-change-analysis.html",
   manualPageTitle: "How Much Does It Cost to Buy All the Governments?",
-};
-
-export const GOV_REPLACEMENT_ENGINEER_ANNUAL_COST: Parameter = {
-  value: 500000.0,
-  parameterName: "GOV_REPLACEMENT_ENGINEER_ANNUAL_COST",
-  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-gov_replacement_engineer_annual_cost",
-  unit: "USD",
-  displayName: "Fully Loaded Annual Cost per Engineer",
-  description: "Fully loaded annual cost per engineer (salary, benefits, equipment, overhead) assumed for all government replacement modules. Set at the top of market rates.",
-  sourceType: "definition",
-  confidence: "high",
-  confidenceInterval: [300000.0, 900000.0],
-  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
-  manualPageTitle: "The Automated Revenue Service",
 };
 
 export const HALE_LONGEVITY_REALIZATION_SHARE_YEAR_15: Parameter = {
@@ -12804,6 +12774,20 @@ export const TESTED_RELATIONSHIPS_ESTIMATE: Parameter = {
   manualPageTitle: "The Untapped Therapeutic Frontier",
 };
 
+export const TRANSPARENT_SECURITIES_COMMISSION_ANNUAL_OPEX: Parameter = {
+  value: 20000000.0,
+  parameterName: "TRANSPARENT_SECURITIES_COMMISSION_ANNUAL_OPEX",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-transparent_securities_commission_annual_opex",
+  unit: "USD",
+  displayName: "Transparent Securities Commission Annual Operating Cost",
+  description: "All-in annual operating cost of the Transparent Securities Commission: standardized disclosure schema plus continuous fraud-pattern detection across every issuer on the ledger. Anchored to the most similar existing systems: the real-time fraud-detection operations card networks already run at market scale.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [8000000.0, 50000000.0],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/transparent-securities-commission.html",
+  manualPageTitle: "The Transparent Securities Commission",
+};
+
 export const TREATY_CAMPAIGN_BUDGET_LOBBYING: Parameter = {
   value: 650000000.0,
   parameterName: "TREATY_CAMPAIGN_BUDGET_LOBBYING",
@@ -12930,44 +12914,16 @@ export const TRIAL_RELEVANT_DISEASES_COUNT: Parameter = {
   manualPageTitle: "The Untapped Therapeutic Frontier",
 };
 
-export const UNIVERSAL_SECURITY_ADMIN_DEPOSIT_COST_PER_TRANSACTION: Parameter = {
-  value: 0.0002,
-  parameterName: "UNIVERSAL_SECURITY_ADMIN_DEPOSIT_COST_PER_TRANSACTION",
-  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-universal_security_admin_deposit_cost_per_transaction",
+export const UNIVERSAL_SECURITY_ADMIN_ALL_IN_COST_PER_CITIZEN_ANNUAL: Parameter = {
+  value: 0.3,
+  parameterName: "UNIVERSAL_SECURITY_ADMIN_ALL_IN_COST_PER_CITIZEN_ANNUAL",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-universal_security_admin_all_in_cost_per_citizen_annual",
   unit: "USD",
-  displayName: "Cost per UBI Deposit",
-  description: "Assumed cost per daily UBI deposit (two hundredths of a cent per transfer).",
+  displayName: "Universal Security Administration All-In Annual Cost per Citizen",
+  description: "All-in annual cost per citizen served: sybil-resistant identity, 365 daily deposits, and the mostly-AI workforce. Anchored to the most similar system that exists: India's national biometric identity system serves 1.4 billion people at costs in this range per person per year, and payment rails move deposits for fractions of a cent.",
   sourceType: "definition",
   confidence: "high",
-  confidenceInterval: [5e-05, 0.001],
-  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/universal-security-administration.html",
-  manualPageTitle: "The Universal Security Administration",
-};
-
-export const UNIVERSAL_SECURITY_ADMIN_ENGINEER_HEADCOUNT: Parameter = {
-  value: 50.0,
-  parameterName: "UNIVERSAL_SECURITY_ADMIN_ENGINEER_HEADCOUNT",
-  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-universal_security_admin_engineer_headcount",
-  unit: "engineers",
-  displayName: "Universal Security Administration Engineer Headcount",
-  description: "Engineering and operations headcount assumed for running the UBI distribution contract and identity integration.",
-  sourceType: "definition",
-  confidence: "high",
-  confidenceInterval: [25.0, 150.0],
-  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/universal-security-administration.html",
-  manualPageTitle: "The Universal Security Administration",
-};
-
-export const UNIVERSAL_SECURITY_ADMIN_IDENTITY_COST_PER_CITIZEN: Parameter = {
-  value: 0.15,
-  parameterName: "UNIVERSAL_SECURITY_ADMIN_IDENTITY_COST_PER_CITIZEN",
-  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-universal_security_admin_identity_cost_per_citizen",
-  unit: "USD",
-  displayName: "Identity Layer Annual Cost per Citizen",
-  description: "Assumed annual cost per citizen for sybil-resistant identity verification and maintenance, generous against national-scale digital-identity systems.",
-  sourceType: "definition",
-  confidence: "high",
-  confidenceInterval: [0.05, 0.6],
+  confidenceInterval: [0.1, 1.0],
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/universal-security-administration.html",
   manualPageTitle: "The Universal Security Administration",
 };
@@ -13625,7 +13581,6 @@ export const parameters = {
   WORKFORCE_WITH_PRODUCTIVITY_LOSS,
   ADDITIONAL_DRUGS_FROM_COST_ELIMINATION,
   AI_DIPLOMATIC_CORPS_ANNUAL_COST,
-  ALIGNED_ELECTION_COMMISSION_ANNUAL_OPEX,
   APOCALYPSE_MARKUP,
   APOCALYPSE_MARKUP_MULTIPLIER,
   AUTOMATED_REVENUE_SERVICE_ANNUAL_OPEX,
@@ -14062,14 +14017,13 @@ export const parameters = {
   ADAPTABLE_TRIAL_PATIENTS,
   AI_NEGOTIATOR_AGENTS_PER_GOVERNMENT,
   AI_NEGOTIATOR_COST_PER_AGENT_HOUR,
-  ALIGNED_ELECTION_COMMISSION_ENGINEER_HEADCOUNT,
+  ALGORITHMIC_MONETARY_AUTHORITY_ANNUAL_OPEX,
+  ALIGNED_ELECTION_COMMISSION_ANNUAL_OPEX,
   ALLOCATION_DECISION_SPREAD,
   ANNUAL_WORKING_HOURS,
   APPROVED_DRUG_DISEASE_PAIRINGS,
+  AUTOMATED_REVENUE_SERVICE_ALL_IN_COST_PER_TRANSACTION,
   AUTOMATED_REVENUE_SERVICE_ANNUAL_TRANSACTION_VOLUME,
-  AUTOMATED_REVENUE_SERVICE_ENGINEER_HEADCOUNT,
-  AUTOMATED_REVENUE_SERVICE_INFRA_COST_PER_TRANSACTION,
-  AUTOMATED_REVENUE_SERVICE_SECURITY_ANNUAL_COST,
   AVG_LIFE_EXTENSION_PER_BENEFICIARY,
   CAMPAIGN_CELEBRITY_ENDORSEMENT,
   CAMPAIGN_COMMUNITY_ORGANIZING,
@@ -14114,6 +14068,7 @@ export const parameters = {
   CUMULATIVE_MILITARY_SPENDING_FED_ERA,
   DAYS_PER_YEAR,
   DCT_PLATFORM_FUNDING_MEDIUM,
+  DECENTRALIZED_CENSUS_BUREAU_ANNUAL_OPEX,
   DEFENSE_SECTOR_RETENTION_PCT,
   DEFENSE_TAKEOVER_ACQUISITION_PREMIUM,
   DEFENSE_TAKEOVER_CONTROL_FRACTION,
@@ -14153,7 +14108,6 @@ export const parameters = {
   GLOBAL_EFFECTIVE_TAX_RATE_MEDIAN,
   GLOBAL_MEDIAN_SHARE_EROSION_RATE_ANNUAL,
   GLOBAL_TO_US_POLITICAL_COST_RATIO,
-  GOV_REPLACEMENT_ENGINEER_ANNUAL_COST,
   HALE_LONGEVITY_REALIZATION_SHARE_YEAR_15,
   HOURS_PER_DAY,
   HOURS_PER_YEAR,
@@ -14206,6 +14160,7 @@ export const parameters = {
   SHIRT_SEED_WEARERS_THRESHOLD,
   SHIRT_WEARING_FRICTION_COST_USD,
   TESTED_RELATIONSHIPS_ESTIMATE,
+  TRANSPARENT_SECURITIES_COMMISSION_ANNUAL_OPEX,
   TREATY_CAMPAIGN_BUDGET_LOBBYING,
   TREATY_CAMPAIGN_BUDGET_RESERVE,
   TREATY_CAMPAIGN_DURATION_YEARS,
@@ -14215,9 +14170,7 @@ export const parameters = {
   TREATY_REDIRECTED_SPENDING_INFINITE_ROI,
   TREATY_REDUCTION_PCT,
   TRIAL_RELEVANT_DISEASES_COUNT,
-  UNIVERSAL_SECURITY_ADMIN_DEPOSIT_COST_PER_TRANSACTION,
-  UNIVERSAL_SECURITY_ADMIN_ENGINEER_HEADCOUNT,
-  UNIVERSAL_SECURITY_ADMIN_IDENTITY_COST_PER_CITIZEN,
+  UNIVERSAL_SECURITY_ADMIN_ALL_IN_COST_PER_CITIZEN_ANNUAL,
   US_CONGRESS_MEMBER_COUNT,
   US_DEFENSE_FP_COAST_GUARD,
   US_DEFENSE_FP_CYBER,
@@ -16769,10 +16722,10 @@ export const citations: Record<string, Citation> = {
 
 /** Summary statistics */
 export const PARAMETER_STATS = {
-  total: 862,
+  total: 859,
   external: 237,
-  calculated: 436,
-  definitions: 189,
+  calculated: 435,
+  definitions: 187,
   citations: 182,
 } as const;
 

--- a/packages/data/src/parameters/parameters-calculations-citations.ts
+++ b/packages/data/src/parameters/parameters-calculations-citations.ts
@@ -1906,6 +1906,21 @@ export const ICD_10_TOTAL_CODES: Parameter = {
   manualPageTitle: "The Untapped Therapeutic Frontier",
 };
 
+export const IRS_ANNUAL_OPERATING_BUDGET: Parameter = {
+  value: 12320000000.0,
+  parameterName: "IRS_ANNUAL_OPERATING_BUDGET",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-irs_annual_operating_budget",
+  unit: "USD",
+  displayName: "IRS Annual Operating Budget",
+  description: "IRS enacted annual appropriation, FY2024 (CRS IF12647, Table 1).",
+  sourceType: "external",
+  sourceRef: "crs-irs-appropriations-fy2025",
+  sourceUrl: "https://www.congress.gov/crs_external_products/IF/PDF/IF12647/IF12647.2.pdf",
+  confidence: "high",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
+  manualPageTitle: "The Automated Revenue Service",
+};
+
 export const LEADED_GASOLINE_US_AVG_IQ_LOSS_POINTS: Parameter = {
   value: 2.6,
   parameterName: "LEADED_GASOLINE_US_AVG_IQ_LOSS_POINTS",
@@ -3812,6 +3827,38 @@ export const ADDITIONAL_DRUGS_FROM_COST_ELIMINATION: Parameter = {
   manualPageTitle: "The 1% Treaty: An Incentive-Compatible Approach to Ending War and Disease",
 };
 
+export const AI_DIPLOMATIC_CORPS_ANNUAL_COST: Parameter = {
+  value: 8541000.0,
+  parameterName: "AI_DIPLOMATIC_CORPS_ANNUAL_COST",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-ai_diplomatic_corps_annual_cost",
+  unit: "USD",
+  displayName: "AI Diplomatic Corps Annual Cost",
+  description: "Bottom-up annual cost of the AI diplomatic corps: negotiator agents for every government, running every hour of the year, at blended frontier inference prices. Uncertainty propagates from the component distributions via Monte Carlo.",
+  sourceType: "calculated",
+  confidence: "high",
+  formula: "GOVERNMENTS × AGENTS_PER_GOVERNMENT × 8760 hours × COST_PER_AGENT_HOUR",
+  latex: "\\begin{gathered}\nCost_{ann} \\\\\n= N_{leader} \\times Ai \\times Cost_{per} \\times 8760 \\\\\n= 195 \\times 10 \\times \\$0.5 \\times 8760 \\\\\n= \\$8.54M\n\\end{gathered}",
+  confidenceInterval: [829434.8570727136, 29444832.407966193],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/department-of-peace.html",
+  manualPageTitle: "Department of Peace",
+};
+
+export const ALIGNED_ELECTION_COMMISSION_ANNUAL_OPEX: Parameter = {
+  value: 10000000.0,
+  parameterName: "ALIGNED_ELECTION_COMMISSION_ANNUAL_OPEX",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-aligned_election_commission_annual_opex",
+  unit: "USD",
+  displayName: "Aligned Election Commission Annual Operating Cost",
+  description: "Bottom-up annual operating cost of the Aligned Election Commission: the arithmetic is simple enough that engineers are the whole budget. Uncertainty propagates from the component distributions via Monte Carlo.",
+  sourceType: "calculated",
+  confidence: "high",
+  formula: "ENGINEERS × COST_PER_ENGINEER",
+  latex: "\\begin{gathered}\nCost_{opex,ann} \\\\\n= Aligned \\times Cost_{ann} \\\\\n= 20 \\times \\$500K \\\\\n= \\$10M\n\\end{gathered}",
+  confidenceInterval: [3740425.850699416, 22999358.211654056],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/aligned-election-commission.html",
+  manualPageTitle: "The Aligned Election Commission",
+};
+
 export const APOCALYPSE_MARKUP: Parameter = {
   value: 2719248427416.0605,
   parameterName: "APOCALYPSE_MARKUP",
@@ -3841,6 +3888,38 @@ export const APOCALYPSE_MARKUP_MULTIPLIER: Parameter = {
   confidenceInterval: [1258.6489497229195, 5859.786529997165],
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/appendix/extinction-surplus.html",
   manualPageTitle: "The Apocalypse Markup",
+};
+
+export const AUTOMATED_REVENUE_SERVICE_ANNUAL_OPEX: Parameter = {
+  value: 200000000.0,
+  parameterName: "AUTOMATED_REVENUE_SERVICE_ANNUAL_OPEX",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-automated_revenue_service_annual_opex",
+  unit: "USD",
+  displayName: "Automated Revenue Service Annual Operating Cost",
+  description: "Bottom-up annual operating cost of the Automated Revenue Service: engineers plus per-transaction infrastructure plus security. Uncertainty propagates from the component distributions via Monte Carlo.",
+  sourceType: "calculated",
+  confidence: "high",
+  formula: "ENGINEERS × COST_PER_ENGINEER + TRANSACTIONS × COST_PER_TRANSACTION + SECURITY",
+  latex: "\\begin{gathered}\nCost_{opex,ann} \\\\\n= \\text{ENGINEERS} \\times \\text{COST\\_PER\\_ENGINEER} \\\\\n+ \\text{TRANSACTIONS} \\times \\text{COST\\_PER\\_TRANSACTION} \\\\\n+ \\text{SECURITY}\n\\end{gathered}",
+  confidenceInterval: [106578571.31340095, 340477778.8185683],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
+  manualPageTitle: "The Automated Revenue Service",
+};
+
+export const AUTOMATED_REVENUE_SERVICE_SAVINGS_PER_AMERICAN_ANNUAL: Parameter = {
+  value: 1666.0298507462687,
+  parameterName: "AUTOMATED_REVENUE_SERVICE_SAVINGS_PER_AMERICAN_ANNUAL",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-automated_revenue_service_savings_per_american_annual",
+  unit: "USD",
+  displayName: "Automated Revenue Service Annual Savings per American",
+  description: "Annual savings per American from replacing the IRS and the tax-compliance burden with the Automated Revenue Service, net of the padded replacement budget.",
+  sourceType: "calculated",
+  confidence: "high",
+  formula: "(TAX_COMPLIANCE_BURDEN + IRS_BUDGET − ARS_BUDGET) / US_POPULATION",
+  latex: "\\begin{gathered}\nSavings_{ann} = (\\text{TAX\\_COMPLIANCE\\_BURDEN} + \\text{IRS\\_BUDGET} − \\text{ARS\\_BUDGET}) / \\text{US\\_POPULATION}\n\\\\[0.5em]\n\\text{where } Cost_{opex,ann} = \\text{ENGINEERS} \\times \\text{COST\\_PER\\_ENGINEER} + \\text{TRANSACTIONS} \\times \\text{COST\\_PER\\_TRANSACTION} + \\text{SECURITY}\n\\end{gathered}",
+  confidenceInterval: [1418.2020471537328, 1917.2744588047267],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
+  manualPageTitle: "The Automated Revenue Service",
 };
 
 export const BEST_PRACTICE_LIFE_EXPECTANCY_GAIN: Parameter = {
@@ -6503,6 +6582,22 @@ export const GLOBAL_DISEASE_TOTAL_MARKET_COST_ANNUAL: Parameter = {
   confidenceInterval: [11924462024252.91, 18328394950626.133],
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/problem/cost-of-disease.html",
   manualPageTitle: "The Cost of Disease",
+};
+
+export const GLOBAL_EVENTUALLY_AVOIDABLE_DISEASE_DEATHS_DAILY: Parameter = {
+  value: 138941.7118512781,
+  parameterName: "GLOBAL_EVENTUALLY_AVOIDABLE_DISEASE_DEATHS_DAILY",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-global_eventually_avoidable_disease_deaths_daily",
+  unit: "deaths/day",
+  displayName: "Eventually Avoidable Deaths per Day",
+  description: "Daily global deaths that are eventually avoidable with sufficient biomedical research. Each day the disease-eradication date slips adds roughly this many deaths to the total schedule cost.",
+  sourceType: "calculated",
+  confidence: "medium",
+  formula: "GLOBAL_DISEASE_DEATHS_DAILY × EVENTUALLY_AVOIDABLE_DEATH_PCT",
+  latex: "\\begin{gathered}\nDeaths_{avoid,daily} \\\\\n= Deaths_{disease,daily} \\times Pct_{avoid,death} \\\\\n= 150{,}000 \\times 92.6\\% \\\\\n= 139{,}000\n\\end{gathered}",
+  confidenceInterval: [95672.50666696663, 157290.95119782313],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/appendix/where-am-i-wrong.html",
+  manualPageTitle: "Where Am I Wrong?",
 };
 
 export const GLOBAL_GOVERNMENT_EXPENSE_ANNUAL: Parameter = {
@@ -9415,6 +9510,22 @@ export const UNEXPLORED_RATIO: Parameter = {
   manualPageTitle: "NIH Fails to Institute Health",
 };
 
+export const UNIVERSAL_SECURITY_ADMIN_ANNUAL_OPEX: Parameter = {
+  value: 99705000.0,
+  parameterName: "UNIVERSAL_SECURITY_ADMIN_ANNUAL_OPEX",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-universal_security_admin_annual_opex",
+  unit: "USD",
+  displayName: "Universal Security Administration Annual Operating Cost",
+  description: "Bottom-up annual operating cost of the Universal Security Administration: identity layer plus 365 daily deposits per citizen plus engineers. Uncertainty propagates from the component distributions via Monte Carlo.",
+  sourceType: "calculated",
+  confidence: "high",
+  formula: "POPULATION × IDENTITY_COST + POPULATION × 365 × DEPOSIT_COST + ENGINEERS × COST_PER_ENGINEER",
+  latex: "\\begin{gathered}\nCost_{opex,ann} \\\\\n= \\text{POPULATION} \\times \\text{IDENTITY\\_COST} \\\\\n+ \\text{POPULATION} \\times 365 \\times \\text{DEPOSIT\\_COST} \\\\\n+ \\text{ENGINEERS} \\times \\text{COST\\_PER\\_ENGINEER}\n\\end{gathered}",
+  confidenceInterval: [43271726.39325468, 198663200.1746349],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/universal-security-administration.html",
+  manualPageTitle: "The Universal Security Administration",
+};
+
 export const US_1939_MILITARY_SPENDING_PCT_LOWER_THAN_CURRENT: Parameter = {
   value: 0.9672686230248307,
   parameterName: "US_1939_MILITARY_SPENDING_PCT_LOWER_THAN_CURRENT",
@@ -10690,6 +10801,48 @@ export const ADAPTABLE_TRIAL_PATIENTS: Parameter = {
   manualPageTitle: "The 1% Treaty: An Incentive-Compatible Approach to Ending War and Disease",
 };
 
+export const AI_NEGOTIATOR_AGENTS_PER_GOVERNMENT: Parameter = {
+  value: 10.0,
+  parameterName: "AI_NEGOTIATOR_AGENTS_PER_GOVERNMENT",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-ai_negotiator_agents_per_government",
+  unit: "agents",
+  displayName: "AI Negotiator Agents per Government",
+  description: "Concurrent AI negotiator agents assigned to each government: leaders, ministries, and back-channel tracks running in parallel.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [3.0, 30.0],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/department-of-peace.html",
+  manualPageTitle: "Department of Peace",
+};
+
+export const AI_NEGOTIATOR_COST_PER_AGENT_HOUR: Parameter = {
+  value: 0.5,
+  parameterName: "AI_NEGOTIATOR_COST_PER_AGENT_HOUR",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-ai_negotiator_cost_per_agent_hour",
+  unit: "USD",
+  displayName: "AI Negotiator Blended Cost per Agent-Hour",
+  description: "Blended inference cost per agent-hour for a frontier-model negotiator: agents reason at full burn only in bursts, and monitoring hours cost pennies. Rounded up from current API prices.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [0.1, 3.0],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/department-of-peace.html",
+  manualPageTitle: "Department of Peace",
+};
+
+export const ALIGNED_ELECTION_COMMISSION_ENGINEER_HEADCOUNT: Parameter = {
+  value: 20.0,
+  parameterName: "ALIGNED_ELECTION_COMMISSION_ENGINEER_HEADCOUNT",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-aligned_election_commission_engineer_headcount",
+  unit: "engineers",
+  displayName: "Aligned Election Commission Engineer Headcount",
+  description: "Engineering headcount assumed for alignment-score computation, public data pipelines, and campaign-fund routing.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [10.0, 60.0],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/aligned-election-commission.html",
+  manualPageTitle: "The Aligned Election Commission",
+};
+
 export const ALLOCATION_DECISION_SPREAD: Parameter = {
   value: 0.08,
   parameterName: "ALLOCATION_DECISION_SPREAD",
@@ -10729,6 +10882,61 @@ export const APPROVED_DRUG_DISEASE_PAIRINGS: Parameter = {
   confidenceInterval: [1500.0, 2000.0],
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/problem/untapped-therapeutic-frontier.html",
   manualPageTitle: "The Untapped Therapeutic Frontier",
+};
+
+export const AUTOMATED_REVENUE_SERVICE_ANNUAL_TRANSACTION_VOLUME: Parameter = {
+  value: 500000000000.0,
+  parameterName: "AUTOMATED_REVENUE_SERVICE_ANNUAL_TRANSACTION_VOLUME",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-automated_revenue_service_annual_transaction_volume",
+  unit: "transactions",
+  displayName: "Automated Revenue Service Annual Transaction Volume",
+  description: "Design capacity: annual final-consumption settlements processed by the protocol, set well above current US card-network transaction volume.",
+  sourceType: "definition",
+  confidence: "high",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
+  manualPageTitle: "The Automated Revenue Service",
+};
+
+export const AUTOMATED_REVENUE_SERVICE_ENGINEER_HEADCOUNT: Parameter = {
+  value: 200.0,
+  parameterName: "AUTOMATED_REVENUE_SERVICE_ENGINEER_HEADCOUNT",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-automated_revenue_service_engineer_headcount",
+  unit: "engineers",
+  displayName: "Automated Revenue Service Engineer Headcount",
+  description: "Engineering, security, and operations headcount assumed for running the settlement-tax protocol at national scale.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [100.0, 400.0],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
+  manualPageTitle: "The Automated Revenue Service",
+};
+
+export const AUTOMATED_REVENUE_SERVICE_INFRA_COST_PER_TRANSACTION: Parameter = {
+  value: 0.0001,
+  parameterName: "AUTOMATED_REVENUE_SERVICE_INFRA_COST_PER_TRANSACTION",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-automated_revenue_service_infra_cost_per_transaction",
+  unit: "USD",
+  displayName: "Infrastructure Cost per Settlement Transaction",
+  description: "Assumed compute, storage, and bandwidth cost per settlement (a hundredth of a cent), generous against modern payment-rail marginal costs.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [3e-05, 0.0005],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
+  manualPageTitle: "The Automated Revenue Service",
+};
+
+export const AUTOMATED_REVENUE_SERVICE_SECURITY_ANNUAL_COST: Parameter = {
+  value: 50000000.0,
+  parameterName: "AUTOMATED_REVENUE_SERVICE_SECURITY_ANNUAL_COST",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-automated_revenue_service_security_annual_cost",
+  unit: "USD",
+  displayName: "Automated Revenue Service Annual Security Budget",
+  description: "Annual budget for security audits, red teams, and bug bounties on the settlement-tax protocol.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [20000000.0, 150000000.0],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
+  manualPageTitle: "The Automated Revenue Service",
 };
 
 export const AVG_LIFE_EXTENSION_PER_BENEFICIARY: Parameter = {
@@ -11888,6 +12096,20 @@ export const GLOBAL_TO_US_POLITICAL_COST_RATIO: Parameter = {
   manualPageTitle: "How Much Does It Cost to Buy All the Governments?",
 };
 
+export const GOV_REPLACEMENT_ENGINEER_ANNUAL_COST: Parameter = {
+  value: 500000.0,
+  parameterName: "GOV_REPLACEMENT_ENGINEER_ANNUAL_COST",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-gov_replacement_engineer_annual_cost",
+  unit: "USD",
+  displayName: "Fully Loaded Annual Cost per Engineer",
+  description: "Fully loaded annual cost per engineer (salary, benefits, equipment, overhead) assumed for all government replacement modules. Set at the top of market rates.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [300000.0, 900000.0],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html",
+  manualPageTitle: "The Automated Revenue Service",
+};
+
 export const HALE_LONGEVITY_REALIZATION_SHARE_YEAR_15: Parameter = {
   value: 0.3,
   parameterName: "HALE_LONGEVITY_REALIZATION_SHARE_YEAR_15",
@@ -12708,6 +12930,48 @@ export const TRIAL_RELEVANT_DISEASES_COUNT: Parameter = {
   manualPageTitle: "The Untapped Therapeutic Frontier",
 };
 
+export const UNIVERSAL_SECURITY_ADMIN_DEPOSIT_COST_PER_TRANSACTION: Parameter = {
+  value: 0.0002,
+  parameterName: "UNIVERSAL_SECURITY_ADMIN_DEPOSIT_COST_PER_TRANSACTION",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-universal_security_admin_deposit_cost_per_transaction",
+  unit: "USD",
+  displayName: "Cost per UBI Deposit",
+  description: "Assumed cost per daily UBI deposit (two hundredths of a cent per transfer).",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [5e-05, 0.001],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/universal-security-administration.html",
+  manualPageTitle: "The Universal Security Administration",
+};
+
+export const UNIVERSAL_SECURITY_ADMIN_ENGINEER_HEADCOUNT: Parameter = {
+  value: 50.0,
+  parameterName: "UNIVERSAL_SECURITY_ADMIN_ENGINEER_HEADCOUNT",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-universal_security_admin_engineer_headcount",
+  unit: "engineers",
+  displayName: "Universal Security Administration Engineer Headcount",
+  description: "Engineering and operations headcount assumed for running the UBI distribution contract and identity integration.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [25.0, 150.0],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/universal-security-administration.html",
+  manualPageTitle: "The Universal Security Administration",
+};
+
+export const UNIVERSAL_SECURITY_ADMIN_IDENTITY_COST_PER_CITIZEN: Parameter = {
+  value: 0.15,
+  parameterName: "UNIVERSAL_SECURITY_ADMIN_IDENTITY_COST_PER_CITIZEN",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-universal_security_admin_identity_cost_per_citizen",
+  unit: "USD",
+  displayName: "Identity Layer Annual Cost per Citizen",
+  description: "Assumed annual cost per citizen for sybil-resistant identity verification and maintenance, generous against national-scale digital-identity systems.",
+  sourceType: "definition",
+  confidence: "high",
+  confidenceInterval: [0.05, 0.6],
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/universal-security-administration.html",
+  manualPageTitle: "The Universal Security Administration",
+};
+
 export const US_CONGRESS_MEMBER_COUNT: Parameter = {
   value: 535.0,
   parameterName: "US_CONGRESS_MEMBER_COUNT",
@@ -13239,6 +13503,7 @@ export const parameters = {
   HUMAN_GENOME_PROJECT_TOTAL_ECONOMIC_IMPACT,
   HUMAN_INTERACTOME_TARGETED_PCT,
   ICD_10_TOTAL_CODES,
+  IRS_ANNUAL_OPERATING_BUDGET,
   LEADED_GASOLINE_US_AVG_IQ_LOSS_POINTS,
   LIFE_EXTENSION_YEARS,
   LOBBYIST_SALARY_MAX,
@@ -13359,8 +13624,12 @@ export const parameters = {
   WHO_QALY_THRESHOLD_COST_EFFECTIVE,
   WORKFORCE_WITH_PRODUCTIVITY_LOSS,
   ADDITIONAL_DRUGS_FROM_COST_ELIMINATION,
+  AI_DIPLOMATIC_CORPS_ANNUAL_COST,
+  ALIGNED_ELECTION_COMMISSION_ANNUAL_OPEX,
   APOCALYPSE_MARKUP,
   APOCALYPSE_MARKUP_MULTIPLIER,
+  AUTOMATED_REVENUE_SERVICE_ANNUAL_OPEX,
+  AUTOMATED_REVENUE_SERVICE_SAVINGS_PER_AMERICAN_ANNUAL,
   BEST_PRACTICE_LIFE_EXPECTANCY_GAIN,
   BULLETS_PER_PERSON_ANNUAL,
   CELL_THERAPY_DISEASE_COMBINATIONS,
@@ -13528,6 +13797,7 @@ export const parameters = {
   GLOBAL_DISEASE_DEATHS_PER_MINUTE,
   GLOBAL_DISEASE_ECONOMIC_BURDEN_ANNUAL,
   GLOBAL_DISEASE_TOTAL_MARKET_COST_ANNUAL,
+  GLOBAL_EVENTUALLY_AVOIDABLE_DISEASE_DEATHS_DAILY,
   GLOBAL_GOVERNMENT_EXPENSE_ANNUAL,
   GLOBAL_HALE_GAP,
   GLOBAL_INDUSTRY_CLINICAL_TRIALS_SPENDING_ANNUAL,
@@ -13709,6 +13979,7 @@ export const parameters = {
   TYPE_II_ERROR_COST_RATIO,
   TYPE_I_ERROR_BENEFIT_DALYS,
   UNEXPLORED_RATIO,
+  UNIVERSAL_SECURITY_ADMIN_ANNUAL_OPEX,
   US_1939_MILITARY_SPENDING_PCT_LOWER_THAN_CURRENT,
   US_CONGRESS_FULL_ADVOCACY_COST,
   US_DEFENSE_FIRST_PRINCIPLES_CUT_PCT,
@@ -13789,9 +14060,16 @@ export const parameters = {
   WISHONIA_TRAJECTORY_VS_TREATY_TRAJECTORY_GDP_MULTIPLIER_YEAR_20,
   WISHONIA_VS_CURRENT_MEDIAN_INCOME_MULTIPLIER_YEAR_20,
   ADAPTABLE_TRIAL_PATIENTS,
+  AI_NEGOTIATOR_AGENTS_PER_GOVERNMENT,
+  AI_NEGOTIATOR_COST_PER_AGENT_HOUR,
+  ALIGNED_ELECTION_COMMISSION_ENGINEER_HEADCOUNT,
   ALLOCATION_DECISION_SPREAD,
   ANNUAL_WORKING_HOURS,
   APPROVED_DRUG_DISEASE_PAIRINGS,
+  AUTOMATED_REVENUE_SERVICE_ANNUAL_TRANSACTION_VOLUME,
+  AUTOMATED_REVENUE_SERVICE_ENGINEER_HEADCOUNT,
+  AUTOMATED_REVENUE_SERVICE_INFRA_COST_PER_TRANSACTION,
+  AUTOMATED_REVENUE_SERVICE_SECURITY_ANNUAL_COST,
   AVG_LIFE_EXTENSION_PER_BENEFICIARY,
   CAMPAIGN_CELEBRITY_ENDORSEMENT,
   CAMPAIGN_COMMUNITY_ORGANIZING,
@@ -13875,6 +14153,7 @@ export const parameters = {
   GLOBAL_EFFECTIVE_TAX_RATE_MEDIAN,
   GLOBAL_MEDIAN_SHARE_EROSION_RATE_ANNUAL,
   GLOBAL_TO_US_POLITICAL_COST_RATIO,
+  GOV_REPLACEMENT_ENGINEER_ANNUAL_COST,
   HALE_LONGEVITY_REALIZATION_SHARE_YEAR_15,
   HOURS_PER_DAY,
   HOURS_PER_YEAR,
@@ -13936,6 +14215,9 @@ export const parameters = {
   TREATY_REDIRECTED_SPENDING_INFINITE_ROI,
   TREATY_REDUCTION_PCT,
   TRIAL_RELEVANT_DISEASES_COUNT,
+  UNIVERSAL_SECURITY_ADMIN_DEPOSIT_COST_PER_TRANSACTION,
+  UNIVERSAL_SECURITY_ADMIN_ENGINEER_HEADCOUNT,
+  UNIVERSAL_SECURITY_ADMIN_IDENTITY_COST_PER_CITIZEN,
   US_CONGRESS_MEMBER_COUNT,
   US_DEFENSE_FP_COAST_GUARD,
   US_DEFENSE_FP_CYBER,
@@ -14343,6 +14625,20 @@ export const citations: Record<string, Citation> = {
         publisher: "Congressional Research Service",
         URL: "https://www.congress.gov/crs_external_products/R/PDF/R44824/R44824.7.pdf",
         note: "Table 1 reports NIH CRISPR-related funding totaling \\$3,083,419,930 for FY2011-FY2018.",
+  },
+  "crs-irs-appropriations-fy2025": {
+        id: "crs-irs-appropriations-fy2025",
+        type: "report",
+        title: "Internal Revenue Service Appropriations, FY2025 (IF12647)",
+        author: [
+          {
+            literal: "Congressional Research Service"
+          },
+        ],
+        issued: { 'date-parts': [[2024]] },
+        publisher: "Congressional Research Service",
+        URL: "https://www.congress.gov/crs_external_products/IF/PDF/IF12647/IF12647.2.pdf",
+        note: "Table 1: FY2024 enacted IRS appropriations total \\$12.32 billion. Verified quote: \"In FY2024, appropriations accounted for 58% (\\$12.3 billion) of the \\$21.0 billion IRS budget.\"",
   },
   "cs-global-wealth-report-2023": {
         id: "cs-global-wealth-report-2023",
@@ -16473,11 +16769,11 @@ export const citations: Record<string, Citation> = {
 
 /** Summary statistics */
 export const PARAMETER_STATS = {
-  total: 844,
-  external: 236,
-  calculated: 430,
-  definitions: 178,
-  citations: 181,
+  total: 862,
+  external: 237,
+  calculated: 436,
+  definitions: 189,
+  citations: 182,
 } as const;
 
 // ============================================================================

--- a/packages/db/src/managed-data/optimize-earth-task-tree.ts
+++ b/packages/db/src/managed-data/optimize-earth-task-tree.ts
@@ -33,6 +33,8 @@ import {
   COURT_OF_HUMANITY_CHARTER_TASK_KEY,
   COURT_OF_HUMANITY_TASK_ID,
   COURT_OF_HUMANITY_TASK_KEY,
+  DFDA_CREATE_TASK_ID,
+  DFDA_CREATE_TASK_KEY,
   END_WAR_AND_DISEASE_TASK_ID,
   END_WAR_AND_DISEASE_TASK_KEY,
   ENFORCE_ONE_PERCENT_TREATY_SETTLEMENT_TASK_ID,
@@ -52,6 +54,8 @@ import {
   REGISTER_PLAINTIFFS_TASK_KEY,
   RENDER_VERDICT_TASK_ID,
   RENDER_VERDICT_TASK_KEY,
+  SHIRT_SEED_TASK_ID,
+  SHIRT_SEED_TASK_KEY,
   SUMMON_JURORS_TASK_ID,
   SUMMON_JURORS_TASK_KEY,
   TREATY_PARENT_TASK_ID,
@@ -498,8 +502,8 @@ export const OPTIMIZE_EARTH_TASK_TREE: ManagedTaskRecord[] = [
   {
     ...defaultTaskFields,
     category: TaskCategory.RESEARCH,
-    id: "dfda",
-    taskKey: "program:dfda:create",
+    id: DFDA_CREATE_TASK_ID,
+    taskKey: DFDA_CREATE_TASK_KEY,
     parentTaskId: END_WAR_AND_DISEASE_TASK_ID,
     title: "Fund the decentralized FDA directly",
     description: [
@@ -522,8 +526,8 @@ export const OPTIMIZE_EARTH_TASK_TREE: ManagedTaskRecord[] = [
   {
     ...defaultTaskFields,
     category: TaskCategory.OUTREACH,
-    id: "shirt-seed",
-    taskKey: "program:shirt-seed",
+    id: SHIRT_SEED_TASK_ID,
+    taskKey: SHIRT_SEED_TASK_KEY,
     parentTaskId: END_WAR_AND_DISEASE_TASK_ID,
     title: "Seed the shirt cascade",
     description: [

--- a/packages/db/src/task-keys.ts
+++ b/packages/db/src/task-keys.ts
@@ -98,6 +98,16 @@ export const EARTH_OPTIMIZATION_PRIZE_TASK_ID = "earth-optimization-prize";
 export const EARTH_OPTIMIZATION_PRIZE_TASK_KEY =
   "program:earth-optimization-prize";
 
+// dFDA direct funding program
+
+export const DFDA_CREATE_TASK_ID = "dfda";
+export const DFDA_CREATE_TASK_KEY = "program:dfda:create";
+
+// Shirt cascade seed program
+
+export const SHIRT_SEED_TASK_ID = "shirt-seed";
+export const SHIRT_SEED_TASK_KEY = "program:shirt-seed";
+
 // Earth Optimization Services capitalization
 
 export const EOS_CAPITALIZE_TASK_ID = "eos-capitalize";

--- a/packages/web/src/app/agencies/dfec/alignment/page.logged-out.md
+++ b/packages/web/src/app/agencies/dfec/alignment/page.logged-out.md
@@ -2,13 +2,13 @@
 
 ## Metadata
 
-- Page title: Alignment | International Campaign to End War and Disease
+- Page title: Politician Alignment | International Campaign to End War and Disease
 - Meta description: Find out which politicians accidentally agree with you. Spoiler: fewer than you'd hope.
 - Canonical: https://warondisease.org/agencies/dfec/alignment
-- Open Graph title: Alignment
+- Open Graph title: Politician Alignment
 - Open Graph description: Find out which politicians accidentally agree with you. Spoiler: fewer than you'd hope.
 - Open Graph image: https://warondisease.org/api/og/route?path=%2Fagencies%2Fdfec%2Falignment
-- Twitter title: Alignment
+- Twitter title: Politician Alignment
 - Twitter description: Find out which politicians accidentally agree with you. Spoiler: fewer than you'd hope.
 
 ## Visible Page Copy

--- a/packages/web/src/app/eos/page.logged-out.md
+++ b/packages/web/src/app/eos/page.logged-out.md
@@ -14,13 +14,13 @@
 ## Visible Page Copy
 
 - EARTH OPTIMIZATION SERVICES
-- NOW ACCEPTING APPLICATIONS.
-- [REQUEST THE DATA ROOM](mailto:m@warondisease.org?subject=EOS%20data%20room%20request)
-- [BOOK A CALL](mailto:m@warondisease.org?subject=EOS%20investor%20call)
-## GOVERNMENTS ARE SUPPOSED TO MAKE PEOPLE HEALTHIER AND RICHER. WE'RE BUYING THE POWER TO MAKE THEM.
-- [SEE WHAT YOUR STAKE BECOMES](#eos-calculator)
+- CORRECTION: YOUR APPLICATION WAS ACCEPTED AT BIRTH. YOU ARE ONE OF 8,000,000,000 PRESIDENTS.
+- [VOTE ON THE FIRST PURCHASE](https://warondisease.org)
+- [TOUR THE DEPARTMENTS](#departments)
+## THE GOVERNMENT OF TOMORROW IS IN STOCK.
+- It measures whether people live longer and earn more, keeps the policies that work, and drops the ones that don't. Your current model spends [604](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html)x more testing weapons than cures. Trade-ins accepted. The first purchase is the 1% Treaty.
 ### WHAT THIS IS
-- A government has one job: make the median person healthier and richer. Most are bad at it, because the people who profit from the current setup pay to keep it that way — governments spend [604](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html)x more testing weapons than testing cures. So we do the boring thing. We buy a controlling share of the companies whose lobbying blocks the fix, hand that power to ordinary people instead of a boardroom, and point it at the policies that nearly every country's data says actually raise health and income. The lobby that spent decades stopping cures starts paying for them. It's almost like pointing the money at the goal works better. Weird. (This already runs as software. The math is public.)
+- A government has one job: make the median person healthier and richer. The current models misplace about [$101 trillion](https://manual.WarOnDisease.org/knowledge/appendix/optimocracy-paper.html) a year — the gap between the policies you get and the optimal ones a working government would pick. Below is the replacement catalog, plus a service counter of repairs you can order today. All of it is open source. This page is just the tour.
 ### YOUR GOVERNMENT HAS NO THERMOSTAT.
 - Your oven measures the temperature, compares it to what you asked for, and adjusts. So does your fridge, your cruise control, your toilet. Your government runs the most complex system on Earth with less feedback than a toaster.
 #### YOUR OVEN
@@ -31,69 +31,73 @@
 - It never checks whether the policy worked. This is why your citizens are dead.
 - INSTALLS THE THERMOSTAT
 - Measure two numbers — how long people live, how much they earn — keep the policies that raise them, drop the ones that don't, repeat.
-### HOW IT WORKS
-#### BUY THE POWER
-- Buy a controlling share of the big weapons companies. The people you buy out get richer doing it - the share price goes up, not down.
-#### HAND IT TO EVERYONE
-- Instead of one boardroom deciding what that power does, every person gets a say - simple this-or-that choices that add up to what the public actually wants.
-#### FIND THE POLICIES THAT WORK
-- Feed in two centuries of data from nearly every country: which laws actually made people live longer and earn more. Rank them.
-#### USE THE LOBBY TO INSTALL THEM
-- The lobbying budget that used to block the fix now pays to pass it - starting with [$27.2 billion/year](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) a year redirected into testing cures.
+### THE DEPARTMENTS
+- Every agency you already pay for, rebuilt so it can tell whether it's working. Prices are for planetary installation.
+- REPLACES: LEGISLATIVE GUESSWORK
+#### THE OPTIMITRON
+- The machine that writes laws and budgets from evidence. Two centuries of data from nearly every country go in. Three features come standard: the Optimal Policy Generator finds the laws that raise health and income, the Optimal Budget Generator does the same for spending, and Wishocracy is the ballot where eight billion presidents split the budget with simple this-or-that choices. It already runs as software. The math is public.
+- [READ THE SPEC](https://manual.warondisease.org/knowledge/appendix/optimocracy-paper.html)
+- REPLACES: THE FDA
+#### THE DECENTRALIZED FDA
+- Turns ordinary healthcare into evidence. Pragmatic trials at [$929/patient](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) instead of [$41,000/patient](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html), run in real clinics on outcomes that matter. It prevents a year of death and suffering for [84 cents](https://manual.WarOnDisease.org/knowledge/appendix/dfda-impact-paper.html), which is the best price anyone has quoted on anything.
+- [$40.0 million](https://manual.WarOnDisease.org/knowledge/appendix/dfda-impact-paper.html)
+- [READ THE SPEC](https://manual.warondisease.org/knowledge/appendix/dfda-impact-paper.html)
+- REPLACES: THE NIH
+#### DECENTRALIZED INSTITUTES OF HEALTH
+- Receives the treaty's [$27.2 billion/year](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) and pays for results instead of grant paperwork. Nobody gets paid for writing essays about why they should be allowed to try curing things. They get paid for curing things.
+- [$230 million](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- [$21.1 million/year](https://manual.WarOnDisease.org/knowledge/appendix/dfda-impact-paper.html)
+- [READ THE BLUEPRINT](https://manual.warondisease.org/knowledge/solution/dih.html)
+- REPLACES: COURTS THAT CAN'T SUBPOENA A GOVERNMENT
+#### COURT OF HUMANITY
+- Where eight billion humans judge governments that spend public money against the public. Registers plaintiffs, summons jurors, publishes the evidence, renders the verdict, and enforces the settlement — the 1% Treaty.
+- [$30.0 million](https://manual.WarOnDisease.org/knowledge/solution/court-of-humanity.html)
+- [ENTER THE COURT](/court)
+- REPLACES: THE WAR DEPARTMENT
+#### DEPARTMENT OF PEACE
+- You are picturing a very strong robot that collects the missiles and throws them into the sun. We have something stronger: a buy order. The department buys the weapons companies — the sellers get richer, and nobody shoots at a brokerage account — converts the stockpiles into reactor fuel (your species already did this once; it powered your lightbulbs for twenty years), and retires the war budget at 1% a year, verified. Talking is the cheap part: [10](https://manual.WarOnDisease.org/knowledge/solution/department-of-peace.html) AI negotiators per government at [$0.50](https://manual.WarOnDisease.org/knowledge/solution/department-of-peace.html) an agent-hour. Disputes take six minutes. Nobody dies.
+- [$8.54 million](https://manual.WarOnDisease.org/knowledge/solution/department-of-peace.html)
+- [$2.72 trillion](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- [READ THE SPEC](https://manual.warondisease.org/knowledge/solution/department-of-peace.html)
+- REPLACES: THE IRS
+#### AUTOMATED REVENUE SERVICE
+- Your tax code is 17.5 Harry Potters long, except Harry Potter has a coherent plot and your tax code has loopholes. The replacement is six lines of code: every transfer sends 0.5% to the treasury. No filing. No forms. No audits. You cannot lobby a smart contract.
+- [$150 million](https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html)
+- [$12.3 billion](https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html)
+- [$1,670](https://manual.WarOnDisease.org/knowledge/solution/automated-revenue-service.html)
+- [READ THE SPEC](https://manual.warondisease.org/knowledge/solution/automated-revenue-service.html)
+- REPLACES: 80+ WELFARE PROGRAMS
+#### UNIVERSAL SECURITY ADMINISTRATION
+- The welfare bureaucracy becomes a for-loop: if you are human, you qualify. No applications, no caseworkers, no 45-day wait while the hungry stay hungry. Running the whole thing costs [$0.30](https://manual.WarOnDisease.org/knowledge/solution/universal-security-administration.html) per citizen a year.
+- [$101 million](https://manual.WarOnDisease.org/knowledge/solution/universal-security-administration.html)
+- [READ THE SPEC](https://manual.warondisease.org/knowledge/solution/universal-security-administration.html)
+- REPLACES: THE FEC AND CAMPAIGN FINANCE
+#### ALIGNED ELECTION COMMISSION
+- One number per politician: how closely their votes match what citizens actually want. Score high, get funded. Represent donors instead, get nothing. The current system is a vending machine where lobbyists insert money and legislation comes out. The replacement is a scoreboard where citizens insert preferences and representation comes out.
+- [$7.00 million](https://manual.WarOnDisease.org/knowledge/solution/aligned-election-commission.html)
+- [READ THE SPEC](https://manual.warondisease.org/knowledge/solution/aligned-election-commission.html)
+### THE SERVICE COUNTER
+- Civilization repairs, priced and guaranteed. Your money sits in escrow until the work happens — if it doesn't, it comes back. Every line item reports its expected return before you pay.
+#### [Ratify the 1% Treaty](/tasks/1-pct-treaty#funding)
+- The fastest known settlement is one percent of the war budget pointed at disease.
+- $2,500 COMMITTED - 0%
+- [FUND IT](/tasks/1-pct-treaty#funding)
+- [VOTE YES](https://warondisease.org)
+#### [Establish the Court of Humanity](/tasks/court-of-humanity#funding)
+- A majority jury needs a court-shaped place to render the verdict.
+- OPENING DAY. BE THE FIRST.
+- [FUND IT](/tasks/court-of-humanity#funding)
+#### [Fund the decentralized FDA directly](/tasks/dfda#funding)
+- The treaty redirects money to trials; the dFDA is the trials. Funding it directly skips the politics.
+- [FUND IT](/tasks/dfda#funding)
+#### [The Loving Takeover](/tasks/loving-takeover#funding)
+- The best lobbyists money can buy currently block the treaty. So we buy them.
+- [FUND IT](/tasks/loving-takeover#funding)
+#### [Seed the shirt cascade](/tasks/shirt-seed#funding)
+- A small paid seed of visible wearers turns into billions of free ones. The funder buys the spark, not the fire.
+- [FUND IT](/tasks/shirt-seed#funding)
 ### EMPLOYEE MANUAL
-- The manual at warondisease.org is the employee handbook. Earth Optimization Services is the Company, which is you and everyone else. Your title is President of Earth Optimization Services, and so is everyone's. Eight billion presidents, no boss. You run the planet now.
+- The manual at manual.warondisease.org is the employee handbook. Earth Optimization Services is the Company, which is you and everyone else. You run the planet now.
 - [READ THE EMPLOYEE MANUAL](https://manual.warondisease.org)
-### WHY IT PAYS
-- The whole takeover costs about [$873 billion](https://manual.WarOnDisease.org/knowledge/appendix/loving-takeover.html) - roughly [$109](https://manual.WarOnDisease.org/knowledge/appendix/loving-takeover.html) per person, if every human chipped in. Nobody collects $90 from anybody. You put money in, you own part of it, and the returns come from those companies getting more valuable as the economy grows. You are not paying to fix the planet. You own part of the fix.
-### YOUR CALCULATOR
-- Use your own assumptions. If the numbers stop working, good - you just saved yourself the money. Either way you leave knowing.
-#### YOUR ASSUMPTIONS
-- HOW MUCH YOU INVEST$25,000
-- YOUR ODDS IT WORKS (%) 10.0%
-- YEARS YOU HOLD 10
-- ADVANCED
-- MARKET-IMPLIED ENTRY PROBABILITY 5.0%
-- DEFENSE STOCK RETURN IF IT FAILS 10.0%
-- ECONOMY-EXPOSED NET WORTH$250,000
-- TREATY/CURRENT GDP MULTIPLIER 1.4x
-- 95% CI: 1.2X - 1.6X. BASE CASE: [1.43](https://manual.WarOnDisease.org/knowledge/economics/gdp-trajectories.html).
-- ILLUSTRATIVE. YOUR ASSUMPTIONS, NOT A PROMISE OR OFFER. NOT INVESTMENT ADVICE.
-#### WHAT THE SHARE BECOMES
-#### VALUE IF CAMPAIGN SUCCEEDS
-- $35,687
-- 1.4x your investment
-#### VALUE IF CAMPAIGN FAILS
-- $64,844
-- Defense stocks at 10.0%/yr for 10 years
-#### EXPECTED VALUE (PROBABILITY-WEIGHTED)
-- $61,928
-- 10.0% chance of $35,687 + 90.0% chance of $64,844
-- You invest $25,000. If the campaign succeeds (10.0% estimated), your shares appreciate to $35,687 (1.4x). If it fails, you hold defense stocks worth $64,844 at market return. The probability-weighted expected value is $61,928, which is $2,916 less than the S&P would have returned. You also do not die of a curable disease, which is not reflected above but is arguably the better return.
-- ADVANCED (FOR THE FINANCE-MINDED)
-#### IF THE MARKET IS ASLEEP (THE THESIS)
-- 29x
-- success multiple buying at 5.0% implied (1.4x assets times the repricing from 5.0% to certainty) = $713,731 on $25,000
-#### IF THE MARKET IS EFFICIENT (TEXTBOOK)
-- then the price already reflects the odds, entry timing is fair, and you are paid in variance, not extra expected value. Early just means cheaper and riskier.
-#### YOUR EDGE OVER THE MARKET
-- 2.0x
-- your 10.0% belief divided by the 5.0% the market prices in. Above 1x, the market is underpaying you for the risk.
-#### PROTECTED UPSIDE
-- $106,866
-- $250,000 riding the 1.4x trajectory gap; probability-weighted $10,687.
-#### ASLEEP EXPECTED VALUE
-- $129,732
-- market-asleep expected value at your assumptions, using the same fail path above.
-### TERMS
-- The pitch is public. The paperwork is not. For accredited investors, the securities materials live off-page, where the law wants them.
-#### $25,000
-- Friends and family minimum.
-#### $100,000
-- Institutional minimum.
-#### 2 PRODUCTS
-- Earth Optimization Services shares and Incentive Alignment Bonds.
-#### 0%
-- Founder equity.
-### TALK TO US
-- Request the data room or book a call. The math is public. The buy-in is not a one-click checkout - the law makes us talk first.
-- ACCREDITED-ONLY SECURITIES DISCUSSION. NOT AN OFFER. NOT INVESTMENT ADVICE.
+- EOS also sells shares. That conversation is legally required to be boring, so it happens over here.
+- [SHAREHOLDER PAPERWORK](/fund)

--- a/packages/web/src/app/foundations/page.logged-out.md
+++ b/packages/web/src/app/foundations/page.logged-out.md
@@ -41,11 +41,11 @@
 - OPEN
 - SUPPORTERS
 - 1 SUPPORTER
-- Ada Example — paid — 1 day ago
+- Ada Example — paid — 2 days ago
 #### SEED THE SHIRT CASCADE
 - $2,500 of $50,000,000 paid or pledged
 - $49,997,500 remaining - 0%
-- Grace Example — paid — 1 day ago
+- Grace Example — paid — 2 days ago
 #### ESTABLISH THE COURT OF HUMANITY
 - $0 of $30,000,000 paid or pledged
 - $30,000,000 remaining - 0%

--- a/packages/web/src/app/fund/page.logged-out.md
+++ b/packages/web/src/app/fund/page.logged-out.md
@@ -18,15 +18,69 @@
 - Here is the price list. Every task below is a bottleneck between you and that planet, ranked by how much each dollar moves us there. Fund one — your money stays pinned to that exact work and pays the worker the second a claim is verified. Nothing proven, nothing paid.
 - [BROWSE EVERY TASK](/tasks)
 - [FUND THE PRIZE](/prize)
-### [Ratify the 1% Treaty](/tasks/1-pct-treaty#funding)
+#### [Ratify the 1% Treaty](/tasks/1-pct-treaty#funding)
 - $2,500 COMMITTED - 0%
 - [FUND TASK](/tasks/1-pct-treaty#funding)
-### [Seed the shirt cascade](/tasks/shirt-seed#funding)
+#### [Seed the shirt cascade](/tasks/shirt-seed#funding)
 - [FUND TASK](/tasks/shirt-seed#funding)
-### [Establish the Court of Humanity](/tasks/court-of-humanity#funding)
-- $0.00 COMMITTED - 0%
+#### [Establish the Court of Humanity](/tasks/court-of-humanity#funding)
+- OPENING DAY. BE THE FIRST.
 - [FUND TASK](/tasks/court-of-humanity#funding)
-### [Fund the decentralized FDA directly](/tasks/dfda#funding)
+#### [Fund the decentralized FDA directly](/tasks/dfda#funding)
 - [FUND TASK](/tasks/dfda#funding)
-### [The Loving Takeover](/tasks/loving-takeover#funding)
+#### [The Loving Takeover](/tasks/loving-takeover#funding)
 - [FUND TASK](/tasks/loving-takeover#funding)
+### YOUR CALCULATOR
+- Use your own assumptions. If the numbers stop working, good - you just saved yourself the money. Either way you leave knowing.
+#### YOUR ASSUMPTIONS
+- HOW MUCH YOU INVEST$25,000
+- YOUR ODDS IT WORKS (%) 10.0%
+- YEARS YOU HOLD 10
+- ADVANCED
+- MARKET-IMPLIED ENTRY PROBABILITY 5.0%
+- DEFENSE STOCK RETURN IF IT FAILS 10.0%
+- ECONOMY-EXPOSED NET WORTH$250,000
+- TREATY/CURRENT GDP MULTIPLIER 1.4x
+- 95% CI: 1.2X - 1.6X. BASE CASE: [1.43](https://manual.WarOnDisease.org/knowledge/economics/gdp-trajectories.html).
+- ILLUSTRATIVE. YOUR ASSUMPTIONS, NOT A PROMISE OR OFFER. NOT INVESTMENT ADVICE.
+#### WHAT THE SHARE BECOMES
+#### VALUE IF CAMPAIGN SUCCEEDS
+- $35,687
+- 1.4x your investment
+#### VALUE IF CAMPAIGN FAILS
+- $64,844
+- Defense stocks at 10.0%/yr for 10 years
+#### EXPECTED VALUE (PROBABILITY-WEIGHTED)
+- $61,928
+- 10.0% chance of $35,687 + 90.0% chance of $64,844
+- You invest $25,000. If the campaign succeeds (10.0% estimated), your shares appreciate to $35,687 (1.4x). If it fails, you hold defense stocks worth $64,844 at market return. The probability-weighted expected value is $61,928, which is $2,916 less than the S&P would have returned. You also do not die of a curable disease, which is not reflected above but is arguably the better return.
+- ADVANCED (FOR THE FINANCE-MINDED)
+#### IF THE MARKET IS ASLEEP (THE THESIS)
+- 29x
+- success multiple buying at 5.0% implied (1.4x assets times the repricing from 5.0% to certainty) = $713,731 on $25,000
+#### IF THE MARKET IS EFFICIENT (TEXTBOOK)
+- then the price already reflects the odds, entry timing is fair, and you are paid in variance, not extra expected value. Early just means cheaper and riskier.
+#### YOUR EDGE OVER THE MARKET
+- 2.0x
+- your 10.0% belief divided by the 5.0% the market prices in. Above 1x, the market is underpaying you for the risk.
+#### PROTECTED UPSIDE
+- $106,866
+- $250,000 riding the 1.4x trajectory gap; probability-weighted $10,687.
+#### ASLEEP EXPECTED VALUE
+- $129,732
+- market-asleep expected value at your assumptions, using the same fail path above.
+### TERMS
+- These minimums are for shares and bonds — the price list above takes any amount. The pitch is public. The paperwork is not. For accredited investors, the securities materials live off-page, where the law wants them.
+#### $25,000
+- Friends and family minimum.
+#### $100,000
+- Institutional minimum.
+#### 2 PRODUCTS
+- Earth Optimization Services shares and Incentive Alignment Bonds.
+#### 0%
+- Founder equity.
+### TALK TO US
+- Request the data room or book a call. The math is public. The buy-in is not a one-click checkout - the law makes us talk first.
+- [REQUEST THE DATA ROOM](mailto:m@warondisease.org?subject=EOS%20data%20room%20request)
+- [BOOK A CALL](mailto:m@warondisease.org?subject=EOS%20investor%20call)
+- ACCREDITED-ONLY SECURITIES DISCUSSION. NOT AN OFFER. NOT INVESTMENT ADVICE.

--- a/packages/web/src/app/fund/page.tsx
+++ b/packages/web/src/app/fund/page.tsx
@@ -1,14 +1,60 @@
 import Link from "next/link";
-import { TaskStatus } from "@optimitron/db";
+import { FundingTaskCard } from "@/components/task-funding/FundingTaskCard";
+import { EosInvestmentCalculator } from "@/components/site/EosInvestmentCalculator";
 import { getRouteMetadata } from "@/lib/metadata";
-import { fundLink, getTaskPath, ROUTES } from "@/lib/routes";
-import { getTasksPageData } from "@/lib/tasks.server";
+import { fundLink, ROUTES } from "@/lib/routes";
+import {
+  collectFundableTasks,
+  getExpectedValueUsd,
+  getFundingDenominator,
+  type FundingTask,
+} from "@/lib/task-funding/fundable-tasks.server";
 import { getTaskFundingStatus } from "@/lib/task-funding/status.server";
+import { getTasksPageData } from "@/lib/tasks.server";
 
 export const metadata = getRouteMetadata(fundLink);
 
-type TasksPageData = Awaited<ReturnType<typeof getTasksPageData>>;
-type FundingTask = TasksPageData["allTasks"][number];
+const requestDataRoomSubject = "EOS data room request";
+const bookCallSubject = "EOS investor call";
+const requestDataRoomHref = `mailto:m@warondisease.org?subject=${encodeURIComponent(
+  requestDataRoomSubject,
+)}`;
+const bookCallHref = `mailto:m@warondisease.org?subject=${encodeURIComponent(
+  bookCallSubject,
+)}`;
+const requestDataRoomLabel = "Request the data room";
+const bookCallLabel = "Book a call";
+
+const calculatorHeading = "Your calculator";
+const calculatorDeck =
+  "Use your own assumptions. If the numbers stop working, good - you just saved yourself the money. Either way you leave knowing.";
+const termsHeading = "Terms";
+const termsDeck =
+  "These minimums are for shares and bonds — the price list above takes any amount. The pitch is public. The paperwork is not. For accredited investors, the securities materials live off-page, where the law wants them.";
+const finalHeading = "Talk to us";
+const finalDeck =
+  "Request the data room or book a call. The math is public. The buy-in is not a one-click checkout - the law makes us talk first.";
+const legalGateText =
+  "Accredited-only securities discussion. Not an offer. Not investment advice.";
+
+const terms = [
+  {
+    body: "Friends and family minimum.",
+    label: "$25,000",
+  },
+  {
+    body: "Institutional minimum.",
+    label: "$100,000",
+  },
+  {
+    body: "Earth Optimization Services shares and Incentive Alignment Bonds.",
+    label: "2 products",
+  },
+  {
+    body: "Founder equity.",
+    label: "0%",
+  },
+] as const;
 
 interface RankedFundingTask {
   denominatorCents: bigint;
@@ -16,88 +62,6 @@ interface RankedFundingTask {
   fundingSource: "target" | "compensation";
   score: number;
   task: FundingTask;
-}
-
-function formatUsdCents(cents: bigint | number) {
-  const dollars =
-    typeof cents === "bigint" ? Number(cents) / 100 : Number(cents) / 100;
-  if (!Number.isFinite(dollars)) return "$0";
-
-  return new Intl.NumberFormat("en-US", {
-    currency: "USD",
-    currencyDisplay: "narrowSymbol",
-    maximumFractionDigits: dollars >= 1000 ? 0 : 2,
-    notation: dollars >= 100_000 ? "compact" : "standard",
-    style: "currency",
-  }).format(dollars);
-}
-
-function formatUsd(value: number) {
-  if (!Number.isFinite(value)) return "$0";
-  return new Intl.NumberFormat("en-US", {
-    currency: "USD",
-    currencyDisplay: "narrowSymbol",
-    maximumFractionDigits: value >= 1000 ? 0 : 2,
-    notation: value >= 100_000 ? "compact" : "standard",
-    style: "currency",
-  }).format(value);
-}
-
-function formatRatio(value: number) {
-  if (!Number.isFinite(value) || value <= 0) return "Unranked";
-  return `${formatUsd(value)} expected per $1`;
-}
-
-function formatPercent(percent: number) {
-  if (!Number.isFinite(percent) || percent <= 0) return "0%";
-  if (percent >= 100) return "100%";
-  return `${percent < 1 ? "<1" : Math.round(percent)}%`;
-}
-
-function getFundingDenominator(task: FundingTask): Pick<
-  RankedFundingTask,
-  "denominatorCents" | "fundingSource"
-> | null {
-  if (
-    task.fundingTarget?.targetAmountCents &&
-    task.fundingTarget.targetAmountCents > 0n
-  ) {
-    return {
-      denominatorCents: task.fundingTarget.targetAmountCents,
-      fundingSource: "target",
-    };
-  }
-  if (
-    task.compensationMaxAmountMinorUnits &&
-    task.compensationMaxAmountMinorUnits > 0n
-  ) {
-    return {
-      denominatorCents: task.compensationMaxAmountMinorUnits,
-      fundingSource: "compensation",
-    };
-  }
-  return null;
-}
-
-function getExpectedValueUsd(task: FundingTask) {
-  const value = task.selectedImpactFrame?.expectedEconomicValueUsdBase;
-  return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
-
-function collectFundableTasks(data: TasksPageData) {
-  const byId = new Map<string, FundingTask>();
-  for (const task of data.topLevelTasks) {
-    byId.set(task.id, task);
-    for (const child of task.childTasks) {
-      byId.set(child.id, child);
-    }
-  }
-  for (const task of data.allTasks) {
-    byId.set(task.id, task);
-  }
-  return Array.from(byId.values()).filter(
-    (task) => task.status === TaskStatus.ACTIVE && task.isPublic,
-  );
 }
 
 function dedupeRankedTasks(tasks: RankedFundingTask[]) {
@@ -118,34 +82,31 @@ function dedupeRankedTasks(tasks: RankedFundingTask[]) {
 }
 
 function rankFundingTasks(tasks: FundingTask[]) {
-  const ranked = tasks
-    .flatMap((task): RankedFundingTask[] => {
-      const denominator = getFundingDenominator(task);
-      const expectedValueUsd = getExpectedValueUsd(task);
-      if (
-        !denominator ||
-        denominator.denominatorCents <= 0n ||
-        expectedValueUsd <= 0
-      ) {
-        return [];
-      }
-      return [
-        {
-          denominatorCents: denominator.denominatorCents,
-          expectedValueUsd,
-          fundingSource: denominator.fundingSource,
-          score:
-            expectedValueUsd / (Number(denominator.denominatorCents) / 100),
-          task,
-        },
-      ];
-    });
+  const ranked = tasks.flatMap((task): RankedFundingTask[] => {
+    const denominator = getFundingDenominator(task);
+    const expectedValueUsd = getExpectedValueUsd(task);
+    if (
+      !denominator ||
+      denominator.denominatorCents <= 0n ||
+      expectedValueUsd <= 0
+    ) {
+      return [];
+    }
+    return [
+      {
+        denominatorCents: denominator.denominatorCents,
+        expectedValueUsd,
+        fundingSource: denominator.fundingSource,
+        score: expectedValueUsd / (Number(denominator.denominatorCents) / 100),
+        task,
+      },
+    ];
+  });
 
-  return dedupeRankedTasks(ranked)
-    .sort((left, right) => {
-      if (right.score !== left.score) return right.score - left.score;
-      return left.task.title.localeCompare(right.task.title);
-    });
+  return dedupeRankedTasks(ranked).sort((left, right) => {
+    if (right.score !== left.score) return right.score - left.score;
+    return left.task.title.localeCompare(right.task.title);
+  });
 }
 
 export default async function FundPage() {
@@ -153,10 +114,10 @@ export default async function FundPage() {
   const rankedTasks = rankFundingTasks(collectFundableTasks(data)).slice(0, 12);
   const fundingStatuses = new Map(
     await Promise.all(
-      rankedTasks.map(async ({ task }) => [
-        task.id,
-        await getTaskFundingStatus(task.id).catch(() => null),
-      ] as const),
+      rankedTasks.map(
+        async ({ task }) =>
+          [task.id, await getTaskFundingStatus(task.id).catch(() => null)] as const,
+      ),
     ),
   );
 
@@ -199,92 +160,19 @@ export default async function FundPage() {
       <section className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
         {rankedTasks.length > 0 ? (
           <div className="grid gap-4">
-            {rankedTasks.map((rankedTask, index) => {
-              const {
-                denominatorCents,
-                expectedValueUsd,
-                fundingSource,
-                score,
-                task,
-              } = rankedTask;
-              const funding = fundingStatuses.get(task.id);
-              const percent =
-                funding && funding.targetUsdCents > 0n
-                  ? Math.min(100, funding.percentToTarget)
-                  : 0;
-
-              return (
-                <article
-                  className="grid gap-4 border border-foreground p-4 sm:grid-cols-[auto_minmax(0,1fr)] lg:grid-cols-[auto_minmax(0,1fr)_auto]"
-                  key={task.id}
-                >
-                  <div className="flex size-12 items-center justify-center border border-foreground text-lg font-black">
-                    {index + 1}
-                  </div>
-                  <div className="min-w-0 space-y-4">
-                    <div>
-                      <h2 className="text-xl font-black leading-tight">
-                        <Link
-                          className="underline-offset-4 hover:underline"
-                          href={`${getTaskPath(task.id)}#funding`}
-                        >
-                          {task.title}
-                        </Link>
-                      </h2>
-                      <dl className="mt-3 grid gap-2 text-sm font-bold text-muted-foreground sm:grid-cols-3">
-                        <div>
-                          <dt className="text-xs font-black uppercase tracking-[0.12em]">
-                            Return per $1
-                          </dt>
-                          <dd className="text-foreground">
-                            {formatRatio(score)}
-                          </dd>
-                        </div>
-                        <div>
-                          <dt className="text-xs font-black uppercase tracking-[0.12em]">
-                            Task value
-                          </dt>
-                          <dd className="text-foreground">
-                            {formatUsd(expectedValueUsd)}
-                          </dd>
-                        </div>
-                        <div>
-                          <dt className="text-xs font-black uppercase tracking-[0.12em]">
-                            {fundingSource === "target"
-                              ? "Funding goal"
-                              : "Worker payout"}
-                          </dt>
-                          <dd className="text-foreground">
-                            {formatUsdCents(denominatorCents)}
-                          </dd>
-                        </div>
-                      </dl>
-                    </div>
-                    <div>
-                      <div className="h-2 border border-foreground">
-                        <div
-                          className="h-full bg-foreground"
-                          style={{ width: `${percent}%` }}
-                        />
-                      </div>
-                      <p className="mt-1 text-xs font-black uppercase tracking-[0.12em] text-muted-foreground">
-                        {funding
-                          ? `${formatUsdCents(funding.committedUsdCents)} committed - ${formatPercent(percent)}`
-                          : "Pays a verified worker after completion"}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-start sm:col-start-2 lg:col-start-auto lg:justify-end">
-                    <Link
-                      className="inline-flex min-h-10 items-center justify-center border border-foreground bg-foreground px-4 py-2 text-sm font-black uppercase text-background hover:bg-background hover:text-foreground"
-                      href={`${getTaskPath(task.id)}#funding`}
-                    >
-                      Fund task
-                    </Link>
-                  </div>
-                </article>
-              );
-            })}
+            {rankedTasks.map((rankedTask, index) => (
+              <FundingTaskCard
+                denominatorCents={rankedTask.denominatorCents}
+                expectedValueUsd={rankedTask.expectedValueUsd}
+                funding={fundingStatuses.get(rankedTask.task.id) ?? null}
+                fundingSource={rankedTask.fundingSource}
+                index={index + 1}
+                key={rankedTask.task.id}
+                score={rankedTask.score}
+                taskId={rankedTask.task.id}
+                title={rankedTask.task.title}
+              />
+            ))}
           </div>
         ) : (
           <div className="border border-foreground p-6">
@@ -296,6 +184,75 @@ export default async function FundPage() {
             </p>
           </div>
         )}
+      </section>
+
+      <section className="border-t border-foreground">
+        <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+          <h2
+            className="text-3xl font-black uppercase leading-none sm:text-5xl"
+            id="eos-calculator"
+          >
+            {calculatorHeading}
+          </h2>
+          <p className="mt-4 max-w-3xl text-lg font-bold leading-8 sm:text-xl">
+            {calculatorDeck}
+          </p>
+          <div className="mt-10">
+            <EosInvestmentCalculator />
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-foreground">
+        <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+          <h2 className="text-3xl font-black uppercase leading-none sm:text-5xl">
+            {termsHeading}
+          </h2>
+          <p className="mt-4 max-w-3xl text-lg font-bold leading-8 sm:text-xl">
+            {termsDeck}
+          </p>
+          <div className="mt-10 grid border-t-2 border-foreground sm:grid-cols-2 lg:grid-cols-4">
+            {terms.map((term) => (
+              <article
+                className="border-b-2 border-foreground py-5 sm:border-r-2 sm:px-5 sm:even:border-r-0 lg:even:border-r-2 lg:last:border-r-0 lg:first:pl-0"
+                key={term.label}
+              >
+                <h3 className="text-3xl font-black uppercase">{term.label}</h3>
+                <p className="mt-3 text-base font-bold leading-7">
+                  {term.body}
+                </p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-foreground">
+        <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+          <h2 className="text-3xl font-black uppercase leading-none sm:text-5xl">
+            {finalHeading}
+          </h2>
+          <p className="mt-4 max-w-3xl text-lg font-bold leading-8 sm:text-xl">
+            {finalDeck}
+          </p>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <a
+              className="inline-flex min-h-10 items-center justify-center border-2 border-foreground bg-foreground px-5 py-3 font-black uppercase text-background hover:bg-background hover:text-foreground"
+              href={requestDataRoomHref}
+            >
+              {requestDataRoomLabel}
+            </a>
+            <a
+              className="inline-flex min-h-10 items-center justify-center border-2 border-foreground bg-background px-5 py-3 font-black uppercase text-foreground hover:bg-foreground hover:text-background"
+              href={bookCallHref}
+            >
+              {bookCallLabel}
+            </a>
+          </div>
+          <p className="mt-6 border-2 border-foreground p-3 text-xs font-black uppercase">
+            {legalGateText}
+          </p>
+        </div>
       </section>
     </main>
   );

--- a/packages/web/src/app/fund/page.tsx
+++ b/packages/web/src/app/fund/page.tsx
@@ -160,6 +160,7 @@ export default async function FundPage() {
       <section className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
         {rankedTasks.length > 0 ? (
           <div className="grid gap-4">
+            <h2 className="sr-only">The price list</h2>
             {rankedTasks.map((rankedTask, index) => (
               <FundingTaskCard
                 denominatorCents={rankedTask.denominatorCents}

--- a/packages/web/src/app/game/page.logged-out.md
+++ b/packages/web/src/app/game/page.logged-out.md
@@ -142,7 +142,7 @@
 - Productive Economy
 - Parasitic Economy
 - % of GDP
-- [💀2 HUMANS TERMINATED🔥$4.6M BURNED BY MISALIGNED GOVERNMENTS💣$607K SPENT ON DESTRUCTION INSTEAD OF CURES](/plaintiffs)
+- [💀2 HUMANS TERMINATED🔥$4.5M BURNED BY MISALIGNED GOVERNMENTS💣$586K SPENT ON DESTRUCTION INSTEAD OF CURES](/plaintiffs)
 - Right now, doing nothing means you lose. Vote and you stop.
 ### EVERY POLICY GRADED A THROUGH F
 - I ran causal inference on decades of data across dozens of countries. Most of your policies fail.

--- a/packages/web/src/components/site/EarthOptimizationServicesLandingPage.tsx
+++ b/packages/web/src/components/site/EarthOptimizationServicesLandingPage.tsx
@@ -101,7 +101,7 @@ const thermostatPanels = [
 ] as const;
 
 interface Department {
-  action: { external?: boolean; href: string; label: string };
+  action: { href: string; label: string };
   body: ReactNode;
   priceLines: { label: string; value: ReactNode }[];
   replaces: string;
@@ -111,7 +111,6 @@ interface Department {
 const departments: Department[] = [
   {
     action: {
-      external: true,
       href: MANUAL_URLS.optimocracyPaper,
       label: "Read the spec",
     },
@@ -132,7 +131,6 @@ const departments: Department[] = [
   },
   {
     action: {
-      external: true,
       href: MANUAL_URLS.dfdaImpactPaper,
       label: "Read the spec",
     },
@@ -160,7 +158,7 @@ const departments: Department[] = [
     title: "The decentralized FDA",
   },
   {
-    action: { external: true, href: MANUAL_URLS.dih, label: "Read the blueprint" },
+    action: { href: MANUAL_URLS.dih, label: "Read the blueprint" },
     body: (
       <>
         Receives the treaty&apos;s{" "}
@@ -202,7 +200,6 @@ const departments: Department[] = [
   },
   {
     action: {
-      external: true,
       href: MANUAL_URLS.departmentOfPeace,
       label: "Read the spec",
     },
@@ -249,7 +246,6 @@ const departments: Department[] = [
   },
   {
     action: {
-      external: true,
       href: MANUAL_URLS.automatedRevenueService,
       label: "Read the spec",
     },
@@ -297,7 +293,6 @@ const departments: Department[] = [
   },
   {
     action: {
-      external: true,
       href: MANUAL_URLS.universalSecurityAdministration,
       label: "Read the spec",
     },
@@ -329,7 +324,6 @@ const departments: Department[] = [
   },
   {
     action: {
-      external: true,
       href: MANUAL_URLS.alignedElectionCommission,
       label: "Read the spec",
     },

--- a/packages/web/src/components/site/EarthOptimizationServicesLandingPage.tsx
+++ b/packages/web/src/components/site/EarthOptimizationServicesLandingPage.tsx
@@ -1,58 +1,77 @@
 import {
-  DEFENSE_TAKEOVER_COST_PER_HUMAN,
-  DEFENSE_TAKEOVER_COST_TOTAL,
+  AI_DIPLOMATIC_CORPS_ANNUAL_COST,
+  AI_NEGOTIATOR_AGENTS_PER_GOVERNMENT,
+  AI_NEGOTIATOR_COST_PER_AGENT_HOUR,
+  ALIGNED_ELECTION_COMMISSION_ANNUAL_OPEX,
+  AUTOMATED_REVENUE_SERVICE_ANNUAL_OPEX,
+  AUTOMATED_REVENUE_SERVICE_SAVINGS_PER_AMERICAN_ANNUAL,
+  COURT_BUILD_COST,
+  DFDA_DIRECT_FUNDING_COST_PER_DALY,
+  DFDA_PRAGMATIC_TRIAL_COST_PER_PATIENT,
+  DFDA_UPFRONT_BUILD,
+  DIH_NPV_ANNUAL_OPEX_INITIATIVES,
+  DIH_NPV_UPFRONT_COST_INITIATIVES,
+  GLOBAL_MILITARY_SPENDING_ANNUAL_2024,
+  IRS_ANNUAL_OPERATING_BUDGET,
   MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO,
+  POLITICAL_DYSFUNCTION_GLOBAL_OPPORTUNITY_COST_TOTAL,
+  TRADITIONAL_PHASE3_COST_PER_PATIENT,
   TREATY_ANNUAL_FUNDING,
+  UNIVERSAL_SECURITY_ADMIN_ALL_IN_COST_PER_CITIZEN_ANNUAL,
+  UNIVERSAL_SECURITY_ADMIN_ANNUAL_OPEX,
 } from "@optimitron/data/parameters";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { Button } from "@/components/retroui/Button";
 import { ParameterValue } from "@/components/shared/ParameterValue";
-import { EosInvestmentCalculator } from "@/components/site/EosInvestmentCalculator";
+import { EosServiceCounter } from "@/components/site/EosServiceCounter";
 import { Container } from "@/components/ui/container";
 import { SectionContainer } from "@/components/ui/section-container";
-import { fullManualPaperLink } from "@/lib/routes";
+import { fullManualPaperLink, ROUTES } from "@/lib/routes";
 
-const requestDataRoomSubject = "EOS data room request";
-const bookCallSubject = "EOS investor call";
-const requestDataRoomHref = `mailto:m@warondisease.org?subject=${encodeURIComponent(
-  requestDataRoomSubject,
-)}`;
-const bookCallHref = `mailto:m@warondisease.org?subject=${encodeURIComponent(
-  bookCallSubject,
-)}`;
-const calculatorHref = "#eos-calculator";
+/** The treaty vote lives on the campaign domain, not optimitron.com. */
+const WAR_ON_DISEASE_URL = "https://warondisease.org";
+
+const MANUAL_URLS = {
+  alignedElectionCommission:
+    "https://manual.warondisease.org/knowledge/solution/aligned-election-commission.html",
+  automatedRevenueService:
+    "https://manual.warondisease.org/knowledge/solution/automated-revenue-service.html",
+  departmentOfPeace:
+    "https://manual.warondisease.org/knowledge/solution/department-of-peace.html",
+  dfdaImpactPaper:
+    "https://manual.warondisease.org/knowledge/appendix/dfda-impact-paper.html",
+  dih: "https://manual.warondisease.org/knowledge/solution/dih.html",
+  optimocracyPaper:
+    "https://manual.warondisease.org/knowledge/appendix/optimocracy-paper.html",
+  universalSecurityAdministration:
+    "https://manual.warondisease.org/knowledge/solution/universal-security-administration.html",
+} as const;
 
 const mastheadLabel = "Earth Optimization Services";
-const mastheadStatus = "Now accepting applications.";
-const investorActionsLabel = "Investor actions";
-const calculatorLabel = "See what your stake becomes";
-const requestDataRoomLabel = "Request the data room";
-const bookCallLabel = "Book a call";
+const mastheadStatus =
+  "Correction: your application was accepted at birth. You are one of 8,000,000,000 presidents.";
+const voteLabel = "Vote on the first purchase";
+const tourLabel = "Tour the departments";
 
-const heroHeading =
-  "Governments are supposed to make people healthier and richer. We're buying the power to make them.";
+const heroHeading = "The Government of Tomorrow is in stock.";
 const whatThisIsHeading = "What this is";
 const thermostatHeading = "Your government has no thermostat.";
 const thermostatDeck =
   "Your oven measures the temperature, compares it to what you asked for, and adjusts. So does your fridge, your cruise control, your toilet. Your government runs the most complex system on Earth with less feedback than a toaster.";
-const howItWorksHeading = "How it works";
+const departmentsHeading = "The departments";
+const departmentsDeck =
+  "Every agency you already pay for, rebuilt so it can tell whether it's working. Prices are for planetary installation.";
+const serviceCounterHeading = "The service counter";
+const serviceCounterDeck =
+  "Civilization repairs, priced and guaranteed. Your money sits in escrow until the work happens — if it doesn't, it comes back. Every line item reports its expected return before you pay.";
 const employeeManualHeading = "Employee manual";
 const employeeManualDeck =
-  "The manual at warondisease.org is the employee handbook. Earth Optimization Services is the Company, which is you and everyone else. Your title is President of Earth Optimization Services, and so is everyone's. Eight billion presidents, no boss. You run the planet now.";
+  "The manual at manual.warondisease.org is the employee handbook. Earth Optimization Services is the Company, which is you and everyone else. You run the planet now.";
 const employeeManualLabel = "Read the employee manual";
-const whyItPaysHeading = "Why it pays";
-const calculatorHeading = "Your calculator";
-const calculatorDeck =
-  "Use your own assumptions. If the numbers stop working, good - you just saved yourself the money. Either way you leave knowing.";
-const termsHeading = "Terms";
-const termsDeck =
-  "The pitch is public. The paperwork is not. For accredited investors, the securities materials live off-page, where the law wants them.";
-const finalHeading = "Talk to us";
-const finalDeck =
-  "Request the data room or book a call. The math is public. The buy-in is not a one-click checkout - the law makes us talk first.";
-const legalGateText =
-  "Accredited-only securities discussion. Not an offer. Not investment advice.";
+const shareholderStripText =
+  "EOS also sells shares. That conversation is legally required to be boring, so it happens over here.";
+const shareholderStripLabel = "Shareholder paperwork";
 
 const thermostatPanels = [
   {
@@ -81,42 +100,263 @@ const thermostatPanels = [
   },
 ] as const;
 
-const howItWorksSteps = [
-  {
-    body:
-      "Buy a controlling share of the big weapons companies. The people you buy out get richer doing it - the share price goes up, not down.",
-    title: "Buy the power",
-  },
-  {
-    body:
-      "Instead of one boardroom deciding what that power does, every person gets a say - simple this-or-that choices that add up to what the public actually wants.",
-    title: "Hand it to everyone",
-  },
-  {
-    body:
-      "Feed in two centuries of data from nearly every country: which laws actually made people live longer and earn more. Rank them.",
-    title: "Find the policies that work",
-  },
-] as const;
+interface Department {
+  action: { external?: boolean; href: string; label: string };
+  body: ReactNode;
+  priceLines: { label: string; value: ReactNode }[];
+  replaces: string;
+  title: string;
+}
 
-const terms = [
+const departments: Department[] = [
   {
-    body: "Friends and family minimum.",
-    label: "$25,000",
+    action: {
+      external: true,
+      href: MANUAL_URLS.optimocracyPaper,
+      label: "Read the spec",
+    },
+    body: (
+      <>
+        The machine that writes laws and budgets from evidence. Two centuries
+        of data from nearly every country go in. Three features come standard:
+        the Optimal Policy Generator finds the laws that raise health and
+        income, the Optimal Budget Generator does the same for spending, and
+        Wishocracy is the ballot where eight billion presidents split the
+        budget with simple this-or-that choices. It already runs as software.
+        The math is public.
+      </>
+    ),
+    priceLines: [{ label: "Price", value: "Included with every government" }],
+    replaces: "Legislative guesswork",
+    title: "The Optimitron",
   },
   {
-    body: "Institutional minimum.",
-    label: "$100,000",
+    action: {
+      external: true,
+      href: MANUAL_URLS.dfdaImpactPaper,
+      label: "Read the spec",
+    },
+    body: (
+      <>
+        Turns ordinary healthcare into evidence. Pragmatic trials at{" "}
+        <ParameterValue param={DFDA_PRAGMATIC_TRIAL_COST_PER_PATIENT} /> instead
+        of <ParameterValue param={TRADITIONAL_PHASE3_COST_PER_PATIENT} />, run
+        in real clinics on outcomes that matter. It prevents a year of death
+        and suffering for{" "}
+        <ParameterValue
+          param={DFDA_DIRECT_FUNDING_COST_PER_DALY}
+          valueOverride="84 cents"
+        />
+        , which is the best price anyone has quoted on anything.
+      </>
+    ),
+    priceLines: [
+      {
+        label: "Build",
+        value: <ParameterValue param={DFDA_UPFRONT_BUILD} />,
+      },
+    ],
+    replaces: "The FDA",
+    title: "The decentralized FDA",
   },
   {
-    body: "Earth Optimization Services shares and Incentive Alignment Bonds.",
-    label: "2 products",
+    action: { external: true, href: MANUAL_URLS.dih, label: "Read the blueprint" },
+    body: (
+      <>
+        Receives the treaty&apos;s{" "}
+        <ParameterValue param={TREATY_ANNUAL_FUNDING} /> and pays for results
+        instead of grant paperwork. Nobody gets paid for writing essays about
+        why they should be allowed to try curing things. They get paid for
+        curing things.
+      </>
+    ),
+    priceLines: [
+      {
+        label: "Setup",
+        value: <ParameterValue param={DIH_NPV_UPFRONT_COST_INITIATIVES} />,
+      },
+      {
+        // Unit is USD/year, so ParameterValue already renders the "/year".
+        label: "Running",
+        value: <ParameterValue param={DIH_NPV_ANNUAL_OPEX_INITIATIVES} />,
+      },
+    ],
+    replaces: "The NIH",
+    title: "Decentralized Institutes of Health",
   },
   {
-    body: "Founder equity.",
-    label: "0%",
+    action: { href: ROUTES.court, label: "Enter the court" },
+    body: (
+      <>
+        Where eight billion humans judge governments that spend public money
+        against the public. Registers plaintiffs, summons jurors, publishes the
+        evidence, renders the verdict, and enforces the settlement — the 1%
+        Treaty.
+      </>
+    ),
+    priceLines: [
+      { label: "Build", value: <ParameterValue param={COURT_BUILD_COST} /> },
+    ],
+    replaces: "Courts that can't subpoena a government",
+    title: "Court of Humanity",
   },
-] as const;
+  {
+    action: {
+      external: true,
+      href: MANUAL_URLS.departmentOfPeace,
+      label: "Read the spec",
+    },
+    body: (
+      <>
+        You are picturing a very strong robot that collects the missiles and
+        throws them into the sun. We have something stronger: a buy order. The
+        department buys the weapons companies — the sellers get richer, and
+        nobody shoots at a brokerage account — converts the stockpiles into
+        reactor fuel (your species already did this once; it powered your
+        lightbulbs for twenty years), and retires the war budget at 1% a year,
+        verified. Talking is the cheap part:{" "}
+        <ParameterValue
+          display="integer"
+          param={AI_NEGOTIATOR_AGENTS_PER_GOVERNMENT}
+        />{" "}
+        AI negotiators per government at{" "}
+        <ParameterValue figures={2} param={AI_NEGOTIATOR_COST_PER_AGENT_HOUR} />{" "}
+        an agent-hour. Disputes take six minutes. Nobody dies.
+      </>
+    ),
+    priceLines: [
+      {
+        label: "Price",
+        value: (
+          <>
+            <ParameterValue param={AI_DIPLOMATIC_CORPS_ANNUAL_COST} />
+            {"/yr"}
+          </>
+        ),
+      },
+      {
+        label: "Current model",
+        value: (
+          <>
+            <ParameterValue param={GLOBAL_MILITARY_SPENDING_ANNUAL_2024} />
+            {"/yr"}
+          </>
+        ),
+      },
+    ],
+    replaces: "The war department",
+    title: "Department of Peace",
+  },
+  {
+    action: {
+      external: true,
+      href: MANUAL_URLS.automatedRevenueService,
+      label: "Read the spec",
+    },
+    body: (
+      <>
+        Your tax code is 17.5 Harry Potters long, except Harry Potter has a
+        coherent plot and your tax code has loopholes. The replacement is six
+        lines of code: every transfer sends 0.5% to the treasury. No filing.
+        No forms. No audits. You cannot lobby a smart contract.
+      </>
+    ),
+    priceLines: [
+      {
+        label: "Price",
+        value: (
+          <>
+            <ParameterValue param={AUTOMATED_REVENUE_SERVICE_ANNUAL_OPEX} />
+            {"/yr"}
+          </>
+        ),
+      },
+      {
+        label: "The IRS",
+        value: (
+          <>
+            <ParameterValue param={IRS_ANNUAL_OPERATING_BUDGET} />
+            {"/yr"}
+          </>
+        ),
+      },
+      {
+        label: "Saves",
+        value: (
+          <>
+            <ParameterValue
+              param={AUTOMATED_REVENUE_SERVICE_SAVINGS_PER_AMERICAN_ANNUAL}
+            />
+            {"/American/yr"}
+          </>
+        ),
+      },
+    ],
+    replaces: "The IRS",
+    title: "Automated Revenue Service",
+  },
+  {
+    action: {
+      external: true,
+      href: MANUAL_URLS.universalSecurityAdministration,
+      label: "Read the spec",
+    },
+    body: (
+      <>
+        The welfare bureaucracy becomes a for-loop: if you are human, you
+        qualify. No applications, no caseworkers, no 45-day wait while the
+        hungry stay hungry. Running the whole thing costs{" "}
+        <ParameterValue
+          figures={2}
+          param={UNIVERSAL_SECURITY_ADMIN_ALL_IN_COST_PER_CITIZEN_ANNUAL}
+        />{" "}
+        per citizen a year.
+      </>
+    ),
+    priceLines: [
+      {
+        label: "Price",
+        value: (
+          <>
+            <ParameterValue param={UNIVERSAL_SECURITY_ADMIN_ANNUAL_OPEX} />
+            {"/yr"}
+          </>
+        ),
+      },
+    ],
+    replaces: "80+ welfare programs",
+    title: "Universal Security Administration",
+  },
+  {
+    action: {
+      external: true,
+      href: MANUAL_URLS.alignedElectionCommission,
+      label: "Read the spec",
+    },
+    body: (
+      <>
+        One number per politician: how closely their votes match what citizens
+        actually want. Score high, get funded. Represent donors instead, get
+        nothing. The current system is a vending machine where lobbyists insert
+        money and legislation comes out. The replacement is a scoreboard where
+        citizens insert preferences and representation comes out.
+      </>
+    ),
+    priceLines: [
+      {
+        label: "Price",
+        value: (
+          <>
+            <ParameterValue param={ALIGNED_ELECTION_COMMISSION_ANNUAL_OPEX} />
+            {"/yr"}
+          </>
+        ),
+      },
+    ],
+    replaces: "The FEC and campaign finance",
+    title: "Aligned Election Commission",
+  },
+];
 
 function ActionButton({
   children,
@@ -234,6 +474,37 @@ function ThermostatPanel({
   );
 }
 
+function DepartmentCard({ department }: { department: Department }) {
+  return (
+    <article className="flex flex-col border-2 border-foreground p-4 sm:p-6">
+      <p className="text-xs font-black uppercase tracking-[0.14em] text-muted-foreground">
+        Replaces: {department.replaces}
+      </p>
+      <h3 className="mt-2 text-2xl font-black uppercase leading-none">
+        {department.title}
+      </h3>
+      <p className="mt-4 flex-1 text-base font-bold leading-7">
+        {department.body}
+      </p>
+      <dl className="mt-5 grid gap-2 border-t-2 border-foreground pt-4 sm:grid-cols-2">
+        {department.priceLines.map((line) => (
+          <div key={line.label}>
+            <dt className="text-xs font-black uppercase tracking-[0.14em] text-muted-foreground">
+              {line.label}
+            </dt>
+            <dd className="text-lg font-black">{line.value}</dd>
+          </div>
+        ))}
+      </dl>
+      <div className="mt-5">
+        <ActionButton href={department.action.href}>
+          {department.action.label}
+        </ActionButton>
+      </div>
+    </article>
+  );
+}
+
 export function EarthOptimizationServicesLandingPage() {
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -249,18 +520,15 @@ export function EarthOptimizationServicesLandingPage() {
               <p className="text-sm font-black uppercase tracking-normal">
                 {mastheadLabel}
               </p>
-              <p className="mt-2 text-sm font-bold uppercase text-muted-foreground">
+              <p className="mt-2 max-w-md text-sm font-bold uppercase text-muted-foreground">
                 {mastheadStatus}
               </p>
             </div>
-            <nav
-              aria-label={investorActionsLabel}
-              className="flex flex-wrap gap-3"
-            >
-              <ActionButton href={requestDataRoomHref} primary>
-                {requestDataRoomLabel}
+            <nav aria-label="Primary actions" className="flex flex-wrap gap-3">
+              <ActionButton href={WAR_ON_DISEASE_URL} primary>
+                {voteLabel}
               </ActionButton>
-              <ActionButton href={bookCallHref}>{bookCallLabel}</ActionButton>
+              <ActionButton href="#departments">{tourLabel}</ActionButton>
             </nav>
           </header>
 
@@ -268,12 +536,22 @@ export function EarthOptimizationServicesLandingPage() {
             <h1 className="max-w-5xl text-4xl font-black uppercase leading-none sm:text-6xl lg:text-7xl">
               {heroHeading}
             </h1>
+            <p className="mt-6 max-w-4xl text-xl font-bold leading-9 sm:text-2xl sm:leading-10">
+              It measures whether people live longer and earn more, keeps the
+              policies that work, and drops the ones that don&apos;t. Your
+              current model spends{" "}
+              <ParameterValue
+                display="integer"
+                param={MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO}
+              />
+              x more testing weapons than cures. Trade-ins accepted. The first
+              purchase is the 1% Treaty.
+            </p>
             <div className="mt-8 flex flex-wrap gap-3">
-              <ActionButton href={requestDataRoomHref} primary>
-                {requestDataRoomLabel}
+              <ActionButton href={WAR_ON_DISEASE_URL} primary>
+                {voteLabel}
               </ActionButton>
-              <ActionButton href={bookCallHref}>{bookCallLabel}</ActionButton>
-              <ActionButton href={calculatorHref}>{calculatorLabel}</ActionButton>
+              <ActionButton href="#departments">{tourLabel}</ActionButton>
             </div>
           </section>
         </Container>
@@ -281,21 +559,15 @@ export function EarthOptimizationServicesLandingPage() {
 
       <PageSection title={whatThisIsHeading}>
         <p className="max-w-5xl text-xl font-bold leading-9 sm:text-2xl sm:leading-10">
-          A government has one job: make the median person healthier and richer.
-          Most are bad at it, because the people who profit from the current
-          setup pay to keep it that way — governments spend{" "}
+          A government has one job: make the median person healthier and
+          richer. The current models misplace about{" "}
           <ParameterValue
-            display="integer"
-            param={MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO}
-          />
-          x more testing weapons than testing cures. So we do the boring thing.
-          We buy a controlling share of the companies whose lobbying blocks the
-          fix, hand that power to ordinary people instead of a boardroom, and
-          point it at the policies that nearly every country&apos;s data says
-          actually raise health and income. The lobby that spent decades
-          stopping cures starts paying for them. It&apos;s almost like pointing the
-          money at the goal works better. Weird. (This already runs as software.
-          The math is public.)
+            param={POLITICAL_DYSFUNCTION_GLOBAL_OPPORTUNITY_COST_TOTAL}
+          />{" "}
+          a year — the gap between the policies you get and the optimal ones a
+          working government would pick. Below is the replacement catalog,
+          plus a service counter of repairs you can order today. All of it is
+          open source. This page is just the tour.
         </p>
       </PageSection>
 
@@ -307,82 +579,26 @@ export function EarthOptimizationServicesLandingPage() {
         </div>
       </PageSection>
 
-      <PageSection title={howItWorksHeading}>
-        <div className="grid border-t-2 border-foreground md:grid-cols-2">
-          {howItWorksSteps.map((step, index) => (
-            <article
-              className="border-b-2 border-foreground py-6 md:border-r-2 md:px-6 md:even:border-r-0 md:first:pl-0"
-              key={step.title}
-            >
-              <p className="text-sm font-black uppercase text-muted-foreground">
-                {index + 1}
-              </p>
-              <h3 className="mt-2 text-2xl font-black uppercase">
-                {step.title}
-              </h3>
-              <p className="mt-4 text-base font-bold leading-7">{step.body}</p>
-            </article>
+      <PageSection
+        deck={departmentsDeck}
+        id="departments"
+        title={departmentsHeading}
+      >
+        <div className="grid gap-5 md:grid-cols-2">
+          {departments.map((department) => (
+            <DepartmentCard department={department} key={department.title} />
           ))}
-          <article className="border-b-2 border-foreground py-6 md:border-r-2 md:px-6 md:even:border-r-0">
-            <p className="text-sm font-black uppercase text-muted-foreground">4</p>
-            <h3 className="mt-2 text-2xl font-black uppercase">
-              Use the lobby to install them
-            </h3>
-            <p className="mt-4 text-base font-bold leading-7">
-              The lobbying budget that used to block the fix now pays to pass it
-              - starting with{" "}
-              <ParameterValue display="withUnit" param={TREATY_ANNUAL_FUNDING} />{" "}
-              a year redirected into testing cures.
-            </p>
-          </article>
         </div>
+      </PageSection>
+
+      <PageSection deck={serviceCounterDeck} title={serviceCounterHeading}>
+        <EosServiceCounter />
       </PageSection>
 
       <PageSection deck={employeeManualDeck} title={employeeManualHeading}>
         <ActionButton href={fullManualPaperLink.href}>
           {employeeManualLabel}
         </ActionButton>
-      </PageSection>
-
-      <PageSection title={whyItPaysHeading}>
-        <p className="max-w-5xl text-xl font-bold leading-9 sm:text-2xl sm:leading-10">
-          The whole takeover costs about{" "}
-          <ParameterValue
-            display="withUnit"
-            param={DEFENSE_TAKEOVER_COST_TOTAL}
-          />{" "}
-          - roughly{" "}
-          <ParameterValue
-            display="withUnit"
-            param={DEFENSE_TAKEOVER_COST_PER_HUMAN}
-          />{" "}
-          per person, if every human chipped in. Nobody collects $90 from
-          anybody. You put money in, you own part of it, and the returns come
-          from those companies getting more valuable as the economy grows. You
-          are not paying to fix the planet. You own part of the fix.
-        </p>
-      </PageSection>
-
-      <PageSection
-        deck={calculatorDeck}
-        id="eos-calculator"
-        title={calculatorHeading}
-      >
-        <EosInvestmentCalculator />
-      </PageSection>
-
-      <PageSection deck={termsDeck} title={termsHeading}>
-        <div className="grid border-t-2 border-foreground sm:grid-cols-2 lg:grid-cols-4">
-          {terms.map((term) => (
-            <article
-              className="border-b-2 border-foreground py-5 sm:border-r-2 sm:px-5 sm:even:border-r-0 lg:even:border-r-2 lg:last:border-r-0 lg:first:pl-0"
-              key={term.label}
-            >
-              <h3 className="text-3xl font-black uppercase">{term.label}</h3>
-              <p className="mt-3 text-base font-bold leading-7">{term.body}</p>
-            </article>
-          ))}
-        </div>
       </PageSection>
 
       <SectionContainer
@@ -392,23 +608,14 @@ export function EarthOptimizationServicesLandingPage() {
         padding="lg"
       >
         <Container size="lg">
-          <div className="max-w-4xl">
-            <h2 className="text-3xl font-black uppercase leading-none sm:text-5xl">
-              {finalHeading}
-            </h2>
-            <p className="mt-4 text-lg font-bold leading-8 sm:text-xl">
-              {finalDeck}
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="max-w-3xl text-base font-bold leading-7">
+              {shareholderStripText}
             </p>
-          </div>
-          <div className="mt-8 flex flex-wrap gap-3">
-            <ActionButton href={requestDataRoomHref} primary>
-              {requestDataRoomLabel}
+            <ActionButton href={ROUTES.fund}>
+              {shareholderStripLabel}
             </ActionButton>
-            <ActionButton href={bookCallHref}>{bookCallLabel}</ActionButton>
           </div>
-          <p className="mt-6 border-2 border-foreground p-3 text-xs font-black uppercase">
-            {legalGateText}
-          </p>
         </Container>
       </SectionContainer>
     </div>

--- a/packages/web/src/components/site/EosServiceCounter.tsx
+++ b/packages/web/src/components/site/EosServiceCounter.tsx
@@ -1,0 +1,107 @@
+import Link from "next/link";
+import { FundingTaskCard } from "@/components/task-funding/FundingTaskCard";
+import {
+  collectFundableTasks,
+  getExpectedValueUsd,
+  getFundingDenominator,
+} from "@/lib/task-funding/fundable-tasks.server";
+import { getTaskFundingStatus } from "@/lib/task-funding/status.server";
+import { getTasksPageData } from "@/lib/tasks.server";
+import { ROUTES } from "@/lib/routes";
+import {
+  COURT_OF_HUMANITY_TASK_KEY,
+  DFDA_CREATE_TASK_KEY,
+  EARTH_OPTIMIZATION_PRIZE_TASK_KEY,
+  LOVING_TAKEOVER_TASK_KEY,
+  SHIRT_SEED_TASK_KEY,
+  TREATY_PARENT_TASK_KEY,
+} from "@/lib/tasks/task-keys";
+
+/** The treaty vote lives on the campaign domain, not optimitron.com. */
+const WAR_ON_DISEASE_URL = "https://warondisease.org";
+
+/**
+ * Curated order for the landing-page service counter. Flagship first; every
+ * key must exist in the managed optimize-earth task tree.
+ */
+const SERVICE_TASK_KEYS: readonly string[] = [
+  TREATY_PARENT_TASK_KEY,
+  COURT_OF_HUMANITY_TASK_KEY,
+  DFDA_CREATE_TASK_KEY,
+  LOVING_TAKEOVER_TASK_KEY,
+  EARTH_OPTIMIZATION_PRIZE_TASK_KEY,
+  SHIRT_SEED_TASK_KEY,
+];
+
+export async function EosServiceCounter() {
+  const data = await getTasksPageData(null);
+  const byKey = new Map(
+    collectFundableTasks(data).flatMap((task) =>
+      task.taskKey ? [[task.taskKey, task] as const] : [],
+    ),
+  );
+  const services = SERVICE_TASK_KEYS.flatMap((key) => {
+    const task = byKey.get(key);
+    if (!task) return [];
+    const denominator = getFundingDenominator(task);
+    if (!denominator) return [];
+    return [{ denominator, task }];
+  });
+
+  if (services.length === 0) {
+    return (
+      <p className="max-w-3xl text-lg font-bold leading-8">
+        The counter is restocking.{" "}
+        <Link className="underline underline-offset-4" href={ROUTES.fund}>
+          The full price list is here.
+        </Link>
+      </p>
+    );
+  }
+
+  const fundingStatuses = new Map(
+    await Promise.all(
+      services.map(
+        async ({ task }) =>
+          [task.id, await getTaskFundingStatus(task.id).catch(() => null)] as const,
+      ),
+    ),
+  );
+
+  return (
+    <div className="grid gap-4">
+      {services.map(({ denominator, task }) => {
+        const expectedValueUsd = getExpectedValueUsd(task);
+        const score =
+          denominator.denominatorCents > 0n
+            ? expectedValueUsd / (Number(denominator.denominatorCents) / 100)
+            : 0;
+
+        return (
+          <FundingTaskCard
+            blurb={task.impactStatement}
+            denominatorCents={denominator.denominatorCents}
+            expectedValueUsd={expectedValueUsd}
+            extraAction={
+              task.taskKey === TREATY_PARENT_TASK_KEY ? (
+                <a
+                  className="inline-flex min-h-10 items-center justify-center border border-foreground bg-background px-4 py-2 text-sm font-black uppercase text-foreground hover:bg-foreground hover:text-background"
+                  href={WAR_ON_DISEASE_URL}
+                >
+                  Vote yes
+                </a>
+              ) : undefined
+            }
+            fundButtonLabel="Fund it"
+            funding={fundingStatuses.get(task.id) ?? null}
+            fundingSource={denominator.fundingSource}
+            key={task.id}
+            score={score}
+            taskId={task.id}
+            title={task.title}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/components/task-funding/FundingTaskCard.tsx
+++ b/packages/web/src/components/task-funding/FundingTaskCard.tsx
@@ -1,0 +1,134 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+import {
+  formatPercent,
+  formatRatio,
+  formatUsd,
+  formatUsdCents,
+} from "@/lib/task-funding/format";
+import type { getTaskFundingStatus } from "@/lib/task-funding/status.server";
+import { getTaskPath } from "@/lib/routes";
+
+type TaskFundingStatusResult = Awaited<ReturnType<typeof getTaskFundingStatus>>;
+
+export interface FundingTaskCardProps {
+  /** Optional one-line pitch shown under the title (task impactStatement). */
+  blurb?: string | null;
+  denominatorCents: bigint;
+  expectedValueUsd: number;
+  /** Extra action button rendered beside the fund button (e.g. a vote link). */
+  extraAction?: ReactNode;
+  fundButtonLabel?: string;
+  funding: TaskFundingStatusResult | null;
+  fundingSource: "target" | "compensation";
+  /** 1-based rank badge; omitted hides the badge column. */
+  index?: number;
+  score: number;
+  taskId: string;
+  title: string;
+}
+
+export function FundingTaskCard({
+  blurb,
+  denominatorCents,
+  expectedValueUsd,
+  extraAction,
+  fundButtonLabel = "Fund task",
+  funding,
+  fundingSource,
+  index,
+  score,
+  taskId,
+  title,
+}: FundingTaskCardProps) {
+  const percent =
+    funding && funding.targetUsdCents > 0n
+      ? Math.min(100, funding.percentToTarget)
+      : 0;
+  const fundingHref = `${getTaskPath(taskId)}#funding`;
+
+  return (
+    <article
+      className={
+        index === undefined
+          ? "grid gap-4 border border-foreground p-4 lg:grid-cols-[minmax(0,1fr)_auto]"
+          : "grid gap-4 border border-foreground p-4 sm:grid-cols-[auto_minmax(0,1fr)] lg:grid-cols-[auto_minmax(0,1fr)_auto]"
+      }
+    >
+      {index === undefined ? null : (
+        <div className="flex size-12 items-center justify-center border border-foreground text-lg font-black">
+          {index}
+        </div>
+      )}
+      <div className="min-w-0 space-y-4">
+        <div>
+          <h3 className="text-xl font-black leading-tight">
+            <Link
+              className="underline-offset-4 hover:underline"
+              href={fundingHref}
+            >
+              {title}
+            </Link>
+          </h3>
+          {blurb ? (
+            <p className="mt-2 text-sm font-bold leading-relaxed text-muted-foreground">
+              {blurb}
+            </p>
+          ) : null}
+          <dl className="mt-3 grid gap-2 text-sm font-bold text-muted-foreground sm:grid-cols-3">
+            <div>
+              <dt className="text-xs font-black uppercase tracking-[0.12em]">
+                Return per $1
+              </dt>
+              <dd className="text-foreground">{formatRatio(score)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-black uppercase tracking-[0.12em]">
+                Task value
+              </dt>
+              <dd className="text-foreground">{formatUsd(expectedValueUsd)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-black uppercase tracking-[0.12em]">
+                {fundingSource === "target" ? "Funding goal" : "Worker payout"}
+              </dt>
+              <dd className="text-foreground">
+                {formatUsdCents(denominatorCents)}
+              </dd>
+            </div>
+          </dl>
+        </div>
+        <div>
+          <div className="h-2 border border-foreground">
+            <div
+              className="h-full bg-foreground"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+          <p className="mt-1 text-xs font-black uppercase tracking-[0.12em] text-muted-foreground">
+            {funding
+              ? funding.committedUsdCents > 0n
+                ? `${formatUsdCents(funding.committedUsdCents)} committed - ${formatPercent(percent)}`
+                : "Opening day. Be the first."
+              : "Pays a verified worker after completion"}
+          </p>
+        </div>
+      </div>
+      <div
+        className={
+          index === undefined
+            ? "flex flex-wrap items-start gap-2 lg:justify-end"
+            : "flex flex-wrap items-start gap-2 sm:col-start-2 lg:col-start-auto lg:justify-end"
+        }
+      >
+        <Link
+          className="inline-flex min-h-10 items-center justify-center border border-foreground bg-foreground px-4 py-2 text-sm font-black uppercase text-background hover:bg-background hover:text-foreground"
+          href={fundingHref}
+        >
+          {fundButtonLabel}
+        </Link>
+        {extraAction}
+      </div>
+    </article>
+  );
+}

--- a/packages/web/src/components/tasks/task-row.tsx
+++ b/packages/web/src/components/tasks/task-row.tsx
@@ -23,6 +23,7 @@ import {
 import { getPersonHref } from "@/lib/person-href";
 import { getTaskPath } from "@/lib/routes";
 import type { TaskCardTask } from "./task-card";
+import { getTaskAssigneeLabels } from "@/lib/tasks/assignee-label";
 import { TaskRowShare } from "./task-row-share";
 import { DeathCounter } from "./death-counter";
 import { LiveCounter } from "./live-counter";
@@ -73,9 +74,6 @@ function getLeaderHandle(task: TaskCardTask): string | null {
 }
 
 /** True when a task is assigned to the "Humanity" org — i.e. "you". */
-function isAssignedToYou(task: TaskCardTask): boolean {
-  return task.assigneeOrganization?.slug === "humanity";
-}
 
 /** Format an estimated effort duration. Sub-minute → seconds, sub-hour → minutes, else hours. */
 function formatDuration(hours: number | null | undefined): string {
@@ -301,10 +299,8 @@ export function TaskRow({
   now: Date | null;
 }) {
   const delayStats = now ? getTaskDelayStats(task, now) : null;
-  const assignedToYou = isAssignedToYou(task);
-  const targetLabel = assignedToYou
-    ? "You"
-    : task.assigneePerson?.displayName ?? task.assigneeOrganization?.name ?? task.title;
+  const { display: targetLabel, share: shareTargetLabel } =
+    getTaskAssigneeLabels(task);
   const countryCode = task.assigneePerson?.countryCode ?? null;
   const assigneeBudget = getAssigneeMilitaryBudgetUsd(task.contextJson);
   const governmentBudgetUsd = getAssigneeGovernmentBudgetUsd(task.contextJson);
@@ -323,7 +319,7 @@ export function TaskRow({
     currentEconomicValueUsdLost: delayStats?.currentEconomicValueUsdLost ?? null,
     currentHumanLivesLost: delayStats?.currentHumanLivesLost ?? null,
     currentSufferingHoursLost: delayStats?.currentSufferingHoursLost ?? null,
-    targetLabel,
+    targetLabel: shareTargetLabel,
     taskTitle: task.title,
   });
   const leaderHandle = getLeaderHandle(task);
@@ -339,7 +335,7 @@ export function TaskRow({
     militaryToClinicalTrialsRatio,
     militaryBudgetUsdPerYear: assigneeBudget,
     now,
-    targetLabel,
+    targetLabel: shareTargetLabel,
     taskTitle: task.title,
   }) : undefined;
 
@@ -602,7 +598,7 @@ export function TaskRow({
             <TaskRowShare
               shareText={signerShareText}
               shareTokens={signerShareTokens}
-              targetLabel={targetLabel}
+              targetLabel={shareTargetLabel}
               taskId={task.id}
               taskTitle={task.title}
             />
@@ -876,7 +872,7 @@ export function TaskRow({
           <TaskRowShare
             shareText={shareText}
             shareTokens={shareTokens}
-            targetLabel={targetLabel}
+            targetLabel={shareTargetLabel}
             taskId={task.id}
             taskTitle={task.title}
           />

--- a/packages/web/src/lib/alignment-benchmarks.ts
+++ b/packages/web/src/lib/alignment-benchmarks.ts
@@ -76,7 +76,7 @@ export const ALIGNMENT_BENCHMARKS: AlignmentBenchmarkProfile[] = [
     district: "Massachusetts",
     chamber: "senate",
     summary:
-      "Progressive redistributive posture that strongly favors education, treatment, and anti-capture cuts to fossil and defense spending.",
+      "Progressive redistributive posture that strongly favors education, treatment, and anti-capture cuts to fossil and military spending.",
     sourceType: "curated_real",
     sourceLabel: "Current federal benchmark profile",
     sourceNote:
@@ -116,7 +116,7 @@ export const ALIGNMENT_BENCHMARKS: AlignmentBenchmarkProfile[] = [
     district: "Connecticut",
     chamber: "senate",
     summary:
-      "Reallocation-focused center-left profile that still funds defense, but tilts harder toward treatment and education than the caucus median.",
+      "Reallocation-focused center-left profile that still funds the military, but tilts harder toward treatment and education than the caucus median.",
     sourceType: "curated_real",
     sourceLabel: "Current federal benchmark profile",
     sourceNote:
@@ -156,7 +156,7 @@ export const ALIGNMENT_BENCHMARKS: AlignmentBenchmarkProfile[] = [
     district: "Maine",
     chamber: "senate",
     summary:
-      "Moderate Republican benchmark that keeps defense and enforcement meaningful but leaves room for treatment and education.",
+      "Moderate Republican benchmark that keeps military and enforcement spending meaningful but leaves room for treatment and education.",
     sourceType: "curated_real",
     sourceLabel: "Current federal benchmark profile",
     sourceNote:

--- a/packages/web/src/lib/email/coordination-feedback-note.ts
+++ b/packages/web/src/lib/email/coordination-feedback-note.ts
@@ -19,6 +19,9 @@ export function getFeedbackUrl(pathname = ROUTES.feedback) {
   return `${getAppBaseUrl()}${pathname}`;
 }
 
+const FEEDBACK_NOTE_LEDE =
+  "This is a decentralized to-do list for humanity: coordinate the work required to end war and disease in the least irritating way possible.";
+
 export function buildCoordinationFeedbackNote(input?: {
   replyEnabled?: boolean;
 }): CoordinationFeedbackNote {
@@ -27,15 +30,13 @@ export function buildCoordinationFeedbackNote(input?: {
     ? `Reply to this email with criticism, suggestions, or anything that would make this less annoying. You can also use ${feedbackUrl}.`
     : `Send criticism, suggestions, or anything that would make this less annoying: ${feedbackUrl}`;
   const text = [
-    "We are building a decentralized to-do list for humanity: coordinate the work required to end war and disease in the least irritating way possible.",
+    FEEDBACK_NOTE_LEDE,
     action,
     "If this is irritating, tell us and we will stop bothering you.",
   ].join(" ");
   const html = [
     `<p style="margin:18px 0 0;font-size:13px;line-height:1.6;color:#3f3f46;">`,
-    escapeHtml(
-      "We are building a decentralized to-do list for humanity: coordinate the work required to end war and disease in the least irritating way possible.",
-    ),
+    escapeHtml(FEEDBACK_NOTE_LEDE),
     " ",
     input?.replyEnabled
       ? `${escapeHtml(

--- a/packages/web/src/lib/task-funding/format.ts
+++ b/packages/web/src/lib/task-funding/format.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared display formatting for task funding amounts. Extracted from
+ * `app/fund/page.tsx` so the /fund price list and the landing-page service
+ * counter render identical numbers.
+ */
+
+export function formatUsdCents(cents: bigint | number) {
+  const dollars = Number(cents) / 100;
+  if (!Number.isFinite(dollars)) return "$0";
+
+  return new Intl.NumberFormat("en-US", {
+    currency: "USD",
+    currencyDisplay: "narrowSymbol",
+    maximumFractionDigits: dollars >= 1000 ? 0 : 2,
+    notation: dollars >= 100_000 ? "compact" : "standard",
+    style: "currency",
+  }).format(dollars);
+}
+
+export function formatUsd(value: number) {
+  if (!Number.isFinite(value)) return "$0";
+  return new Intl.NumberFormat("en-US", {
+    currency: "USD",
+    currencyDisplay: "narrowSymbol",
+    maximumFractionDigits: value >= 1000 ? 0 : 2,
+    notation: value >= 100_000 ? "compact" : "standard",
+    style: "currency",
+  }).format(value);
+}
+
+export function formatRatio(value: number) {
+  if (!Number.isFinite(value) || value <= 0) return "Unranked";
+  return `${formatUsd(value)} expected per $1`;
+}
+
+export function formatPercent(percent: number) {
+  if (!Number.isFinite(percent) || percent <= 0) return "0%";
+  if (percent >= 100) return "100%";
+  return `${percent < 1 ? "<1" : Math.round(percent)}%`;
+}

--- a/packages/web/src/lib/task-funding/fundable-tasks.server.ts
+++ b/packages/web/src/lib/task-funding/fundable-tasks.server.ts
@@ -1,0 +1,61 @@
+import { TaskStatus } from "@optimitron/db";
+import type { getTasksPageData } from "@/lib/tasks.server";
+
+/**
+ * Shared selection helpers for pages that render fundable tasks (the /fund
+ * price list and the landing-page service counter). Extracted from
+ * `app/fund/page.tsx` verbatim so both surfaces price tasks identically.
+ */
+
+export type TasksPageData = Awaited<ReturnType<typeof getTasksPageData>>;
+export type FundingTask = TasksPageData["allTasks"][number];
+
+export interface FundingDenominator {
+  denominatorCents: bigint;
+  fundingSource: "target" | "compensation";
+}
+
+export function getFundingDenominator(
+  task: FundingTask,
+): FundingDenominator | null {
+  if (
+    task.fundingTarget?.targetAmountCents &&
+    task.fundingTarget.targetAmountCents > 0n
+  ) {
+    return {
+      denominatorCents: task.fundingTarget.targetAmountCents,
+      fundingSource: "target",
+    };
+  }
+  if (
+    task.compensationMaxAmountMinorUnits &&
+    task.compensationMaxAmountMinorUnits > 0n
+  ) {
+    return {
+      denominatorCents: task.compensationMaxAmountMinorUnits,
+      fundingSource: "compensation",
+    };
+  }
+  return null;
+}
+
+export function getExpectedValueUsd(task: FundingTask) {
+  const value = task.selectedImpactFrame?.expectedEconomicValueUsdBase;
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function collectFundableTasks(data: TasksPageData) {
+  const byId = new Map<string, FundingTask>();
+  for (const task of data.topLevelTasks) {
+    byId.set(task.id, task);
+    for (const child of task.childTasks) {
+      byId.set(child.id, child);
+    }
+  }
+  for (const task of data.allTasks) {
+    byId.set(task.id, task);
+  }
+  return Array.from(byId.values()).filter(
+    (task) => task.status === TaskStatus.ACTIVE && task.isPublic,
+  );
+}

--- a/packages/web/src/lib/tasks.server.ts
+++ b/packages/web/src/lib/tasks.server.ts
@@ -335,6 +335,7 @@ const taskListSelect = {
     },
   },
   id: true,
+  impactStatement: true,
   interestTags: true,
   isPublic: true,
   kind: true,

--- a/packages/web/src/lib/tasks/__tests__/assignee-label.test.ts
+++ b/packages/web/src/lib/tasks/__tests__/assignee-label.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { getTaskAssigneeLabels } from "../assignee-label";
+
+describe("getTaskAssigneeLabels", () => {
+  it("uses the assignee person's name for display and share", () => {
+    const labels = getTaskAssigneeLabels({
+      assigneePerson: { displayName: "Ada Lovelace" },
+    });
+    expect(labels).toEqual({ display: "Ada Lovelace", share: "Ada Lovelace" });
+  });
+
+  it("uses the assignee organization's name when no person is assigned", () => {
+    const labels = getTaskAssigneeLabels({
+      assigneeOrganization: { name: "World Health Organization", slug: "who" },
+    });
+    expect(labels).toEqual({
+      display: "World Health Organization",
+      share: "World Health Organization",
+    });
+  });
+
+  it("shows You for humanity-org tasks but shares as Humanity", () => {
+    const labels = getTaskAssigneeLabels({
+      assigneeOrganization: { name: "Humanity", slug: "humanity" },
+    });
+    expect(labels).toEqual({ display: "You", share: "Humanity" });
+  });
+
+  it("never echoes the task title for an unassigned task", () => {
+    // Regression: unassigned rows used to fall back to task.title, so every
+    // open task appeared to be assigned to itself.
+    const labels = getTaskAssigneeLabels({
+      assigneeOrganization: null,
+      assigneePerson: null,
+    });
+    expect(labels).toEqual({ display: "Anyone", share: "Humanity" });
+  });
+});

--- a/packages/web/src/lib/tasks/__tests__/task-assignment-notification-email.test.ts
+++ b/packages/web/src/lib/tasks/__tests__/task-assignment-notification-email.test.ts
@@ -45,10 +45,10 @@ describe("buildTaskAssignmentNotificationEmail", () => {
       "Reply to this email to add a comment to the task.",
     );
     // Minimalism guard: drop the secondary "Mark complete" CTA and the
-    // "we are building a decentralized to-do list" feedback chrome.
+    // "decentralized to-do list" feedback chrome.
     expect(email.text).not.toContain("Mark complete");
     expect(email.text).not.toContain(
-      "We are building a decentralized to-do list for humanity",
+      "decentralized to-do list for humanity",
     );
     expect(email.html).toContain("Institute for Accelerated Medicine");
     expect(email.html).toContain(ORGANIZATION_ACTIVATION_TASK_TITLE);

--- a/packages/web/src/lib/tasks/assignee-label.ts
+++ b/packages/web/src/lib/tasks/assignee-label.ts
@@ -1,0 +1,40 @@
+/**
+ * Assignee labels for task rows and reminder/share text.
+ *
+ * Lives in lib (not components/tasks/task-row.tsx) because it's pure logic:
+ * the component module graph executes JSX at import time, which node-env
+ * tests can't load.
+ */
+
+/** Structural slice of a task the labels depend on (TaskCardTask fits). */
+export interface TaskAssigneeSource {
+  assigneeOrganization?: { name: string; slug: string | null } | null;
+  assigneePerson?: { displayName: string | null } | null;
+}
+
+/** Tasks assigned to the humanity organization are addressed to the reader. */
+export function isAssignedToHumanity(task: TaskAssigneeSource): boolean {
+  return task.assigneeOrganization?.slug === "humanity";
+}
+
+/**
+ * `display` is what the assignee column and avatar show; `share` is what
+ * reminder/share text calls the responsible party ("<share> is overdue on
+ * <task>").
+ *
+ * An unassigned task is open to any president — never echo the task title as
+ * if it were a person's name. In share text "You" and "Anyone" don't parse,
+ * so humanity owns those rows.
+ */
+export function getTaskAssigneeLabels(task: TaskAssigneeSource): {
+  display: string;
+  share: string;
+} {
+  const assignedToYou = isAssignedToHumanity(task);
+  const assigneeName =
+    task.assigneePerson?.displayName ?? task.assigneeOrganization?.name ?? null;
+  return {
+    display: assignedToYou ? "You" : assigneeName ?? "Anyone",
+    share: !assignedToYou && assigneeName ? assigneeName : "Humanity",
+  };
+}


### PR DESCRIPTION
## What this is

optimitron.com `/` stops being an investor pitch and becomes Wishonia's product catalog: the decentralized government agencies as departments with price tags, and the fundable program tasks as a service counter with live assurance-escrow progress. Direction, copy, and the Department of Peace rewrite were gated by Mike in-session (2026-07-03).

## Changes

**Landing (`EarthOptimizationServicesLandingPage`)**
- Masthead: "Correction: your application was accepted at birth. You are one of 8,000,000,000 presidents." (closes the approved 2026-06-09 masthead TODO)
- Hero: "THE GOVERNMENT OF TOMORROW IS IN STOCK." + 604x weapons-vs-cures ratio; the 1% Treaty is named at the CTA
- Departments grid: 8 agency cards (Optimitron, dFDA, DIH, Court of Humanity, Department of Peace, Automated Revenue Service, Universal Security Administration, Aligned Election Commission), every number a `ParameterValue` from the generated parameters snapshot; card lines quote the manual's "Your Government, Debugged" pages
- Service counter: curated managed program tasks (treaty, court, dFDA, Loving Takeover, prize, shirt cascade) with live escrow funding bars; treaty card gets a Vote yes action
- Investor sections removed; one shareholder footer strip → /fund
- Thermostat + employee-manual sections kept (previously gated copy)
- No $WISH/token mention anywhere; no "Decentralized Federal Reserve" card (ARS + USA cover it)

**/fund**
- Gains the calculator, terms grid, data-room/call CTAs, and legal gate (moved verbatim from the old landing, plus a scoping line so the minimums don't read as price-list terms)
- Refactored onto shared `FundingTaskCard` + `lib/task-funding/format.ts` + `fundable-tasks.server.ts` so /fund and the landing counter price identically

**Data/infra**
- `DFDA_CREATE_*` / `SHIRT_SEED_*` task keys added to the `@optimitron/db` registry (were inlined in managed data)
- `impactStatement` added to `taskListSelect`
- Latest generated parameters snapshot (agency cost params; the manual pipeline regenerated mid-session with renames, and the page rides the regeneration since nothing is hardcoded)

## Verification

- `tsc` clean (web + db + data), lint 0 errors, db tests 149/149, web tests 1844 passed
- Known pre-existing flake: `pledges.server.test.ts` threshold-event race fails under full-suite parallelism (Prisma P2034), passes isolated — documented in TODO.md
- Rendered pages verified on local dev (curl + Playwright, desktop/mobile); copy previews regenerated (`/eos`, `/fund`, ...)
- voice-critic and cold-stranger-ux passes applied; deferred items logged in TODO.md (generated-param additions via manual pipeline, treaty EV display audit, citation-dialog LaTeX overflow on mobile, calculator viewport reorder)

todo-touched: EOS landing v2 Government of Tomorrow showroom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed EOS landing experience with updated navigation, department showcases, funding/service sections, and new employee-manual content.
  * Introduced a reusable funding card and calculator experience for task pages, with clearer pricing, progress, and expected-value details.
  * Expanded visible task data across the app, including additional impact information and new funding-related items.

* **Bug Fixes**
  * Replaced hardcoded task identifiers with shared values to keep task links and funding actions consistent.
  * Updated displayed amounts and copy in several logged-out pages for more accurate, current information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->