### PR TITLE
Improve visual review artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          # Full history so build-visual-review.mjs can diff copy snapshots
+          # against the merge-base of origin/main. The default shallow clone
+          # has no main ref, which silently disabled the markdown-diff panels.
+          fetch-depth: 0
 
       - name: Enable Corepack
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ packages/web/public/media/
 packages/web/scripts/cold-stranger-*.cjs
 .codex-tmp/
 .claude/state/
+.gstack/
+packages/web/public/review-variants/
+packages/web/screenshots.bak/

--- a/packages/web/scripts/build-visual-review.mjs
+++ b/packages/web/scripts/build-visual-review.mjs
@@ -14,6 +14,8 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { extractHunksAndAlignment } from "./visual-review-hunks.mjs";
+import { renderReviewHtml } from "./visual-review-page.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -57,13 +59,6 @@ const reviewCommitSha =
   process.env.GITHUB_SHA ??
   null;
 const reviewGeneratedAt = new Date();
-const reviewCacheKey = [
-  reviewCommitSha ? shortSha(reviewCommitSha) : "local",
-  process.env.GITHUB_RUN_ID ?? null,
-  reviewGeneratedAt.getTime(),
-]
-  .filter(Boolean)
-  .join("-");
 const routeSpecs = loadRouteSpecs();
 const routePaths = new Map(
   [...routeSpecs.entries()].map(([name, spec]) => [name, spec.path]),
@@ -261,1438 +256,108 @@ function groupScreenshots(screenshots) {
 }
 
 function renderHtml(groups) {
-  const generatedAt = reviewGeneratedAt.toISOString();
-  const generatedAtCentral = formatCentralTime(reviewGeneratedAt);
-  const summary = summarizeGroups(groups);
-  const body = groups.length > 0
-    ? groups.map(renderRouteGroup).join("\n")
-    : `<section class="empty">
-        <h2>No visual screenshots found</h2>
-        <p>Run <code>pnpm --filter @optimitron/web run e2e -- visual</code>, then regenerate this page.</p>
-      </section>`;
-
-  return `<!doctype html>
+  if (groups.length === 0) {
+    return `<!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Optimitron Visual Review</title>
-  <style>
-    :root {
-      color-scheme: light;
-      --bg: #ffffff;
-      --fg: #000000;
-      --muted: #555555;
-      --line: #000000;
-    }
-
-    * {
-      box-sizing: border-box;
-    }
-
-    body {
-      margin: 0;
-      background: var(--bg);
-      color: var(--fg);
-      font-family: Arial, Helvetica, sans-serif;
-      line-height: 1.45;
-    }
-
-    header {
-      border-bottom: 1px solid var(--line);
-      background: var(--bg);
-      padding: 16px 24px;
-    }
-
-    h1 {
-      margin: 0;
-      font-size: 22px;
-      letter-spacing: 0;
-    }
-
-    .meta {
-      margin-top: 4px;
-      color: var(--muted);
-      font-size: 13px;
-    }
-
-    .summary-line {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-      margin-top: 10px;
-      font-size: 12px;
-      font-weight: 700;
-      text-transform: uppercase;
-    }
-
-    main {
-      padding: 24px;
-    }
-
-    details.route {
-      border-top: 1px solid var(--line);
-    }
-
-    details.route:first-child {
-      border-top: 0;
-    }
-
-    summary {
-      align-items: center;
-      cursor: pointer;
-      display: flex;
-      gap: 12px;
-      justify-content: space-between;
-      list-style: none;
-      padding: 18px 0;
-    }
-
-    summary::-webkit-details-marker {
-      display: none;
-    }
-
-    summary::before {
-      content: "+";
-      flex: 0 0 auto;
-      font-family: Consolas, "Liberation Mono", monospace;
-      font-size: 18px;
-      font-weight: 700;
-    }
-
-    details[open] > summary::before {
-      content: "-";
-    }
-
-    .route-title {
-      flex: 1 1 auto;
-      font-size: 18px;
-      font-weight: 700;
-      letter-spacing: 0;
-    }
-
-    .pairs {
-      display: grid;
-      gap: 28px;
-      padding: 0 0 40px;
-    }
-
-    .pair {
-      border: 1px solid var(--line);
-    }
-
-    .pair summary {
-      align-items: center;
-      cursor: pointer;
-      display: flex;
-      gap: 10px;
-      justify-content: space-between;
-      margin: 0;
-      border-bottom: 1px solid var(--line);
-      padding: 8px 10px;
-      font-size: 15px;
-      font-weight: 700;
-      letter-spacing: 0;
-      list-style: none;
-    }
-
-    .pair summary::-webkit-details-marker {
-      display: none;
-    }
-
-    .pair summary::before {
-      content: "+";
-      flex: 0 0 auto;
-      font-family: Consolas, "Liberation Mono", monospace;
-      font-size: 16px;
-      font-weight: 700;
-    }
-
-    .pair[open] > summary::before {
-      content: "-";
-    }
-
-    .pair-screens {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      align-items: start;
-    }
-
-    @media (min-width: 1200px) {
-      .pair-screens.has-review-map {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-      }
-
-      .pair-screens.has-review-map > figure:nth-child(3) {
-        border-left: 1px solid var(--line);
-      }
-    }
-
-    figure {
-      margin: 0;
-      background: #ffffff;
-    }
-
-    .pair-screens > figure:nth-child(even) {
-      border-left: 1px solid var(--line);
-    }
-
-    .markdown-diff-figure {
-      border-left: 0 !important;
-      border-top: 1px solid var(--line);
-      grid-column: 1 / -1;
-    }
-
-    /* Mobile: per-pair horizontal carousel.
-       DOM order stays [before, after, pixel diff, markdown diff]
-       (desktop-correct, reviewers want before/after side-by-side).
-       On mobile we use CSS order to surface the pixel diff first when
-       present: visual order becomes [pixel diff, before, after,
-       markdown diff]. Native scroll-snap, no JS. When there is no
-       pixel diff, the markdown diff is not promoted. */
-    @media (max-width: 768px) {
-      .pair-screens {
-        display: flex;
-        grid-template-columns: none;
-        overflow-x: auto;
-        overflow-y: hidden;
-        scroll-snap-type: x mandatory;
-        scroll-behavior: smooth;
-        -webkit-overflow-scrolling: touch;
-        touch-action: pan-x pan-y pinch-zoom;
-      }
-      .pair-screens > figure,
-      .pair-screens > .missing {
-        flex: 0 0 100%;
-        min-width: 100%;
-        scroll-snap-align: start;
-        scroll-snap-stop: always;
-      }
-      .pair-screens > .review-map-figure:nth-child(3) {
-        order: -1;
-      }
-      .pair-screens > figure:nth-child(even) {
-        border-left: none;
-      }
-      .pair-screens > figure + figure,
-      .pair-screens > .missing + figure,
-      .pair-screens > figure + .missing,
-      .pair-screens > .missing + .missing {
-        border-left: none;
-        border-top: 1px solid var(--line);
-      }
-      .pair-screens figcaption {
-        position: sticky;
-        top: 0;
-        background: #ffffff;
-        z-index: 1;
-      }
-      .pair-screens figcaption::after {
-        content: "  · swipe ← → ";
-        color: var(--muted);
-        font-weight: 400;
-        font-size: 11px;
-        letter-spacing: 0.04em;
-      }
-    }
-
-    figcaption {
-      border-bottom: 1px solid var(--line);
-      padding: 8px 10px;
-      font-size: 13px;
-      font-weight: 700;
-    }
-
-    .pill {
-      align-items: center;
-      background: #ffffff;
-      border: 1px solid var(--line);
-      color: var(--fg);
-      display: inline-flex;
-      font-size: 11px;
-      font-weight: 700;
-      min-height: 24px;
-      padding: 3px 7px;
-      text-transform: uppercase;
-      white-space: nowrap;
-    }
-
-    .pill.changed,
-    .pill.missing,
-    .pill.error {
-      background: #000000;
-      color: #ffffff;
-    }
-
-    .pill.unchanged {
-      border-color: #777777;
-      color: var(--muted);
-    }
-
-    img {
-      display: block;
-      width: 100%;
-      height: auto;
-    }
-
-    .screenshot-frame {
-      line-height: 0;
-      position: relative;
-    }
-
-    .screenshot-frame.whole-image-added::before,
-    .screenshot-frame.whole-image-removed::before,
-    .screenshot-frame.whole-image-resized::before {
-      background: #ffffff;
-      border: 1px solid #c4002f;
-      color: #c4002f;
-      content: attr(data-change-label);
-      font-size: 11px;
-      font-weight: 700;
-      left: 8px;
-      line-height: 1;
-      padding: 4px 6px;
-      position: absolute;
-      text-transform: uppercase;
-      top: 8px;
-      z-index: 2;
-    }
-
-    .screenshot-frame.whole-image-added::after,
-    .screenshot-frame.whole-image-removed::after,
-    .screenshot-frame.whole-image-resized::after {
-      border: 3px solid #c4002f;
-      content: "";
-      inset: 0;
-      pointer-events: none;
-      position: absolute;
-      z-index: 1;
-    }
-
-    .diff-region {
-      border: 2px solid #c4002f;
-      box-shadow:
-        0 0 0 1px #ffffff,
-        0 0 0 3px rgba(196, 0, 47, 0.2);
-      pointer-events: none;
-      position: absolute;
-      z-index: 1;
-    }
-
-    figure img {
-      cursor: zoom-in;
-    }
-
-    .markdown-diff-block {
-      background: #ffffff;
-      font-family: Consolas, "Liberation Mono", monospace;
-      font-size: 12px;
-      line-height: 1.45;
-      margin: 0;
-      max-height: 72vh;
-      overflow: auto;
-      padding: 12px;
-      white-space: pre;
-    }
-
-    .markdown-diff-line {
-      display: block;
-      min-height: 1.45em;
-    }
-
-    .markdown-diff-line.added {
-      background: #e8f7ee;
-      color: #14532d;
-    }
-
-    .markdown-diff-line.removed {
-      background: #fdecec;
-      color: #7f1d1d;
-    }
-
-    .markdown-diff-line.header,
-    .markdown-diff-line.hunk {
-      background: #f5f5f5;
-      color: #333333;
-      font-weight: 700;
-    }
-
-    .lightbox {
-      align-items: center;
-      background: rgba(0, 0, 0, 0.92);
-      cursor: zoom-out;
-      display: none;
-      inset: 0;
-      justify-content: center;
-      overflow: auto;
-      padding: 24px;
-      position: fixed;
-      z-index: 100;
-    }
-
-    .lightbox.open {
-      display: flex;
-    }
-
-    .lightbox img {
-      cursor: zoom-in;
-      display: block;
-      height: auto;
-      margin: auto;
-      max-height: 100%;
-      max-width: 100%;
-      object-fit: contain;
-      width: auto;
-    }
-
-    .lightbox img.zoomed {
-      cursor: zoom-out;
-      height: auto;
-      margin: 0;
-      max-height: none;
-      max-width: none;
-      width: auto;
-    }
-
-    .lightbox-caption {
-      color: #ffffff;
-      font-size: 12px;
-      font-weight: 700;
-      left: 24px;
-      max-width: calc(100% - 200px);
-      overflow: hidden;
-      position: fixed;
-      text-overflow: ellipsis;
-      text-transform: uppercase;
-      top: 16px;
-      white-space: nowrap;
-    }
-
-    .lightbox-close {
-      background: #ffffff;
-      border: 0;
-      color: #000000;
-      cursor: pointer;
-      font-family: inherit;
-      font-size: 12px;
-      font-weight: 700;
-      padding: 6px 10px;
-      position: fixed;
-      right: 24px;
-      text-transform: uppercase;
-      top: 16px;
-    }
-
-    .lightbox-hint {
-      bottom: 16px;
-      color: rgba(255, 255, 255, 0.7);
-      font-size: 11px;
-      font-weight: 700;
-      left: 50%;
-      position: fixed;
-      text-transform: uppercase;
-      transform: translateX(-50%);
-    }
-
-    .route-summary-actions {
-      align-items: center;
-      display: flex;
-      flex: 0 0 auto;
-      gap: 10px;
-    }
-
-    .copy-context-button {
-      background: var(--bg);
-      border: 1px solid var(--line);
-      color: var(--fg);
-      cursor: pointer;
-      font-family: inherit;
-      font-size: 11px;
-      font-weight: 700;
-      padding: 4px 8px;
-      text-transform: uppercase;
-      white-space: nowrap;
-    }
-
-    .copy-context-button:hover {
-      background: var(--fg);
-      color: var(--bg);
-    }
-
-    .copy-context-button.copied {
-      background: var(--fg);
-      color: var(--bg);
-    }
-
-    /* Block click bubbling so toggling the route doesn't toggle when you
-       click the button. JS also calls stopPropagation, but a CSS hint
-       helps keep the button visually distinct from the summary. */
-    .copy-context-button:focus-visible {
-      outline: 2px solid var(--fg);
-      outline-offset: 2px;
-    }
-
-    .toolbar {
-      align-items: center;
-      border-bottom: 1px solid var(--line);
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      padding: 10px 24px;
-      background: var(--bg);
-      position: sticky;
-      top: 0;
-      z-index: 2;
-    }
-
-    .toolbar-current-route {
-      color: var(--fg);
-      flex: 1 1 auto;
-      font-size: 13px;
-      font-weight: 700;
-      overflow: hidden;
-      text-align: right;
-      text-overflow: ellipsis;
-      text-transform: none;
-      white-space: nowrap;
-    }
-
-    .toolbar-current-route:empty::before {
-      color: var(--muted);
-      content: "Scroll to see current route";
-      font-weight: 400;
-      font-style: italic;
-    }
-
-    .toolbar input[type="search"] {
-      background: var(--bg);
-      border: 1px solid var(--line);
-      color: var(--fg);
-      flex: 1 1 280px;
-      font-family: inherit;
-      font-size: 13px;
-      font-weight: 700;
-      max-width: 360px;
-      min-width: 220px;
-      padding: 6px 10px;
-    }
-
-    .toolbar-button {
-      background: var(--bg);
-      border: 1px solid var(--line);
-      color: var(--fg);
-      cursor: pointer;
-      font-family: inherit;
-      font-size: 11px;
-      font-weight: 700;
-      padding: 4px 10px;
-      text-transform: uppercase;
-    }
-
-    .toolbar-button:hover {
-      background: var(--fg);
-      color: var(--bg);
-    }
-
-    .toolbar-route-actions {
-      align-items: center;
-      display: flex;
-      gap: 8px;
-    }
-
-    .toolbar-page-link {
-      align-items: center;
-      display: inline-flex;
-      min-height: 24px;
-      text-decoration: none;
-    }
-
-    .toolbar-button:disabled,
-    .toolbar-page-link[aria-disabled="true"] {
-      border-color: #cccccc;
-      color: var(--muted);
-      cursor: not-allowed;
-    }
-
-    .toolbar-button:disabled:hover,
-    .toolbar-page-link[aria-disabled="true"]:hover {
-      background: var(--bg);
-      color: var(--muted);
-    }
-
-    .toolbar-count {
-      color: var(--muted);
-      font-size: 11px;
-      font-weight: 700;
-    }
-
-    /* Hidden by search filter — still in DOM (state preserved on clear). */
-    details.route[hidden] {
-      display: none !important;
-    }
-
-    .missing div {
-      padding: 24px 10px;
-      color: var(--muted);
-      font-size: 13px;
-    }
-
-    .page-link {
-      border: 1px solid var(--line);
-      color: var(--fg);
-      display: inline-flex;
-      font-size: 11px;
-      font-weight: 700;
-      margin-right: 8px;
-      min-height: 24px;
-      padding: 3px 7px;
-      text-decoration: none;
-      text-transform: uppercase;
-      white-space: nowrap;
-    }
-
-    .page-link:hover {
-      background: var(--fg);
-      color: var(--bg);
-    }
-
-    /* Inline link inside a figcaption — opens the live preview page on
-       the Vercel deploy at this route. Sits to the LEFT of the screen-
-       name label, sized for a comfortable mobile thumb tap target. */
-    .page-link-inline,
-    .copy-context-inline {
-      align-items: center;
-      border: 1px solid var(--line);
-      color: var(--fg);
-      display: inline-flex;
-      font-size: 14px;
-      font-weight: 700;
-      justify-content: center;
-      line-height: 1;
-      margin-right: 8px;
-      min-height: 28px;
-      min-width: 28px;
-      text-decoration: none;
-      vertical-align: middle;
-    }
-
-    .page-link-inline:hover,
-    .copy-context-inline:hover {
-      background: var(--fg);
-      color: var(--bg);
-    }
-
-    .copy-context-inline,
-    .complain-button {
-      background: var(--bg);
-      cursor: pointer;
-      padding: 0;
-    }
-
-    .complain-button {
-      align-items: center;
-      border: 1px solid var(--line);
-      color: var(--fg);
-      display: inline-flex;
-      font-size: 14px;
-      font-weight: 700;
-      justify-content: center;
-      line-height: 1;
-      margin-right: 8px;
-      min-height: 28px;
-      min-width: 28px;
-      text-decoration: none;
-      vertical-align: middle;
-    }
-
-    .complain-button:hover {
-      background: var(--fg);
-      color: var(--bg);
-    }
-
-    code {
-      font-family: Consolas, "Liberation Mono", monospace;
-      font-size: 0.95em;
-    }
-
-    .empty {
-      max-width: 760px;
-    }
-
-    @media (max-width: 820px) and (min-width: 769px) {
-      .pair-screens {
-        grid-template-columns: 1fr;
-      }
-
-      figure + figure {
-        border-left: 0;
-        border-top: 1px solid var(--line);
-      }
-    }
-  </style>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Optimitron Visual Review</title>
 </head>
 <body>
-  <header>
-    <h1>Optimitron Visual Review</h1>
-    <div class="meta">
-      Generated ${escapeHtml(generatedAtCentral)} Central time (${escapeHtml(generatedAt)} UTC).${reviewCommitSha ? ` Commit ${escapeHtml(shortSha(reviewCommitSha))}.` : ""} ${beforeScreenshotsRoot ? "Left side is the latest main baseline artifact; right side is this pull request." : "No main baseline artifact was available, so this page shows pull request screenshots only."} Changed or missing-baseline pages are expanded; unchanged pages are collapsed but still captured.
-    </div>
-    <div class="summary-line">
-      <span class="pill changed">${summary.changedRoutes} changed</span>
-      <span class="pill unchanged">${summary.unchangedRoutes} unchanged</span>
-      <span class="pill missing">${summary.missingPairs} missing pairs</span>
-      <span class="pill error">${summary.erroredRoutes} errored</span>
-    </div>
-  </header>
-  <div class="toolbar" role="toolbar" aria-label="Visual review controls">
-    <input
-      type="search"
-      id="route-filter"
-      placeholder="Filter routes — try 'treaty' or 'dashboard'"
-      autocomplete="off"
-    />
-    <button type="button" class="toolbar-button" data-toolbar-action="expand-all">Expand all</button>
-    <button type="button" class="toolbar-button" data-toolbar-action="collapse-all">Collapse all</button>
-    <button type="button" class="toolbar-button" data-toolbar-action="expand-changed">Only show changed</button>
-    <span class="toolbar-route-actions" aria-label="Current route actions">
-      <button type="button" class="toolbar-button copy-context-button" id="toolbar-copy-context" aria-label="Copy context for the current route to clipboard" disabled>Copy context</button>
-      <a class="toolbar-button toolbar-page-link" id="toolbar-open-page" aria-label="Open page for the current route" aria-disabled="true" tabindex="-1">Open page</a>
-    </span>
-    <span class="toolbar-count" id="route-count" aria-live="polite"></span>
-    <span class="toolbar-current-route" id="current-route" aria-live="polite"></span>
-  </div>
-  <main>
-    ${body}
-  </main>
-  <div id="lightbox" class="lightbox" role="dialog" aria-modal="true" aria-hidden="true">
-    <button type="button" class="lightbox-close" aria-label="Close (Esc)">Close</button>
-    <div class="lightbox-caption" id="lightbox-caption"></div>
-    <img id="lightbox-img" alt="">
-    <div class="lightbox-hint">Click image to toggle 1:1 zoom · click background or press Esc to close</div>
-  </div>
-  <script>
-    (function () {
-      var lightbox = document.getElementById("lightbox");
-      var lightboxImg = document.getElementById("lightbox-img");
-      var lightboxCaption = document.getElementById("lightbox-caption");
-      var closeBtn = lightbox.querySelector(".lightbox-close");
-
-      function open(src, alt) {
-        lightboxImg.src = src;
-        lightboxImg.alt = alt || "";
-        lightboxImg.classList.remove("zoomed");
-        lightboxCaption.textContent = alt || "";
-        lightbox.classList.add("open");
-        lightbox.setAttribute("aria-hidden", "false");
-        document.body.style.overflow = "hidden";
-      }
-
-      function close() {
-        lightbox.classList.remove("open");
-        lightbox.setAttribute("aria-hidden", "true");
-        lightboxImg.classList.remove("zoomed");
-        lightboxImg.removeAttribute("src");
-        document.body.style.overflow = "";
-      }
-
-      document.addEventListener("click", function (event) {
-        var img = event.target.closest("figure img");
-        if (img) {
-          event.preventDefault();
-          open(img.currentSrc || img.src, img.alt);
-        }
-      });
-
-      lightboxImg.addEventListener("click", function (event) {
-        event.stopPropagation();
-        lightboxImg.classList.toggle("zoomed");
-      });
-
-      closeBtn.addEventListener("click", function (event) {
-        event.stopPropagation();
-        close();
-      });
-
-      lightbox.addEventListener("click", function (event) {
-        if (event.target === lightbox) close();
-      });
-
-      document.addEventListener("keydown", function (event) {
-        if (event.key === "Escape" && lightbox.classList.contains("open")) {
-          close();
-        }
-      });
-    })();
-
-    // Toolbar: live route-name filter + expand/collapse all.
-    (function () {
-      var filter = document.getElementById("route-filter");
-      var countEl = document.getElementById("route-count");
-      var routes = Array.prototype.slice.call(
-        document.querySelectorAll("details.route"),
-      );
-
-      function applyFilter() {
-        var query = filter.value.trim().toLowerCase();
-        var visible = 0;
-        for (var i = 0; i < routes.length; i++) {
-          var r = routes[i];
-          var titleEl = r.querySelector(".route-title");
-          var title = titleEl ? titleEl.textContent.toLowerCase() : "";
-          var match = query === "" || title.indexOf(query) !== -1;
-          if (match) {
-            r.removeAttribute("hidden");
-            visible += 1;
-          } else {
-            r.setAttribute("hidden", "");
-          }
-        }
-        countEl.textContent =
-          query === ""
-            ? routes.length + " routes"
-            : visible + " of " + routes.length + " match";
-      }
-
-      filter.addEventListener("input", applyFilter);
-
-      document.addEventListener("click", function (event) {
-        var button = event.target.closest("[data-toolbar-action]");
-        if (!button) return;
-        var action = button.getAttribute("data-toolbar-action");
-        if (action === "expand-all") {
-          for (var i = 0; i < routes.length; i++) {
-            if (!routes[i].hasAttribute("hidden")) routes[i].open = true;
-          }
-        } else if (action === "collapse-all") {
-          for (var j = 0; j < routes.length; j++) {
-            routes[j].open = false;
-          }
-        } else if (action === "expand-changed") {
-          // Hide unchanged routes entirely so the page only shows what
-          // moved vs main. Filter input still works; clearing the input
-          // and clicking "Expand all" restores everything.
-          var changedCount = 0;
-          for (var k = 0; k < routes.length; k++) {
-            var isChanged = routes[k].classList.contains("changed");
-            if (isChanged) {
-              routes[k].removeAttribute("hidden");
-              routes[k].open = true;
-              changedCount += 1;
-            } else {
-              routes[k].setAttribute("hidden", "");
-              routes[k].open = false;
-            }
-          }
-          countEl.textContent =
-            changedCount + " changed (of " + routes.length + ")";
-        }
-      });
-
-      // Initial count.
-      applyFilter();
-
-      // Keyboard shortcut: "/" focuses the filter input (like GitHub).
-      document.addEventListener("keydown", function (event) {
-        if (
-          event.key === "/" &&
-          document.activeElement !== filter &&
-          !event.metaKey &&
-          !event.ctrlKey &&
-          !event.altKey
-        ) {
-          event.preventDefault();
-          filter.focus();
-          filter.select();
-        }
-      });
-    })();
-
-    // "Copy context" button: builds a markdown blob suitable for pasting
-    // into a coding agent when complaining about a route, then writes it
-    // to the clipboard. Payload includes PR/branch/commit ids, the route
-    // + auth state, before/after screenshot URLs, and explicit
-    // instructions telling the agent to download + view the screenshots
-    // when relevant.
-    (function () {
-      function formatContext(ctx) {
-        var lines = [];
-        lines.push("### Visual-review context");
-        lines.push("");
-        if (ctx.viewing) {
-          lines.push("- Viewing: **" + ctx.viewing.toUpperCase() + "** in " + (ctx.projectLabel || ctx.project));
-        }
-        if (ctx.pr) lines.push("- PR: #" + ctx.pr + (ctx.repo ? " (" + ctx.repo + ")" : ""));
-        if (ctx.branch) lines.push("- Branch: \`" + ctx.branch + "\`");
-        if (ctx.shortSha) lines.push("- Commit: \`" + ctx.shortSha + "\`" + (ctx.commitSha ? " (" + ctx.commitSha + ")" : ""));
-        lines.push("- Route: \`" + ctx.route + "\` (" + ctx.routeLabel + ")");
-        if (ctx.routeUrl) lines.push("- Live URL: " + ctx.routeUrl);
-        lines.push("- Auth state: " + ctx.authState);
-        if (ctx.diffLabel) lines.push("- Diff vs main: " + ctx.diffLabel);
-        else if (ctx.status) lines.push("- Diff vs main: " + ctx.status);
-        if (ctx.imageUrl) {
-          lines.push("- Screenshot: " + ctx.imageUrl);
-          lines.push("    curl -sLO " + ctx.imageUrl);
-        }
-        if (ctx.reviewUrl) lines.push("- Visual review: " + ctx.reviewUrl);
-        lines.push("");
-        if (ctx.screenshots && ctx.screenshots.length > 0) {
-          lines.push("**Screenshots** — please \`curl -o\` these and look at them before responding so you understand what I am seeing:");
-          lines.push("");
-          for (var i = 0; i < ctx.screenshots.length; i++) {
-            var s = ctx.screenshots[i];
-            lines.push("- **" + s.project + "** (" + s.diff + ")");
-            if (s.beforeUrl) lines.push("  - before (main): " + s.beforeUrl);
-            if (s.afterUrl) lines.push("  - after (this PR): " + s.afterUrl);
-          }
-          lines.push("");
-          lines.push("Suggested download commands (run from /tmp or similar):");
-          for (var j = 0; j < ctx.screenshots.length; j++) {
-            var sj = ctx.screenshots[j];
-            if (sj.beforeUrl) lines.push("    curl -sLO " + sj.beforeUrl);
-            if (sj.afterUrl) lines.push("    curl -sLO " + sj.afterUrl);
-          }
-          lines.push("");
-        }
-        lines.push("**My complaint:**");
-        lines.push("> _(replace this line with what looks wrong)_");
-        return lines.join("\\n");
-      }
-
-      function copyToClipboard(text) {
-        if (navigator.clipboard && navigator.clipboard.writeText) {
-          return navigator.clipboard.writeText(text);
-        }
-        return new Promise(function (resolve, reject) {
-          var ta = document.createElement("textarea");
-          ta.value = text;
-          ta.style.position = "fixed";
-          ta.style.opacity = "0";
-          document.body.appendChild(ta);
-          ta.select();
-          try {
-            document.execCommand("copy");
-            resolve();
-          } catch (err) {
-            reject(err);
-          } finally {
-            document.body.removeChild(ta);
-          }
-        });
-      }
-
-      document.addEventListener("click", function (event) {
-        var button = event.target.closest(".copy-context-button");
-        if (!button) return;
-        event.preventDefault();
-        event.stopPropagation();
-        var raw = button.getAttribute("data-context");
-        if (!raw) return;
-        var prev = button.textContent;
-        var ctx;
-        try {
-          ctx = JSON.parse(raw);
-        } catch (err) {
-          console.error("[visual-review] bad context payload", err);
-          return;
-        }
-        var formatted = formatContext(ctx);
-        copyToClipboard(formatted).then(function () {
-          button.textContent = "✓ Copied";
-          button.classList.add("copied");
-          window.setTimeout(function () {
-            button.textContent = prev;
-            button.classList.remove("copied");
-          }, 1500);
-        }, function () {
-          button.textContent = "Copy failed";
-          window.setTimeout(function () {
-            button.textContent = prev;
-          }, 1500);
-        });
-      });
-
-      // Complain button: open a pre-filled GitHub issue URL in a new
-      // tab. On mobile the GitHub app (if installed) catches the URL.
-      // Title summarizes route + view; body includes the same markdown
-      // context as the clipboard payload, plus an explicit complaint
-      // placeholder and a back-reference to the originating PR so an
-      // agent-watcher workflow can find it.
-      document.addEventListener("click", function (event) {
-        var button = event.target.closest(".complain-button");
-        if (!button) return;
-        event.preventDefault();
-        event.stopPropagation();
-        var raw = button.getAttribute("data-context");
-        if (!raw) return;
-        var ctx;
-        try {
-          ctx = JSON.parse(raw);
-        } catch (err) {
-          console.error("[visual-review] bad context payload", err);
-          return;
-        }
-        if (!ctx.repo) {
-          console.warn("[visual-review] complain: no repo in context");
-          return;
-        }
-        var titleParts = ["Visual review"];
-        if (ctx.routeLabel) titleParts.push(ctx.routeLabel);
-        if (ctx.viewing) titleParts.push(ctx.viewing);
-        if (ctx.projectLabel) titleParts.push(ctx.projectLabel);
-        var title = titleParts.join(" — ");
-        var body = formatContext(ctx);
-        if (ctx.pr) {
-          body = "Originating PR: #" + ctx.pr + "\\n\\n" + body;
-        }
-        var url =
-          "https://github.com/" + ctx.repo + "/issues/new" +
-          "?title=" + encodeURIComponent(title) +
-          "&body=" + encodeURIComponent(body);
-        window.open(url, "_blank", "noopener,noreferrer");
-      });
-    })();
-
-    // Current-route indicator: as the user scrolls through the page, show
-    // the title of the route currently anchored at the top of the viewport
-    // in the sticky toolbar. Without this, scrolling past a route's
-    // expanded screenshots loses context — you can't tell which route you're
-    // looking at unless you scroll back up to its title.
-    (function () {
-      var indicator = document.getElementById("current-route");
-      if (!indicator) return;
-      var toolbarCopyButton = document.getElementById("toolbar-copy-context");
-      var toolbarOpenPage = document.getElementById("toolbar-open-page");
-      var routes = Array.prototype.slice.call(
-        document.querySelectorAll("details.route"),
-      );
-      if (routes.length === 0) return;
-
-      function getRouteTitle(route) {
-        var titleEl = route.querySelector(".route-title");
-        return titleEl ? titleEl.textContent.trim() : "";
-      }
-
-      // Account for the sticky toolbar's height when deciding which route
-      // is "at the top." The toolbar sits flush with viewport top:0; we
-      // use its rendered height as the offset.
-      function getToolbarOffset() {
-        var toolbar = document.querySelector(".toolbar");
-        return toolbar ? toolbar.getBoundingClientRect().height : 0;
-      }
-
-      function setCurrentRoute(route) {
-        var routeTitle = route ? getRouteTitle(route) : "";
-        if (indicator.textContent !== routeTitle) {
-          indicator.textContent = routeTitle;
-        }
-
-        if (toolbarCopyButton) {
-          var sourceCopyButton = route
-            ? route.querySelector(".route-summary-actions .copy-context-button")
-            : null;
-          var context = sourceCopyButton
-            ? sourceCopyButton.getAttribute("data-context")
-            : "";
-          if (context) {
-            toolbarCopyButton.disabled = false;
-            toolbarCopyButton.setAttribute("data-context", context);
-            toolbarCopyButton.setAttribute(
-              "aria-label",
-              "Copy context for " + routeTitle + " to clipboard",
-            );
-          } else {
-            toolbarCopyButton.disabled = true;
-            toolbarCopyButton.removeAttribute("data-context");
-            toolbarCopyButton.setAttribute(
-              "aria-label",
-              "Copy context for the current route to clipboard",
-            );
-          }
-        }
-
-        if (toolbarOpenPage) {
-          var routeUrl = route ? route.getAttribute("data-route-url") : "";
-          if (routeUrl) {
-            toolbarOpenPage.href = routeUrl;
-            toolbarOpenPage.target = "_blank";
-            toolbarOpenPage.rel = "noreferrer";
-            toolbarOpenPage.removeAttribute("aria-disabled");
-            toolbarOpenPage.removeAttribute("tabindex");
-            toolbarOpenPage.setAttribute(
-              "aria-label",
-              "Open " + routeTitle + " page",
-            );
-          } else {
-            toolbarOpenPage.removeAttribute("href");
-            toolbarOpenPage.setAttribute("aria-disabled", "true");
-            toolbarOpenPage.setAttribute("tabindex", "-1");
-            toolbarOpenPage.setAttribute(
-              "aria-label",
-              "Open page for the current route",
-            );
-          }
-        }
-      }
-
-      function updateCurrent() {
-        var offset = getToolbarOffset();
-        var currentRoute = null;
-        var firstVisibleRoute = null;
-        var lastPastRoute = null;
-        for (var i = 0; i < routes.length; i++) {
-          // Skip routes hidden by the filter / "only show changed" — they
-          // still have getBoundingClientRect but it returns zeros, and a
-          // stale title from before filtering would otherwise stick.
-          if (routes[i].hasAttribute("hidden")) continue;
-          if (!firstVisibleRoute) {
-            firstVisibleRoute = routes[i];
-          }
-          var rect = routes[i].getBoundingClientRect();
-          if (rect.top - offset <= 0) {
-            lastPastRoute = routes[i];
-          }
-          // Route is "current" if its top has crossed above the toolbar
-          // bottom edge AND its bottom hasn't passed yet.
-          if (rect.top - offset <= 0 && rect.bottom > offset) {
-            currentRoute = routes[i];
-            break;
-          }
-        }
-        if (!currentRoute) {
-          currentRoute = lastPastRoute || firstVisibleRoute;
-        }
-        setCurrentRoute(currentRoute);
-      }
-
-      // Throttle scroll handler via requestAnimationFrame.
-      var ticking = false;
-      function onScroll() {
-        if (ticking) return;
-        ticking = true;
-        window.requestAnimationFrame(function () {
-          updateCurrent();
-          ticking = false;
-        });
-      }
-
-      window.addEventListener("scroll", onScroll, { passive: true });
-      window.addEventListener("resize", onScroll, { passive: true });
-      if (toolbarOpenPage) {
-        toolbarOpenPage.addEventListener("click", function (event) {
-          if (toolbarOpenPage.getAttribute("aria-disabled") === "true") {
-            event.preventDefault();
-          }
-        });
-      }
-      // Also update when a route is expanded/collapsed (changes layout).
-      document.addEventListener("toggle", onScroll, true);
-
-      // Filter input + toolbar buttons mutate the hidden attribute on routes
-      // without firing scroll/toggle. Watch the attribute via MutationObserver
-      // so the indicator refreshes regardless of which control changed
-      // visibility (filter typing, Expand all, Collapse all, Only show
-      // changed).
-      if (typeof MutationObserver === "function") {
-        var observer = new MutationObserver(onScroll);
-        for (var i = 0; i < routes.length; i++) {
-          observer.observe(routes[i], {
-            attributes: true,
-            attributeFilter: ["hidden"],
-          });
-        }
-      }
-
-      updateCurrent();
-    })();
-  </script>
+<h1>No visual screenshots found</h1>
+<p>Run <code>pnpm --filter @optimitron/web run e2e -- visual</code>, then regenerate this page.</p>
 </body>
 </html>
 `;
-}
-
-function renderRouteGroup(group) {
-  const pairs = group.pairs.map(renderPair).join("\n");
-  const openAttr = group.changed || group.errored ? " open" : "";
-  const routeContext = buildRouteContext(group);
-  const contextJson = JSON.stringify(routeContext);
-  const routeUrlAttr = routeContext.routeUrl
-    ? ` data-route-url="${escapeHtml(routeContext.routeUrl)}"`
-    : "";
-  const anchorId = `route-${slugifyForAnchor(group.routeName)}`;
-  return `<details id="${escapeHtml(anchorId)}" class="route ${group.changed || group.errored ? "changed" : "unchanged"}"${routeUrlAttr}${openAttr}>
-    <summary>
-      <span class="route-title">${escapeHtml(labelRoute(group.routeName))}</span>
-      <span class="route-summary-actions">
-        <button
-          type="button"
-          class="copy-context-button"
-          data-context='${escapeJsonForAttr(contextJson)}'
-          aria-label="Copy context for this route to clipboard"
-        >📋 Copy context</button>
-        <span class="pill ${group.errored ? "error" : group.changed ? "changed" : "unchanged"}">${escapeHtml(routeStatusLabel(group))}</span>
-      </span>
-    </summary>
-    <div class="pairs">
-      ${pairs}
-    </div>
-  </details>`;
+  }
+  return renderReviewHtml(buildReviewPageInput(groups));
 }
 
 /**
- * Pull together everything a reviewer would want to paste into a coding
- * agent when complaining about a route: PR + commit + branch identifiers,
- * the route's URL, whether the screenshots cover the auth state, and
- * which projects ran. The button's click handler formats this as
- * markdown and writes it to the clipboard.
+ * Adapter: map the analyzed screenshot groups onto the data contract
+ * expected by renderReviewHtml (scripts/visual-review-page.mjs). Routes are
+ * ordered changed -> copy-only -> unchanged; the sort is stable, so
+ * routeOrder is preserved within each rank.
  */
-function buildRouteContext(group) {
-  const routeUrl = getRouteUrl(group.routeName);
-  const authState = getRouteAuthState(group.routeName);
-  const status = group.errored
-    ? "errored"
-    : group.changed
-      ? "changed vs main"
-      : "unchanged vs main";
-  const sha = reviewCommitSha ? shortSha(reviewCommitSha) : null;
+function buildReviewPageInput(groups) {
   const reviewBase = getPublishedReviewBase();
-
-  // Per-project before/after screenshot URLs so the coding agent can
-  // download and look at them. relPath is the on-disk path inside the
-  // latest.html publish dir; the gh-pages site mounts that same tree at
-  // pr-N/<sha>/.
-  const screenshots = group.pairs.map((pair) => ({
-    project: pair.projectName,
-    diff: pair.diff?.label ?? "unknown",
-    beforeUrl: pair.before && reviewBase ? `${reviewBase}/${pair.before.relPath}` : null,
-    afterUrl: pair.after && reviewBase ? `${reviewBase}/${pair.after.relPath}` : null,
-  }));
-
+  const routes = groups.map((group) => buildReviewPageRoute(group));
+  const rank = (route) =>
+    route.changed || route.errored ? 0 : route.copyChanged ? 1 : 2;
+  routes.sort((a, b) => rank(a) - rank(b));
   return {
-    pr: prNumber,
-    branch: headBranch,
-    repo: repoSlug,
-    commitSha: reviewCommitSha,
-    shortSha: sha,
-    route: group.routeName,
+    meta: {
+      prNumber,
+      shortSha: reviewCommitSha ? shortSha(reviewCommitSha) : null,
+      commitSha: reviewCommitSha,
+      headBranch,
+      generatedAt: reviewGeneratedAt.toISOString(),
+      generatedAtCentral: formatCentralTime(reviewGeneratedAt),
+      previewBaseUrl: pageLinkBaseUrl ? pageLinkBaseUrl.toString() : null,
+      productionBaseUrl: "https://optimitron.com",
+      reviewUrl: reviewBase ? `${reviewBase}/latest.html` : null,
+      baselineDescription: buildBaselineDescription(),
+    },
+    summary: {
+      changedRoutes: routes.filter((route) => route.changed).length,
+      copyOnlyRoutes: routes.filter((route) => rank(route) === 1).length,
+      unchangedRoutes: routes.filter((route) => rank(route) === 2).length,
+      erroredRoutes: routes.filter((route) => route.errored).length,
+      totalRoutes: routes.length,
+    },
+    routes,
+  };
+}
+
+function buildBaselineDescription() {
+  const copyRef = getBaselineRef();
+  const copyRefLabel = /^[0-9a-f]{40}$/i.test(copyRef)
+    ? shortSha(copyRef)
+    : copyRef;
+  return [
+    beforeScreenshotsRoot
+      ? "screenshots vs main baseline artifact"
+      : "no screenshot baseline artifact",
+    `copy vs ${copyRefLabel}`,
+  ].join(" · ");
+}
+
+function buildReviewPageRoute(group) {
+  const markdownDiff = buildMarkdownDiff(group.routeName);
+  const routePath = routePaths.get(group.routeName) ?? null;
+  return {
+    routeName: group.routeName,
     routeLabel: labelRoute(group.routeName),
-    routeUrl,
-    authState,
-    status,
-    screenshots,
-    reviewUrl: reviewBase
-      ? `${reviewBase}/latest.html#route-${slugifyForAnchor(group.routeName)}`
-      : null,
+    routePath,
+    routeUrl: getRouteUrl(group.routeName),
+    authState: getRouteAuthState(group.routeName),
+    changed: group.changed,
+    copyChanged: Boolean(markdownDiff),
+    errored: group.errored,
+    statusLabel: routeStatusLabel(group),
+    markdownDiff,
+    pairs: group.pairs.map((pair) => buildReviewPagePair(pair)),
   };
 }
 
-function slugifyForAnchor(value) {
-  return String(value).toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "");
-}
-
-/** Escape a JSON string so it survives unscathed inside a single-quoted
- * HTML attribute. `&` → `&amp;` so the browser doesn't re-encode it,
- * `'` → `&apos;` so the attribute doesn't terminate early. */
-function escapeJsonForAttr(value) {
-  return String(value).replace(/&/g, "&amp;").replace(/'/g, "&apos;");
-}
-
-function renderPair(pair) {
-  const routeUrl = getRouteUrl(pair.routeName);
-  const markdownDiff = buildMarkdownDiff(pair);
-  const hasPixelDiff = Boolean(pair.diff?.diffRelPath);
-  const hasAddedCaptureMap = Boolean(
-    pair.diff?.missing && !pair.before && pair.after,
-  );
-  const hasRemovedCaptureMap = Boolean(
-    pair.diff?.missing && pair.before && !pair.after,
-  );
-  const hasReviewMap =
-    hasPixelDiff || hasAddedCaptureMap || hasRemovedCaptureMap;
-  const imageLoading =
-    pair.diff?.changed || pair.diff?.missing || pair.diff?.errored
-      ? "eager"
-      : "lazy";
-  const diffRegions = pair.diff?.regions ?? [];
-  const beforeRegions = pair.diff?.beforeRegions ?? diffRegions;
-  const afterRegions = pair.diff?.afterRegions ?? diffRegions;
-  const beforeOptions = {
-    loading: imageLoading,
-    regions: beforeRegions,
-    wholeImageChange:
-      pair.diff?.missing && pair.before && !pair.after
-        ? "removed"
-        : pair.diff?.dimensionChanged
-          ? "resized"
-          : null,
-  };
-  const afterOptions = {
-    loading: imageLoading,
-    regions: afterRegions,
-    wholeImageChange:
-      pair.diff?.missing && !pair.before && pair.after
-        ? "added"
-        : pair.diff?.dimensionChanged
-          ? "resized"
-          : null,
-  };
-  // Default: mobile pairs open, desktop pairs collapsed.
-  const isMobile = pair.projectName === "visual-mobile";
-  const openAttr = isMobile ? " open" : "";
-  return `<details class="pair" data-project="${escapeHtml(pair.projectName)}"${openAttr}>
-    <summary>
-      <span>${escapeHtml(labelProject(pair.projectName))}</span>
-      <span>
-        ${routeUrl ? `<a class="page-link" href="${escapeHtml(routeUrl)}" target="_blank" rel="noreferrer">Open page</a>` : ""}
-        <span class="pill ${escapeHtml(pair.diff.statusClass)}">${escapeHtml(pair.diff.label)}</span>
-      </span>
-    </summary>
-    <div class="pair-screens${hasReviewMap ? " has-review-map" : ""}">
-      ${renderFigure(pair.before, "Before: main", routeUrl, buildScreenContext(pair, "before", pair.before?.relPath), beforeOptions)}
-      ${renderFigure(pair.after, "After: pull request", routeUrl, buildScreenContext(pair, "after", pair.after?.relPath), afterOptions)}
-      ${pair.diff?.diffRelPath ? renderDiffFigure(pair.diff.diffRelPath, pair.routeName, pair.projectName, routeUrl, buildScreenContext(pair, "diff", pair.diff.diffRelPath), imageLoading) : ""}
-      ${hasAddedCaptureMap ? renderWholeImageReviewFigure(pair.after, "Added capture", routeUrl, buildScreenContext(pair, "diff", pair.after.relPath), "added", imageLoading) : ""}
-      ${hasRemovedCaptureMap ? renderWholeImageReviewFigure(pair.before, "Removed capture", routeUrl, buildScreenContext(pair, "diff", pair.before.relPath), "removed", imageLoading) : ""}
-      ${markdownDiff ? renderMarkdownDiffFigure(markdownDiff, routeUrl, buildScreenContext(pair, "markdown-diff", null)) : ""}
-    </div>
-  </details>`;
-}
-
-function renderDiffFigure(diffRelPath, routeName, projectName, routeUrl, screenContext, loading = "lazy") {
-  return `<figure class="review-map-figure pixel-diff-figure">
-    ${renderFigcaption("Diff map", routeUrl, screenContext)}
-    <img src="${escapeHtml(`${diffRelPath}?v=${encodeURIComponent(reviewCacheKey)}`)}" alt="${escapeHtml(`${routeName} ${projectName} diff overlay`)}" loading="${escapeHtml(loading)}">
-  </figure>`;
-}
-
-function renderWholeImageReviewFigure(
-  screenshot,
-  label,
-  routeUrl,
-  screenContext,
-  wholeImageChange,
-  loading = "lazy",
-) {
-  return `<figure class="review-map-figure whole-image-review-figure">
-    ${renderFigcaption(label, routeUrl, screenContext)}
-    <div class="screenshot-frame whole-image-${escapeHtml(wholeImageChange)}" data-change-label="${escapeHtml(labelWholeImageChange(wholeImageChange))}">
-      <img src="${escapeHtml(`${screenshot.relPath}?v=${encodeURIComponent(reviewCacheKey)}`)}" alt="${escapeHtml(`${screenshot.routeName} ${screenshot.projectName} ${label}`)}" loading="${escapeHtml(loading)}">
-    </div>
-  </figure>`;
-}
-
-function renderMarkdownDiffFigure(markdownDiff, routeUrl, screenContext) {
-  return `<figure class="markdown-diff-figure">
-    ${renderFigcaption(markdownDiff.label, routeUrl, screenContext)}
-    <pre class="markdown-diff-block" aria-label="${escapeHtml(markdownDiff.label)}">${renderMarkdownDiffLines(markdownDiff.lines)}</pre>
-  </figure>`;
-}
-
-function renderFigure(screenshot, label, routeUrl, screenContext, options = {}) {
-  if (!screenshot) {
-    return `<figure class="missing">
-    ${renderFigcaption(label, routeUrl, screenContext)}
-    <div>Not captured</div>
-  </figure>`;
-  }
-  const wholeImageChange = options.wholeImageChange ?? null;
-  const loading = options.loading ?? "lazy";
-  const regions = Array.isArray(options.regions) ? options.regions : [];
-  const frameClasses = ["screenshot-frame"];
-  if (wholeImageChange) {
-    frameClasses.push(`whole-image-${wholeImageChange}`);
-  }
-  return `<figure class="screenshot-figure">
-    ${renderFigcaption(label, routeUrl, screenContext)}
-    <div class="${escapeHtml(frameClasses.join(" "))}"${wholeImageChange ? ` data-change-label="${escapeHtml(labelWholeImageChange(wholeImageChange))}"` : ""}>
-      <img src="${escapeHtml(`${screenshot.relPath}?v=${encodeURIComponent(reviewCacheKey)}`)}" alt="${escapeHtml(`${screenshot.routeName} ${screenshot.projectName} ${label}`)}" loading="${escapeHtml(loading)}">
-      ${renderDiffRegions(regions)}
-    </div>
-  </figure>`;
-}
-
-function labelWholeImageChange(value) {
-  if (value === "added") {
-    return "new capture";
-  }
-  if (value === "removed") {
-    return "removed capture";
-  }
-  if (value === "resized") {
-    return "resized";
-  }
-  return "changed";
-}
-
-function renderDiffRegions(regions) {
-  return regions
-    .filter(isValidDiffRegion)
-    .map((region) => `<span class="diff-region" style="left: ${formatStylePercent(region.left)}; top: ${formatStylePercent(region.top)}; width: ${formatStylePercent(region.width)}; height: ${formatStylePercent(region.height)};" aria-hidden="true"></span>`)
-    .join("");
-}
-
-function isValidDiffRegion(region) {
-  return (
-    region &&
-    Number.isFinite(region.left) &&
-    Number.isFinite(region.top) &&
-    Number.isFinite(region.width) &&
-    Number.isFinite(region.height) &&
-    region.width > 0 &&
-    region.height > 0
-  );
-}
-
-// Figcaption with optional preview-page link (↗) and copy-context button
-// (📋) on the LEFT of the screen-name label. Sticky on mobile so it stays
-// visible while you swipe-scroll within a tall card. The copy button
-// gives reviewers a per-screen payload to paste into a coding agent.
-function renderFigcaption(label, routeUrl, screenContext) {
-  let inner = "";
-  if (routeUrl) {
-    inner += `<a class="page-link-inline" href="${escapeHtml(routeUrl)}" target="_blank" rel="noreferrer" aria-label="Open ${escapeHtml(label)} page on preview deploy">↗</a>`;
-  }
-  if (screenContext) {
-    const json = JSON.stringify(screenContext);
-    const jsonAttr = escapeJsonForAttr(json);
-    inner += `<button type="button" class="copy-context-button copy-context-inline" data-context='${jsonAttr}' aria-label="Copy context for ${escapeHtml(label)} to clipboard">📋</button>`;
-    if (screenContext.repo) {
-      inner += `<button type="button" class="complain-button" data-context='${jsonAttr}' aria-label="Open a GitHub issue to complain about ${escapeHtml(label)}">💬</button>`;
-    }
-  }
-  inner += escapeHtml(label);
-  return `<figcaption>${inner}</figcaption>`;
-}
-
-/**
- * Build the per-screen "Copy context" payload — what a reviewer pastes
- * into a coding agent when complaining about ONE specific view (diff /
- * before / after) of ONE specific pair (project × route). Narrower than
- * buildRouteContext, which covers the whole route group across projects.
- */
-function buildScreenContext(pair, viewing, relPath) {
-  const routeUrl = getRouteUrl(pair.routeName);
-  const authState = getRouteAuthState(pair.routeName);
-  const sha = reviewCommitSha ? shortSha(reviewCommitSha) : null;
-  const reviewBase = getPublishedReviewBase();
-  const imageUrl = relPath && reviewBase ? `${reviewBase}/${relPath}` : null;
+function buildReviewPagePair(pair) {
   return {
-    pr: prNumber,
-    branch: headBranch,
-    repo: repoSlug,
-    commitSha: reviewCommitSha,
-    shortSha: sha,
-    route: pair.routeName,
-    routeLabel: labelRoute(pair.routeName),
-    routeUrl,
-    authState,
-    project: pair.projectName,
+    projectName: pair.projectName,
     projectLabel: labelProject(pair.projectName),
-    viewing,
-    diffLabel: pair.diff?.label,
-    imageUrl,
-    reviewUrl: reviewBase
-      ? `${reviewBase}/latest.html#route-${slugifyForAnchor(pair.routeName)}`
-      : null,
+    changed: Boolean(pair.diff?.changed),
+    missing: Boolean(pair.diff?.missing),
+    errored: Boolean(pair.diff?.errored),
+    diffLabel: pair.diff?.label ?? null,
+    beforeRelPath: pair.before?.relPath ?? null,
+    afterRelPath: pair.after?.relPath ?? null,
+    diffRelPath: pair.diff?.diffRelPath ?? null,
+    beforeWidth: pair.diff?.beforeWidth ?? null,
+    beforeHeight: pair.diff?.beforeHeight ?? null,
+    afterWidth: pair.diff?.afterWidth ?? null,
+    afterHeight: pair.diff?.afterHeight ?? null,
+    hunks: pair.diff?.hunks ?? [],
+    alignmentAnchors: pair.diff?.alignmentAnchors ?? [],
   };
 }
 
@@ -1786,6 +451,19 @@ async function comparePair(pair) {
     const ratio = totalPixels > 0 ? diffPixels / totalPixels : 0;
     const changedByPixels = ratio > diffPixelRatioThreshold;
     const changed = dimensionChanged || changedByPixels;
+    let hunks = [];
+    let alignmentAnchors = buildDefaultAlignmentAnchors(before, after);
+    if (changed) {
+      try {
+        const extracted = extractHunksAndAlignment({ before, after });
+        hunks = extracted.hunks;
+        alignmentAnchors = extracted.alignmentAnchors;
+      } catch (error) {
+        console.warn(
+          `[visual-review] hunk extraction failed for ${pair.routeName}/${pair.projectName}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
     // Only write the diff PNG when there's an actual diff to highlight -
     // saving thousands of empty diff PNGs is wasted disk + asset upload time.
     let diffRelPath = null;
@@ -1825,10 +503,16 @@ async function comparePair(pair) {
     }
     return {
       changed,
+      alignmentAnchors,
       beforeRegions,
+      beforeHeight: before.height,
+      beforeWidth: before.width,
       dimensionChanged,
       diffRelPath,
       afterRegions,
+      afterHeight: after.height,
+      afterWidth: after.width,
+      hunks,
       label: dimensionChanged
         ? `${before.width}x${before.height} -> ${after.width}x${after.height}; ${formatPercent(ratio)} overlap`
         : `${formatPercent(ratio)} changed`,
@@ -1846,6 +530,13 @@ async function comparePair(pair) {
       statusClass: "error",
     };
   }
+}
+
+function buildDefaultAlignmentAnchors(before, after) {
+  return [
+    { beforeY: 0, afterY: 0 },
+    { beforeY: before.height, afterY: after.height },
+  ];
 }
 
 function getComparableImageData(image, width, height) {
@@ -2075,8 +766,8 @@ function roundPercent(value) {
   return Math.round(value * 100) / 100;
 }
 
-function buildMarkdownDiff(pair) {
-  const snapshot = getMarkdownSnapshot(pair.routeName);
+function buildMarkdownDiff(routeName) {
+  const snapshot = getMarkdownSnapshot(routeName);
   if (!snapshot) {
     return null;
   }
@@ -2098,10 +789,20 @@ function buildMarkdownDiff(pair) {
   }
 
   const after = readFileSync(workingPath, "utf8");
+  const lines = buildUnifiedMarkdownDiffLines(before, after, snapshot.repoRelativePath);
+  const addedLines = lines.filter((line) => line.kind === "add").length;
+  const removedLines = lines.filter((line) => line.kind === "del").length;
+  if (addedLines === 0 && removedLines === 0) {
+    markdownDiffCache.set(snapshot.repoRelativePath, null);
+    return null;
+  }
   const diff = {
+    addedLines,
     fileName: snapshot.fileName,
     label: `Text diff: ${snapshot.fileName}`,
-    lines: buildUnifiedMarkdownDiffLines(before, after, snapshot.repoRelativePath),
+    lines,
+    metaChanges: [],
+    removedLines,
     repoRelativePath: snapshot.repoRelativePath,
   };
   markdownDiffCache.set(snapshot.repoRelativePath, diff);
@@ -2136,13 +837,47 @@ function isAuthenticatedMarkdownRoute(routeName) {
   );
 }
 
+let cachedBaselineRef;
+/**
+ * Ref the copy snapshots are diffed against. Overridable for local variant
+ * demos (VISUAL_REVIEW_BASELINE_REF=HEAD~1); defaults to the merge-base with
+ * origin/main so PR branches diff against where they forked, and falls back
+ * to local `main` for checkouts without the remote ref.
+ */
+function getBaselineRef() {
+  if (cachedBaselineRef !== undefined) return cachedBaselineRef;
+  const envRef = process.env.VISUAL_REVIEW_BASELINE_REF?.trim();
+  if (envRef) {
+    cachedBaselineRef = envRef;
+    return cachedBaselineRef;
+  }
+  for (const candidate of [["merge-base", "origin/main", "HEAD"]]) {
+    try {
+      cachedBaselineRef = execFileSync("git", candidate, {
+        cwd: repoRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      return cachedBaselineRef;
+    } catch {
+      // fall through
+    }
+  }
+  cachedBaselineRef = "main";
+  return cachedBaselineRef;
+}
+
 function readMainFile(repoRelativePath) {
   try {
-    return execFileSync("git", ["show", `main:${repoRelativePath}`], {
-      cwd: repoRoot,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
+    return execFileSync(
+      "git",
+      ["show", `${getBaselineRef()}:${repoRelativePath}`],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
   } catch {
     return null;
   }
@@ -2173,9 +908,9 @@ function buildUnifiedMarkdownDiffLines(before, after, repoRelativePath) {
     });
     for (const row of hunk.rows) {
       if (row.kind === "add") {
-        lines.push({ kind: "added", text: `+${row.text}` });
+        lines.push({ kind: "add", text: `+${row.text}` });
       } else if (row.kind === "remove") {
-        lines.push({ kind: "removed", text: `-${row.text}` });
+        lines.push({ kind: "del", text: `-${row.text}` });
       } else {
         lines.push({ kind: "context", text: ` ${row.text}` });
       }
@@ -2322,9 +1057,9 @@ function formatUnifiedRange(start, count) {
 function renderMarkdownDiffLines(lines) {
   return lines
     .map((line) => {
-      const className = line.kind === "added"
+      const className = line.kind === "add" || line.kind === "added"
         ? "added"
-        : line.kind === "removed"
+        : line.kind === "del" || line.kind === "removed"
           ? "removed"
           : line.kind === "hunk"
             ? "hunk"
@@ -2377,7 +1112,7 @@ function buildReviewManifest(groups) {
       erroredPairs: group.erroredPairs,
       statusLabel: routeStatusLabel(group),
       reviewUrl: reviewBase
-        ? `${reviewBase}/latest.html#route-${slugifyForAnchor(group.routeName)}`
+        ? `${reviewBase}/latest.html#route=${encodeURIComponent(group.routeName)}`
         : null,
       projects: group.pairs.map((pair) => ({
         projectName: pair.projectName,

--- a/packages/web/scripts/build-visual-review.mjs
+++ b/packages/web/scripts/build-visual-review.mjs
@@ -297,6 +297,7 @@ function buildReviewPageInput(groups) {
       previewBaseUrl: pageLinkBaseUrl ? pageLinkBaseUrl.toString() : null,
       productionBaseUrl: "https://optimitron.com",
       reviewUrl: reviewBase ? `${reviewBase}/latest.html` : null,
+      repo: repoSlug,
       baselineDescription: buildBaselineDescription(),
     },
     summary: {
@@ -455,7 +456,7 @@ async function comparePair(pair) {
     let alignmentAnchors = buildDefaultAlignmentAnchors(before, after);
     if (changed) {
       try {
-        const extracted = extractHunksAndAlignment({ before, after });
+        const extracted = extractHunksAndAlignment({ before, after, noiseFloorPct: 0 });
         hunks = extracted.hunks;
         alignmentAnchors = extracted.alignmentAnchors;
       } catch (error) {

--- a/packages/web/scripts/visual-review-hunks.mjs
+++ b/packages/web/scripts/visual-review-hunks.mjs
@@ -1,0 +1,275 @@
+/**
+ * visual-review-hunks.mjs
+ *
+ * Computes screenshot diff HUNKS and a scroll ALIGNMENT map for two
+ * full-page screenshots of (possibly) different heights.
+ *
+ * Dependency-free pure ESM. Callers pass decoded pngjs-shaped PNG objects
+ * ({ width, height, data: RGBA buffer }); this module never imports pngjs.
+ *
+ * Algorithm:
+ *   1. Slice each image into horizontal slabs of `slabHeight` px.
+ *   2. Hash each slab (RGB quantized >>4, every 4th pixel horizontally,
+ *      every 2nd row, over the overlapping width) into a 32-bit FNV-1a hash.
+ *   3. LCS-diff the two slab-hash sequences (classic DP; sequences ~1000).
+ *   4. Matched slabs -> alignment anchors; unmatched runs -> hunks
+ *      ('changed' when both sides have content, 'deleted' before-only,
+ *      'inserted' after-only).
+ *   5. Merge hunks separated by < contextPx of matched content, drop hunks
+ *      below the noise floor (unless the only hunk), extend by contextPx.
+ */
+
+const FNV_OFFSET = 0x811c9dc5;
+const FNV_PRIME = 0x01000193;
+
+/** @typedef {{ width: number, height: number, data: Uint8Array | Buffer }} PngLike */
+
+function assertPngLike(name, png) {
+  if (
+    !png ||
+    !Number.isInteger(png.width) ||
+    !Number.isInteger(png.height) ||
+    png.width < 0 ||
+    png.height < 0
+  ) {
+    throw new TypeError(`${name} must be a PNG-like object with integer width/height`);
+  }
+  if (!png.data || png.data.length < png.width * png.height * 4) {
+    throw new TypeError(`${name}.data must be an RGBA buffer of >= width*height*4 bytes`);
+  }
+}
+
+/**
+ * Hash every slab of the image. Quantizes RGB to 4 bits per channel so
+ * antialiasing / compression wobble does not split hashes, samples every
+ * 4th pixel horizontally and every 2nd row, over `sampleWidth` px only
+ * (the width both images share).
+ *
+ * @param {PngLike} png
+ * @param {number} slabHeight
+ * @param {number} sampleWidth
+ * @returns {number[]} one 32-bit hash per slab
+ */
+function slabHashes(png, slabHeight, sampleWidth) {
+  const { data, width, height } = png;
+  const count = Math.ceil(height / slabHeight);
+  const hashes = new Array(count);
+  for (let s = 0; s < count; s++) {
+    const yStart = s * slabHeight;
+    const yEnd = Math.min(yStart + slabHeight, height);
+    let h = FNV_OFFSET;
+    for (let y = yStart; y < yEnd; y += 2) {
+      const rowOffset = y * width * 4;
+      for (let x = 0; x < sampleWidth; x += 4) {
+        const o = rowOffset + x * 4;
+        const q = ((data[o] >> 4) << 8) | ((data[o + 1] >> 4) << 4) | (data[o + 2] >> 4);
+        h = Math.imul(h ^ q, FNV_PRIME);
+      }
+    }
+    hashes[s] = h >>> 0;
+  }
+  return hashes;
+}
+
+/**
+ * Classic DP longest-common-subsequence over two hash sequences.
+ * Sequences are ~height/slabHeight items (~1000 for a long page), so the
+ * O(n*m) table is fine (a 2500x2500 Uint32 table is ~25 MB, transient).
+ *
+ * @param {number[]} a
+ * @param {number[]} b
+ * @returns {Array<[number, number]>} matched index pairs, ascending in both
+ */
+function lcsMatches(a, b) {
+  const n = a.length;
+  const m = b.length;
+  if (n === 0 || m === 0) return [];
+  const W = m + 1;
+  const dp = new Uint32Array((n + 1) * W);
+  for (let i = 1; i <= n; i++) {
+    const ai = a[i - 1];
+    const row = i * W;
+    const prev = row - W;
+    for (let j = 1; j <= m; j++) {
+      if (ai === b[j - 1]) {
+        dp[row + j] = dp[prev + j - 1] + 1;
+      } else {
+        const up = dp[prev + j];
+        const left = dp[row + j - 1];
+        dp[row + j] = up >= left ? up : left;
+      }
+    }
+  }
+  /** @type {Array<[number, number]>} */
+  const matches = [];
+  let i = n;
+  let j = m;
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      matches.push([i - 1, j - 1]);
+      i--;
+      j--;
+    } else if (dp[(i - 1) * W + j] >= dp[i * W + j - 1]) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+  matches.reverse();
+  return matches;
+}
+
+/**
+ * Compute diff hunks and scroll-alignment anchors for two full-page
+ * screenshots.
+ *
+ * @param {object} options
+ * @param {PngLike} options.before
+ * @param {PngLike} options.after
+ * @param {number} [options.slabHeight=8]   slab height in px
+ * @param {number} [options.contextPx=160]  merge threshold + hunk padding in px
+ * @param {number} [options.noiseFloorPct=0.10] hunks changing fewer slabs than
+ *   this fraction of the page are dropped (unless the only hunk)
+ * @returns {{
+ *   hunks: Array<{
+ *     before: { yStart: number, yEnd: number },
+ *     after: { yStart: number, yEnd: number },
+ *     kind: 'changed' | 'inserted' | 'deleted',
+ *     pctOfPage: number,
+ *   }>,
+ *   alignmentAnchors: Array<{ beforeY: number, afterY: number }>,
+ *   matchedPct: number,
+ *   slabCount: number,
+ * }}
+ */
+export function extractHunksAndAlignment({
+  before,
+  after,
+  slabHeight = 8,
+  contextPx = 160,
+  noiseFloorPct = 0.1,
+}) {
+  assertPngLike('before', before);
+  assertPngLike('after', after);
+  if (!Number.isInteger(slabHeight) || slabHeight < 1) {
+    throw new TypeError('slabHeight must be a positive integer');
+  }
+
+  const beforeHeight = before.height;
+  const afterHeight = after.height;
+  // Width mismatch: hash only the overlapping width so identical content
+  // at different capture widths still matches.
+  const sampleWidth = Math.min(before.width, after.width);
+
+  const beforeHashes = slabHashes(before, slabHeight, sampleWidth);
+  const afterHashes = slabHashes(after, slabHeight, sampleWidth);
+  const slabCount = Math.max(beforeHashes.length, afterHashes.length);
+
+  const matches = lcsMatches(beforeHashes, afterHashes);
+
+  /** Slab index -> pixel y, clamped to the image height (last slab may be partial). */
+  const bPx = (slab) => Math.min(slab * slabHeight, beforeHeight);
+  const aPx = (slab) => Math.min(slab * slabHeight, afterHeight);
+
+  // ---- raw hunks: the unmatched gaps between consecutive matches ----
+  /** @type {Array<{ kind: 'changed'|'inserted'|'deleted', before: {yStart:number,yEnd:number}, after: {yStart:number,yEnd:number}, changedSlabs: number }>} */
+  const raw = [];
+  let cursorB = 0;
+  let cursorA = 0;
+  const flushGap = (endB, endA) => {
+    const lenB = endB - cursorB;
+    const lenA = endA - cursorA;
+    if (lenB === 0 && lenA === 0) return;
+    raw.push({
+      kind: lenB > 0 && lenA > 0 ? 'changed' : lenB > 0 ? 'deleted' : 'inserted',
+      before: { yStart: bPx(cursorB), yEnd: bPx(endB) },
+      after: { yStart: aPx(cursorA), yEnd: aPx(endA) },
+      // extent of the change: the larger of the two runs
+      changedSlabs: Math.max(lenB, lenA),
+    });
+  };
+  for (const [mi, mj] of matches) {
+    flushGap(mi, mj);
+    cursorB = mi + 1;
+    cursorA = mj + 1;
+  }
+  flushGap(beforeHashes.length, afterHashes.length);
+
+  // ---- merge hunks separated by < contextPx of matched content ----
+  const merged = [];
+  for (const h of raw) {
+    const last = merged[merged.length - 1];
+    if (last) {
+      const gap = Math.min(
+        h.before.yStart - last.before.yEnd,
+        h.after.yStart - last.after.yEnd,
+      );
+      if (gap < contextPx) {
+        last.before.yEnd = h.before.yEnd;
+        last.after.yEnd = h.after.yEnd;
+        last.changedSlabs += h.changedSlabs;
+        if (last.kind !== h.kind) last.kind = 'changed';
+        continue;
+      }
+    }
+    merged.push({
+      kind: h.kind,
+      before: { ...h.before },
+      after: { ...h.after },
+      changedSlabs: h.changedSlabs,
+    });
+  }
+
+  // ---- noise floor: drop tiny hunks unless it's the only hunk ----
+  const floorSlabs = noiseFloorPct * slabCount;
+  const kept =
+    merged.length === 1 ? merged : merged.filter((h) => h.changedSlabs >= floorSlabs);
+
+  // ---- extend each hunk by contextPx both sides (clamped) ----
+  const hunks = kept.map((h) => ({
+    before: {
+      yStart: Math.max(0, h.before.yStart - contextPx),
+      yEnd: Math.min(beforeHeight, h.before.yEnd + contextPx),
+    },
+    after: {
+      yStart: Math.max(0, h.after.yStart - contextPx),
+      yEnd: Math.min(afterHeight, h.after.yEnd + contextPx),
+    },
+    kind: h.kind,
+    pctOfPage: slabCount === 0 ? 0 : (h.changedSlabs / slabCount) * 100,
+  }));
+
+  // ---- alignment anchors ----
+  // Collapse matches into runs of consecutive (i, j) pairs; the scroll offset
+  // is constant inside a run, so each run contributes its start point and its
+  // exclusive end point. Always includes {0,0} and {beforeHeight, afterHeight}.
+  const alignmentAnchors = [{ beforeY: 0, afterY: 0 }];
+  const pushAnchor = (beforeY, afterY) => {
+    const last = alignmentAnchors[alignmentAnchors.length - 1];
+    if (beforeY < last.beforeY || afterY < last.afterY) return; // keep monotonic
+    if (beforeY === last.beforeY && afterY === last.afterY) return; // dedupe
+    alignmentAnchors.push({ beforeY, afterY });
+  };
+  let r = 0;
+  while (r < matches.length) {
+    let e = r;
+    while (
+      e + 1 < matches.length &&
+      matches[e + 1][0] === matches[e][0] + 1 &&
+      matches[e + 1][1] === matches[e][1] + 1
+    ) {
+      e++;
+    }
+    pushAnchor(bPx(matches[r][0]), aPx(matches[r][1]));
+    pushAnchor(bPx(matches[e][0] + 1), aPx(matches[e][1] + 1));
+    r = e + 1;
+  }
+  pushAnchor(beforeHeight, afterHeight);
+
+  return {
+    hunks,
+    alignmentAnchors,
+    matchedPct: slabCount === 0 ? 100 : (matches.length / slabCount) * 100,
+    slabCount,
+  };
+}

--- a/packages/web/scripts/visual-review-hunks.mjs
+++ b/packages/web/scripts/visual-review-hunks.mjs
@@ -128,7 +128,7 @@ function lcsMatches(a, b) {
  * @param {PngLike} options.after
  * @param {number} [options.slabHeight=8]   slab height in px
  * @param {number} [options.contextPx=160]  merge threshold + hunk padding in px
- * @param {number} [options.noiseFloorPct=0.10] hunks changing fewer slabs than
+ * @param {number} [options.noiseFloorPct=0.001] hunks changing fewer slabs than
  *   this fraction of the page are dropped (unless the only hunk)
  * @returns {{
  *   hunks: Array<{
@@ -147,7 +147,7 @@ export function extractHunksAndAlignment({
   after,
   slabHeight = 8,
   contextPx = 160,
-  noiseFloorPct = 0.1,
+  noiseFloorPct = 0.001,
 }) {
   assertPngLike('before', before);
   assertPngLike('after', after);

--- a/packages/web/scripts/visual-review-hunks.test.mjs
+++ b/packages/web/scripts/visual-review-hunks.test.mjs
@@ -1,0 +1,179 @@
+/**
+ * Tests for visual-review-hunks.mjs.
+ * Run: cd packages/web && pnpm exec node --test scripts/visual-review-hunks.test.mjs
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { extractHunksAndAlignment } from './visual-review-hunks.mjs';
+
+const require = createRequire(import.meta.url);
+const { PNG } = require('pngjs');
+
+const SLAB = 8;
+const WIDTH = 640;
+const WHITE = [255, 255, 255];
+
+/**
+ * Deterministic per-slab color, unique under 4-bit quantization for the
+ * first 4096 slabs (channel value = (nibble << 4) + 8, mid-bucket).
+ */
+function contentColor(y) {
+  const i = Math.floor(y / SLAB);
+  return [((i & 15) << 4) + 8, (((i >> 4) & 15) << 4) + 8, (((i >> 8) & 15) << 4) + 8];
+}
+
+function makePng(height, colorFor, width = WIDTH) {
+  const png = new PNG({ width, height });
+  for (let y = 0; y < height; y++) {
+    const [r, g, b] = colorFor(y);
+    for (let x = 0; x < width; x++) {
+      const o = (y * width + x) * 4;
+      png.data[o] = r;
+      png.data[o + 1] = g;
+      png.data[o + 2] = b;
+      png.data[o + 3] = 255;
+    }
+  }
+  return png;
+}
+
+function assertMonotonicAnchors(anchors) {
+  for (let k = 1; k < anchors.length; k++) {
+    assert.ok(
+      anchors[k].beforeY >= anchors[k - 1].beforeY,
+      `anchor ${k} beforeY not monotonic`,
+    );
+    assert.ok(
+      anchors[k].afterY >= anchors[k - 1].afterY,
+      `anchor ${k} afterY not monotonic`,
+    );
+  }
+}
+
+test('identical images: 0 hunks, full anchors, 100% matched', () => {
+  const before = makePng(2000, contentColor);
+  const after = makePng(2000, contentColor);
+  const res = extractHunksAndAlignment({ before, after });
+
+  assert.equal(res.hunks.length, 0);
+  assert.equal(res.matchedPct, 100);
+  assert.equal(res.slabCount, 250);
+  assert.deepEqual(res.alignmentAnchors[0], { beforeY: 0, afterY: 0 });
+  assert.deepEqual(res.alignmentAnchors[res.alignmentAnchors.length - 1], {
+    beforeY: 2000,
+    afterY: 2000,
+  });
+  assertMonotonicAnchors(res.alignmentAnchors);
+});
+
+test('width mismatch: identical content at different widths compares at min width', () => {
+  const before = makePng(2000, contentColor, 640);
+  const after = makePng(2000, contentColor, 600);
+  const res = extractHunksAndAlignment({ before, after });
+
+  assert.equal(res.hunks.length, 0);
+  assert.equal(res.matchedPct, 100);
+});
+
+test('recolored band mid-page: 1 changed hunk covering the band plus context', () => {
+  const before = makePng(2000, contentColor);
+  // rows 800..1199 (slabs 100..149) recolored
+  const after = makePng(2000, (y) => (y >= 800 && y < 1200 ? WHITE : contentColor(y)));
+  const res = extractHunksAndAlignment({ before, after });
+
+  assert.equal(res.hunks.length, 1);
+  const hunk = res.hunks[0];
+  assert.equal(hunk.kind, 'changed');
+  assert.equal(hunk.before.yStart, 800 - 160);
+  assert.equal(hunk.before.yEnd, 1200 + 160);
+  assert.equal(hunk.after.yStart, 800 - 160);
+  assert.equal(hunk.after.yEnd, 1200 + 160);
+  assert.equal(hunk.pctOfPage, 20); // 50 of 250 slabs
+
+  assertMonotonicAnchors(res.alignmentAnchors);
+  // content above and below the band stays aligned 1:1
+  for (const a of res.alignmentAnchors) assert.equal(a.beforeY, a.afterY);
+});
+
+test('400px band inserted mid-page: 1 inserted hunk, anchors realign below', () => {
+  const before = makePng(2000, contentColor);
+  const after = makePng(2400, (y) => {
+    if (y < 1000) return contentColor(y);
+    if (y < 1400) return WHITE; // inserted band
+    return contentColor(y - 400); // original content shifted down
+  });
+  const res = extractHunksAndAlignment({ before, after });
+
+  assert.equal(res.hunks.length, 1);
+  const hunk = res.hunks[0];
+  assert.equal(hunk.kind, 'inserted');
+  assert.equal(hunk.after.yStart, 1000 - 160);
+  assert.equal(hunk.after.yEnd, 1400 + 160);
+  // before side is the insertion point extended by context
+  assert.equal(hunk.before.yStart, 1000 - 160);
+  assert.equal(hunk.before.yEnd, 1000 + 160);
+  assert.ok(hunk.pctOfPage > 10);
+
+  const anchors = res.alignmentAnchors;
+  assertMonotonicAnchors(anchors);
+  assert.deepEqual(anchors[0], { beforeY: 0, afterY: 0 });
+  assert.deepEqual(anchors[anchors.length - 1], { beforeY: 2000, afterY: 2400 });
+  // every anchor below the inserted band carries the +400 offset
+  const postInsert = anchors.filter((a) => a.afterY >= 1400);
+  assert.ok(postInsert.length > 0, 'expected anchors below the inserted band');
+  for (const a of postInsert) assert.equal(a.afterY - a.beforeY, 400);
+  // content above the band stays aligned 1:1
+  for (const a of anchors.filter((x) => x.afterY <= 1000)) {
+    assert.equal(a.beforeY, a.afterY);
+  }
+});
+
+test('400px band deleted mid-page: 1 deleted hunk, anchors realign below', () => {
+  const before = makePng(2400, (y) => {
+    if (y < 1000) return contentColor(y);
+    if (y < 1400) return WHITE;
+    return contentColor(y - 400);
+  });
+  const after = makePng(2000, contentColor);
+  const res = extractHunksAndAlignment({ before, after });
+
+  assert.equal(res.hunks.length, 1);
+  const hunk = res.hunks[0];
+  assert.equal(hunk.kind, 'deleted');
+  assert.equal(hunk.before.yStart, 1000 - 160);
+  assert.equal(hunk.before.yEnd, 1400 + 160);
+  assert.equal(hunk.after.yStart, 1000 - 160);
+  assert.equal(hunk.after.yEnd, 1000 + 160);
+
+  const postDelete = res.alignmentAnchors.filter((a) => a.beforeY >= 1400);
+  assert.ok(postDelete.length > 0);
+  for (const a of postDelete) assert.equal(a.beforeY - a.afterY, 400);
+});
+
+test('noise below the floor is dropped when a real hunk exists', () => {
+  const before = makePng(2000, contentColor);
+  const after = makePng(2000, (y) => {
+    if (y >= 800 && y < 1200) return WHITE; // real change: 50 slabs = 20%
+    if (y >= 1760 && y < 1768) return WHITE; // noise: 1 slab = 0.4%
+    return contentColor(y);
+  });
+  const res = extractHunksAndAlignment({ before, after });
+
+  assert.equal(res.hunks.length, 1);
+  assert.equal(res.hunks[0].kind, 'changed');
+  assert.equal(res.hunks[0].before.yStart, 640);
+  assert.equal(res.hunks[0].before.yEnd, 1360); // noise did not stretch the hunk
+});
+
+test('a below-floor hunk survives when it is the only hunk', () => {
+  const before = makePng(2000, contentColor);
+  const after = makePng(2000, (y) => (y >= 1760 && y < 1768 ? WHITE : contentColor(y)));
+  const res = extractHunksAndAlignment({ before, after });
+
+  assert.equal(res.hunks.length, 1);
+  assert.equal(res.hunks[0].kind, 'changed');
+  assert.ok(res.hunks[0].pctOfPage < 10);
+  assert.equal(res.hunks[0].before.yStart, 1760 - 160);
+  assert.equal(res.hunks[0].before.yEnd, 1768 + 160);
+});

--- a/packages/web/scripts/visual-review-hunks.test.mjs
+++ b/packages/web/scripts/visual-review-hunks.test.mjs
@@ -158,12 +158,27 @@ test('noise below the floor is dropped when a real hunk exists', () => {
     if (y >= 1760 && y < 1768) return WHITE; // noise: 1 slab = 0.4%
     return contentColor(y);
   });
-  const res = extractHunksAndAlignment({ before, after });
+  const res = extractHunksAndAlignment({ before, after, noiseFloorPct: 0.1 });
 
   assert.equal(res.hunks.length, 1);
   assert.equal(res.hunks[0].kind, 'changed');
   assert.equal(res.hunks[0].before.yStart, 640);
   assert.equal(res.hunks[0].before.yEnd, 1360); // noise did not stretch the hunk
+});
+
+test('default keeps multiple small real hunks visible', () => {
+  const before = makePng(2000, contentColor);
+  const after = makePng(2000, (y) => {
+    if (y >= 320 && y < 336) return WHITE; // 2 slabs = 0.8%
+    if (y >= 1600 && y < 1616) return WHITE; // 2 slabs = 0.8%
+    return contentColor(y);
+  });
+  const res = extractHunksAndAlignment({ before, after });
+
+  assert.equal(res.hunks.length, 2);
+  assert.equal(res.hunks[0].kind, 'changed');
+  assert.equal(res.hunks[1].kind, 'changed');
+  assert.ok(res.hunks.every((hunk) => hunk.pctOfPage < 10));
 });
 
 test('a below-floor hunk survives when it is the only hunk', () => {

--- a/packages/web/scripts/visual-review-page.mjs
+++ b/packages/web/scripts/visual-review-page.mjs
@@ -1,0 +1,1815 @@
+/**
+ * visual-review-page.mjs — renders latest.html for the PR visual+copy review artifact.
+ *
+ * Hybrid of review-variants/v2.html (Inspector base: header chips, grouped rail,
+ * per-route detail pane, viewport toggle, comparator modes, hash deep links,
+ * mobile accordion) and v3.html (verdict system: looks-right/needs-work/skip
+ * persisted to localStorage keyed by commit, j/k + 1/2/s keys, reviewed count,
+ * markdown export; mobile defaults to the swipe comparator).
+ *
+ * New in this rewrite: hunked screenshot strips with collapsed identical
+ * regions, linked full-page scrolling via piecewise-linear alignment anchors,
+ * diff minimap with n/p hunk stepping, overlay (diff-PNG composite) mode,
+ * hunk permalinks, client-side noise threshold, collapsing header chrome,
+ * production-only live compare (Vercel SSO blocks preview iframes).
+ *
+ * DATA CONTRACT — renderReviewHtml(input) where input is:
+ * {
+ *   meta: { prNumber, shortSha, commitSha, headBranch, generatedAt,
+ *           generatedAtCentral, previewBaseUrl, productionBaseUrl,
+ *           reviewUrl, baselineDescription },
+ *   summary: { changedRoutes, copyOnlyRoutes, unchangedRoutes, erroredRoutes, totalRoutes },
+ *   routes: [{
+ *     routeName, routeLabel, routePath, routeUrl, authState,
+ *     changed, copyChanged, errored, statusLabel,
+ *     markdownDiff: null | { addedLines, removedLines,
+ *       metaChanges: [{field,before,after}],
+ *       lines: [{kind: 'header'|'hunk'|'context'|'add'|'del', text}] },
+ *     pairs: [{
+ *       projectName, projectLabel, changed, missing, errored, diffLabel,
+ *       beforeRelPath, afterRelPath, diffRelPath,   // relative to output root, null when absent
+ *       beforeWidth, beforeHeight, afterWidth, afterHeight,
+ *       hunks: [{ before:{yStart,yEnd}, after:{yStart,yEnd},
+ *                 kind:'changed'|'inserted'|'deleted', pctOfPage }],
+ *       alignmentAnchors: [{ beforeY, afterY }]     // monotonic, incl. {0,0} and ends
+ *     }]
+ *   }]
+ * }
+ * Returns the COMPLETE html string for latest.html. All assets referenced
+ * relative to the emitted file (assets/...). No external network dependencies
+ * except live-compare iframes and preview links.
+ */
+
+export function escapeHtml(value) {
+  return String(value == null ? "" : value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+/** JSON safe to inline inside a <script> element. */
+function jsonIsland(input) {
+  return JSON.stringify(input)
+    .replaceAll("<", "\\u003c")
+    .replaceAll(" ", "\\u2028")
+    .replaceAll(" ", "\\u2029");
+}
+
+const CSS = `
+  :root {
+    --bg: #f6f7f8;
+    --panel: #ffffff;
+    --ink: #16181d;
+    --dim: #6e7781;
+    --border: #d9dce1;
+    --accent: #0b62d6;
+    --accent-soft: #e8f0fc;
+    --add-bg: #e6ffec;
+    --add-ink: #116329;
+    --del-bg: #ffebe9;
+    --del-ink: #82071e;
+    --err: #d1242f;
+    --good: #137a3a;
+    --good-soft: #e5f3ea;
+    --bad: #b3261e;
+    --bad-soft: #fbeae9;
+    --band: #e05d44;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0;
+    font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--ink);
+    display: flex;
+    flex-direction: column;
+    overflow-x: hidden;
+  }
+  a { color: var(--accent); }
+  button { font: inherit; color: inherit; cursor: pointer; }
+  select { font: inherit; }
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  [hidden] { display: none !important; }
+
+  /* ---------- header ---------- */
+  header#hdr {
+    flex: 0 0 auto;
+    background: var(--panel);
+    border-bottom: 1px solid var(--border);
+    padding: 8px 16px;
+    z-index: 20;
+  }
+  .hdr-row1 { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .hdr-row1 h1 { font-size: 15px; margin: 0; font-weight: 700; white-space: nowrap; }
+  .chips { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+  .chip {
+    font-size: 12px;
+    padding: 1px 8px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--bg);
+    white-space: nowrap;
+  }
+  .chip.changed { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+  .chip.errored { border-color: var(--err); color: var(--err); }
+  .chip.reviewed { border-color: var(--good); color: var(--good); background: var(--good-soft); }
+  .hdr-spacer { flex: 1 1 auto; }
+  .noise-label { font-size: 12px; color: var(--dim); display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; }
+  #noise { padding: 3px 4px; border: 1px solid var(--border); border-radius: 4px; background: var(--panel); font-size: 12px; }
+  .hbtn {
+    font-size: 12px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--panel);
+    padding: 3px 10px;
+    white-space: nowrap;
+  }
+  .hbtn:hover { border-color: var(--dim); }
+  .hdr-row2 { font-size: 12px; color: var(--dim); margin-top: 4px; overflow-wrap: anywhere; }
+  .hdr-row2 code { font-family: var(--mono); font-size: 11px; }
+  body.condensed .hdr-row2 { display: none; }
+  body.condensed header#hdr { box-shadow: 0 1px 4px rgba(0,0,0,.08); }
+
+  /* ---------- layout ---------- */
+  .app { flex: 1 1 auto; display: flex; min-height: 0; }
+
+  /* ---------- mobile rail toggle ---------- */
+  #rail-toggle {
+    display: none;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    min-height: 44px;
+    padding: 8px 12px;
+    text-align: left;
+    background: var(--panel);
+    border: none;
+    border-bottom: 1px solid var(--border);
+    font-weight: 600;
+  }
+  #rail-toggle .rt-caret { display: inline-block; transition: transform .12s; color: var(--dim); }
+  body.rail-open #rail-toggle .rt-caret { transform: rotate(180deg); }
+  #rail-toggle .rt-sel {
+    font-weight: 400; color: var(--dim);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;
+  }
+
+  /* ---------- rail ---------- */
+  nav.rail {
+    flex: 0 0 280px;
+    width: 280px;
+    border-right: 1px solid var(--border);
+    background: var(--panel);
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+  .rail-filter { position: sticky; top: 0; background: var(--panel); padding: 8px; border-bottom: 1px solid var(--border); z-index: 2; }
+  .rail-filter input {
+    width: 100%; padding: 5px 8px;
+    border: 1px solid var(--border); border-radius: 4px;
+    font: inherit; background: var(--bg);
+  }
+  .rail-group-h {
+    font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em;
+    color: var(--dim); padding: 10px 10px 4px;
+  }
+  button.rail-group-h {
+    display: block; width: 100%; text-align: left;
+    background: none; border: none; padding: 10px 10px;
+  }
+  button.rail-group-h:hover { color: var(--ink); }
+  .route-row {
+    display: block; width: 100%; text-align: left;
+    background: none; border: none; border-left: 3px solid transparent;
+    padding: 6px 10px 6px 9px;
+  }
+  .route-row:hover { background: var(--bg); }
+  .route-row.selected { background: var(--accent-soft); border-left-color: var(--accent); }
+  .route-row .r-top { display: flex; align-items: center; gap: 6px; }
+  .dot { flex: 0 0 8px; width: 8px; height: 8px; border-radius: 50%; background: #c4c9d0; }
+  .dot.changed { background: var(--accent); }
+  .dot.copy { background: var(--panel); border: 2px solid var(--accent); }
+  .dot.errored { background: var(--err); }
+  .r-label { font-weight: 600; font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1 1 auto; min-width: 0; }
+  .r-verdict { flex: 0 0 auto; font-size: 12px; }
+  .r-badges { display: flex; gap: 4px; margin: 3px 0 0 14px; flex-wrap: wrap; }
+  .badge {
+    font-family: var(--mono); font-size: 10.5px; padding: 0 5px;
+    border: 1px solid var(--border); border-radius: 3px;
+    color: var(--dim); background: var(--bg); white-space: nowrap;
+  }
+  .badge.hot { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+  .badge.err { border-color: var(--err); color: var(--err); }
+  .badge.copy { color: var(--ink); }
+  .badge .plus { color: var(--add-ink); }
+  .badge .minus { color: var(--del-ink); }
+  .kbd-hint { font-size: 11px; color: var(--dim); padding: 8px 10px 14px; }
+  kbd {
+    font-family: var(--mono); font-size: 10px;
+    border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px;
+    padding: 0 4px; background: var(--bg);
+  }
+
+  /* ---------- pane ---------- */
+  main.pane { flex: 1 1 auto; min-width: 0; overflow-y: auto; display: flex; flex-direction: column; }
+  #pane-content { padding: 16px 20px 120px; flex: 1 0 auto; }
+  .route-head { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+  .route-head h2 { margin: 0; font-size: 20px; }
+  .route-head .path { font-family: var(--mono); font-size: 13px; color: var(--dim); overflow-wrap: anywhere; }
+  .route-head .auth {
+    font-size: 11px; border: 1px solid var(--border); border-radius: 3px;
+    padding: 0 6px; color: var(--dim);
+  }
+  .route-head .auth.v-good { border-color: var(--good); color: var(--good); background: var(--good-soft); }
+  .route-head .auth.v-bad { border-color: var(--bad); color: var(--bad); background: var(--bad-soft); }
+  .route-meta { display: flex; align-items: center; gap: 6px; margin: 4px 0 14px; font-size: 12px; color: var(--dim); min-width: 0; flex-wrap: wrap; }
+  .route-meta a { min-width: 0; flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .copy-url {
+    flex: 0 0 auto; font-size: 11px;
+    border: 1px solid var(--border); border-radius: 3px;
+    background: var(--bg); color: var(--dim); padding: 1px 8px;
+  }
+  .copy-url:hover { color: var(--ink); }
+
+  .toolbar { display: flex; gap: 16px; flex-wrap: wrap; align-items: center; margin-bottom: 10px; }
+  .seg { display: inline-flex; flex-wrap: wrap; max-width: 100%; border: 1px solid var(--border); border-radius: 5px; overflow: hidden; background: var(--panel); }
+  .seg button { border: none; background: none; padding: 5px 12px; font-size: 13px; border-right: 1px solid var(--border); }
+  .seg button:last-child { border-right: none; }
+  .seg button[aria-pressed="true"] { background: var(--accent); color: #fff; }
+  .seg button:disabled { color: var(--border); cursor: not-allowed; }
+  .seg-label { font-size: 12px; color: var(--dim); margin-right: -8px; }
+  .vp-info { font-size: 12px; color: var(--dim); font-family: var(--mono); margin: 0 0 8px; overflow-wrap: anywhere; }
+  .vp-info b { color: var(--ink); }
+
+  section.card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 16px;
+    min-width: 0;
+  }
+  section.card > h3 { margin: 0 0 8px; font-size: 13px; text-transform: uppercase; letter-spacing: .03em; color: var(--dim); }
+  .img-missing {
+    padding: 24px; text-align: center; color: var(--dim); font-size: 13px;
+    border: 1px dashed var(--border); background: var(--bg);
+  }
+  .err-note {
+    padding: 10px 12px; font-size: 13px;
+    border: 1px solid var(--err); color: var(--err); background: #fff5f5;
+    margin-bottom: 10px;
+  }
+
+  /* ---------- comparator + minimap ---------- */
+  .cmp-row { display: flex; gap: 8px; align-items: stretch; }
+  .cmp-main { flex: 1 1 auto; min-width: 0; }
+  .cmp-scroll { max-height: 75vh; overflow: auto; border: 1px solid var(--border); background: #eceef1; }
+  .cmp-hint, .onion-ctl, .overlay-ctl { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 12px; color: var(--dim); margin: 0 0 8px; }
+  .onion-ctl input[type=range] { width: 240px; max-width: 100%; min-width: 0; accent-color: var(--accent); }
+
+  .mm {
+    position: relative;
+    flex: 0 0 14px; width: 14px;
+    min-height: 120px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    cursor: pointer;
+    align-self: stretch;
+  }
+  .mm-band {
+    position: absolute; left: 1px; right: 1px;
+    top: calc(var(--start, 0) * 100%);
+    height: max(3px, calc(var(--len, 0) * 100%));
+    background: var(--band); border-radius: 1px;
+  }
+  .mm-band.active { background: var(--accent); }
+  .mm-view {
+    position: absolute; left: 0; right: 0;
+    top: calc(var(--start, 0) * 100%);
+    height: calc(var(--len, 0) * 100%);
+    background: rgba(11,98,214,.14);
+    border: 1px solid rgba(11,98,214,.5);
+    pointer-events: none;
+  }
+
+  /* hunk strips */
+  .hunk-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; padding: 8px 8px 0; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--dim); }
+  .hunk-block { padding: 8px; }
+  .hunk-block.flash { animation: hunkflash 1.6s ease-out; }
+  @keyframes hunkflash {
+    0% { background: rgba(255,166,0,.35); }
+    100% { background: transparent; }
+  }
+  .hunk-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 11.5px; color: var(--dim); font-family: var(--mono); margin-bottom: 4px; }
+  .hunk-head .hk { font-weight: 700; color: var(--ink); }
+  .hunk-head .kind-changed { color: var(--accent); }
+  .hunk-head .kind-inserted { color: var(--add-ink); }
+  .hunk-head .kind-deleted { color: var(--del-ink); }
+  .hunk-link {
+    border: 1px solid var(--border); border-radius: 3px; background: var(--panel);
+    color: var(--dim); font-size: 11px; padding: 0 6px; margin-left: auto;
+  }
+  .hunk-link:hover { color: var(--accent); border-color: var(--accent); }
+  .hunk-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .strip { position: relative; overflow: hidden; background: #fff; border: 1px solid var(--border); }
+  .strip img { display: block; width: 100%; height: auto; }
+  .strip-cap { display: none; font-size: 10px; text-transform: uppercase; letter-spacing: .04em; color: var(--dim); margin: 2px 0; }
+  .hatch {
+    border: 1px dashed var(--border);
+    background: repeating-linear-gradient(45deg, #f2f3f5, #f2f3f5 8px, #e3e6ea 8px, #e3e6ea 16px);
+    display: flex; align-items: center; justify-content: center;
+    color: var(--dim); font-size: 11px; min-height: 40px;
+  }
+  .gap-row { padding: 0 8px; }
+  .gap-btn {
+    display: block; width: 100%;
+    border: 1px dashed var(--border); border-radius: 3px;
+    background: var(--bg); color: var(--dim);
+    font-size: 12px; padding: 4px 8px; text-align: center; margin: 4px 0;
+  }
+  .gap-btn:hover { color: var(--ink); }
+  .gap-open { padding: 4px 0; }
+
+  /* full page linked scrolling */
+  .full-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .full-grid figure { margin: 0; min-width: 0; }
+  .full-grid figcaption { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--dim); margin-bottom: 4px; }
+  .well { height: 70vh; overflow: auto; border: 1px solid var(--border); background: #fff; }
+  .well img { display: block; width: 100%; height: auto; }
+
+  /* swipe / onion / overlay stage */
+  .cmp-stage { position: relative; }
+  .cmp-stage.mode-swipe { touch-action: pan-y; }
+  .cmp-stage.vp-narrow { max-width: 420px; margin: 0 auto; }
+  .cmp-stage img { display: block; width: 100%; height: auto; }
+  .cmp-stage .img-top { position: absolute; top: 0; left: 0; }
+  .cmp-stage .img-top.blend { mix-blend-mode: multiply; }
+  .swipe-handle {
+    position: absolute; top: 0; bottom: 0; width: 2px;
+    background: var(--accent); cursor: ew-resize; touch-action: none; z-index: 3;
+  }
+  .swipe-handle::before { content: ""; position: absolute; top: 0; bottom: 0; left: -20px; right: -20px; }
+  .swipe-pill {
+    position: absolute; left: 50%; top: 120px;
+    transform: translate(-50%, -50%);
+    background: var(--accent); color: #fff;
+    font-size: 11px; padding: 3px 8px; border-radius: 10px;
+    white-space: nowrap; pointer-events: none;
+  }
+  .cmp-stage.swiping { cursor: ew-resize; user-select: none; }
+
+  /* plain side-by-side fallback (no hunk data) */
+  .sbs { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .sbs figure { margin: 0; min-width: 0; }
+  .sbs figcaption { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--dim); margin-bottom: 4px; }
+  .sbs img { display: block; width: 100%; height: auto; border: 1px solid var(--border); background: #fff; }
+
+  /* ---------- copy diff ---------- */
+  .tbl-scroll { overflow-x: auto; margin-bottom: 10px; }
+  .meta-table { border-collapse: collapse; font-size: 12px; width: 100%; }
+  .meta-table th, .meta-table td { border: 1px solid var(--border); padding: 3px 8px; text-align: left; vertical-align: top; }
+  .meta-table th { background: var(--bg); font-weight: 600; }
+  .meta-table .b { background: var(--del-bg); color: var(--del-ink); }
+  .meta-table .a { background: var(--add-bg); color: var(--add-ink); }
+  .diff-view {
+    font-family: var(--mono); font-size: 12px; line-height: 1.5;
+    border: 1px solid var(--border); background: #fff;
+    max-height: 420px; overflow: auto;
+  }
+  .diff-view .ln { white-space: pre-wrap; overflow-wrap: anywhere; padding: 0 10px; }
+  .diff-view .add { background: var(--add-bg); color: var(--add-ink); }
+  .diff-view .del { background: var(--del-bg); color: var(--del-ink); }
+  .diff-view .hunk { background: var(--accent-soft); color: var(--dim); }
+  .diff-view .meta { color: var(--dim); }
+  .no-copy { color: var(--dim); font-size: 13px; }
+
+  /* ---------- live compare ---------- */
+  .live-btn {
+    border: 1px solid var(--accent); background: var(--panel); color: var(--accent);
+    border-radius: 5px; padding: 6px 14px; font-weight: 600;
+  }
+  .live-btn[aria-pressed="true"] { background: var(--accent); color: #fff; }
+  .live-note { font-size: 12px; color: var(--dim); margin: 10px 0 8px; overflow-wrap: anywhere; }
+  .live-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .live-label { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--dim); margin: 0 0 4px; }
+  .live-grid iframe { width: 100%; height: 70vh; border: 1px solid var(--border); background: #fff; }
+  .preview-panel {
+    border: 2px solid var(--accent); background: var(--accent-soft);
+    min-height: 200px; height: 70vh;
+    display: flex; flex-direction: column; gap: 12px;
+    align-items: flex-start; justify-content: center; padding: 24px;
+  }
+  .preview-panel p { margin: 0; font-size: 13px; color: var(--ink); max-width: 40ch; }
+  .preview-open {
+    display: inline-block; background: var(--accent); color: #fff;
+    padding: 10px 18px; border-radius: 5px; font-weight: 600; text-decoration: none;
+  }
+
+  /* ---------- verdict bar ---------- */
+  .verdict-bar {
+    position: sticky; bottom: 0; z-index: 10;
+    background: var(--panel); border-top: 1px solid var(--border);
+    padding: 8px 20px;
+    display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+  }
+  .vbtn { border: 1px solid var(--border); border-radius: 4px; background: var(--panel); padding: 6px 12px; white-space: nowrap; }
+  .vbtn.btn-good { border-color: var(--good); color: var(--good); }
+  .vbtn.btn-good.on, .vbtn.btn-good:hover { background: var(--good-soft); }
+  .vbtn.btn-bad { border-color: var(--bad); color: var(--bad); }
+  .vbtn.btn-bad.on, .vbtn.btn-bad:hover { background: var(--bad-soft); }
+  .vbtn.btn-skip { border-style: dashed; }
+  .vbtn.btn-skip.on { background: var(--bg); }
+  .note-box { flex: 1 1 200px; min-width: 160px; }
+  .note-box input {
+    width: 100%; font: inherit;
+    border: 1px solid var(--border); border-radius: 4px; padding: 6px 8px;
+  }
+  .v-kbd { font-size: 11px; color: var(--dim); white-space: nowrap; }
+
+  .fatal { margin: 40px auto; max-width: 520px; padding: 20px; background: var(--panel); border: 1px solid var(--err); color: var(--err); }
+
+  /* ---------- touch targets ---------- */
+  @media (pointer: coarse) {
+    .seg button { min-height: 40px; padding: 8px 14px; }
+    .live-btn, .hbtn, .vbtn, .gap-btn, .hunk-link { min-height: 40px; }
+    .route-row { min-height: 40px; }
+    .rail-filter input, #noise { min-height: 40px; }
+    .copy-url { min-height: 40px; min-width: 40px; }
+    .kbd-hint, .v-kbd { display: none; }
+  }
+
+  /* ---------- narrow screens ---------- */
+  @media (max-width: 700px) {
+    .app { flex-direction: column; }
+    #rail-toggle { display: flex; }
+    nav.rail {
+      display: none; flex: 0 0 auto; width: 100%;
+      max-height: 55vh; border-right: none; border-bottom: 1px solid var(--border);
+    }
+    body.rail-open nav.rail { display: flex; }
+    #pane-content { padding: 12px 12px 170px; }
+    .hunk-grid, .full-grid, .sbs, .live-grid { grid-template-columns: minmax(0, 1fr); }
+    .hunk-cols { display: none; }
+    .strip-cap { display: block; }
+    .cmp-row { flex-direction: column; }
+    .mm { width: 100%; height: 14px; flex: 0 0 14px; min-height: 0; align-self: auto; order: -1; }
+    .mm-band {
+      top: 1px; bottom: 1px; height: auto; right: auto;
+      left: calc(var(--start, 0) * 100%);
+      width: max(3px, calc(var(--len, 0) * 100%));
+    }
+    .mm-view {
+      top: 0; bottom: 0; height: auto; right: auto;
+      left: calc(var(--start, 0) * 100%);
+      width: calc(var(--len, 0) * 100%);
+    }
+    .well { height: 60vh; }
+    .cmp-scroll { max-height: 65vh; }
+    .live-grid iframe { height: 55vh; }
+    .preview-panel { height: auto; min-height: 140px; }
+    .verdict-bar { padding: 6px 10px; gap: 6px; }
+    .vbtn { padding: 8px 10px; font-size: 13px; }
+    .note-box input { font-size: 16px; } /* stops iOS focus zoom */
+  }
+`;
+
+/**
+ * Client JS. Embedded verbatim inside the emitted HTML.
+ * IMPORTANT: no backtick and no dollar-brace sequences in here — the whole
+ * script lives inside a server-side template literal.
+ */
+const CLIENT_JS = `
+(function () {
+  "use strict";
+
+  var DATA = JSON.parse(document.getElementById("review-data").textContent);
+  var meta = DATA.meta || {};
+  var routes = DATA.routes || [];
+
+  /* ---------------- state ---------------- */
+  var selectedName = null;
+  var pairName = null;          // selected viewport (projectName) for the current route
+  var cmpMode = null;           // "hunks" | "full" | "swipe" | "onion" | "overlay"
+  var noise = 0;                // hide hunks with pctOfPage below this (percent)
+  var swipePos = 50;
+  var onionOpacity = 50;
+  var overlayStyle = "blend";   // "blend" | "tint"
+  var hunkPointer = -1;         // n/p stepping index into visible hunks
+  var minimap = null;           // { el, update(startFrac, lenFrac), setActive(origIdx) }
+  var fullWells = null;         // linked-scroll wells for the current full-page render
+  var verdicts = {};            // routeName -> { v, note, ts, commit }
+  var storeKey = "visualReview:" + (meta.commitSha || meta.shortSha || "unknown");
+  var MOBILE_MQ = "(max-width: 700px)";
+  var STRIP_CONTEXT_PX = 16;    // extra context cropped around each hunk band
+
+  /* ---------------- helpers ---------------- */
+  function esc(s) {
+    return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+  function el(tag, attrs, children) {
+    var n = document.createElement(tag);
+    if (attrs) Object.keys(attrs).forEach(function (k) {
+      if (k === "text") n.textContent = attrs[k];
+      else if (k === "html") n.innerHTML = attrs[k];
+      else if (attrs[k] != null) n.setAttribute(k, attrs[k]);
+    });
+    (children || []).forEach(function (c) { if (c) n.appendChild(c); });
+    return n;
+  }
+  function joinRouteUrl(base, routePath) {
+    if (!base || !routePath) return "";
+    return String(base).replace(/\\/$/, "") + routePath;
+  }
+  function isMobile() { return window.matchMedia(MOBILE_MQ).matches; }
+  function fmtPx(n) { return Math.round(n).toLocaleString("en-US"); }
+  function fmtPct(n) {
+    if (!isFinite(n)) return "0";
+    var fixed = Number(n).toFixed(n >= 10 ? 1 : 2);
+    return fixed.replace(/\.?0+$/, "");
+  }
+  function pctOf(label) {
+    var m = /([\\d.]+%)/.exec(label || "");
+    return m ? m[1] : (label || "\\u2014");
+  }
+  function pctNum(label) {
+    var m = /([\\d.]+)%/.exec(label || "");
+    return m ? parseFloat(m[1]) : 0;
+  }
+  function routeByName(name) {
+    return routes.find(function (r) { return r.routeName === name; });
+  }
+  function pairOf(r, name) {
+    return ((r && r.pairs) || []).find(function (p) { return p.projectName === name; }) || null;
+  }
+  function groupOf(r) {
+    if (r.changed || r.errored) return "changed";
+    if (r.copyChanged) return "copy";
+    return "cold";
+  }
+  function visibleHunks(pair) {
+    var out = [];
+    ((pair && pair.hunks) || []).forEach(function (h, i) {
+      if (!noise || (h.pctOfPage || 0) >= noise) out.push({ h: h, i: i });
+    });
+    return out;
+  }
+  function pairIsHot(pair) {
+    if (!pair) return false;
+    if (pair.errored) return true;
+    if (!pair.changed) return false;
+    if (pair.hunks && pair.hunks.length) return visibleHunks(pair).length > 0;
+    return true;
+  }
+  function defaultPairFor(r) {
+    if (!r || !r.pairs || !r.pairs.length) return null;
+    var best = null;
+    r.pairs.forEach(function (p) {
+      if (!pairIsHot(p)) return;
+      if (!best || pctNum(p.diffLabel) > pctNum(best.diffLabel)) best = p;
+    });
+    return (best || r.pairs[0]).projectName;
+  }
+  function defaultModeFor(pair) {
+    if (isMobile()) return "swipe";
+    if (pair && pair.hunks && pair.hunks.length) return "hunks";
+    return "full";
+  }
+  function anchorsFor(pair) {
+    var a = (pair && pair.alignmentAnchors) || [];
+    if (a.length >= 2) return a;
+    var bh = (pair && pair.beforeHeight) || 1;
+    var ah = (pair && pair.afterHeight) || 1;
+    return [{ beforeY: 0, afterY: 0 }, { beforeY: bh, afterY: ah }];
+  }
+  // piecewise-linear map over alignment anchors (NOT naive percentage)
+  function mapY(y, anchors, fromKey, toKey) {
+    if (!anchors || anchors.length < 2) return y;
+    var seg = anchors.length - 2;
+    for (var k = 0; k < anchors.length - 1; k++) {
+      if (y <= anchors[k + 1][fromKey]) { seg = k; break; }
+    }
+    var a = anchors[seg], b = anchors[seg + 1];
+    var span = b[fromKey] - a[fromKey];
+    var t = span > 0 ? (y - a[fromKey]) / span : 0;
+    return a[toKey] + t * (b[toKey] - a[toKey]);
+  }
+  function cssEscape(s) {
+    return (window.CSS && CSS.escape) ? CSS.escape(s) : String(s).replace(/[^a-zA-Z0-9_-]/g, "\\\\$&");
+  }
+
+  /* ---------------- verdict storage ---------------- */
+  function loadVerdicts() {
+    try {
+      var raw = localStorage.getItem(storeKey);
+      if (!raw) return;
+      var saved = JSON.parse(raw);
+      if (saved && typeof saved.verdicts === "object" && saved.verdicts) verdicts = saved.verdicts;
+    } catch (e) { /* corrupted state loses politely */ }
+  }
+  function saveVerdicts() {
+    try { localStorage.setItem(storeKey, JSON.stringify({ verdicts: verdicts })); }
+    catch (e) { /* private mode: verdicts live for the session only */ }
+  }
+  function verdictOf(r) { return verdicts[r.routeName] || null; }
+  function verdictMark(v) {
+    return v ? (v.v === "looks-right" ? "\\uD83D\\uDC4D" : v.v === "needs-work" ? "\\uD83D\\uDC4E" : "\\u23ED") : "";
+  }
+  function reviewable() {
+    return routes.filter(function (r) { return groupOf(r) !== "cold"; });
+  }
+  function updateReviewedChip() {
+    var pool = reviewable();
+    var done = 0, flagged = 0;
+    pool.forEach(function (r) {
+      var v = verdictOf(r);
+      if (v && v.v !== "skipped") done++;
+      if (v && v.v === "needs-work") flagged++;
+    });
+    var chip = document.getElementById("chip-reviewed");
+    chip.textContent = done + "/" + pool.length + " reviewed" + (flagged ? " \\u00b7 " + flagged + " flagged" : "");
+    chip.classList.toggle("reviewed", done > 0);
+  }
+
+  /* ---------------- hash deep links ---------------- */
+  function parseHash() {
+    var h = (location.hash || "").replace(/^#/, "");
+    if (!h) return null;
+    if (h.indexOf("=") === -1) return { route: decodeURIComponent(h) };
+    var out = {};
+    h.split("&").forEach(function (kv) {
+      var i = kv.indexOf("=");
+      if (i === -1) return;
+      out[decodeURIComponent(kv.slice(0, i))] = decodeURIComponent(kv.slice(i + 1));
+    });
+    return out;
+  }
+  function hunkPermalink(routeName, pName, i) {
+    return location.href.split("#")[0] +
+      "#route=" + encodeURIComponent(routeName) +
+      "&pair=" + encodeURIComponent(pName) +
+      "&hunk=" + i;
+  }
+
+  /* ---------------- header wiring ---------------- */
+  function wireHeader() {
+    var noiseSel = document.getElementById("noise");
+    noiseSel.addEventListener("change", function () {
+      noise = parseFloat(noiseSel.value) || 0;
+      refreshRailBadges();
+      renderPane(true);
+    });
+    document.getElementById("export-btn").addEventListener("click", exportNotes);
+    document.getElementById("reset-btn").addEventListener("click", function () {
+      if (!confirm("Clear all saved verdicts and notes for commit " + (meta.shortSha || "?") + "?")) return;
+      verdicts = {};
+      saveVerdicts();
+      updateReviewedChip();
+      refreshRailMarks();
+      renderPane(true);
+    });
+    // collapsing chrome: condense to one sticky line once the pane scrolls
+    var pane = document.getElementById("pane");
+    pane.addEventListener("scroll", function () {
+      var y = pane.scrollTop;
+      if (y > 48) document.body.classList.add("condensed");
+      else if (y < 8) document.body.classList.remove("condensed");
+    });
+  }
+
+  /* ---------------- rail ---------------- */
+  var coldOpen = false;
+  function renderRail() {
+    var rail = document.getElementById("rail");
+    rail.innerHTML = "";
+
+    var filterWrap = el("div", { class: "rail-filter" });
+    var input = el("input", {
+      type: "search", id: "route-filter", placeholder: "Filter routes\\u2026",
+      "aria-label": "Filter routes", autocomplete: "off"
+    });
+    input.addEventListener("input", applyFilter);
+    filterWrap.appendChild(input);
+    rail.appendChild(filterWrap);
+
+    var changed = routes.filter(function (r) { return groupOf(r) === "changed"; });
+    var copy = routes.filter(function (r) { return groupOf(r) === "copy"; });
+    var cold = routes.filter(function (r) { return groupOf(r) === "cold"; });
+
+    function addGroup(title, list, key) {
+      if (!list.length) return;
+      var wrap = el("div", { class: "rail-group", "data-title": title, "data-total": String(list.length), "data-key": key });
+      wrap.appendChild(el("div", { class: "rail-group-h", text: title + " (" + list.length + ")" }));
+      list.forEach(function (r) { wrap.appendChild(routeRow(r)); });
+      rail.appendChild(wrap);
+    }
+    addGroup("Changed", changed, "changed");
+    addGroup("Copy only", copy, "copy");
+
+    // unchanged routes park behind a count toggle
+    if (cold.length) {
+      var wrap = el("div", { class: "rail-group", "data-title": "Unchanged", "data-total": String(cold.length), "data-key": "cold" });
+      var toggle = el("button", {
+        type: "button", class: "rail-group-h", "aria-expanded": String(coldOpen),
+        text: (coldOpen ? "\\u25be" : "\\u25b8") + " Unchanged (" + cold.length + ")"
+      });
+      toggle.addEventListener("click", function () {
+        coldOpen = !coldOpen;
+        renderRail();
+        markSelectedRow();
+        applyFilter();
+      });
+      wrap.appendChild(toggle);
+      if (coldOpen) cold.forEach(function (r) { wrap.appendChild(routeRow(r)); });
+      rail.appendChild(wrap);
+    }
+
+    rail.appendChild(el("div", {
+      class: "kbd-hint",
+      html: "<kbd>j</kbd>/<kbd>k</kbd> routes \\u00b7 <kbd>n</kbd>/<kbd>p</kbd> hunks \\u00b7 <kbd>1</kbd> \\uD83D\\uDC4D \\u00b7 <kbd>2</kbd> \\uD83D\\uDC4E \\u00b7 <kbd>s</kbd> skip"
+    }));
+  }
+
+  function routeRow(r) {
+    var btn = el("button", {
+      class: "route-row",
+      "data-route": r.routeName,
+      "data-filter": (r.routeLabel + " " + r.routeName + " " + r.routePath).toLowerCase(),
+      title: r.routeLabel + " \\u2014 " + r.statusLabel
+    });
+    var dotCls = "dot";
+    if (r.errored) dotCls += " errored";
+    else if (r.changed) dotCls += " changed";
+    else if (r.copyChanged) dotCls += " copy";
+    btn.appendChild(el("div", { class: "r-top" }, [
+      el("span", { class: dotCls }),
+      el("span", { class: "r-label", text: r.routeLabel }),
+      el("span", { class: "r-verdict", "data-verdict-for": r.routeName, text: verdictMark(verdictOf(r)) })
+    ]));
+
+    var badges = el("div", { class: "r-badges", "data-badges-for": r.routeName });
+    fillRouteBadges(badges, r);
+    if (badges.childNodes.length) btn.appendChild(badges);
+    btn.addEventListener("click", function () { selectRoute(r.routeName); });
+    return btn;
+  }
+
+  function fillRouteBadges(container, r) {
+    container.innerHTML = "";
+    (r.pairs || []).forEach(function (p) {
+      var initial = String(p.projectLabel || p.projectName || "?").charAt(0).toUpperCase();
+      var cls = "badge";
+      if (p.errored) cls += " err";
+      else if (pairIsHot(p)) cls += " hot";
+      container.appendChild(el("span", {
+        class: cls,
+        title: (p.projectLabel || p.projectName) + ": " + (p.diffLabel || (p.missing ? "missing" : "")),
+        text: initial + " " + (p.missing ? "\\u2014" : pctOf(p.diffLabel))
+      }));
+    });
+    if (!(r.pairs || []).length) {
+      container.appendChild(el("span", { class: "badge", title: r.statusLabel, text: "no shots" }));
+    }
+    var c = r.markdownDiff;
+    if (r.copyChanged && c) {
+      var b = el("span", { class: "badge copy", title: "Copy changed: +" + c.addedLines + " / \\u2212" + c.removedLines });
+      b.innerHTML = 'copy <span class="plus">+' + Number(c.addedLines) + '</span> <span class="minus">\\u2212' + Number(c.removedLines) + "</span>";
+      container.appendChild(b);
+    }
+  }
+
+  function refreshRailBadges() {
+    routes.forEach(function (r) {
+      var c = document.querySelector('[data-badges-for="' + cssEscape(r.routeName) + '"]');
+      if (c) fillRouteBadges(c, r);
+    });
+  }
+  function refreshRailMarks() {
+    routes.forEach(function (r) {
+      var m = document.querySelector('[data-verdict-for="' + cssEscape(r.routeName) + '"]');
+      if (m) m.textContent = verdictMark(verdictOf(r));
+    });
+  }
+
+  function applyFilter() {
+    var inp = document.getElementById("route-filter");
+    var q = inp ? inp.value.trim().toLowerCase() : "";
+    document.querySelectorAll(".rail-group").forEach(function (group) {
+      var visible = 0;
+      group.querySelectorAll(".route-row").forEach(function (row) {
+        var show = !q || row.getAttribute("data-filter").indexOf(q) !== -1;
+        row.style.display = show ? "" : "none";
+        if (show) visible++;
+      });
+      var total = Number(group.getAttribute("data-total"));
+      var h = group.querySelector(".rail-group-h");
+      if (h && h.tagName !== "BUTTON") {
+        h.textContent = group.getAttribute("data-title") + " (" + (visible < total ? visible + "/" + total : String(total)) + ")";
+      }
+      if (group.getAttribute("data-key") !== "cold") group.style.display = visible ? "" : "none";
+    });
+  }
+
+  function visibleRows() {
+    return Array.prototype.filter.call(document.querySelectorAll(".route-row"), function (r) {
+      return r.style.display !== "none" && r.offsetParent !== null;
+    });
+  }
+  // Route order for j/k and verdict auto-advance. Rail rows when visible;
+  // otherwise (mobile, rail accordion closed) the same grouped order the rail would show.
+  function navNames() {
+    var rows = visibleRows();
+    if (rows.length) return rows.map(function (row) { return row.getAttribute("data-route"); });
+    var changed = routes.filter(function (r) { return groupOf(r) === "changed"; });
+    var copy = routes.filter(function (r) { return groupOf(r) === "copy"; });
+    var cold = coldOpen ? routes.filter(function (r) { return groupOf(r) === "cold"; }) : [];
+    return changed.concat(copy, cold).map(function (r) { return r.routeName; });
+  }
+  function markSelectedRow() {
+    document.querySelectorAll(".route-row").forEach(function (row) {
+      var sel = row.getAttribute("data-route") === selectedName;
+      row.classList.toggle("selected", sel);
+      if (sel && row.scrollIntoView) row.scrollIntoView({ block: "nearest" });
+    });
+  }
+
+  /* ---------------- selection ---------------- */
+  function selectRoute(name, opts) {
+    opts = opts || {};
+    var r = routeByName(name);
+    if (!r) return;
+    selectedName = name;
+    pairName = (opts.pair && pairOf(r, opts.pair)) ? opts.pair : defaultPairFor(r);
+    if (opts.mode) cmpMode = opts.mode;
+    else if (!cmpMode) cmpMode = defaultModeFor(pairOf(r, pairName));
+    hunkPointer = -1;
+    if (!opts.skipHash) history.replaceState(null, "", "#route=" + encodeURIComponent(name));
+    markSelectedRow();
+    var sel = document.getElementById("rail-toggle-sel");
+    if (sel) sel.textContent = "\\u00b7 " + r.routeLabel;
+    if (isMobile()) {
+      document.body.classList.remove("rail-open");
+      document.getElementById("rail-toggle").setAttribute("aria-expanded", "false");
+    }
+    renderPane(false, opts.hunk);
+  }
+
+  /* ---------------- pane ---------------- */
+  function renderPane(keepScroll, focusHunk) {
+    var pane = document.getElementById("pane");
+    var y = keepScroll ? pane.scrollTop : 0;
+    pane.innerHTML = "";
+    minimap = null;
+    fullWells = null;
+    var r = routeByName(selectedName);
+    if (!r) { pane.textContent = "No route selected."; return; }
+
+    var content = el("div", { id: "pane-content" });
+    pane.appendChild(content);
+
+    // head
+    var v = verdictOf(r);
+    var headBits = [
+      el("h2", { text: r.routeLabel }),
+      el("span", { class: "path", text: r.routePath }),
+      el("span", { class: "auth", text: r.authState }),
+      el("span", { class: "auth", text: r.statusLabel })
+    ];
+    if (v) headBits.push(el("span", {
+      class: "auth " + (v.v === "looks-right" ? "v-good" : v.v === "needs-work" ? "v-bad" : ""),
+      text: verdictMark(v) + " " + (v.v === "looks-right" ? "looks right" : v.v === "needs-work" ? "needs work" : "skipped")
+    }));
+    content.appendChild(el("div", { class: "route-head" }, headBits));
+
+    var metaRow = el("div", { class: "route-meta" });
+    metaRow.appendChild(el("span", { text: "Preview:" }));
+    var previewUrl = r.routeUrl || joinRouteUrl(meta.previewBaseUrl, r.routePath);
+    if (previewUrl) {
+      metaRow.appendChild(el("a", { href: previewUrl, target: "_blank", rel: "noopener", text: previewUrl, title: previewUrl }));
+      var cp = el("button", { type: "button", class: "copy-url", text: "Copy" });
+      cp.addEventListener("click", function () {
+        copyText(previewUrl, function (ok) {
+          cp.textContent = ok ? "Copied" : "Copy failed";
+          setTimeout(function () { cp.textContent = "Copy"; }, 1500);
+        });
+      });
+      metaRow.appendChild(cp);
+    } else {
+      metaRow.appendChild(el("span", { text: "n/a" }));
+    }
+    content.appendChild(metaRow);
+
+    if (r.errored) {
+      content.appendChild(el("div", { class: "err-note", text: "This route errored during capture: " + r.statusLabel }));
+    }
+
+    var hasPairs = (r.pairs || []).length > 0;
+    if (hasPairs) {
+      var pair = pairOf(r, pairName) || r.pairs[0];
+      pairName = pair.projectName;
+
+      // toolbar: viewport + comparator mode
+      var toolbar = el("div", { class: "toolbar" });
+      toolbar.appendChild(el("span", { class: "seg-label", text: "Viewport" }));
+      toolbar.appendChild(segControl(
+        r.pairs.map(function (p) { return { v: p.projectName, t: p.projectLabel || p.projectName }; }),
+        function () { return pairName; },
+        function (val) { pairName = val; hunkPointer = -1; renderPane(true); }
+      ));
+      toolbar.appendChild(el("span", { class: "seg-label", text: "Compare" }));
+      var hunkCount = visibleHunks(pair).length;
+      toolbar.appendChild(segControl(
+        [
+          { v: "hunks", t: "Hunks" + ((pair.hunks || []).length ? " (" + hunkCount + ")" : "") },
+          { v: "full", t: "Full page" },
+          { v: "swipe", t: "Swipe" },
+          { v: "onion", t: "Onion skin" },
+          { v: "overlay", t: "Overlay", disabled: !pair.diffRelPath }
+        ],
+        function () { return cmpMode; },
+        function (val) { cmpMode = val; renderPane(true); }
+      ));
+      content.appendChild(toolbar);
+
+      var info = el("p", { class: "vp-info" });
+      info.innerHTML = "<b>" + esc(pair.projectLabel || pair.projectName) + ":</b> " + esc(pair.diffLabel || "no diff data") +
+        (noise && (pair.hunks || []).length ? " \\u00b7 noise filter hides hunks under " + noise + "%" : "");
+      content.appendChild(info);
+
+      var cmpCard = el("section", { class: "card" }, [
+        el("h3", { text: "Screenshots \\u2014 before (" + (meta.baselineDescription || "baseline") + ") vs after (PR)" })
+      ]);
+      if (pair.errored) {
+        cmpCard.appendChild(el("div", { class: "err-note", text: "This capture errored \\u2014 " + (pair.diffLabel || "no image pair.") }));
+      }
+      if (pair.missing) {
+        cmpCard.appendChild(el("div", { class: "img-missing", text: "No screenshots for this viewport." }));
+      } else {
+        cmpCard.appendChild(buildComparator(r, pair));
+      }
+      content.appendChild(cmpCard);
+    } else {
+      content.appendChild(el("section", { class: "card" }, [
+        el("h3", { text: "Screenshots" }),
+        el("div", { class: "img-missing", text: "This route was not in the screenshot run \\u2014 no before/after images exist. The copy diff below is the whole story." })
+      ]));
+    }
+
+    content.appendChild(buildCopyDiff(r));
+    content.appendChild(buildLiveCompare(r));
+
+    pane.appendChild(buildVerdictBar(r));
+    pane.scrollTop = y;
+
+    if (typeof focusHunk === "number" && cmpMode === "hunks") {
+      setTimeout(function () { jumpToHunk(focusHunk, true); }, 60);
+    }
+  }
+
+  function segControl(options, get, set) {
+    var seg = el("div", { class: "seg", role: "group" });
+    options.forEach(function (o) {
+      var attrs = { type: "button", "aria-pressed": String(get() === o.v), text: o.t };
+      if (o.disabled) attrs.disabled = "disabled";
+      var b = el("button", attrs);
+      if (!o.disabled) b.addEventListener("click", function () { set(o.v); });
+      seg.appendChild(b);
+    });
+    return seg;
+  }
+
+  function copyText(text, done) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () { done(true); }, function () { done(false); });
+    } else done(false);
+  }
+
+  function lazyImg(src, cls, alt) {
+    return el("img", { src: src, loading: "lazy", alt: alt || "", class: cls || "" });
+  }
+
+  /* ---------------- comparator dispatch ---------------- */
+  function buildComparator(r, pair) {
+    var row = el("div", { class: "cmp-row" });
+    var main = el("div", { class: "cmp-main" });
+    var mm = buildMinimap(r, pair);
+    row.appendChild(main);
+    if (mm) row.appendChild(mm.el);
+    minimap = mm;
+
+    if (cmpMode === "hunks") main.appendChild(buildHunksMode(r, pair));
+    else if (cmpMode === "full") main.appendChild(buildFullMode(r, pair));
+    else if (cmpMode === "overlay") main.appendChild(buildOverlayMode(r, pair));
+    else main.appendChild(buildStageMode(r, pair)); // swipe / onion
+    return row;
+  }
+
+  /* ---------------- hunk strips ---------------- */
+  function stripHtml(relPath, imgW, imgH, y0, y1, alt) {
+    if (!relPath || !imgW || !imgH || y1 <= y0) {
+      return '<div class="hatch">no image</div>';
+    }
+    var shift = (y0 / imgH) * 100;
+    return '<div class="strip" style="aspect-ratio:' + imgW + '/' + (y1 - y0) + '">' +
+      '<img loading="lazy" src="' + esc(relPath) + '" alt="' + esc(alt || "") + '"' +
+      ' style="transform:translateY(-' + shift.toFixed(4) + '%)"></div>';
+  }
+  function clampBand(y0, y1, imgH, pad) {
+    return [Math.max(0, y0 - pad), imgH ? Math.min(imgH, y1 + pad) : y1 + pad];
+  }
+
+  function buildHunksMode(r, pair) {
+    var wrap = el("div");
+    var hunks = pair.hunks || [];
+    var hv = visibleHunks(pair);
+
+    if (!hunks.length) {
+      // no hunk data: plain full-image side-by-side fallback (v2 style)
+      wrap.appendChild(el("p", {
+        class: "no-copy",
+        text: pair.changed
+          ? "No hunk data for this pair \\u2014 showing full images."
+          : "No visual change reported for this viewport. Full images below for the suspicious."
+      }));
+      var grid = el("div", { class: "sbs" });
+      [["Before", pair.beforeRelPath], ["After", pair.afterRelPath]].forEach(function (d) {
+        var fig = el("figure", {}, [el("figcaption", { text: d[0] })]);
+        if (d[1]) {
+          var img = lazyImg(d[1], "", d[0]);
+          img.addEventListener("error", function () {
+            fig.innerHTML = "";
+            fig.appendChild(el("div", { class: "img-missing", text: d[0] + ": image unavailable." }));
+          });
+          fig.appendChild(img);
+        } else {
+          fig.appendChild(el("div", { class: "img-missing", text: d[0] + ": no image." }));
+        }
+        grid.appendChild(fig);
+      });
+      wrap.appendChild(grid);
+      return wrap;
+    }
+
+    if (!hv.length) {
+      var note = el("p", { class: "no-copy" });
+      note.textContent = "All " + hunks.length + " hunks are below the " + noise + "% noise threshold.";
+      var reset = el("button", { type: "button", class: "gap-btn", text: "Show them anyway" });
+      reset.addEventListener("click", function () {
+        noise = 0;
+        document.getElementById("noise").value = "0";
+        refreshRailBadges();
+        renderPane(true);
+      });
+      wrap.appendChild(note);
+      wrap.appendChild(reset);
+      return wrap;
+    }
+
+    var scroll = el("div", { class: "cmp-scroll", "data-cmp-scroll": "" });
+    scroll.appendChild(el("div", { class: "hunk-cols" }, [
+      el("span", { text: "Before \\u2014 baseline" }),
+      el("span", { text: "After \\u2014 this PR" })
+    ]));
+
+    var bW = pair.beforeWidth, bH = pair.beforeHeight;
+    var aW = pair.afterWidth, aH = pair.afterHeight;
+    var prevBeforeEnd = 0, prevAfterEnd = 0;
+
+    hv.forEach(function (entry) {
+      var h = entry.h, origIdx = entry.i;
+      // collapsed identical region before this hunk
+      appendGapRow(scroll, pair, prevBeforeEnd, h.before.yStart, prevAfterEnd, h.after.yStart);
+      prevBeforeEnd = Math.max(prevBeforeEnd, h.before.yEnd);
+      prevAfterEnd = Math.max(prevAfterEnd, h.after.yEnd);
+
+      var block = el("div", { class: "hunk-block", id: "hunk-" + origIdx });
+      var head = el("div", { class: "hunk-head" });
+      head.appendChild(el("span", { class: "hk", text: "Hunk " + (origIdx + 1) + "/" + hunks.length }));
+      head.appendChild(el("span", { class: "kind-" + h.kind, text: h.kind }));
+      if (h.pctOfPage != null) head.appendChild(el("span", { text: fmtPct(h.pctOfPage) + "% of page" }));
+      head.appendChild(el("span", {
+        text: "before " + fmtPx(h.before.yStart) + "\\u2013" + fmtPx(h.before.yEnd) +
+          "px \\u2192 after " + fmtPx(h.after.yStart) + "\\u2013" + fmtPx(h.after.yEnd) + "px"
+      }));
+      var link = el("button", { type: "button", class: "hunk-link", title: "Copy permalink to this hunk", text: "\\uD83D\\uDD17 link" });
+      link.addEventListener("click", function () {
+        copyText(hunkPermalink(r.routeName, pair.projectName, origIdx), function (ok) {
+          link.textContent = ok ? "Copied" : "Copy failed";
+          setTimeout(function () { link.textContent = "\\uD83D\\uDD17 link"; }, 1500);
+        });
+      });
+      head.appendChild(link);
+      block.appendChild(head);
+
+      var grid = el("div", { class: "hunk-grid" });
+      // before column
+      var beforeCell = el("div");
+      beforeCell.appendChild(el("div", { class: "strip-cap", text: "before" }));
+      if (h.kind === "inserted") {
+        var ph = el("div", { class: "hatch", text: "inserted \\u2014 nothing here before" });
+        if (aW && (h.after.yEnd - h.after.yStart) > 0) {
+          ph.style.aspectRatio = aW + "/" + (h.after.yEnd - h.after.yStart + 2 * STRIP_CONTEXT_PX);
+        }
+        beforeCell.appendChild(ph);
+      } else {
+        var bBand = clampBand(h.before.yStart, h.before.yEnd, bH, STRIP_CONTEXT_PX);
+        beforeCell.appendChild(el("div", { html: stripHtml(pair.beforeRelPath, bW, bH, bBand[0], bBand[1], "Before hunk " + (origIdx + 1)) }));
+      }
+      grid.appendChild(beforeCell);
+      // after column
+      var afterCell = el("div");
+      afterCell.appendChild(el("div", { class: "strip-cap", text: "after" }));
+      if (h.kind === "deleted") {
+        var ph2 = el("div", { class: "hatch", text: "deleted \\u2014 gone in this PR" });
+        if (bW && (h.before.yEnd - h.before.yStart) > 0) {
+          ph2.style.aspectRatio = bW + "/" + (h.before.yEnd - h.before.yStart + 2 * STRIP_CONTEXT_PX);
+        }
+        afterCell.appendChild(ph2);
+      } else {
+        var aBand = clampBand(h.after.yStart, h.after.yEnd, aH, STRIP_CONTEXT_PX);
+        afterCell.appendChild(el("div", { html: stripHtml(pair.afterRelPath, aW, aH, aBand[0], aBand[1], "After hunk " + (origIdx + 1)) }));
+      }
+      grid.appendChild(afterCell);
+      block.appendChild(grid);
+      scroll.appendChild(block);
+    });
+
+    // trailing identical region
+    appendGapRow(scroll, pair, prevBeforeEnd, bH || prevBeforeEnd, prevAfterEnd, aH || prevAfterEnd);
+
+    wrap.appendChild(scroll);
+    return wrap;
+  }
+
+  function appendGapRow(container, pair, b0, b1, a0, a1) {
+    var gapPx = Math.max(0, a1 - a0);
+    if (gapPx < 24) return;
+    var row = el("div", { class: "gap-row" });
+    var open = false;
+    function render() {
+      row.innerHTML = "";
+      var btn = el("button", {
+        type: "button", class: "gap-btn",
+        text: (open ? "\\u25be " : "\\u25b8 ") + fmtPx(gapPx) + "px identical \\u2014 " + (open ? "collapse" : "expand")
+      });
+      btn.addEventListener("click", function () { open = !open; render(); });
+      row.appendChild(btn);
+      if (open) {
+        var grid = el("div", { class: "hunk-grid gap-open" });
+        var beforeCell = el("div");
+        beforeCell.appendChild(el("div", { class: "strip-cap", text: "before" }));
+        beforeCell.appendChild(el("div", { html: stripHtml(pair.beforeRelPath, pair.beforeWidth, pair.beforeHeight, b0, b1, "Identical region (before)") }));
+        var afterCell = el("div");
+        afterCell.appendChild(el("div", { class: "strip-cap", text: "after" }));
+        afterCell.appendChild(el("div", { html: stripHtml(pair.afterRelPath, pair.afterWidth, pair.afterHeight, a0, a1, "Identical region (after)") }));
+        grid.appendChild(beforeCell);
+        grid.appendChild(afterCell);
+        row.appendChild(grid);
+      }
+    }
+    render();
+    container.appendChild(row);
+  }
+
+  /* ---------------- full page: linked scrolling ---------------- */
+  function buildFullMode(r, pair) {
+    var wrap = el("div");
+    wrap.appendChild(el("div", { class: "cmp-hint", text: "Scroll either side \\u2014 the other follows via alignment anchors, not naive percentage." }));
+    var grid = el("div", { class: "full-grid" });
+    var anchors = anchorsFor(pair);
+    var wells = {};
+
+    [["before", "Before \\u2014 baseline", pair.beforeRelPath, pair.beforeHeight],
+     ["after", "After \\u2014 this PR", pair.afterRelPath, pair.afterHeight]].forEach(function (d) {
+      var fig = el("figure", {}, [el("figcaption", { text: d[1] })]);
+      var well = el("div", { class: "well", "data-well": d[0] });
+      if (d[2]) {
+        var img = lazyImg(d[2], "", d[1]);
+        img.addEventListener("error", function () {
+          well.innerHTML = "";
+          well.appendChild(el("div", { class: "img-missing", text: d[1] + ": image unavailable." }));
+        });
+        well.appendChild(img);
+        wells[d[0]] = { well: well, img: img, imgH: d[3] };
+      } else {
+        well.appendChild(el("div", { class: "img-missing", text: d[1] + ": no image." }));
+      }
+      fig.appendChild(well);
+      grid.appendChild(fig);
+    });
+    wrap.appendChild(grid);
+
+    if (wells.before && wells.after) {
+      wireLinkedScroll(wells.before, wells.after, anchors);
+    }
+    return wrap;
+  }
+
+  function wireLinkedScroll(b, a, anchors) {
+    // the driver is whichever well the pointer/touch/wheel is on;
+    // its scroll handler maps its image-space y through the anchors
+    var active = null;
+    function arm(side) {
+      ["pointerenter", "wheel", "touchstart"].forEach(function (evt) {
+        side.well.addEventListener(evt, function () { active = side; }, { passive: true });
+      });
+    }
+    arm(b); arm(a);
+    function imgYOf(side) {
+      var hPx = side.img.clientHeight || 1;
+      var hNat = side.imgH || side.img.naturalHeight || hPx;
+      return (side.well.scrollTop / hPx) * hNat;
+    }
+    function setImgY(side, yImg) {
+      var hPx = side.img.clientHeight || 1;
+      var hNat = side.imgH || side.img.naturalHeight || hPx;
+      side.well.scrollTop = (yImg / hNat) * hPx;
+    }
+    b.well.addEventListener("scroll", function () {
+      if (active === b) setImgY(a, mapY(imgYOf(b), anchors, "beforeY", "afterY"));
+      updateMinimapView(a);
+    });
+    a.well.addEventListener("scroll", function () {
+      if (active === a) setImgY(b, mapY(imgYOf(a), anchors, "afterY", "beforeY"));
+      updateMinimapView(a);
+    });
+    updateMinimapView(a);
+    fullWells = { b: b, a: a, anchors: anchors };
+  }
+
+  function updateMinimapView(side) {
+    if (!minimap) return;
+    var hPx = side.img.clientHeight || 1;
+    minimap.update(side.well.scrollTop / hPx, side.well.clientHeight / hPx);
+  }
+
+  /* ---------------- swipe / onion (shared overlay stage) ---------------- */
+  function buildStageMode(r, pair) {
+    var wrap = el("div");
+    if (!pair.beforeRelPath || !pair.afterRelPath) {
+      wrap.appendChild(el("div", { class: "img-missing", text: "Overlay compare needs both images \\u2014 one is missing. Try Hunks or Full page." }));
+      return wrap;
+    }
+    var isNarrowVp = (pair.beforeWidth || 1000) <= 500;
+    var scroll = el("div", { class: "cmp-scroll", "data-cmp-scroll": "" });
+    var stage = el("div", { class: "cmp-stage" + (isNarrowVp && !isMobile() ? " vp-narrow" : "") + (cmpMode === "swipe" ? " mode-swipe" : "") });
+    var imgB = lazyImg(pair.beforeRelPath, "img-base", "Before");
+    var imgA = lazyImg(pair.afterRelPath, "img-top", "After");
+    var deadNote = function (which) {
+      stage.innerHTML = "";
+      stage.appendChild(el("div", { class: "img-missing", text: which + " image unavailable \\u2014 overlay compare needs both. Try Hunks." }));
+    };
+    imgB.addEventListener("error", function () { deadNote("Before"); });
+    imgA.addEventListener("error", function () { deadNote("After"); });
+    stage.appendChild(imgB);
+    stage.appendChild(imgA);
+    scroll.appendChild(stage);
+    scroll.addEventListener("scroll", function () { updateStageMinimap(scroll, imgB); });
+    imgB.addEventListener("load", function () { updateStageMinimap(scroll, imgB); });
+
+    if (cmpMode === "swipe") {
+      var applyClip = function () { imgA.style.clipPath = "inset(0 0 0 " + swipePos + "%)"; };
+      applyClip();
+      var handle = el("div", { class: "swipe-handle", style: "left:" + swipePos + "%" });
+      var pill = el("span", { class: "swipe-pill", text: "\\u25c2 \\u25b8", "aria-hidden": "true" });
+      handle.appendChild(pill);
+      stage.appendChild(handle);
+      var placePill = function () {
+        var visible = Math.min(scroll.clientHeight || 0, stage.offsetHeight || 0);
+        pill.style.top = (scroll.scrollTop + Math.max(40, visible * 0.4)) + "px";
+      };
+      scroll.addEventListener("scroll", placePill);
+      imgB.addEventListener("load", placePill);
+      placePill();
+      var dragging = false;
+      var setPos = function (clientX) {
+        var rect = stage.getBoundingClientRect();
+        var p = ((clientX - rect.left) / rect.width) * 100;
+        swipePos = Math.max(1, Math.min(99, p));
+        applyClip();
+        handle.style.left = swipePos + "%";
+      };
+      stage.addEventListener("pointerdown", function (e) {
+        dragging = true;
+        stage.classList.add("swiping");
+        stage.setPointerCapture(e.pointerId);
+        setPos(e.clientX);
+        e.preventDefault();
+      });
+      stage.addEventListener("pointermove", function (e) { if (dragging) setPos(e.clientX); });
+      stage.addEventListener("pointerup", function () { dragging = false; stage.classList.remove("swiping"); });
+      stage.addEventListener("pointercancel", function () { dragging = false; stage.classList.remove("swiping"); });
+      wrap.appendChild(el("div", { class: "cmp-hint", text: "Drag the divider. Left of the line is the baseline (before); right is this PR (after)." }));
+      wrap.appendChild(scroll);
+    } else { // onion
+      imgA.style.opacity = String(onionOpacity / 100);
+      var ctl = el("div", { class: "onion-ctl" });
+      ctl.appendChild(el("span", { text: "Before" }));
+      var range = el("input", { type: "range", min: "0", max: "100", value: String(onionOpacity), "aria-label": "After image opacity" });
+      range.addEventListener("input", function () {
+        onionOpacity = Number(range.value);
+        imgA.style.opacity = String(onionOpacity / 100);
+      });
+      ctl.appendChild(range);
+      ctl.appendChild(el("span", { text: "After" }));
+      wrap.appendChild(ctl);
+      wrap.appendChild(scroll);
+    }
+    return wrap;
+  }
+
+  function updateStageMinimap(scroll, baseImg) {
+    if (!minimap) return;
+    var h = baseImg.clientHeight || scroll.scrollHeight || 1;
+    minimap.update(scroll.scrollTop / h, scroll.clientHeight / h);
+  }
+
+  /* ---------------- overlay: after + diff PNG composite ---------------- */
+  function buildOverlayMode(r, pair) {
+    var wrap = el("div");
+    if (!pair.diffRelPath || !pair.afterRelPath) {
+      wrap.appendChild(el("div", { class: "img-missing", text: "No pixel-diff image for this pair \\u2014 Overlay has nothing to composite." }));
+      return wrap;
+    }
+    var ctl = el("div", { class: "overlay-ctl" });
+    ctl.appendChild(el("span", { text: "Diff composite:" }));
+    ctl.appendChild(segControl(
+      [{ v: "blend", t: "Multiply" }, { v: "tint", t: "55% opacity" }],
+      function () { return overlayStyle; },
+      function (val) { overlayStyle = val; renderPane(true); }
+    ));
+    wrap.appendChild(ctl);
+
+    var scroll = el("div", { class: "cmp-scroll", "data-cmp-scroll": "" });
+    var stage = el("div", { class: "cmp-stage" });
+    var imgA = lazyImg(pair.afterRelPath, "", "After");
+    var imgD = lazyImg(pair.diffRelPath, "img-top" + (overlayStyle === "blend" ? " blend" : ""), "Pixel diff overlay");
+    if (overlayStyle === "tint") imgD.style.opacity = "0.55";
+    imgD.addEventListener("error", function () {
+      stage.innerHTML = "";
+      stage.appendChild(el("div", { class: "img-missing", text: "Diff image unavailable." }));
+    });
+    stage.appendChild(imgA);
+    stage.appendChild(imgD);
+    scroll.appendChild(stage);
+    scroll.addEventListener("scroll", function () { updateStageMinimap(scroll, imgA); });
+    imgA.addEventListener("load", function () { updateStageMinimap(scroll, imgA); });
+    wrap.appendChild(scroll);
+    return wrap;
+  }
+
+  /* ---------------- minimap ---------------- */
+  function buildMinimap(r, pair) {
+    if (!pair || pair.missing || !(pair.hunks || []).length) return null;
+    var aH = pair.afterHeight || 1;
+    var node = el("div", { class: "mm", title: "Diff minimap \\u2014 click a band to jump; n/p step hunks", role: "img", "aria-label": "Diff minimap" });
+    var hv = visibleHunks(pair);
+    hv.forEach(function (entry) {
+      var h = entry.h;
+      var y0 = h.after.yStart, y1 = h.after.yEnd;
+      if (y1 <= y0) { y0 = h.before.yStart; y1 = h.before.yEnd; } // deleted: place at before-side position
+      var band = el("div", { class: "mm-band", "data-hunk": String(entry.i), title: "Hunk " + (entry.i + 1) + " \\u00b7 " + h.kind });
+      band.style.setProperty("--start", String(Math.min(1, y0 / aH)));
+      band.style.setProperty("--len", String(Math.max(0.002, (y1 - y0) / aH)));
+      node.appendChild(band);
+    });
+    var view = el("div", { class: "mm-view" });
+    node.appendChild(view);
+
+    node.addEventListener("click", function (e) {
+      var rect = node.getBoundingClientRect();
+      var horizontal = rect.width > rect.height;
+      var frac = horizontal
+        ? (e.clientX - rect.left) / rect.width
+        : (e.clientY - rect.top) / rect.height;
+      var bestI = -1, bestDist = Infinity;
+      hv.forEach(function (entry) {
+        var mid = ((entry.h.after.yStart + entry.h.after.yEnd) / 2) / aH;
+        var d = Math.abs(mid - frac);
+        if (d < bestDist) { bestDist = d; bestI = entry.i; }
+      });
+      if (bestI >= 0) jumpToHunk(bestI, true);
+    });
+
+    return {
+      el: node,
+      update: function (startFrac, lenFrac) {
+        view.style.setProperty("--start", String(Math.max(0, Math.min(1, startFrac))));
+        view.style.setProperty("--len", String(Math.max(0, Math.min(1, lenFrac))));
+      },
+      setActive: function (origIdx) {
+        node.querySelectorAll(".mm-band").forEach(function (bEl) {
+          bEl.classList.toggle("active", bEl.getAttribute("data-hunk") === String(origIdx));
+        });
+      }
+    };
+  }
+
+  function jumpToHunk(origIdx, flash) {
+    var r = routeByName(selectedName);
+    var pair = pairOf(r, pairName);
+    if (!pair) return;
+    var h = (pair.hunks || [])[origIdx];
+    if (!h) return;
+    hunkPointer = visibleHunks(pair).findIndex(function (entry) { return entry.i === origIdx; });
+    if (minimap) minimap.setActive(origIdx);
+
+    if (cmpMode === "hunks") {
+      var block = document.getElementById("hunk-" + origIdx);
+      if (block) {
+        block.scrollIntoView({ block: "center", behavior: "smooth" });
+        if (flash) {
+          block.classList.remove("flash");
+          void block.offsetWidth; // restart the animation
+          block.classList.add("flash");
+        }
+      }
+      return;
+    }
+    if (cmpMode === "full" && fullWells) {
+      var a = fullWells.a;
+      var hPx = a.img.clientHeight || 1;
+      var hNat = a.imgH || a.img.naturalHeight || hPx;
+      a.well.scrollTop = Math.max(0, (h.after.yStart / hNat) * hPx - 40);
+      var bY = mapY(h.after.yStart, fullWells.anchors, "afterY", "beforeY");
+      var b = fullWells.b;
+      var bPx = b.img.clientHeight || 1;
+      var bNat = b.imgH || b.img.naturalHeight || bPx;
+      b.well.scrollTop = Math.max(0, (bY / bNat) * bPx - 40);
+      return;
+    }
+    // swipe / onion / overlay: single stage scroll container
+    var scroll = document.querySelector("[data-cmp-scroll]");
+    if (scroll) {
+      var stageImg = scroll.querySelector("img");
+      var sPx = stageImg ? stageImg.clientHeight : scroll.scrollHeight;
+      var sNat = pair.afterHeight || (stageImg && stageImg.naturalHeight) || sPx || 1;
+      scroll.scrollTop = Math.max(0, (h.after.yStart / sNat) * sPx - 40);
+    }
+  }
+
+  function stepHunk(dir) {
+    var r = routeByName(selectedName);
+    var pair = pairOf(r, pairName);
+    if (!pair) return;
+    var hv = visibleHunks(pair);
+    if (!hv.length) return;
+    hunkPointer = (hunkPointer + dir + hv.length) % hv.length;
+    var target = hv[hunkPointer];
+    if (target) jumpToHunk(target.i, true);
+  }
+
+  /* ---------------- copy diff ---------------- */
+  function buildCopyDiff(r) {
+    var card = el("section", { class: "card" }, [el("h3", { text: "Copy diff" })]);
+    var d = r.markdownDiff;
+    if (!d) {
+      card.appendChild(el("p", { class: "no-copy", text: "No copy changes on this route." }));
+      return card;
+    }
+    var head = el("div", { class: "cmp-hint" });
+    head.innerHTML = '<span class="badge copy">copy changed <span class="plus">+' + Number(d.addedLines) +
+      '</span> / <span class="minus">\\u2212' + Number(d.removedLines) + "</span></span>";
+    card.appendChild(head);
+
+    if (d.metaChanges && d.metaChanges.length) {
+      var tbl = el("table", { class: "meta-table" });
+      tbl.appendChild(el("tr", {}, [
+        el("th", { text: "Field" }), el("th", { text: "Before" }), el("th", { text: "After" })
+      ]));
+      d.metaChanges.forEach(function (mc) {
+        tbl.appendChild(el("tr", {}, [
+          el("td", { text: String(mc.field != null ? mc.field : "") }),
+          el("td", { class: "b", text: String(mc.before != null ? mc.before : "") }),
+          el("td", { class: "a", text: String(mc.after != null ? mc.after : "") })
+        ]));
+      });
+      card.appendChild(el("div", { class: "tbl-scroll" }, [tbl]));
+    }
+
+    var view = el("div", { class: "diff-view" });
+    (d.lines || []).forEach(function (line) {
+      var cls = "ln";
+      if (line.kind === "hunk") cls += " hunk";
+      else if (line.kind === "header") cls += " meta";
+      else if (line.kind === "add") cls += " add";
+      else if (line.kind === "del") cls += " del";
+      view.appendChild(el("div", { class: cls, text: line.text === "" ? " " : line.text }));
+    });
+    card.appendChild(view);
+    return card;
+  }
+
+  /* ---------------- live compare ---------------- */
+  function buildLiveCompare(r) {
+    var card = el("section", { class: "card" }, [el("h3", { text: "Live compare" })]);
+    var prodUrl = joinRouteUrl(meta.productionBaseUrl, r.routePath);
+    var prevUrl = r.routeUrl || joinRouteUrl(meta.previewBaseUrl, r.routePath);
+    if (!prodUrl && !prevUrl) {
+      card.appendChild(el("p", {
+        class: "no-copy",
+        text: "No live page URL for this artifact."
+      }));
+      return card;
+    }
+
+    var btn = el("button", {
+      type: "button", class: "live-btn", "data-live-toggle": "", "aria-pressed": "false",
+      text: "Load live compare (production + preview link)"
+    });
+    var mount = el("div");
+    btn.addEventListener("click", function () {
+      var on = btn.getAttribute("aria-pressed") === "true";
+      if (on) {
+        mount.innerHTML = "";
+        btn.setAttribute("aria-pressed", "false");
+        btn.textContent = "Load live compare (production + preview link)";
+        return;
+      }
+      btn.setAttribute("aria-pressed", "true");
+      btn.textContent = "Unload live compare";
+
+      var note = el("div", { class: "live-note" });
+      note.textContent = "Production is live in the frame below. The preview deploy cannot be embedded \\u2014 " +
+        "Vercel deployment protection (SSO) blocks iframes \\u2014 so it opens in a new tab instead. " +
+        "Iframes load with whatever session your browser has.";
+      mount.appendChild(note);
+
+      var grid = el("div", { class: "live-grid" });
+      var prodCol = el("div", {}, [el("div", { class: "live-label", text: "Production (old)" })]);
+      prodCol.appendChild(el("iframe", { src: prodUrl, title: "Production \\u2014 " + r.routeLabel, loading: "lazy" }));
+      grid.appendChild(prodCol);
+
+      var prevCol = el("div", {}, [el("div", { class: "live-label", text: "Preview deploy (new)" })]);
+      var panel = el("div", { class: "preview-panel" });
+      panel.appendChild(el("a", { class: "preview-open", href: prevUrl, target: "_blank", rel: "noopener", text: "Open preview in new tab \\u2197" }));
+      panel.appendChild(el("p", { text: "Vercel deployment protection blocks embedding \\u2014 the preview deploy refuses to render inside an iframe, so this side opens in a new tab." }));
+      panel.appendChild(el("p", { html: '<a href="' + esc(prodUrl) + '" target="_blank" rel="noopener">Open production in a tab too</a> for a same-size A/B.' }));
+      prevCol.appendChild(panel);
+      grid.appendChild(prevCol);
+      mount.appendChild(grid);
+    });
+
+    card.appendChild(btn);
+    card.appendChild(mount);
+    return card;
+  }
+
+  /* ---------------- verdict bar ---------------- */
+  function buildVerdictBar(r) {
+    var bar = el("div", { class: "verdict-bar" });
+    var v = verdictOf(r);
+    var good = el("button", { type: "button", class: "vbtn btn-good" + (v && v.v === "looks-right" ? " on" : ""), title: "Verdict: looks right (key: 1)", text: "Looks right \\uD83D\\uDC4D" });
+    var bad = el("button", { type: "button", class: "vbtn btn-bad" + (v && v.v === "needs-work" ? " on" : ""), title: "Verdict: needs work (key: 2)", text: "Needs work \\uD83D\\uDC4E" });
+    var skip = el("button", { type: "button", class: "vbtn btn-skip" + (v && v.v === "skipped" ? " on" : ""), title: "Records a skipped verdict (key: s)", text: "Skip \\u23ED" });
+    var noteWrap = el("div", { class: "note-box" });
+    var note = el("input", { type: "text", id: "note-input", placeholder: "Note (optional \\u2014 encouraged for \\uD83D\\uDC4E)", value: (v && v.note) || "" });
+    noteWrap.appendChild(note);
+    good.addEventListener("click", function () { setVerdict("looks-right"); });
+    bad.addEventListener("click", function () { setVerdict("needs-work"); });
+    skip.addEventListener("click", function () { setVerdict("skipped"); });
+    note.addEventListener("input", function () {
+      var cur = verdicts[r.routeName];
+      if (cur) { cur.note = note.value.trim(); saveVerdicts(); }
+    });
+    bar.appendChild(good);
+    bar.appendChild(bad);
+    bar.appendChild(skip);
+    bar.appendChild(noteWrap);
+    bar.appendChild(el("span", { class: "v-kbd", html: "<kbd>1</kbd> \\uD83D\\uDC4D <kbd>2</kbd> \\uD83D\\uDC4E <kbd>s</kbd> skip <kbd>j</kbd>/<kbd>k</kbd> next/prev <kbd>n</kbd>/<kbd>p</kbd> hunks" }));
+    return bar;
+  }
+
+  function setVerdict(kind) {
+    var r = routeByName(selectedName);
+    if (!r) return;
+    var noteEl = document.getElementById("note-input");
+    verdicts[r.routeName] = {
+      v: kind,
+      note: noteEl ? noteEl.value.trim() : "",
+      ts: new Date().toISOString(),
+      commit: meta.shortSha
+    };
+    saveVerdicts();
+    updateReviewedChip();
+    refreshRailMarks();
+    // auto-advance to the next route in nav order
+    var names = navNames();
+    var idx = names.indexOf(selectedName);
+    if (idx !== -1 && idx + 1 < names.length) selectRoute(names[idx + 1]);
+    else renderPane(true);
+  }
+
+  /* ---------------- export ---------------- */
+  function exportNotes() {
+    var pool = reviewable();
+    var good = 0, bad = 0, skip = 0;
+    routes.forEach(function (r) {
+      var v = verdictOf(r);
+      if (!v) return;
+      if (v.v === "looks-right") good++;
+      else if (v.v === "needs-work") bad++;
+      else if (v.v === "skipped") skip++;
+    });
+    var tick = String.fromCharCode(96); // backtick; literal would end the server template literal
+    var lines = [];
+    lines.push("# Review notes \\u2014 PR #" + meta.prNumber + " (" + meta.shortSha + ")");
+    lines.push("");
+    lines.push("- Branch: " + tick + meta.headBranch + tick + " @ " + tick + meta.shortSha + tick);
+    lines.push("- Generated: " + (meta.generatedAtCentral || meta.generatedAt));
+    lines.push("- Baseline: " + (meta.baselineDescription || "n/a"));
+    if (meta.reviewUrl) lines.push("- Artifact: " + meta.reviewUrl);
+    lines.push("- Routes: " + routes.length + " total \\u00b7 " + pool.length + " with visual or copy changes");
+    lines.push("- Verdicts: " + good + " looks right \\u00b7 " + bad + " needs work \\u00b7 " + skip + " skipped \\u00b7 " +
+      (routes.length - good - bad - skip) + " not reviewed");
+    lines.push("");
+    var flagged = routes.filter(function (r) { var v = verdictOf(r); return v && v.v === "needs-work"; });
+    if (flagged.length) {
+      lines.push("## Needs work");
+      lines.push("");
+      flagged.forEach(function (r) {
+        var v = verdictOf(r);
+        lines.push("- **" + r.routeLabel + "** (" + tick + r.routePath + tick + ")" + (v.note ? " \\u2014 " + v.note : " \\u2014 (no note)"));
+      });
+      lines.push("");
+    }
+    lines.push("## All verdicts");
+    lines.push("");
+    lines.push("| Route | Path | Status | Verdict | Note |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    routes.forEach(function (r) {
+      var v = verdictOf(r);
+      var label = v
+        ? (v.v === "looks-right" ? "looks right" : v.v === "needs-work" ? "NEEDS WORK" : "skipped")
+        : "not reviewed";
+      var noteTxt = ((v && v.note) || "").replace(/\\|/g, "\\\\|").replace(/\\r?\\n/g, "<br>");
+      lines.push("| " + r.routeLabel + " | " + tick + r.routePath + tick + " | " + r.statusLabel + " | " + label + " | " + noteTxt + " |");
+    });
+    lines.push("");
+    var blob = new Blob([lines.join("\\n")], { type: "text/markdown" });
+    var a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "pr-" + meta.prNumber + "-review-" + meta.shortSha + ".md";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(a.href);
+  }
+
+  /* ---------------- keyboard ---------------- */
+  function onKey(e) {
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+    var tag = (e.target && e.target.tagName) || "";
+    if (tag === "TEXTAREA" || tag === "INPUT" || tag === "SELECT" || (e.target && e.target.isContentEditable)) return;
+    var names, idx;
+    switch (e.key) {
+      case "j": case "ArrowDown":
+        names = navNames();
+        idx = names.indexOf(selectedName);
+        if (idx === -1 && names.length) { e.preventDefault(); selectRoute(names[0]); }
+        else if (idx + 1 < names.length) { e.preventDefault(); selectRoute(names[idx + 1]); }
+        break;
+      case "k": case "ArrowUp":
+        names = navNames();
+        idx = names.indexOf(selectedName);
+        if (idx > 0) { e.preventDefault(); selectRoute(names[idx - 1]); }
+        break;
+      case "1": e.preventDefault(); setVerdict("looks-right"); break;
+      case "2": e.preventDefault(); setVerdict("needs-work"); break;
+      case "s": e.preventDefault(); setVerdict("skipped"); break;
+      case "n": e.preventDefault(); stepHunk(1); break;
+      case "p": e.preventDefault(); stepHunk(-1); break;
+    }
+  }
+
+  /* ---------------- boot ---------------- */
+  function boot() {
+    if (!routes.length) {
+      document.getElementById("pane").innerHTML =
+        '<div class="fatal">No routes in the review data. The generator produced an empty manifest.</div>';
+      return;
+    }
+    loadVerdicts();
+    wireHeader();
+    renderRail();
+    updateReviewedChip();
+
+    var railToggle = document.getElementById("rail-toggle");
+    railToggle.addEventListener("click", function () {
+      var open = document.body.classList.toggle("rail-open");
+      railToggle.setAttribute("aria-expanded", String(open));
+    });
+
+    var h = parseHash();
+    var opts = { skipHash: true };
+    var initial = routes[0].routeName;
+    if (h && h.route && routeByName(h.route)) {
+      initial = h.route;
+      if (h.pair) opts.pair = h.pair;
+      if (h.hunk != null && h.hunk !== "" && !isNaN(parseInt(h.hunk, 10))) {
+        opts.hunk = parseInt(h.hunk, 10);
+        opts.mode = "hunks";
+      }
+    }
+    selectRoute(initial, opts);
+
+    window.addEventListener("hashchange", function () {
+      var hh = parseHash();
+      if (!hh || !hh.route || !routeByName(hh.route)) return;
+      if (hh.route === selectedName && hh.hunk == null) return;
+      var o = { skipHash: true };
+      if (hh.pair) o.pair = hh.pair;
+      if (hh.hunk != null && !isNaN(parseInt(hh.hunk, 10))) { o.hunk = parseInt(hh.hunk, 10); o.mode = "hunks"; }
+      selectRoute(hh.route, o);
+    });
+    document.addEventListener("keydown", onKey);
+  }
+
+  boot();
+})();
+`;
+
+function renderHeaderHtml(meta, summary) {
+  const chips = [];
+  chips.push(`<span class="chip changed">${escapeHtml(summary.changedRoutes)} changed</span>`);
+  if (summary.copyOnlyRoutes) chips.push(`<span class="chip">${escapeHtml(summary.copyOnlyRoutes)} copy-only</span>`);
+  chips.push(`<span class="chip">${escapeHtml(summary.unchangedRoutes)} unchanged</span>`);
+  if (summary.erroredRoutes) chips.push(`<span class="chip errored">${escapeHtml(summary.erroredRoutes)} errored</span>`);
+  chips.push(`<span class="chip">${escapeHtml(summary.totalRoutes)} routes</span>`);
+  chips.push(`<span class="chip" id="chip-reviewed">0 reviewed</span>`);
+
+  const noteBits = [
+    `PR #${escapeHtml(meta.prNumber)}`,
+    `<code>${escapeHtml(meta.headBranch)}</code> @ <code>${escapeHtml(meta.shortSha)}</code>`,
+    `generated ${escapeHtml(meta.generatedAtCentral || meta.generatedAt)}`,
+  ];
+  if (meta.baselineDescription) noteBits.push(escapeHtml(meta.baselineDescription));
+  if (meta.reviewUrl) noteBits.push(`<a href="${escapeHtml(meta.reviewUrl)}" target="_blank" rel="noopener">artifact</a>`);
+
+  return `<header id="hdr">
+  <div class="hdr-row1">
+    <h1>PR #${escapeHtml(meta.prNumber)} review</h1>
+    <div class="chips">${chips.join("")}</div>
+    <span class="hdr-spacer"></span>
+    <label class="noise-label" for="noise">Noise
+      <select id="noise" title="Hide hunks smaller than this share of the page">
+        <option value="0" selected>show all diffs</option>
+        <option value="0.1">hide diffs under 0.1%</option>
+        <option value="0.5">hide diffs under 0.5%</option>
+        <option value="1">hide diffs under 1%</option>
+      </select>
+    </label>
+    <button type="button" id="export-btn" class="hbtn" title="Download every verdict + note as a markdown review packet">Export review notes</button>
+    <button type="button" id="reset-btn" class="hbtn" title="Clear saved verdicts for this commit">Reset</button>
+  </div>
+  <div class="hdr-row2" id="gen-note">${noteBits.join(" · ")}</div>
+</header>`;
+}
+
+/**
+ * Render the complete latest.html string for the given review input.
+ * @param {object} input — see the data contract at the top of this file.
+ * @returns {string} full HTML document
+ */
+export function renderReviewHtml(input) {
+  if (!input || typeof input !== "object") throw new TypeError("renderReviewHtml: input must be an object");
+  const meta = input.meta || {};
+  const summary = input.summary || {};
+  if (!Array.isArray(input.routes)) throw new TypeError("renderReviewHtml: input.routes must be an array");
+
+  const title = `PR #${meta.prNumber ?? "?"} review — ${meta.shortSha ?? "?"}`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>${CSS}</style>
+</head>
+<body>
+${renderHeaderHtml(meta, summary)}
+<div class="app">
+  <button id="rail-toggle" type="button" aria-expanded="false" aria-controls="rail">
+    <span class="rt-caret" aria-hidden="true">▾</span>
+    <span>Routes</span>
+    <span class="rt-sel" id="rail-toggle-sel"></span>
+  </button>
+  <nav class="rail" id="rail" aria-label="Routes"></nav>
+  <main class="pane" id="pane"><p style="color:var(--dim);padding:16px 20px">Loading…</p></main>
+</div>
+<script type="application/json" id="review-data">${jsonIsland(input)}</script>
+<script>${CLIENT_JS}</script>
+</body>
+</html>
+`;
+}
+
+export default renderReviewHtml;

--- a/packages/web/scripts/visual-review-page.mjs
+++ b/packages/web/scripts/visual-review-page.mjs
@@ -15,7 +15,7 @@
  *
  * DATA CONTRACT — renderReviewHtml(input) where input is:
  * {
- *   meta: { prNumber, shortSha, commitSha, headBranch, generatedAt,
+ *   meta: { prNumber, shortSha, commitSha, headBranch, repo, generatedAt,
  *           generatedAtCentral, previewBaseUrl, productionBaseUrl,
  *           reviewUrl, baselineDescription },
  *   summary: { changedRoutes, copyOnlyRoutes, unchangedRoutes, erroredRoutes, totalRoutes },
@@ -53,8 +53,8 @@ export function escapeHtml(value) {
 function jsonIsland(input) {
   return JSON.stringify(input)
     .replaceAll("<", "\\u003c")
-    .replaceAll(" ", "\\u2028")
-    .replaceAll(" ", "\\u2029");
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
 }
 
 const CSS = `
@@ -235,6 +235,14 @@ const CSS = `
     background: var(--bg); color: var(--dim); padding: 1px 8px;
   }
   .copy-url:hover { color: var(--ink); }
+  .context-actions { display: inline-flex; align-items: center; gap: 4px; flex-wrap: wrap; }
+  .context-btn {
+    flex: 0 0 auto; font-size: 11px;
+    border: 1px solid var(--border); border-radius: 3px;
+    background: var(--bg); color: var(--dim); padding: 1px 8px;
+  }
+  .context-btn:hover { color: var(--ink); }
+  .context-btn:disabled { opacity: .45; cursor: not-allowed; }
 
   .toolbar { display: flex; gap: 16px; flex-wrap: wrap; align-items: center; margin-bottom: 10px; }
   .seg { display: inline-flex; flex-wrap: wrap; max-width: 100%; border: 1px solid var(--border); border-radius: 5px; overflow: hidden; background: var(--panel); }
@@ -437,7 +445,7 @@ const CSS = `
   /* ---------- touch targets ---------- */
   @media (pointer: coarse) {
     .seg button { min-height: 40px; padding: 8px 14px; }
-    .live-btn, .hbtn, .vbtn, .gap-btn, .hunk-link { min-height: 40px; }
+    .live-btn, .hbtn, .vbtn, .gap-btn, .hunk-link, .context-btn { min-height: 40px; }
     .route-row { min-height: 40px; }
     .rail-filter input, #noise { min-height: 40px; }
     .copy-url { min-height: 40px; min-width: 40px; }
@@ -527,6 +535,25 @@ const CLIENT_JS = `
   function joinRouteUrl(base, routePath) {
     if (!base || !routePath) return "";
     return String(base).replace(/\\/$/, "") + routePath;
+  }
+  function reviewPageUrl(routeName) {
+    var pageUrl = meta.reviewUrl || (typeof location !== "undefined" ? location.href.split("#")[0] : "");
+    if (!pageUrl) return null;
+    return pageUrl.split("#")[0] + "#route=" + encodeURIComponent(routeName || selectedName || "");
+  }
+  function reviewBaseUrl() {
+    var pageUrl = meta.reviewUrl || (typeof location !== "undefined" ? location.href.split("#")[0] : "");
+    if (!pageUrl) return "";
+    return pageUrl
+      .split("#")[0]
+      .replace(/\\/latest\\.html(?:[?#].*)?$/, "")
+      .replace(/\\/$/, "");
+  }
+  function assetUrl(relPath) {
+    if (!relPath) return null;
+    var base = reviewBaseUrl();
+    var clean = String(relPath).replace(/^\\/+/, "");
+    return base ? base + "/" + clean : clean;
   }
   function isMobile() { return window.matchMedia(MOBILE_MQ).matches; }
   function fmtPx(n) { return Math.round(n).toLocaleString("en-US"); }
@@ -904,6 +931,7 @@ const CLIENT_JS = `
     } else {
       metaRow.appendChild(el("span", { text: "n/a" }));
     }
+    metaRow.appendChild(buildContextActions(r));
     content.appendChild(metaRow);
 
     if (r.errored) {
@@ -986,9 +1014,148 @@ const CLIENT_JS = `
   }
 
   function copyText(text, done) {
+    function fallback() {
+      var ta = document.createElement("textarea");
+      ta.value = text;
+      ta.setAttribute("readonly", "");
+      ta.style.position = "fixed";
+      ta.style.top = "0";
+      ta.style.left = "-9999px";
+      document.body.appendChild(ta);
+      ta.focus();
+      ta.select();
+      var ok = false;
+      try {
+        ok = document.execCommand("copy");
+      } catch (err) {
+        ok = false;
+      } finally {
+        document.body.removeChild(ta);
+      }
+      done(!!ok);
+    }
     if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text).then(function () { done(true); }, function () { done(false); });
-    } else done(false);
+      navigator.clipboard.writeText(text).then(function () { done(true); }, fallback);
+    } else fallback();
+  }
+
+  function buildContext(r) {
+    var pair = pairOf(r, pairName) || ((r.pairs || [])[0] || null);
+    var viewing = "markdown-diff";
+    if (pair) {
+      viewing = (cmpMode === "hunks" || cmpMode === "overlay") && pair.diffRelPath ? "diff" : "after";
+    }
+    var imageRelPath = null;
+    if (pair) {
+      if (viewing === "diff" && pair.diffRelPath) imageRelPath = pair.diffRelPath;
+      else if (viewing === "before") imageRelPath = pair.beforeRelPath;
+      else imageRelPath = pair.afterRelPath || pair.diffRelPath || pair.beforeRelPath;
+    }
+    var screenshots = (r.pairs || []).map(function (p) {
+      return {
+        project: p.projectName,
+        projectLabel: p.projectLabel || p.projectName,
+        diff: p.diffLabel || "unknown",
+        beforeUrl: assetUrl(p.beforeRelPath),
+        afterUrl: assetUrl(p.afterRelPath),
+        diffUrl: assetUrl(p.diffRelPath)
+      };
+    });
+    return {
+      pr: meta.prNumber,
+      branch: meta.headBranch,
+      repo: meta.repo,
+      commitSha: meta.commitSha,
+      shortSha: meta.shortSha,
+      route: r.routeName,
+      routeLabel: r.routeLabel,
+      routeUrl: r.routeUrl || joinRouteUrl(meta.previewBaseUrl, r.routePath),
+      authState: r.authState,
+      project: pair ? pair.projectName : null,
+      projectLabel: pair ? (pair.projectLabel || pair.projectName) : null,
+      viewing: viewing,
+      diffLabel: pair ? pair.diffLabel : r.statusLabel,
+      imageUrl: assetUrl(imageRelPath),
+      reviewUrl: reviewPageUrl(r.routeName),
+      screenshots: screenshots
+    };
+  }
+
+  function formatContext(ctx) {
+    var lines = [];
+    lines.push("### Visual-review context");
+    lines.push("");
+    if (ctx.viewing) lines.push("- Viewing: **" + String(ctx.viewing).toUpperCase() + "**" + (ctx.projectLabel ? " in " + ctx.projectLabel : ""));
+    if (ctx.pr) lines.push("- PR: #" + ctx.pr + (ctx.repo ? " (" + ctx.repo + ")" : ""));
+    if (ctx.branch) lines.push("- Branch: \`" + ctx.branch + "\`");
+    if (ctx.shortSha) lines.push("- Commit: \`" + ctx.shortSha + "\`" + (ctx.commitSha ? " (" + ctx.commitSha + ")" : ""));
+    lines.push("- Route: \`" + ctx.route + "\` (" + ctx.routeLabel + ")");
+    if (ctx.routeUrl) lines.push("- Live URL: " + ctx.routeUrl);
+    lines.push("- Auth state: " + ctx.authState);
+    if (ctx.diffLabel) lines.push("- Diff vs main: " + ctx.diffLabel);
+    if (ctx.imageUrl) {
+      lines.push("- Screenshot: " + ctx.imageUrl);
+      lines.push("    curl -sLO " + ctx.imageUrl);
+    }
+    if (ctx.reviewUrl) lines.push("- Visual review: " + ctx.reviewUrl);
+    lines.push("");
+    if (ctx.screenshots && ctx.screenshots.length > 0) {
+      lines.push("**Screenshots** - please download and inspect these before responding:");
+      lines.push("");
+      for (var i = 0; i < ctx.screenshots.length; i++) {
+        var s = ctx.screenshots[i];
+        lines.push("- **" + (s.projectLabel || s.project) + "** (" + s.diff + ")");
+        if (s.beforeUrl) lines.push("  - before (main): " + s.beforeUrl);
+        if (s.afterUrl) lines.push("  - after (this PR): " + s.afterUrl);
+        if (s.diffUrl) lines.push("  - diff: " + s.diffUrl);
+      }
+      lines.push("");
+    }
+    lines.push("**My complaint:**");
+    lines.push("> _(replace this line with what looks wrong)_");
+    return lines.join("\\n");
+  }
+
+  function openComplaint(ctx) {
+    if (!ctx.repo) return false;
+    var titleParts = ["Visual review"];
+    if (ctx.routeLabel) titleParts.push(ctx.routeLabel);
+    if (ctx.viewing) titleParts.push(ctx.viewing);
+    if (ctx.projectLabel) titleParts.push(ctx.projectLabel);
+    var body = formatContext(ctx);
+    if (ctx.pr) body = "Originating PR: #" + ctx.pr + "\\n\\n" + body;
+    var url =
+      "https://github.com/" + ctx.repo + "/issues/new" +
+      "?title=" + encodeURIComponent(titleParts.join(" \\u2014 ")) +
+      "&body=" + encodeURIComponent(body);
+    window.open(url, "_blank", "noopener,noreferrer");
+    return true;
+  }
+
+  function buildContextActions(r) {
+    var wrap = el("span", { class: "context-actions" });
+    var copy = el("button", { type: "button", class: "context-btn", text: "Copy context", title: "Copy visual-review context for this route and viewport" });
+    copy.addEventListener("click", function () {
+      var ctx = buildContext(r);
+      copyText(formatContext(ctx), function (ok) {
+        copy.textContent = ok ? "Copied" : "Copy failed";
+        setTimeout(function () { copy.textContent = "Copy context"; }, 1500);
+      });
+    });
+    wrap.appendChild(copy);
+
+    var complainAttrs = { type: "button", class: "context-btn", text: "Complain", title: "Open a GitHub issue with visual-review context" };
+    if (!meta.repo) complainAttrs.disabled = "disabled";
+    var complain = el("button", complainAttrs);
+    complain.addEventListener("click", function () {
+      var ok = openComplaint(buildContext(r));
+      if (!ok) {
+        complain.textContent = "No repo";
+        setTimeout(function () { complain.textContent = "Complain"; }, 1500);
+      }
+    });
+    wrap.appendChild(complain);
+    return wrap;
   }
 
   function lazyImg(src, cls, alt) {

--- a/packages/web/scripts/visual-review-page.smoke.mjs
+++ b/packages/web/scripts/visual-review-page.smoke.mjs
@@ -1,0 +1,193 @@
+/**
+ * Smoke test for visual-review-page.mjs.
+ * Renders a small synthetic review input, writes output/visual-page-smoke.html,
+ * extracts the inline client JS, and runs `node --check` on it.
+ *
+ * Run: pnpm exec node scripts/visual-review-page.smoke.mjs   (from packages/web)
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { renderReviewHtml } from "./visual-review-page.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = join(here, "..", "output");
+const htmlPath = join(outDir, "visual-page-smoke.html");
+const clientJsPath = join(outDir, "visual-page-smoke.client.js");
+
+const XSS = 'Home <script>alert("xss")</script> & "quotes" \'single\'';
+
+const input = {
+  meta: {
+    prNumber: 123,
+    shortSha: "abc1234",
+    commitSha: "abc1234def5678900000000000000000000000ff",
+    headBranch: "feature/eos-showroom-registry",
+    generatedAt: "2026-07-05T12:00:00Z",
+    generatedAtCentral: "Jul 5, 2026 7:00 AM Central",
+    previewBaseUrl: "https://optimitron-git-feature-preview.vercel.app",
+    productionBaseUrl: "https://optimitron.com",
+    reviewUrl: "https://mikepsinn.github.io/optimitron/pr-123/abc1234/",
+    baselineDescription: "screenshots vs main @ 871661d, copy vs pre-merge snapshots",
+  },
+  summary: { changedRoutes: 1, copyOnlyRoutes: 1, unchangedRoutes: 0, erroredRoutes: 0, totalRoutes: 2 },
+  routes: [
+    {
+      routeName: "home",
+      routeLabel: XSS,
+      routePath: "/",
+      routeUrl: "https://optimitron-git-feature-preview.vercel.app/",
+      authState: "logged-out",
+      changed: true,
+      copyChanged: true,
+      errored: false,
+      statusLabel: "1 viewport changed",
+      markdownDiff: {
+        addedLines: 3,
+        removedLines: 1,
+        metaChanges: [{ field: "title", before: "Old <title>", after: "New & improved" }],
+        lines: [
+          { kind: "header", text: "--- a/page.logged-out.md" },
+          { kind: "header", text: "+++ b/page.logged-out.md" },
+          { kind: "hunk", text: "@@ -1,4 +1,6 @@" },
+          { kind: "context", text: " Humanity still has about 121 spare apocalypses." },
+          { kind: "del", text: "-Old line" },
+          { kind: "add", text: "+New line with <script>alert(1)</script> markup" },
+          { kind: "add", text: "+Another added line" },
+        ],
+      },
+      pairs: [
+        {
+          projectName: "default",
+          projectLabel: "Desktop",
+          changed: true,
+          missing: false,
+          errored: false,
+          diffLabel: "3.2% changed",
+          beforeRelPath: "assets/before/default/home.png",
+          afterRelPath: "assets/after/default/home.png",
+          diffRelPath: "assets/after/default/home-diff.png",
+          beforeWidth: 1440,
+          beforeHeight: 4000,
+          afterWidth: 1440,
+          afterHeight: 4200,
+          hunks: [
+            { before: { yStart: 300, yEnd: 520 }, after: { yStart: 300, yEnd: 560 }, kind: "changed", pctOfPage: 5.2 },
+            { before: { yStart: 2000, yEnd: 2000 }, after: { yStart: 2100, yEnd: 2400 }, kind: "inserted", pctOfPage: 7.1 },
+            { before: { yStart: 3600, yEnd: 3700 }, after: { yStart: 3980, yEnd: 3980 }, kind: "deleted", pctOfPage: 0.3 },
+          ],
+          alignmentAnchors: [
+            { beforeY: 0, afterY: 0 },
+            { beforeY: 300, afterY: 300 },
+            { beforeY: 2000, afterY: 2100 },
+            { beforeY: 3600, afterY: 3980 },
+            { beforeY: 4000, afterY: 4200 },
+          ],
+        },
+        {
+          projectName: "visual-mobile",
+          projectLabel: "Mobile",
+          changed: false,
+          missing: false,
+          errored: false,
+          diffLabel: "0% changed",
+          beforeRelPath: "assets/before/visual-mobile/home.png",
+          afterRelPath: "assets/after/visual-mobile/home.png",
+          diffRelPath: null,
+          beforeWidth: 390,
+          beforeHeight: 7000,
+          afterWidth: 390,
+          afterHeight: 7000,
+          hunks: [],
+          alignmentAnchors: [{ beforeY: 0, afterY: 0 }, { beforeY: 7000, afterY: 7000 }],
+        },
+      ],
+    },
+    {
+      routeName: "prize",
+      routeLabel: "Prize",
+      routePath: "/prize",
+      routeUrl: null,
+      authState: "logged-out",
+      changed: false,
+      copyChanged: true,
+      errored: false,
+      statusLabel: "copy only — not in the screenshot run",
+      markdownDiff: {
+        addedLines: 1,
+        removedLines: 1,
+        metaChanges: [],
+        lines: [
+          { kind: "hunk", text: "@@ -10,3 +10,3 @@" },
+          { kind: "del", text: "-Deposit USDC." },
+          { kind: "add", text: "+Deposit USDC. Yield accrues." },
+        ],
+      },
+      pairs: [],
+    },
+  ],
+};
+
+// ---------- render ----------
+const html = renderReviewHtml(input);
+
+mkdirSync(outDir, { recursive: true });
+writeFileSync(htmlPath, html, "utf8");
+
+// ---------- assertions ----------
+const failures = [];
+function assert(cond, label) {
+  if (!cond) failures.push(label);
+}
+
+assert(html.startsWith("<!doctype html>"), "starts with doctype");
+assert(html.includes('<meta name="viewport"'), "has viewport meta");
+assert(html.includes("PR #123 review"), "server-rendered header title");
+assert(html.includes('id="review-data"'), "JSON island present");
+assert(html.includes('id="noise"'), "noise select present");
+assert(html.includes('id="export-btn"'), "export button present");
+assert(html.includes("data-live-toggle"), "live-compare toggle keyword in client JS");
+assert(!html.includes('<script>alert("xss")</script>'), "route label XSS not raw in HTML");
+assert(!/<script>alert\(1\)<\/script>/.test(html), "copy-diff XSS not raw in HTML");
+assert(html.includes("\\u003c"), "JSON island escapes < sequences");
+assert(html.includes("1 changed"), "summary chip: changed");
+assert(html.includes("1 copy-only"), "summary chip: copy-only");
+assert(html.includes("2 routes"), "summary chip: total");
+
+// ---------- extract inline JS and node --check it ----------
+const scripts = [];
+const re = /<script(?![^>]*application\/json)[^>]*>([\s\S]*?)<\/script>/g;
+let m;
+while ((m = re.exec(html)) !== null) scripts.push(m[1]);
+assert(scripts.length === 1, "exactly one inline client <script> (got " + scripts.length + ")");
+
+const clientJs = scripts.join("\n;\n");
+writeFileSync(clientJsPath, clientJs, "utf8");
+
+const check = spawnSync(process.execPath, ["--check", clientJsPath], { encoding: "utf8" });
+assert(check.status === 0, "node --check on extracted client JS: " + (check.stderr || "").trim());
+
+// JSON island round-trips
+try {
+  const island = /<script type="application\/json" id="review-data">([\s\S]*?)<\/script>/.exec(html);
+  const parsed = JSON.parse(island[1]);
+  assert(parsed.routes.length === 2, "JSON island round-trips (routes)");
+  assert(parsed.routes[0].pairs[0].hunks.length === 3, "JSON island round-trips (hunks)");
+  assert(parsed.routes[0].routeLabel === XSS, "JSON island preserves raw strings");
+} catch (err) {
+  failures.push("JSON island parse failed: " + err.message);
+}
+
+// ---------- report ----------
+const summary = {
+  ok: failures.length === 0,
+  htmlPath,
+  htmlBytes: Buffer.byteLength(html, "utf8"),
+  clientJsPath,
+  clientJsBytes: Buffer.byteLength(clientJs, "utf8"),
+  nodeCheckExit: check.status,
+  failures,
+};
+console.log(JSON.stringify(summary, null, 2));
+if (failures.length) process.exit(1);

--- a/packages/web/scripts/visual-review-page.smoke.mjs
+++ b/packages/web/scripts/visual-review-page.smoke.mjs
@@ -24,6 +24,7 @@ const input = {
     shortSha: "abc1234",
     commitSha: "abc1234def5678900000000000000000000000ff",
     headBranch: "feature/eos-showroom-registry",
+    repo: "mikepsinn/optimitron",
     generatedAt: "2026-07-05T12:00:00Z",
     generatedAtCentral: "Jul 5, 2026 7:00 AM Central",
     previewBaseUrl: "https://optimitron-git-feature-preview.vercel.app",
@@ -148,6 +149,9 @@ assert(html.includes('id="review-data"'), "JSON island present");
 assert(html.includes('id="noise"'), "noise select present");
 assert(html.includes('id="export-btn"'), "export button present");
 assert(html.includes("data-live-toggle"), "live-compare toggle keyword in client JS");
+assert(html.includes("Copy context"), "context copy action present");
+assert(html.includes("Complain"), "complaint issue action present");
+assert(html.includes("Originating PR: #"), "complaint payload preserves originating PR marker");
 assert(!html.includes('<script>alert("xss")</script>'), "route label XSS not raw in HTML");
 assert(!/<script>alert\(1\)<\/script>/.test(html), "copy-diff XSS not raw in HTML");
 assert(html.includes("\\u003c"), "JSON island escapes < sequences");

--- a/packages/web/src/app/game/page.logged-out.md
+++ b/packages/web/src/app/game/page.logged-out.md
@@ -27,7 +27,7 @@
 - That's it. You're done. 99% of you don't need to know anything else.
 - The rest of this site is the instruction manual. Read it if you're into ending war and disease. But for the love of your species, click the buttons first.
 ### VOTE ON THE 1% TREATY
-- Trade one apocalypse for disease eradication. Humanity has 122 stockpiled — you can spare one to cure the 6,650 diseases with no treatment.
+- Trade one apocalypse for disease eradication. Humanity has [122](https://manual.WarOnDisease.org/knowledge/appendix/extinction-surplus.html) stockpiled — you can spare one to cure the [6,650](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) diseases with no treatment.
 - [VOTE NOW](/vote)
 ## PRESIDENT MANAGEMENT SYSTEM
 - You give these people $37 trillion a year. Their job is to promote the general welfare which means increasing median health and wealth. Your job is to remind them that this is their job. Please do your job by clicking the remind button.
@@ -141,7 +141,7 @@
 - Productive Economy
 - Parasitic Economy
 - % of GDP
-- [💀5 HUMANS TERMINATED🔥$10.1M BURNED BY MISALIGNED GOVERNMENTS💣$1.3M SPENT ON DESTRUCTION INSTEAD OF CURES](/plaintiffs)
+- [💀4 HUMANS TERMINATED🔥$8.9M BURNED BY MISALIGNED GOVERNMENTS💣$1.2M SPENT ON DESTRUCTION INSTEAD OF CURES](/plaintiffs)
 - Right now, doing nothing means you lose. Vote and you stop.
 ### EVERY POLICY GRADED A THROUGH F
 - I ran causal inference on decades of data across dozens of countries. Most of your policies fail.
@@ -329,6 +329,5 @@
 - [minutes]
 - [seconds]
 - Until the destructive economy reaches 50% of GDP — the point where stealing beats creating
-- [💀5 HUMANS TERMINATED🔥$9.8M BURNED BY MISALIGNED GOVERNMENTS💣$1.3M SPENT ON DESTRUCTION INSTEAD OF CURES](/plaintiffs)
 - [SEE THE FULL MATH](/prize)
 - [EXPRESS YOUR PREFERENCES](/agencies/dcongress/wishocracy)

--- a/packages/web/src/app/game/page.logged-out.md
+++ b/packages/web/src/app/game/page.logged-out.md
@@ -27,9 +27,8 @@
 - That's it. You're done. 99% of you don't need to know anything else.
 - The rest of this site is the instruction manual. Read it if you're into ending war and disease. But for the love of your species, click the buttons first.
 ### VOTE ON THE 1% TREATY
-- One slider. One yes-or-no question. Then Humanity Management Training helps you give two humans their treaty voting tasks.
+- Trade one apocalypse for disease eradication. Humanity has 122 stockpiled — you can spare one to cure the 6,650 diseases with no treatment.
 - [VOTE NOW](/vote)
-- [SEE THE QUESTIONS](/questions)
 ## PRESIDENT MANAGEMENT SYSTEM
 - You give these people $37 trillion a year. Their job is to promote the general welfare which means increasing median health and wealth. Your job is to remind them that this is their job. Please do your job by clicking the remind button.
 #### SEND EARTH OPTIMIZATION TASK REMINDER
@@ -142,7 +141,7 @@
 - Productive Economy
 - Parasitic Economy
 - % of GDP
-- [💀2 HUMANS TERMINATED🔥$4.5M BURNED BY MISALIGNED GOVERNMENTS💣$586K SPENT ON DESTRUCTION INSTEAD OF CURES](/plaintiffs)
+- [💀5 HUMANS TERMINATED🔥$10.1M BURNED BY MISALIGNED GOVERNMENTS💣$1.3M SPENT ON DESTRUCTION INSTEAD OF CURES](/plaintiffs)
 - Right now, doing nothing means you lose. Vote and you stop.
 ### EVERY POLICY GRADED A THROUGH F
 - I ran causal inference on decades of data across dozens of countries. Most of your policies fail.
@@ -307,7 +306,7 @@
 - [📋OPTIMAL POLICY GENERATOR 275 humans spend months guessing what a bill will cost. The algorithm does it in 200 milliseconds and shows its work. SEE POLICY GRADES →](/opg)
 - [💰OPTIMAL BUDGET GENERATOR 535 politicians decide how to spend $6.8 trillion. None of them asked you. The eigenvector asks everyone. SEE BUDGET ANALYSIS →](/obg)
 - [🔍DECENTRALIZED ACCOUNTABILITY OFFICE You pay 3,400 humans to audit a ledger that could audit itself. Then you wait eighteen months for the results. VIEW AUDIT →](/agencies/dgao)
-- [🧬OPTIMAL INSTITUTES OF HEALTH You spend $47 billion a year on medical research and 3.3% of it funds actual trials. The rest funds grant proposals about trials. It's like buying 4.7 million cars and spending $1 on a mechanic. OPEN DIH →](/agencies/dih)
+- [🧬DECENTRALIZED INSTITUTES OF HEALTH You spend $47 billion a year on medical research and 3.3% of it funds actual trials. The rest funds grant proposals about trials. It's like buying 4.7 million cars and spending $1 on a mechanic. OPEN DIH →](/agencies/dih)
 - [💊DECENTRALIZED FDA Your FDA makes treatments wait 8.2 years AFTER they've been proven safe. Just sitting there. Being safe. While people die. This replaces the queue with maths. OPEN DFDA →](/agencies/dfda)
 - [💀DEPARTMENT OF PEACE War is a negative-sum game and the spreadsheet agrees. We don't have a Department of War because — and I want to be precise here — war is fucking stupid. LEARN MORE →](/agencies/ddod)
 - [SEE EVERY AGENCY →](/agencies)
@@ -330,5 +329,6 @@
 - [minutes]
 - [seconds]
 - Until the destructive economy reaches 50% of GDP — the point where stealing beats creating
+- [💀5 HUMANS TERMINATED🔥$9.8M BURNED BY MISALIGNED GOVERNMENTS💣$1.3M SPENT ON DESTRUCTION INSTEAD OF CURES](/plaintiffs)
 - [SEE THE FULL MATH](/prize)
 - [EXPRESS YOUR PREFERENCES](/agencies/dcongress/wishocracy)

--- a/packages/web/src/components/animations/LiveDeathTicker.tsx
+++ b/packages/web/src/components/animations/LiveDeathTicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 import { useReducedMotion } from "framer-motion";
 import {
   DEATHS_PER_SECOND,
@@ -58,6 +58,36 @@ const counters: CounterConfig[] = [
   },
 ];
 
+type TickerRefs = ReadonlyArray<RefObject<HTMLSpanElement | null>>;
+
+const activeTickerRefs = new Set<TickerRefs>();
+let tickerStartedAt: number | null = null;
+let tickerInterval: ReturnType<typeof setInterval> | null = null;
+
+function updateTickerRefs(refs: TickerRefs, elapsedSeconds: number) {
+  for (let i = 0; i < counters.length; i++) {
+    const el = refs[i]?.current;
+    if (el) {
+      el.textContent = counters[i]!.format(counters[i]!.rate * elapsedSeconds);
+    }
+  }
+}
+
+function startTickerLoop() {
+  if (tickerStartedAt == null) tickerStartedAt = performance.now();
+  if (tickerInterval != null) return;
+
+  const tick = () => {
+    const elapsedSeconds = Math.max(0, (performance.now() - tickerStartedAt!) / 1000);
+    for (const refs of activeTickerRefs) {
+      updateTickerRefs(refs, elapsedSeconds);
+    }
+  };
+
+  tick();
+  tickerInterval = setInterval(tick, 50);
+}
+
 export function LiveDeathTicker({
   className = "",
   surface = "light",
@@ -75,18 +105,16 @@ export function LiveDeathTicker({
   useEffect(() => {
     if (prefersReducedMotion) return;
 
-    const accumulated = [0, 0, 0];
-    const interval = setInterval(() => {
-      for (let i = 0; i < counters.length; i++) {
-        accumulated[i] += counters[i]!.rate * 0.05;
-        const el = refs[i]!.current;
-        if (el) {
-          el.textContent = counters[i]!.format(accumulated[i]!);
-        }
-      }
-    }, 50);
+    activeTickerRefs.add(refs);
+    startTickerLoop();
 
-    return () => clearInterval(interval);
+    return () => {
+      activeTickerRefs.delete(refs);
+      if (activeTickerRefs.size === 0 && tickerInterval != null) {
+        clearInterval(tickerInterval);
+        tickerInterval = null;
+      }
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prefersReducedMotion]);
 

--- a/packages/web/src/components/landing/TreatyVoteSection.tsx
+++ b/packages/web/src/components/landing/TreatyVoteSection.tsx
@@ -1,7 +1,10 @@
+import { DISEASES_WITHOUT_EFFECTIVE_TREATMENT } from "@optimitron/data/parameters";
 import { Container } from "@/components/ui/container";
+import { ParameterValue } from "@/components/shared/ParameterValue";
 import { GameCTA } from "@/components/ui/game-cta";
 import { SectionContainer } from "@/components/ui/section-container";
 import { ROUTES } from "@/lib/routes";
+import { FLOW_NUCLEAR_WINTER_OVERKILL_FACTOR } from "@/lib/treaty-share-flow-parameters";
 
 export default function TreatyVoteSection() {
   return (
@@ -17,9 +20,21 @@ export default function TreatyVoteSection() {
             Vote on the 1% Treaty
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-base font-bold leading-7 text-muted-foreground sm:text-lg">
-            Trade one apocalypse for disease eradication. Humanity has 122
-            stockpiled — you can spare one to cure the 6,650 diseases with no
-            treatment.
+            Trade one apocalypse for disease eradication. Humanity has{" "}
+            <ParameterValue
+              param={FLOW_NUCLEAR_WINTER_OVERKILL_FACTOR}
+              display="integer"
+              presentation="inline"
+            />{" "}
+            stockpiled — you can spare one to cure the{" "}
+            <ParameterValue
+              param={DISEASES_WITHOUT_EFFECTIVE_TREATMENT}
+              presentation="inline"
+              valueOverride={DISEASES_WITHOUT_EFFECTIVE_TREATMENT.value.toLocaleString(
+                "en-US",
+              )}
+            />{" "}
+            diseases with no treatment.
           </p>
           <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
             <GameCTA href={ROUTES.vote} size="lg" variant="primary">

--- a/packages/web/src/components/landing/TreatyVoteSection.tsx
+++ b/packages/web/src/components/landing/TreatyVoteSection.tsx
@@ -17,15 +17,13 @@ export default function TreatyVoteSection() {
             Vote on the 1% Treaty
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-base font-bold leading-7 text-muted-foreground sm:text-lg">
-            One slider. One yes-or-no question. Then Humanity Management
-            Training helps you give two humans their treaty voting tasks.
+            Trade one apocalypse for disease eradication. Humanity has 122
+            stockpiled — you can spare one to cure the 6,650 diseases with no
+            treatment.
           </p>
           <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
             <GameCTA href={ROUTES.vote} size="lg" variant="primary">
               Vote Now
-            </GameCTA>
-            <GameCTA href={ROUTES.questions} size="lg" variant="outline">
-              See the Questions
             </GameCTA>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Extract the visual review page renderer and screenshot hunk extraction into focused scripts.
- Wire the artifact generator to emit copy diffs, hunk/minimap data, review verdict state, and safer route URLs.
- Fetch full history in the visual-review CI job so copy snapshot diffs can compare against the PR merge base.
- Ignore local review demo fixtures and backup screenshot folders.
- Update the `/game` logged-out treaty CTA copy and generated markdown snapshot.

## Preview Pages
- Game page: https://optimitron-web-git-feature-ci-revi-7db71a-mike-p-sinns-projects.vercel.app/game?logout=1
- Visual review artifact: generated by `web-visual-review` after PR screenshots are available.

## Local Verification
- `pnpm --dir packages/web exec node scripts/visual-review-page.smoke.mjs`
- `pnpm --dir packages/web exec node --test scripts/visual-review-hunks.test.mjs`
- `git diff --check` (only CRLF warnings on Windows working copy)
- Generated and inspected local `packages/web/output/playwright/review/latest.html` with desktop and mobile Playwright screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer visual review page with side-by-side comparisons, deep links, keyboard navigation, and saved review state.
  * Expanded review outputs to better highlight screenshot changes and markdown diffs.
* **Bug Fixes**
  * Improved visual review generation so it works reliably with full git history and correct baseline comparisons.
  * Fixed animated death-count updates to stay in sync across multiple on-screen instances.
* **Documentation**
  * Updated the “Vote on the 1% Treaty” copy and streamlined its call-to-action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->