### PR TITLE
Add trustworthy personal execution planning

### DIFF
--- a/packages/db/src/managed-data/optimize-earth-task-tree.ts
+++ b/packages/db/src/managed-data/optimize-earth-task-tree.ts
@@ -13,6 +13,7 @@ import {
   TaskCategory,
   TaskClaimPolicy,
   TaskDifficulty,
+  TaskKind,
 } from "../generated/prisma/client.js";
 import {
   EARTH_OPTIMIZATION_PRIZE_TASK_ID,
@@ -80,6 +81,7 @@ export const OPTIMIZE_EARTH_TASK_TREE: ManagedTaskRecord[] = [
   {
     ...defaultTaskFields,
     id: OPTIMIZE_EARTH_ROOT_TASK_ID,
+    kind: TaskKind.PROJECT,
     taskKey: OPTIMIZE_EARTH_ROOT_TASK_KEY,
     parentTaskId: null,
     title: "Optimize Earth",

--- a/packages/db/src/managed-data/sync-managed-tasks.test.ts
+++ b/packages/db/src/managed-data/sync-managed-tasks.test.ts
@@ -6,6 +6,7 @@ import {
   TaskCommunicationEndpointVerificationStatus,
   TaskDeadlinePolicy,
   TaskDifficulty,
+  TaskKind,
   TaskStatus,
 } from "../generated/prisma/client.js";
 import {
@@ -48,6 +49,7 @@ type FakeTask = {
   applicationQuestionsJson: unknown;
   executionMode: string;
   category: typeof TaskCategory[keyof typeof TaskCategory];
+  kind: typeof TaskKind[keyof typeof TaskKind];
   difficulty: typeof TaskDifficulty[keyof typeof TaskDifficulty];
   estimatedEffortHours: number | null;
   skillTags: string[];
@@ -148,6 +150,7 @@ function makeTask(input: Partial<FakeTask> & Pick<FakeTask, "id" | "taskKey">): 
     applicationQuestionsJson: null,
     executionMode: "HUMAN_OR_AGENT",
     category: TaskCategory.OTHER,
+    kind: TaskKind.TASK,
     difficulty: TaskDifficulty.INTERMEDIATE,
     estimatedEffortHours: null,
     skillTags: [],
@@ -241,6 +244,7 @@ const fakeTaskScalarFields = new Set<keyof FakeTask>([
   "impactStatement",
   "interestTags",
   "isPublic",
+  "kind",
   "locationText",
   "maxClaims",
   "ownerOrganizationId",

--- a/packages/db/src/managed-data/sync-managed-tasks.ts
+++ b/packages/db/src/managed-data/sync-managed-tasks.ts
@@ -7,6 +7,7 @@ import {
   TaskDeadlinePolicy,
   TaskDifficulty,
   TaskExecutionMode,
+  TaskKind,
   TaskRemotePolicy,
   TaskStatus,
   type Prisma,
@@ -17,6 +18,7 @@ import {
   type TaskDeadlinePolicy as TaskDeadlinePolicyValue,
   type TaskDifficulty as TaskDifficultyValue,
   type TaskExecutionMode as TaskExecutionModeValue,
+  type TaskKind as TaskKindValue,
   type TaskRemotePolicy as TaskRemotePolicyValue,
   type TaskStatus as TaskStatusValue,
 } from "../generated/prisma/client.js";
@@ -46,6 +48,7 @@ export interface ManagedTaskRecord {
   impactStatement?: string | null;
   ownerOrganizationId?: string | null;
   category?: TaskCategoryValue;
+  kind?: TaskKindValue;
   difficulty?: TaskDifficultyValue;
   estimatedEffortHours?: number | null;
   /** Gross conditional value (USD) if the task succeeds. Source from `@optimitron/data` parameters — never hand-typed. */
@@ -109,6 +112,7 @@ interface ManagedTaskRow {
   impactStatement: string | null;
   ownerOrganizationId: string | null;
   category: TaskCategoryValue;
+  kind: TaskKindValue;
   difficulty: TaskDifficultyValue;
   estimatedEffortHours: number | null;
   skillTags: string[];
@@ -423,6 +427,7 @@ function buildTaskScalars(collectionKey: string, record: ManagedTaskRecord) {
     impactStatement: record.impactStatement ?? null,
     ownerOrganizationId: record.ownerOrganizationId ?? null,
     category: record.category ?? TaskCategory.GOVERNANCE,
+    kind: record.kind ?? TaskKind.TASK,
     difficulty: record.difficulty ?? TaskDifficulty.INTERMEDIATE,
     estimatedEffortHours: record.estimatedEffortHours ?? null,
     skillTags: record.skillTags ?? [],
@@ -637,6 +642,7 @@ function managedTaskNeedsUpdate(
     existing.impactStatement !== scalars.impactStatement ||
     existing.ownerOrganizationId !== scalars.ownerOrganizationId ||
     existing.category !== scalars.category ||
+    existing.kind !== scalars.kind ||
     existing.difficulty !== scalars.difficulty ||
     existing.estimatedEffortHours !== scalars.estimatedEffortHours ||
     !sameJson(existing.skillTags, scalars.skillTags) ||
@@ -881,6 +887,7 @@ export async function syncManagedTasks(
       impactStatement: true,
       ownerOrganizationId: true,
       category: true,
+      kind: true,
       difficulty: true,
       estimatedEffortHours: true,
       skillTags: true,

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -3081,6 +3081,13 @@ describe("MCP server tool dispatch", () => {
           expect.objectContaining({ reason: expect.stringContaining("cycle") }),
         ],
       });
+      expect(mocks.taskEdgeFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            fromTaskId: { in: ["draft-a", "draft-b"] },
+          }),
+        }),
+      );
       expect(mocks.taskUpdate).not.toHaveBeenCalled();
     });
 
@@ -4348,6 +4355,11 @@ describe("MCP server tool dispatch", () => {
       expect(parseToolBody(result).error).toContain(
         "Dependency update rejected",
       );
+      expect(mocks.taskEdgeFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ fromTaskId: { in: ["task-a"] } }),
+        }),
+      );
       expect(mocks.taskUpdate).not.toHaveBeenCalled();
       expect(mocks.taskEdgeCreateMany).not.toHaveBeenCalled();
     });
@@ -4419,13 +4431,30 @@ describe("MCP server tool dispatch", () => {
         { id: "task-a", isPublic: false, createdByUserId: "user-1" },
         { id: "task-b", isPublic: false, createdByUserId: "user-1" },
       ]);
-      mocks.taskEdgeFindMany.mockResolvedValue([
-        {
-          edgeType: "BLOCKS",
-          fromTaskId: "task-a",
-          toTaskId: "task-b",
+      mocks.taskEdgeFindMany.mockImplementation(
+        (args: { where?: { fromTaskId?: { in?: string[] } } }) => {
+          const sourceTaskIds = args.where?.fromTaskId?.in ?? [];
+          if (sourceTaskIds.includes("task-a")) {
+            return [
+              {
+                edgeType: "BLOCKS",
+                fromTaskId: "task-a",
+                toTaskId: "middle-task",
+              },
+            ];
+          }
+          if (sourceTaskIds.includes("middle-task")) {
+            return [
+              {
+                edgeType: "BLOCKS",
+                fromTaskId: "middle-task",
+                toTaskId: "task-b",
+              },
+            ];
+          }
+          return [];
         },
-      ]);
+      );
 
       const client = await setup("user-1", ALL_SCOPES, { isAdmin: true });
       const result = await client.callTool({
@@ -4439,6 +4468,13 @@ describe("MCP server tool dispatch", () => {
       expect(result.isError).toBe(true);
       expect(parseToolBody(result).error).toContain(
         "Dependency update rejected",
+      );
+      expect(mocks.taskEdgeFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            fromTaskId: { in: ["middle-task"] },
+          }),
+        }),
       );
       expect(mocks.taskEdgeUpdateMany).not.toHaveBeenCalled();
       expect(mocks.taskEdgeCreateMany).not.toHaveBeenCalled();

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -2324,6 +2324,43 @@ describe("MCP server tool dispatch", () => {
       expect(body.fixedCommitmentMinutes).toBe(60);
     });
 
+    it("scores availability and expiring deadlines at the requested planning window", async () => {
+      mocks.listTasks.mockResolvedValue([
+        makeCreatedTask({
+          availableAt: "2030-01-01T10:00:00.000Z",
+          id: "available-at-window-start",
+          title: "Available at window start",
+        }),
+        makeCreatedTask({
+          deadlinePolicy: "EXPIRES",
+          dueAt: "2030-01-01T09:00:00.000Z",
+          id: "expired-before-window",
+          title: "Expired before window",
+        }),
+      ]);
+      mocks.computeTaskPriority.mockImplementation((task: { id: string }) =>
+        makePriority({
+          priority: task.id === "expired-before-window" ? 1_000 : 100,
+        }),
+      );
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "getExecutionPlan",
+        arguments: {
+          availableMinutes: 60,
+          planningWindowEnd: "2030-01-01T11:00:00.000Z",
+          planningWindowStart: "2030-01-01T10:00:00.000Z",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const body = parseToolBody(result);
+      expect(
+        (body.checklist as Array<{ id: string }>).map((task) => task.id),
+      ).toEqual(["available-at-window-start"]);
+    });
+
     it("rejects organization planning without owner or admin authorization", async () => {
       mocks.canManageOrganization.mockResolvedValue(false);
       const client = await setup("user-1", ALL_SCOPES);

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   taskFindFirst: vi.fn(),
   taskFindMany: vi.fn(),
   taskEdgeCreateMany: vi.fn(),
+  taskEdgeCreate: vi.fn(),
   taskEdgeFindMany: vi.fn(),
   taskEdgeUpdateMany: vi.fn(),
   taskImpactEstimateSetCreate: vi.fn(),
@@ -91,6 +92,7 @@ const mocks = vi.hoisted(() => ({
   removeOrganizationMember: vi.fn(),
   updateOrganizationMemberRole: vi.fn(),
   listOrganizationMembers: vi.fn(),
+  canManageOrganization: vi.fn(),
   softDeleteOrganization: vi.fn(),
   taskFindUnique: vi.fn(),
   upsertSignerReminderTask: vi.fn(),
@@ -105,6 +107,8 @@ const mocks = vi.hoisted(() => ({
   getPageContent: vi.fn(),
   listAdminTaskEmailCommunications: vi.fn(),
   listAdminEmailLogs: vi.fn(),
+  sourceArtifactUpsert: vi.fn(),
+  taskSourceArtifactUpsert: vi.fn(),
 }));
 
 vi.mock("../triggers", () => ({
@@ -250,6 +254,7 @@ vi.mock("../organization.server", () => ({
   removeOrganizationMember: mocks.removeOrganizationMember,
   updateOrganizationMemberRole: mocks.updateOrganizationMemberRole,
   listOrganizationMembers: mocks.listOrganizationMembers,
+  canManageOrganization: mocks.canManageOrganization,
   softDeleteOrganization: mocks.softDeleteOrganization,
   isOrganizationMemberRole: (value: string) => VALID_MEMBER_ROLES.has(value),
   ForbiddenError,
@@ -271,6 +276,7 @@ vi.mock("../prisma", () => ({
       update: mocks.taskUpdate,
     },
     taskEdge: {
+      create: mocks.taskEdgeCreate,
       createMany: mocks.taskEdgeCreateMany,
       findMany: mocks.taskEdgeFindMany,
       updateMany: mocks.taskEdgeUpdateMany,
@@ -312,6 +318,12 @@ vi.mock("../prisma", () => ({
       findMany: mocks.userFindMany,
       update: mocks.userUpdate,
     },
+    sourceArtifact: {
+      upsert: mocks.sourceArtifactUpsert,
+    },
+    taskSourceArtifact: {
+      upsert: mocks.taskSourceArtifactUpsert,
+    },
   },
 }));
 
@@ -351,20 +363,52 @@ function makeCreatedTask(overrides: Record<string, unknown> = {}) {
     difficulty: "TRIVIAL",
     taskKey: "created:1",
     dueAt: null,
-    parentTaskId: null,
+    parentTaskId: "optimize-earth",
     impactStatement: null,
     primaryEndpoint: null,
     claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
     skillTags: [],
     interestTags: [],
     estimatedEffortHours: 1,
+    kind: TaskKind.TASK,
+    activeChildTaskCount: 0,
     blockerStatuses: [],
+    incomingEdges: [],
+    marginalImpactFrame: {
+      estimatedCashCostUsdBase: 0,
+      estimatedEffortHoursBase: 1,
+      expectedEconomicValueUsdBase: 200,
+      successProbabilityBase: 1,
+    },
     childTasks: [],
     assigneePerson: null,
     assigneeOrganization: null,
     assigneePersonId: null,
     assigneeOrganizationId: null,
     createdByUserId: "user-1",
+    ...overrides,
+  };
+}
+
+function makeOptimizeEarthRoot() {
+  return {
+    id: "optimize-earth",
+    kind: TaskKind.PROJECT,
+    parentTaskId: null,
+  };
+}
+
+function makePlanningBranch(overrides: Record<string, unknown> = {}) {
+  return {
+    assigneeOrganizationId: null,
+    assigneePersonId: "person-1",
+    createdByUserId: "user-1",
+    id: "personal-project",
+    isPublic: false,
+    kind: TaskKind.PROJECT,
+    ownerOrganizationId: null,
+    parentTaskId: "optimize-earth",
+    taskKey: "planner:person:person-1",
     ...overrides,
   };
 }
@@ -463,6 +507,15 @@ beforeEach(() => {
       }),
   );
   mocks.listTasks.mockResolvedValue([]);
+  mocks.taskFindMany.mockImplementation(
+    async (args?: { where?: { id?: { in?: string[] } } }) =>
+      args?.where?.id?.in?.includes("optimize-earth")
+        ? [makeOptimizeEarthRoot()]
+        : [],
+  );
+  mocks.canManageOrganization.mockResolvedValue(false);
+  mocks.sourceArtifactUpsert.mockResolvedValue({ id: "source-artifact-1" });
+  mocks.taskSourceArtifactUpsert.mockResolvedValue({ id: "task-source-1" });
   mocks.taskImpactEstimateSetCreate.mockResolvedValue({ id: "estimate-set-1" });
   mocks.taskImpactFrameEstimateCreate.mockResolvedValue({ id: "frame-1" });
   mocks.taskApplicationFindFirst.mockResolvedValue(null);
@@ -669,7 +722,9 @@ describe("MCP server tool dispatch", () => {
       (tool) => tool.name,
     );
 
-    expect(nonAdminNames).not.toContain("proposeTaskBundle");
+    expect(nonAdminNames).toContain("proposeTaskBundle");
+    expect(nonAdminNames).toContain("promoteTask");
+    expect(nonAdminNames).toContain("getExecutionPlan");
     expect(nonAdminNames).not.toContain("setTaskImpact");
     expect(nonAdminNames).not.toContain("addDependency");
     expect(nonAdminNames).not.toContain("acquireLease");
@@ -2216,6 +2271,76 @@ describe("MCP server tool dispatch", () => {
     });
   });
 
+  describe("getExecutionPlan", () => {
+    it("simulates Mercury completion before bank-dependent work and excludes projects", async () => {
+      mocks.listTasks.mockResolvedValue([
+        makeCreatedTask({
+          id: "eos-project",
+          kind: TaskKind.PROJECT,
+          activeChildTaskCount: 2,
+        }),
+        makeCreatedTask({ id: "mercury", estimatedEffortHours: 1 }),
+        makeCreatedTask({
+          id: "bank-dependent",
+          estimatedEffortHours: 1,
+          blockerStatuses: [TaskStatus.ACTIVE],
+          incomingEdges: [
+            {
+              fromTask: { id: "mercury", status: TaskStatus.ACTIVE },
+            },
+          ],
+        }),
+      ]);
+      mocks.computeTaskPriority.mockImplementation((task: { id: string }) =>
+        makePriority({
+          priority: task.id === "bank-dependent" ? 1_000 : 100,
+        }),
+      );
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "getExecutionPlan",
+        arguments: {
+          availableMinutes: 120,
+          fixedCommitments: [
+            {
+              endAt: "2026-07-10T16:00:00.000Z",
+              startAt: "2026-07-10T15:00:00.000Z",
+              title: "Meeting",
+            },
+          ],
+          planningWindowEnd: "2026-07-10T18:00:00.000Z",
+          planningWindowStart: "2026-07-10T14:00:00.000Z",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const body = parseToolBody(result);
+      expect(body.plannerVersion).toBe("frontier-replanning-v1");
+      expect(
+        (body.checklist as Array<{ id: string }>).map((task) => task.id),
+      ).toEqual(["mercury", "bank-dependent"]);
+      expect((body.nextAction as { id: string }).id).toBe("mercury");
+      expect(body.fixedCommitmentMinutes).toBe(60);
+    });
+
+    it("rejects organization planning without owner or admin authorization", async () => {
+      mocks.canManageOrganization.mockResolvedValue(false);
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "getExecutionPlan",
+        arguments: {
+          target: { id: "org-eos", kind: "organization" },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).message).toContain(
+        "owner or admin membership",
+      );
+    });
+  });
+
   describe("personal queues", () => {
     it("splits self-executed tasks from AI-agent-executed tasks", async () => {
       mocks.listTasks.mockResolvedValue([
@@ -2256,7 +2381,7 @@ describe("MCP server tool dispatch", () => {
       const aiQueue = parseToolBody(aiQueueResult).queue as Array<
         Record<string, unknown>
       >;
-      expect(myQueue.map((task) => task.id)).toEqual(["self", "default-self"]);
+      expect(myQueue.map((task) => task.id)).toEqual(["default-self", "self"]);
       expect(aiQueue.map((task) => task.id)).toEqual(["agent"]);
       expect(myQueue[0]).toMatchObject({ priority: 100, executorType: "Self" });
       expect(myQueue[0]?.sprintPriority).toBeUndefined();
@@ -2347,7 +2472,7 @@ describe("MCP server tool dispatch", () => {
       const body = parseToolBody(result);
       expect(body.summary).toMatchObject({
         activeCreatedTasks: 2,
-        unblockedTasks: 2,
+        unblockedTasks: 1,
       });
       const issues = body.issues as Array<{ taskId: string; code: string }>;
       expect(
@@ -2399,6 +2524,12 @@ describe("MCP server tool dispatch", () => {
           dueAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
           deadlinePolicy: "REQUIRED",
           estimatedEffortHours: null,
+          marginalImpactFrame: {
+            estimatedCashCostUsdBase: 0,
+            estimatedEffortHoursBase: null,
+            expectedEconomicValueUsdBase: 200,
+            successProbabilityBase: 1,
+          },
         }),
       ]);
       mocks.taskEdgeFindMany.mockResolvedValue([]);
@@ -2423,6 +2554,499 @@ describe("MCP server tool dispatch", () => {
   });
 
   describe("task writes", () => {
+    it("records each personal execution as a durable execution attempt", async () => {
+      mocks.taskFindUnique.mockResolvedValue({
+        actualCashCostUsd: null,
+        actualEffortSeconds: null,
+        assigneeOrganizationId: null,
+        assigneePersonId: "person-1",
+        contextJson: {},
+        createdByUserId: "user-2",
+        id: "medication-task",
+        isPublic: true,
+        ownerOrganizationId: null,
+        title: "Take medication",
+      });
+      mocks.taskExecutionAttemptCreate.mockResolvedValue({
+        id: "execution-attempt-1",
+      });
+      mocks.taskUpdate.mockResolvedValue({
+        actualCashCostUsd: 2,
+        actualEffortSeconds: 30,
+        id: "medication-task",
+        title: "Take medication",
+      });
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "recordTaskActuals",
+        arguments: {
+          actualCashCostUsd: 2,
+          actualEffortSeconds: 30,
+          completedAt: "2026-07-10T14:12:00.000Z",
+          note: "Completed as planned.",
+          taskId: "medication-task",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.taskExecutionAttemptCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          completedAt: new Date("2026-07-10T14:12:00.000Z"),
+          executorKey: "user:user-1",
+          executorPersonId: "person-1",
+          status: "COMPLETED",
+          taskId: "medication-task",
+        }),
+      });
+      expect(parseToolBody(result).executionAttemptId).toBe(
+        "execution-attempt-1",
+      );
+    });
+
+    it("does not copy previous task actuals into a new execution attempt", async () => {
+      mocks.taskFindUnique.mockResolvedValue({
+        actualCashCostUsd: 7,
+        actualEffortSeconds: 120,
+        assigneeOrganizationId: null,
+        assigneePersonId: "person-1",
+        contextJson: {},
+        createdByUserId: "user-1",
+        id: "recurring-task",
+        isPublic: false,
+        ownerOrganizationId: null,
+        title: "Daily check-in",
+      });
+      mocks.taskExecutionAttemptCreate.mockResolvedValue({
+        id: "execution-attempt-2",
+      });
+      mocks.taskUpdate.mockResolvedValue({
+        actualCashCostUsd: 7,
+        actualEffortSeconds: 120,
+        id: "recurring-task",
+        title: "Daily check-in",
+      });
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "recordTaskActuals",
+        arguments: {
+          note: "Recorded without timing this occurrence.",
+          taskId: "recurring-task",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.taskExecutionAttemptCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          actualCostCurrency: null,
+          actualCostMinorUnits: null,
+          actualDurationSeconds: null,
+          startedAt: null,
+        }),
+      });
+      expect(mocks.taskUpdate).toHaveBeenCalledWith({
+        where: { id: "recurring-task" },
+        data: expect.objectContaining({
+          actualCashCostUsd: 7,
+          actualEffortSeconds: 120,
+        }),
+      });
+    });
+
+    it("creates private caller-owned proposal drafts under an idempotent personal project", async () => {
+      mocks.taskFindFirst.mockImplementation(
+        (args: { where?: { taskKey?: string } }) =>
+          args.where?.taskKey
+            ? null
+            : { id: "optimize-earth", kind: TaskKind.PROJECT },
+      );
+      mocks.taskCreate
+        .mockResolvedValueOnce({
+          id: "personal-project",
+          taskKey: "planner:person:person-1",
+        })
+        .mockResolvedValueOnce({
+          id: "draft-mercury",
+          title: "Open Mercury account for EOS",
+        });
+      mocks.taskFindMany.mockResolvedValue([]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "proposeTaskBundle",
+        arguments: {
+          candidates: [
+            {
+              acceptanceCriteria: ["The account can receive funds."],
+              description:
+                "Open the Mercury account required for Earth Optimization Services banking.",
+              estimatedEffortHours: 1,
+              executorType: "Self",
+              impact: {
+                assumptions: ["Account unblocks banking work."],
+                estimatedCashCostUsdBase: 0,
+                expectedEconomicValueUsdBase: 5_000,
+                successProbabilityBase: 0.9,
+              },
+              source: {
+                sourceKey: "notion-mercury",
+                sourceSystem: "notion",
+                sourceUrl: "https://notion.so/mercury",
+              },
+              title: "Open Mercury account for EOS",
+            },
+          ],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolBody(result).createdDrafts).toEqual([
+        expect.objectContaining({ taskId: "draft-mercury" }),
+      ]);
+      expect(mocks.taskCreate).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            isPublic: false,
+            kind: TaskKind.PROJECT,
+            parentTaskId: "optimize-earth",
+          }),
+        }),
+      );
+      expect(mocks.taskCreate).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            assigneePersonId: "person-1",
+            createdByUserId: "user-1",
+            isPublic: false,
+            kind: TaskKind.TASK,
+            status: TaskStatus.DRAFT,
+          }),
+        }),
+      );
+      expect(mocks.taskImpactFrameEstimateCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            expectedEconomicValueUsdBase: 5_000,
+            successProbabilityBase: 0.9,
+          }),
+        }),
+      );
+      expect(mocks.taskUpdate).toHaveBeenCalledWith({
+        where: { id: "draft-mercury" },
+        data: { parentTaskId: "personal-project" },
+      });
+      expect(mocks.sourceArtifactUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects an occupied planning branch key unless it is the expected private rooted project", async () => {
+      mocks.taskFindFirst.mockImplementation(
+        (args: { where?: { taskKey?: string } }) =>
+          args.where?.taskKey
+            ? makePlanningBranch({ isPublic: true })
+            : makeOptimizeEarthRoot(),
+      );
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "proposeTaskBundle",
+        arguments: {
+          candidates: [
+            {
+              description:
+                "This draft must not attach below an invalid branch.",
+              estimatedEffortHours: 1,
+              title: "Private planning task",
+            },
+          ],
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).message).toContain(
+        "not the expected private, rooted PROJECT",
+      );
+      expect(mocks.taskCreate).not.toHaveBeenCalled();
+    });
+
+    it("reserves person and organization planning branch task keys", async () => {
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "proposeTaskBundle",
+        arguments: {
+          candidates: [
+            {
+              description: "A draft cannot occupy another target's branch key.",
+              estimatedEffortHours: 1,
+              taskKey: "planner:person:person-2",
+              title: "Reserved key collision",
+            },
+          ],
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).error).toContain(
+        "reserved execution-planning branch namespace",
+      );
+      expect(mocks.taskFindFirst).not.toHaveBeenCalled();
+      expect(mocks.taskCreate).not.toHaveBeenCalled();
+    });
+
+    it("reuses a source-identical proposal instead of creating another draft", async () => {
+      mocks.taskFindFirst.mockImplementation(
+        (args: { where?: { taskKey?: string } }) =>
+          args.where?.taskKey ? makePlanningBranch() : makeOptimizeEarthRoot(),
+      );
+      mocks.taskFindMany.mockResolvedValue([
+        {
+          assigneeOrganizationId: null,
+          assigneePersonId: "person-1",
+          createdByUserId: "user-1",
+          id: "existing-draft",
+          isPublic: false,
+          ownerOrganizationId: null,
+          roleTitle: null,
+          sourceArtifacts: [
+            {
+              sourceArtifact: {
+                contentHash: "hash-1",
+                sourceKey: "planner:notion:notion-mercury",
+              },
+            },
+          ],
+          status: TaskStatus.DRAFT,
+          taskKey: "source:mercury",
+          title: "Open Mercury account for EOS",
+        },
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "proposeTaskBundle",
+        arguments: {
+          candidates: [
+            {
+              description:
+                "Open the Mercury account required for Earth Optimization Services banking.",
+              estimatedEffortHours: 1,
+              source: {
+                sourceHash: "hash-1",
+                sourceKey: "notion-mercury",
+                sourceSystem: "notion",
+              },
+              taskKey: "source:mercury",
+              title: "Open Mercury account for EOS",
+            },
+          ],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolBody(result)).toMatchObject({
+        createdDrafts: [],
+        existingDrafts: [expect.objectContaining({ taskId: "existing-draft" })],
+      });
+      expect(mocks.taskCreate).not.toHaveBeenCalled();
+    });
+
+    it("reports a changed source hash without overwriting the existing draft", async () => {
+      mocks.taskFindFirst.mockImplementation(
+        (args: { where?: { taskKey?: string } }) =>
+          args.where?.taskKey ? makePlanningBranch() : makeOptimizeEarthRoot(),
+      );
+      mocks.taskFindMany.mockResolvedValue([
+        {
+          assigneeOrganizationId: null,
+          assigneePersonId: "person-1",
+          createdByUserId: "user-1",
+          id: "existing-draft",
+          isPublic: false,
+          ownerOrganizationId: null,
+          roleTitle: null,
+          sourceArtifacts: [
+            {
+              sourceArtifact: {
+                contentHash: "old-hash",
+                sourceKey: "planner:notion:notion-mercury",
+              },
+            },
+          ],
+          status: TaskStatus.DRAFT,
+          taskKey: "source:mercury",
+          title: "Open Mercury account for EOS",
+        },
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "proposeTaskBundle",
+        arguments: {
+          candidates: [
+            {
+              description: "The upstream source changed.",
+              estimatedEffortHours: 1,
+              source: {
+                sourceHash: "new-hash",
+                sourceKey: "notion-mercury",
+                sourceSystem: "notion",
+              },
+              taskKey: "source:mercury",
+              title: "Open Mercury account for EOS",
+            },
+          ],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolBody(result)).toMatchObject({
+        changedDrafts: [
+          {
+            newSourceHash: "new-hash",
+            previousSourceHash: "old-hash",
+            taskId: "existing-draft",
+          },
+        ],
+        createdDrafts: [],
+        existingDrafts: [],
+      });
+      expect(mocks.taskCreate).not.toHaveBeenCalled();
+      expect(mocks.taskUpdate).not.toHaveBeenCalled();
+      expect(mocks.sourceArtifactUpsert).not.toHaveBeenCalled();
+    });
+
+    it("rejects a personal draft parent outside the caller's planning branch", async () => {
+      mocks.taskFindFirst.mockImplementation(
+        (args: { where?: { taskKey?: string } }) =>
+          args.where?.taskKey ? makePlanningBranch() : makeOptimizeEarthRoot(),
+      );
+      mocks.taskFindMany.mockResolvedValue([
+        {
+          assigneeOrganizationId: null,
+          assigneePersonId: "person-2",
+          createdByUserId: "user-2",
+          id: "foreign-private-project",
+          isPublic: false,
+          ownerOrganizationId: null,
+          roleTitle: null,
+          status: TaskStatus.ACTIVE,
+          taskKey: "planner:person:person-2",
+          title: "Someone else's project",
+        },
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "proposeTaskBundle",
+        arguments: {
+          candidates: [
+            {
+              description: "This must not cross personal ownership branches.",
+              estimatedEffortHours: 1,
+              parentTaskRef: "foreign-private-project",
+              title: "Attach to a foreign project",
+            },
+          ],
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).error).toContain(
+        "Invalid or unauthorized parentTaskRef",
+      );
+      expect(mocks.taskCreate).not.toHaveBeenCalled();
+    });
+
+    it("rejects promotion when the draft dependency graph has a cycle", async () => {
+      const drafts = [
+        {
+          assigneeOrganizationId: null,
+          assigneePersonId: "person-1",
+          communicationEndpoints: [],
+          contextJson: {},
+          createdByUserId: "user-1",
+          description: "First cyclic draft",
+          estimatedEffortHours: 1,
+          id: "draft-a",
+          isPublic: false,
+          kind: TaskKind.TASK,
+          ownerOrganizationId: null,
+          parentTaskId: "optimize-earth",
+          roleTitle: null,
+          status: TaskStatus.DRAFT,
+          taskKey: "draft:a",
+          title: "Draft A",
+        },
+        {
+          assigneeOrganizationId: null,
+          assigneePersonId: "person-1",
+          communicationEndpoints: [],
+          contextJson: {},
+          createdByUserId: "user-1",
+          description: "Second cyclic draft",
+          estimatedEffortHours: 1,
+          id: "draft-b",
+          isPublic: false,
+          kind: TaskKind.TASK,
+          ownerOrganizationId: null,
+          parentTaskId: "optimize-earth",
+          roleTitle: null,
+          status: TaskStatus.DRAFT,
+          taskKey: "draft:b",
+          title: "Draft B",
+        },
+      ];
+      mocks.taskFindMany.mockImplementation(
+        (args: { where?: { id?: { in?: string[] }; status?: string } }) => {
+          if (args.where?.status === TaskStatus.DRAFT) return drafts;
+          if (args.where?.id?.in?.includes("optimize-earth")) {
+            return [
+              {
+                id: "optimize-earth",
+                kind: TaskKind.PROJECT,
+                parentTaskId: null,
+              },
+            ];
+          }
+          return [];
+        },
+      );
+      mocks.taskEdgeFindMany.mockResolvedValue([
+        {
+          edgeType: "BLOCKS",
+          fromTaskId: "draft-a",
+          probabilityDeltaBase: null,
+          timeDeltaDaysBase: null,
+          toTaskId: "draft-b",
+        },
+        {
+          edgeType: "BLOCKS",
+          fromTaskId: "draft-b",
+          probabilityDeltaBase: null,
+          timeDeltaDaysBase: null,
+          toTaskId: "draft-a",
+        },
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "promoteTask",
+        arguments: { proposalRefs: ["draft:a", "draft:b"] },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolBody(result)).toMatchObject({
+        promoted: [],
+        rejected: [
+          expect.objectContaining({ reason: expect.stringContaining("cycle") }),
+          expect.objectContaining({ reason: expect.stringContaining("cycle") }),
+        ],
+      });
+      expect(mocks.taskUpdate).not.toHaveBeenCalled();
+    });
+
     it("createTask schema exposes an explicit visibility override", async () => {
       const client = await setup("admin-1", ALL_SCOPES, { isAdmin: true });
       const result = await client.listTools();
@@ -2514,10 +3138,7 @@ describe("MCP server tool dispatch", () => {
             executionMode: TaskExecutionMode.HUMAN_ONLY,
             kind: TaskKind.ROLE_OPENING,
             locationText: "Edwardsville or St. Louis preferred",
-            preferredSkillTags: [
-              "campaign-management",
-              "nonprofit-outreach",
-            ],
+            preferredSkillTags: ["campaign-management", "nonprofit-outreach"],
             remotePolicy: TaskRemotePolicy.HYBRID,
             requiredCredentialTags: ["nonprofit-campaigns"],
             requiredLanguageTags: ["en"],
@@ -3661,6 +4282,39 @@ describe("MCP server tool dispatch", () => {
       );
     });
 
+    it("updateTask rejects a dependency replacement that creates a cycle", async () => {
+      mocks.getTaskDetailData.mockResolvedValueOnce({
+        task: makeCreatedTask({
+          id: "task-a",
+          createdByUserId: "user-1",
+          contextJson: { executor_type: "Self" },
+        }),
+      });
+      mocks.taskFindMany.mockResolvedValue([
+        { id: "task-b", isPublic: false, createdByUserId: "user-1" },
+      ]);
+      mocks.taskEdgeFindMany.mockResolvedValue([
+        {
+          edgeType: "BLOCKS",
+          fromTaskId: "task-a",
+          toTaskId: "task-b",
+        },
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "updateTask",
+        arguments: { taskId: "task-a", depends_on: ["task-b"] },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).error).toContain(
+        "Dependency update rejected",
+      );
+      expect(mocks.taskUpdate).not.toHaveBeenCalled();
+      expect(mocks.taskEdgeCreateMany).not.toHaveBeenCalled();
+    });
+
     it("addDependency stores downstream lift metadata on the edge", async () => {
       mocks.taskFindMany.mockResolvedValue([
         { id: "blocked-task", isPublic: false, createdByUserId: "user-1" },
@@ -3721,6 +4375,36 @@ describe("MCP server tool dispatch", () => {
           skipDuplicates: true,
         }),
       );
+    });
+
+    it("addDependency rejects an edge that closes a dependency cycle", async () => {
+      mocks.taskFindMany.mockResolvedValue([
+        { id: "task-a", isPublic: false, createdByUserId: "user-1" },
+        { id: "task-b", isPublic: false, createdByUserId: "user-1" },
+      ]);
+      mocks.taskEdgeFindMany.mockResolvedValue([
+        {
+          edgeType: "BLOCKS",
+          fromTaskId: "task-a",
+          toTaskId: "task-b",
+        },
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES, { isAdmin: true });
+      const result = await client.callTool({
+        name: "addDependency",
+        arguments: {
+          blockedTaskId: "task-a",
+          blockerTaskId: "task-b",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).error).toContain(
+        "Dependency update rejected",
+      );
+      expect(mocks.taskEdgeUpdateMany).not.toHaveBeenCalled();
+      expect(mocks.taskEdgeCreateMany).not.toHaveBeenCalled();
     });
   });
 
@@ -4323,13 +5007,15 @@ describe("MCP server tool dispatch", () => {
     function makeAutoSpawnedTasks(userId: string) {
       const parentKey = `program:one-percent-treaty:user:${userId}`;
       return [
-        // Parent (huge realEv → always sorts first)
+        // Parent project (never executable)
         makeCreatedTask({
           id: `parent-${userId}`,
           title: "Get 4 billion people to vote on the 1% Treaty",
           taskKey: parentKey,
           createdByUserId: userId,
-          parentTaskId: "1-pct-treaty",
+          parentTaskId: "optimize-earth",
+          activeChildTaskCount: 4,
+          kind: TaskKind.PROJECT,
         }),
         // Share referral URL (highest among subtasks)
         makeCreatedTask({
@@ -4366,7 +5052,7 @@ describe("MCP server tool dispatch", () => {
       ];
     }
 
-    it("a fresh user sees all five auto-spawned onboarding tasks in priority order (parent first, training meta last)", async () => {
+    it("a fresh user sees only the three atomic onboarding actions", async () => {
       const userId = "fresh-user-1";
       const tasks = makeAutoSpawnedTasks(userId);
       mocks.listTasks.mockResolvedValue(tasks);
@@ -4404,15 +5090,11 @@ describe("MCP server tool dispatch", () => {
         title: string;
       }>;
 
-      expect(queue).toHaveLength(5);
-      // Parent always at top because of its priority
-      expect(queue[0]?.taskKey).toBe(
-        `program:one-percent-treaty:user:${userId}`,
-      );
-      // Training meta-task always at the bottom (auto-completes via the others)
-      expect(queue[queue.length - 1]?.taskKey).toBe(
-        `program:one-percent-treaty:user:${userId}:completeTraining`,
-      );
+      expect(queue).toHaveLength(3);
+      expect(queue.some((task) => task.id === `parent-${userId}`)).toBe(false);
+      expect(
+        queue.some((task) => task.taskKey.endsWith(":completeTraining")),
+      ).toBe(false);
       // Share referral URL is the highest-priority concrete first action
       const shareIndex = queue.findIndex((t) =>
         t.taskKey.endsWith(":shareReferralUrl"),
@@ -4423,7 +5105,7 @@ describe("MCP server tool dispatch", () => {
       expect(shareIndex).toBeLessThan(assign1Index);
     });
 
-    it("after share-referral and both assignments verify, queue collapses to just the parent", async () => {
+    it("after the three real actions verify, no parent or completion gate enters the queue", async () => {
       const userId = "fresh-user-2";
       const tasks = makeAutoSpawnedTasks(userId);
       // Simulate the three subtasks completing — listTasks at status=ACTIVE
@@ -4453,13 +5135,7 @@ describe("MCP server tool dispatch", () => {
 
       const body = parseToolBody(result);
       const queue = body.queue as Array<{ id: string; taskKey: string }>;
-      // Parent + training meta survive (training will auto-VERIFY via
-      // refreshHumanityManagementTrainingCompletion in the real system).
-      expect(queue).toHaveLength(2);
-      expect(queue.map((t) => t.taskKey)).toEqual([
-        `program:one-percent-treaty:user:${userId}`,
-        `program:one-percent-treaty:user:${userId}:completeTraining`,
-      ]);
+      expect(queue).toEqual([]);
     });
 
     it("dynamic invitation tasks rank below the auto-spawned subtasks but above completed ones", async () => {
@@ -4505,15 +5181,14 @@ describe("MCP server tool dispatch", () => {
       const inviteIndex = queue.findIndex((t) =>
         t.taskKey.startsWith("program:one-percent-treaty:referral-invitation:"),
       );
-      const trainingIndex = queue.findIndex((t) =>
-        t.taskKey.endsWith(":completeTraining"),
-      );
       const assignIndex = queue.findIndex((t) =>
         t.taskKey.endsWith(":assignFirstHuman"),
       );
-      // Invite ranks below assignFirstHuman (lower priority value) but above training meta
+      // Invite ranks below the higher-priority atomic assignment.
       expect(inviteIndex).toBeGreaterThan(assignIndex);
-      expect(inviteIndex).toBeLessThan(trainingIndex);
+      expect(
+        queue.some((task) => task.taskKey.endsWith(":completeTraining")),
+      ).toBe(false);
     });
 
     it("a signer-reminder subtask appears in the citizen's queue alongside the onboarding tasks", async () => {
@@ -4524,7 +5199,7 @@ describe("MCP server tool dispatch", () => {
         title: "Remind Raffaella Petrini to sign the 1% Treaty",
         taskKey: `program:one-percent-treaty:reminder:va:${userId}`,
         createdByUserId: userId,
-        parentTaskId: "1-pct-treaty-signer-va",
+        parentTaskId: "optimize-earth",
       });
       mocks.listTasks.mockResolvedValue([...baseline, reminderTask]);
       mocks.isTaskBlocked.mockReturnValue(false);
@@ -4559,10 +5234,7 @@ describe("MCP server tool dispatch", () => {
         t.taskKey.startsWith("program:one-percent-treaty:reminder:"),
       );
       expect(reminderIndex).toBeGreaterThanOrEqual(0);
-      // High priority → ranks above the training meta-task and the assignment subtasks
-      expect(reminderIndex).toBeLessThan(
-        queue.findIndex((t) => t.taskKey.endsWith(":completeTraining")),
-      );
+      expect(reminderIndex).toBe(0);
     });
   });
 

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -20,6 +20,8 @@ import {
   OrgType,
   ReferendumKind,
   ReferendumStatus,
+  SourceArtifactType,
+  SourceSystem,
   TaskCategory,
   TaskApplicationEventType,
   TaskApplicationPolicy,
@@ -30,6 +32,7 @@ import {
   TaskCompensationCadence,
   TaskCompensationKind,
   TaskDifficulty,
+  TaskEdgeType,
   TaskEngagementKind,
   TaskImpactFrameKey,
   TaskExecutionAttemptStatus,
@@ -76,6 +79,19 @@ import type {
   TaskPriorityInput,
   TaskPriorityResult,
 } from "./tasks/rank-tasks";
+import {
+  buildExecutionPlan,
+  type ExecutionPlanningTask,
+  type PlanningBlocker,
+  type PlanningCommitment,
+} from "./tasks/execution-planner";
+import {
+  auditExecutionGraph,
+  getRootedTaskIds,
+  OPTIMIZE_EARTH_ROOT_TASK_ID,
+  type ExecutionGraphEdge,
+  type ExecutionGraphTask,
+} from "./tasks/execution-planner-audit";
 
 export { MCP_SCOPE_DESCRIPTIONS, DEFAULT_CONSENT_SCOPES, ALL_SCOPES, McpScope };
 
@@ -88,12 +104,12 @@ const TOOL_SCOPES: Record<string, McpScope[]> = {
     McpScope.TASKS_ADMIN,
   ],
   createTask: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
-  proposeTaskBundle: [McpScope.TASKS_ADMIN],
-  promoteTask: [McpScope.TASKS_ADMIN],
+  proposeTaskBundle: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
+  promoteTask: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
   deleteTask: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
   updateTask: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
   setTaskImpact: [McpScope.TASKS_ADMIN],
-  recordTaskActuals: [McpScope.TASKS_ADMIN],
+  recordTaskActuals: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
   addDependency: [McpScope.TASKS_ADMIN],
   createReferendum: [McpScope.TASKS_ADMIN],
   createPerson: [McpScope.TASKS_ADMIN],
@@ -155,6 +171,7 @@ const TOOL_SCOPES: Record<string, McpScope[]> = {
   getMyQueue: [McpScope.TASKS_PERSONAL],
   getAIQueue: [McpScope.TASKS_PERSONAL],
   getNextAction: [McpScope.TASKS_PERSONAL],
+  getExecutionPlan: [McpScope.TASKS_PERSONAL],
   findTasksForUser: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
   applyToTask: [McpScope.TASKS_PERSONAL],
   listTaskApplications: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
@@ -178,10 +195,7 @@ const TOOL_SCOPES: Record<string, McpScope[]> = {
 };
 
 const ADMIN_ONLY_TOOLS = new Set([
-  "proposeTaskBundle",
-  "promoteTask",
   "setTaskImpact",
-  "recordTaskActuals",
   "addDependency",
   "createReferendum",
   "createPerson",
@@ -653,10 +667,15 @@ function parseEnumInput<T extends Record<string, string>>(
   if (typeof value !== "string") {
     throw new Error(`${fieldName} must be a string.`);
   }
-  const normalized = value.trim().toUpperCase().replace(/[-\s]+/g, "_");
+  const normalized = value
+    .trim()
+    .toUpperCase()
+    .replace(/[-\s]+/g, "_");
   const parsed = values[normalized as keyof T];
   if (!parsed) {
-    throw new Error(`${fieldName} must be one of: ${Object.keys(values).join(", ")}.`);
+    throw new Error(
+      `${fieldName} must be one of: ${Object.keys(values).join(", ")}.`,
+    );
   }
   return parsed;
 }
@@ -729,7 +748,9 @@ function parseMinorUnitsInput(
     const value = input[fieldName];
     if (value == null || value === "") return null;
     if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
-      throw new Error(`${fieldName} must be a non-negative integer minor-unit amount.`);
+      throw new Error(
+        `${fieldName} must be a non-negative integer minor-unit amount.`,
+      );
     }
     return BigInt(value);
   }
@@ -918,7 +939,8 @@ function buildUserMatchingProfileData(input: Record<string, unknown>) {
     input,
     "maxTaskDifficulty",
   );
-  if (maxTaskDifficulty !== undefined) data.maxTaskDifficulty = maxTaskDifficulty;
+  if (maxTaskDifficulty !== undefined)
+    data.maxTaskDifficulty = maxTaskDifficulty;
 
   if ("availableFrom" in input) {
     const raw = input.availableFrom;
@@ -1018,10 +1040,15 @@ function summarizeCandidateMatch(match: Record<string, unknown>) {
 }
 
 function normalizedTagSet(values: readonly string[] | null | undefined) {
-  return new Set((values ?? []).map((tag) => tag.trim().toLowerCase()).filter(Boolean));
+  return new Set(
+    (values ?? []).map((tag) => tag.trim().toLowerCase()).filter(Boolean),
+  );
 }
 
-function tagCoverageScore(required: readonly string[] | null | undefined, available: readonly string[] | null | undefined) {
+function tagCoverageScore(
+  required: readonly string[] | null | undefined,
+  available: readonly string[] | null | undefined,
+) {
   const requiredSet = normalizedTagSet(required);
   if (requiredSet.size === 0) return 0.5;
   const availableSet = normalizedTagSet(available);
@@ -1032,7 +1059,10 @@ function tagCoverageScore(required: readonly string[] | null | undefined, availa
   return matched / requiredSet.size;
 }
 
-function scoreAgentCandidate(task: Record<string, unknown>, agent: Record<string, unknown>) {
+function scoreAgentCandidate(
+  task: Record<string, unknown>,
+  agent: Record<string, unknown>,
+) {
   const capabilityScore = tagCoverageScore(
     [
       ...asStringArray(task.skillTags),
@@ -1058,7 +1088,12 @@ function scoreAgentCandidate(task: Record<string, unknown>, agent: Record<string
     typeof agent.successRate === "number" && Number.isFinite(agent.successRate)
       ? Math.max(0, Math.min(1, agent.successRate))
       : 0.5;
-  return capabilityScore * 0.45 + toolScore * 0.2 + accessScore * 0.2 + successRate * 0.15;
+  return (
+    capabilityScore * 0.45 +
+    toolScore * 0.2 +
+    accessScore * 0.2 +
+    successRate * 0.15
+  );
 }
 
 function parseAgentRunExecutionStatus(value: unknown) {
@@ -1226,12 +1261,21 @@ function buildStoredProposalContext(input: {
         (input.candidate.assigneeOrganizationId as string) ?? null,
       assigneePersonId: (input.candidate.assigneePersonId as string) ?? null,
       blockerRefs: (input.candidate.blockerRefs as string[]) ?? [],
+      dependencies:
+        (input.candidate.dependencies as Array<Record<string, unknown>>) ?? [],
       contactUrl: (input.candidate.contactUrl as string) ?? null,
       description: (input.candidate.description as string) ?? null,
       estimatedEffortHours:
         (input.candidate.estimatedEffortHours as number) ?? null,
-      impact: (input.candidate.impact as Record<string, number | null>) ?? null,
-      isPublic: (input.candidate.isPublic as boolean) ?? true,
+      executorType: normalizeExecutorType(input.candidate.executorType),
+      bestRoute: (input.candidate.bestRoute as string) ?? null,
+      dueAt: (input.candidate.dueAt as string) ?? null,
+      deadlinePolicy: normalizeDeadlinePolicy(input.candidate.deadlinePolicy),
+      acceptanceCriteria:
+        (input.candidate.acceptanceCriteria as string[]) ?? [],
+      impact: (input.candidate.impact as Record<string, unknown>) ?? null,
+      isPublic: (input.candidate.isPublic as boolean) ?? false,
+      kind: (input.candidate.kind as string) ?? TaskKind.TASK,
       parentTaskRef: (input.candidate.parentTaskRef as string) ?? null,
       proposalRef:
         input.decision?.proposalRef ??
@@ -1249,6 +1293,7 @@ function buildStoredProposalContext(input: {
         : null,
       roleTitle: (input.candidate.roleTitle as string) ?? null,
       sourceUrls: (input.candidate.sourceUrls as string[]) ?? [],
+      source: asObject(input.candidate.source),
       status: "DRAFT",
       taskKey: (input.candidate.taskKey as string) ?? null,
       title: input.candidate.title as string,
@@ -1297,6 +1342,33 @@ function inferProposalDifficulty(candidate: Record<string, unknown>) {
   return TaskDifficulty.BEGINNER;
 }
 
+function getProposalGovernanceImpact(candidate: Record<string, unknown>) {
+  const impact = asObject(candidate.impact) ?? {};
+  const hours = parseFiniteNumber(candidate.estimatedEffortHours);
+  const expectedEconomicValueUsdBase = parseFiniteNumber(
+    impact.expectedEconomicValueUsdBase,
+  );
+  const expectedDalysAvertedBase = parseFiniteNumber(
+    impact.expectedDalysAvertedBase,
+  );
+  return {
+    delayDalysLostPerDay: parseFiniteNumber(impact.delayDalysLostPerDay),
+    delayEconomicValueUsdLostPerDay: parseFiniteNumber(
+      impact.delayEconomicValueUsdLostPerDay,
+    ),
+    expectedValuePerHourDalys:
+      parseFiniteNumber(impact.expectedValuePerHourDalys) ??
+      (hours && expectedDalysAvertedBase != null
+        ? expectedDalysAvertedBase / hours
+        : null),
+    expectedValuePerHourUsd:
+      parseFiniteNumber(impact.expectedValuePerHourUsd) ??
+      (hours && expectedEconomicValueUsdBase != null
+        ? expectedEconomicValueUsdBase / hours
+        : null),
+  };
+}
+
 function matchCandidateToDecision(
   candidate: Record<string, unknown>,
   decision: { proposalRef: string; title: string },
@@ -1324,6 +1396,7 @@ function taskProposalCandidateFromRecord(task: {
   estimatedEffortHours?: number | null;
   id: string;
   isPublic: boolean;
+  kind?: TaskKind | string | null;
   roleTitle?: string | null;
   status: string;
   taskKey?: string | null;
@@ -1356,9 +1429,15 @@ function taskProposalCandidateFromRecord(task: {
     estimatedEffortHours:
       (proposal?.estimatedEffortHours as number) ??
       task.estimatedEffortHours ??
-      null,
+      (task.kind === TaskKind.PROJECT ? 0.1 : null),
     id: task.id,
-    impact: (proposal?.impact as Record<string, number | null>) ?? null,
+    impact: getProposalGovernanceImpact({
+      estimatedEffortHours:
+        (proposal?.estimatedEffortHours as number) ??
+        task.estimatedEffortHours ??
+        null,
+      impact: asObject(proposal?.impact),
+    }),
     isPublic: (proposal?.isPublic as boolean) ?? task.isPublic,
     parentTaskRef: (proposal?.parentTaskRef as string) ?? null,
     roleTitle: (proposal?.roleTitle as string) ?? task.roleTitle ?? null,
@@ -1373,20 +1452,23 @@ async function attachProposalImpactEstimate(input: {
   prisma: Awaited<ReturnType<typeof getPrisma>>;
   taskId: string;
   estimatedEffortHours: number | null;
-  impact: Record<string, number | null> | null;
+  impact: Record<string, unknown> | null;
 }) {
   const impact = input.impact;
   if (!impact) return null;
 
   const hasMeaningfulImpact = Object.values(impact).some(
-    (value) => typeof value === "number" && value > 0,
+    (value) => typeof value === "number" && value !== 0,
   );
   if (!hasMeaningfulImpact) return null;
 
   const estimateSet = await input.prisma.taskImpactEstimateSet.create({
     data: {
-      assumptionsJson: { source: "mcp-proposal" },
-      calculationVersion: "mcp-proposal-v1",
+      assumptionsJson: {
+        assumptions: asStringArray(impact.assumptions),
+        source: "mcp-proposal",
+      },
+      calculationVersion: "mcp-proposal-v2",
       counterfactualKey: "status-quo",
       estimateKind: "FORECAST",
       isCurrent: true,
@@ -1404,17 +1486,47 @@ async function attachProposalImpactEstimate(input: {
       frameKey: TaskImpactFrameKey.TWENTY_YEAR,
       frameSlug: "twenty-year-proposal",
       evaluationHorizonYears: 20,
-      successProbabilityBase: 0.6,
+      successProbabilityLow: (impact.successProbabilityLow as number) ?? null,
+      successProbabilityBase: (impact.successProbabilityBase as number) ?? null,
+      successProbabilityHigh: (impact.successProbabilityHigh as number) ?? null,
       delayDalysLostPerDayBase: (impact.delayDalysLostPerDay as number) ?? null,
       delayEconomicValueUsdLostPerDayBase:
         (impact.delayEconomicValueUsdLostPerDay as number) ?? null,
-      expectedDalysAvertedBase: null,
+      expectedDalysAvertedLow:
+        (impact.expectedDalysAvertedLow as number) ?? null,
+      expectedDalysAvertedBase:
+        (impact.expectedDalysAvertedBase as number) ?? null,
+      expectedDalysAvertedHigh:
+        (impact.expectedDalysAvertedHigh as number) ?? null,
+      medianHealthyLifeYearsEffectLow:
+        (impact.medianHealthyLifeYearsEffectLow as number) ?? null,
+      medianHealthyLifeYearsEffectBase:
+        (impact.medianHealthyLifeYearsEffectBase as number) ?? null,
+      medianHealthyLifeYearsEffectHigh:
+        (impact.medianHealthyLifeYearsEffectHigh as number) ?? null,
+      medianIncomeGrowthEffectPpPerYearLow:
+        (impact.medianIncomeGrowthEffectPpPerYearLow as number) ?? null,
+      medianIncomeGrowthEffectPpPerYearBase:
+        (impact.medianIncomeGrowthEffectPpPerYearBase as number) ?? null,
+      medianIncomeGrowthEffectPpPerYearHigh:
+        (impact.medianIncomeGrowthEffectPpPerYearHigh as number) ?? null,
+      expectedEconomicValueUsdLow:
+        (impact.expectedEconomicValueUsdLow as number) ?? null,
       expectedEconomicValueUsdBase:
-        input.estimatedEffortHours == null ||
+        (impact.expectedEconomicValueUsdBase as number) ??
+        (input.estimatedEffortHours == null ||
         impact.expectedValuePerHourUsd == null
           ? null
-          : impact.expectedValuePerHourUsd * input.estimatedEffortHours,
-      estimatedCashCostUsdBase: null,
+          : (impact.expectedValuePerHourUsd as number) *
+            input.estimatedEffortHours),
+      expectedEconomicValueUsdHigh:
+        (impact.expectedEconomicValueUsdHigh as number) ?? null,
+      estimatedCashCostUsdLow:
+        (impact.estimatedCashCostUsdLow as number) ?? null,
+      estimatedCashCostUsdBase:
+        (impact.estimatedCashCostUsdBase as number) ?? null,
+      estimatedCashCostUsdHigh:
+        (impact.estimatedCashCostUsdHigh as number) ?? null,
       estimatedEffortHoursBase: input.estimatedEffortHours ?? null,
       adoptionRampYears: 0,
       annualDiscountRate: 0.03,
@@ -1429,6 +1541,251 @@ async function attachProposalImpactEstimate(input: {
   });
 
   return estimateSet.id;
+}
+
+function normalizeProposalCandidate(
+  candidate: Record<string, unknown>,
+): Record<string, unknown> {
+  const source = asObject(candidate.source);
+  const sourceSystem =
+    typeof source?.sourceSystem === "string"
+      ? source.sourceSystem.trim().toLowerCase()
+      : null;
+  const sourceKey =
+    typeof source?.sourceKey === "string" ? source.sourceKey.trim() : null;
+  const sourceUrl =
+    typeof source?.sourceUrl === "string" ? source.sourceUrl.trim() : null;
+  const dependencies = Array.isArray(candidate.dependencies)
+    ? (candidate.dependencies as Array<Record<string, unknown>>)
+    : [];
+  const blockerRefs = dedupeStrings([
+    ...asStringArray(candidate.blockerRefs),
+    ...dependencies
+      .map((dependency) => dependency.taskRef)
+      .filter((value): value is string => typeof value === "string"),
+  ]);
+  const sourceUrls = dedupeStrings([
+    ...asStringArray(candidate.sourceUrls),
+    ...(sourceUrl ? [sourceUrl] : []),
+  ]);
+  const normalizedSource =
+    source && sourceSystem && sourceKey
+      ? {
+          ...source,
+          sourceHash:
+            typeof source.sourceHash === "string" && source.sourceHash.trim()
+              ? source.sourceHash.trim()
+              : createHash("sha256")
+                  .update(
+                    JSON.stringify({
+                      acceptanceCriteria: candidate.acceptanceCriteria ?? [],
+                      description: candidate.description ?? null,
+                      sourceKey,
+                      sourceSystem,
+                      title: candidate.title ?? null,
+                    }),
+                  )
+                  .digest("hex"),
+          sourceKey,
+          sourceSystem,
+          sourceUrl,
+        }
+      : null;
+  const generatedTaskKey =
+    normalizedSource && !candidate.taskKey
+      ? `planner-source:${createHash("sha256")
+          .update(`${sourceSystem}:${sourceKey}`)
+          .digest("hex")
+          .slice(0, 32)}`
+      : candidate.taskKey;
+
+  return {
+    ...candidate,
+    blockerRefs,
+    dependencies,
+    isPublic: candidate.isPublic === true,
+    kind:
+      candidate.kind === TaskKind.PROJECT ? TaskKind.PROJECT : TaskKind.TASK,
+    source: normalizedSource,
+    sourceUrls,
+    taskKey: generatedTaskKey,
+  };
+}
+
+async function ensureExecutionPlanningBranch(input: {
+  organizationId?: string | null;
+  personId?: string | null;
+  prisma: Awaited<ReturnType<typeof getPrisma>>;
+  userId: string;
+}) {
+  const targetKind = input.organizationId ? "organization" : "person";
+  const targetId = input.organizationId ?? input.personId ?? input.userId;
+  const taskKey = `planner:${targetKind}:${targetId}`;
+  const root = await input.prisma.task.findFirst({
+    where: {
+      deletedAt: null,
+      id: OPTIMIZE_EARTH_ROOT_TASK_ID,
+    },
+    select: { id: true, kind: true },
+  });
+  if (!root || root.kind !== TaskKind.PROJECT) {
+    throw new Error(
+      "Optimize Earth PROJECT root is missing. Run managed task sync before proposing planning tasks.",
+    );
+  }
+
+  const branchSelect = {
+    assigneeOrganizationId: true,
+    assigneePersonId: true,
+    createdByUserId: true,
+    id: true,
+    isPublic: true,
+    kind: true,
+    ownerOrganizationId: true,
+    parentTaskId: true,
+    taskKey: true,
+  } as const;
+  const validateBranch = (branch: {
+    assigneeOrganizationId: string | null;
+    assigneePersonId: string | null;
+    createdByUserId: string;
+    id: string;
+    isPublic: boolean;
+    kind: TaskKind;
+    ownerOrganizationId: string | null;
+    parentTaskId: string | null;
+    taskKey: string | null;
+  }) => {
+    const matchesTarget = input.organizationId
+      ? branch.assigneeOrganizationId === input.organizationId ||
+        branch.ownerOrganizationId === input.organizationId
+      : input.personId
+        ? branch.assigneePersonId === input.personId
+        : branch.assigneePersonId == null &&
+          branch.assigneeOrganizationId == null &&
+          branch.ownerOrganizationId == null &&
+          branch.createdByUserId === input.userId;
+    if (
+      branch.kind !== TaskKind.PROJECT ||
+      branch.parentTaskId !== root.id ||
+      branch.isPublic ||
+      !matchesTarget
+    ) {
+      throw new Error(
+        `Reserved execution planning branch ${taskKey} is not the expected private, rooted PROJECT for this target.`,
+      );
+    }
+    return { id: branch.id, taskKey: branch.taskKey };
+  };
+  const existing = await input.prisma.task.findFirst({
+    where: { deletedAt: null, taskKey },
+    select: branchSelect,
+  });
+  if (existing) return validateBranch(existing);
+
+  try {
+    return await input.prisma.task.create({
+      data: {
+        assigneeOrganizationId: input.organizationId ?? null,
+        assigneePersonId: input.personId ?? null,
+        category: TaskCategory.OTHER,
+        claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
+        createdByUserId: input.userId,
+        description:
+          targetKind === "organization"
+            ? "Projects owned or assigned to this organization."
+            : "Projects and tasks for this person.",
+        difficulty: TaskDifficulty.INTERMEDIATE,
+        isPublic: false,
+        kind: TaskKind.PROJECT,
+        parentTaskId: root.id,
+        status: TaskStatus.ACTIVE,
+        taskKey,
+        title:
+          targetKind === "organization"
+            ? "Organization projects"
+            : "Personal projects",
+      },
+      select: { id: true, taskKey: true },
+    });
+  } catch (error) {
+    if (asObject(error)?.code !== "P2002") throw error;
+    const racedBranch = await input.prisma.task.findFirst({
+      where: { deletedAt: null, taskKey },
+      select: branchSelect,
+    });
+    if (racedBranch) return validateBranch(racedBranch);
+    throw error;
+  }
+}
+
+function getPlannerSourceArtifactKey(source: Record<string, unknown> | null) {
+  if (!source) return null;
+  const sourceKey = String(source.sourceKey ?? "").trim();
+  const sourceSystemLabel = String(source.sourceSystem ?? "external")
+    .trim()
+    .toLowerCase();
+  return sourceKey && sourceSystemLabel
+    ? `planner:${sourceSystemLabel}:${sourceKey}`
+    : null;
+}
+
+async function attachProposalSourceArtifact(input: {
+  prisma: Awaited<ReturnType<typeof getPrisma>>;
+  source: Record<string, unknown> | null;
+  taskId: string;
+}) {
+  if (!input.source) return null;
+  const sourceKey = String(input.source.sourceKey ?? "").trim();
+  const sourceSystemLabel = String(
+    input.source.sourceSystem ?? "external",
+  ).trim();
+  if (!sourceKey || !sourceSystemLabel) return null;
+  const sourceSystem = Object.values(SourceSystem).includes(
+    sourceSystemLabel.toUpperCase() as SourceSystem,
+  )
+    ? (sourceSystemLabel.toUpperCase() as SourceSystem)
+    : SourceSystem.EXTERNAL;
+  const namespacedSourceKey = getPlannerSourceArtifactKey(input.source);
+  if (!namespacedSourceKey) return null;
+  const artifact = await input.prisma.sourceArtifact.upsert({
+    where: { sourceKey: namespacedSourceKey },
+    create: {
+      artifactType: SourceArtifactType.EXTERNAL_SOURCE,
+      contentHash: (input.source.sourceHash as string) ?? null,
+      externalKey: sourceKey,
+      payloadJson: {
+        importedForExecutionPlanning: true,
+        sourceSystemLabel,
+      },
+      sourceKey: namespacedSourceKey,
+      sourceRef: sourceKey,
+      sourceSystem,
+      sourceUrl: (input.source.sourceUrl as string) ?? null,
+      title: (input.source.title as string) ?? null,
+    },
+    update: {
+      contentHash: (input.source.sourceHash as string) ?? null,
+      deletedAt: null,
+      sourceUrl: (input.source.sourceUrl as string) ?? null,
+      title: (input.source.title as string) ?? null,
+    },
+  });
+  await input.prisma.taskSourceArtifact.upsert({
+    where: {
+      taskId_sourceArtifactId: {
+        sourceArtifactId: artifact.id,
+        taskId: input.taskId,
+      },
+    },
+    create: {
+      isPrimary: true,
+      sourceArtifactId: artifact.id,
+      taskId: input.taskId,
+    },
+    update: { deletedAt: null, isPrimary: true },
+  });
+  return artifact;
 }
 
 async function attachDirectTaskImpactEstimate(input: {
@@ -1579,8 +1936,10 @@ enum TaskVisibility {
 }
 
 type PersonalQueueRow = ReturnType<typeof summarizeTask> & {
+  activeChildTaskCount: number;
   assigneeOrganizationId?: string | null;
   assigneePersonId?: string | null;
+  blockers: PlanningBlocker[];
   blockersCount: number;
   blockersResolved: number;
   blockersResolvedPercent: number;
@@ -1594,9 +1953,11 @@ type PersonalQueueRow = ReturnType<typeof summarizeTask> & {
   latestStartAt: string | null;
   createdByUserId?: string | null;
   executorType: string;
+  hasMarginalEstimate: boolean;
   pSuccess: number | null;
   priority: number;
   realEv: number;
+  rooted: boolean;
   buybackRate: number;
   unblockedBlockers: number;
   unresolvedBlockers: number;
@@ -1614,9 +1975,18 @@ type PersonalQueueTaskRecord = Record<string, unknown> &
     availableAt?: Date | string | null;
     deadlinePolicy?: DeadlinePolicy | string | null;
     contextJson?: unknown;
+    directImpactFrame?: unknown;
+    marginalImpactFrame?: unknown;
     selectedImpactFrame?: unknown;
     isPublic?: boolean | null;
     blockerStatuses?: TaskStatus[] | null;
+    activeChildTaskCount?: number | null;
+    incomingEdges?: Array<{
+      fromTask?: {
+        id?: string | null;
+        status?: TaskStatus | string | null;
+      } | null;
+    }> | null;
   };
 
 function parsePositiveNumber(value: unknown, fallback: number) {
@@ -1828,6 +2198,111 @@ function isSelfExecutableTask(task: PersonalQueueTaskRecord) {
 
 function isAIExecutableTask(task: PersonalQueueTaskRecord) {
   return getTaskExecutorType(task) === AI_EXECUTOR_TYPE;
+}
+
+function isCompletionMilestone(task: PersonalQueueTaskRecord) {
+  if (task.taskKey?.endsWith(":completeTraining")) return true;
+  const plannerContext = asObject(getTaskContext(task).executionPlanner);
+  return plannerContext?.completionMilestone === true;
+}
+
+function getPlanningBlockers(task: PersonalQueueTaskRecord): PlanningBlocker[] {
+  const edgeBlockers = (task.incomingEdges ?? []).flatMap((edge) => {
+    const taskId = edge.fromTask?.id;
+    const status = edge.fromTask?.status;
+    return taskId && status ? [{ taskId, status }] : [];
+  });
+  if (edgeBlockers.length > 0) return edgeBlockers;
+  return (task.blockerStatuses ?? []).map((status, index) => ({
+    status,
+    taskId: `unresolved-blocker:${task.id}:${index}`,
+  }));
+}
+
+function getMarginalImpactFrame(task: PersonalQueueTaskRecord) {
+  return asObject(task.marginalImpactFrame);
+}
+
+function hasMarginalEstimate(task: PersonalQueueTaskRecord) {
+  return (
+    parseFiniteNumber(
+      getMarginalImpactFrame(task)?.expectedEconomicValueUsdBase,
+    ) != null
+  );
+}
+
+function isAtomicExecutionRecord(task: PersonalQueueTaskRecord) {
+  return (
+    (task.kind ?? TaskKind.TASK) === TaskKind.TASK &&
+    (task.activeChildTaskCount ?? task.childTasks?.length ?? 0) === 0 &&
+    !isCompletionMilestone(task)
+  );
+}
+
+async function loadExecutionGraphContext(tasks: PersonalQueueTaskRecord[]) {
+  const prisma = await getPrisma();
+  const graphTaskById = new Map<string, ExecutionGraphTask>();
+  for (const task of tasks) {
+    graphTaskById.set(task.id, {
+      activeChildTaskCount:
+        task.activeChildTaskCount ?? task.childTasks?.length ?? 0,
+      hasMarginalEstimate: hasMarginalEstimate(task),
+      id: task.id,
+      kind: (task.kind as TaskKind | null | undefined) ?? TaskKind.TASK,
+      parentTaskId: task.parentTaskId ?? null,
+    });
+  }
+
+  let pendingParentIds = Array.from(
+    new Set(
+      tasks
+        .map((task) => task.parentTaskId)
+        .filter(
+          (id): id is string => Boolean(id) && !graphTaskById.has(id as string),
+        ),
+    ),
+  );
+  for (let depth = 0; depth < 64 && pendingParentIds.length > 0; depth += 1) {
+    const storedParents =
+      ((await prisma.task.findMany({
+        where: { deletedAt: null, id: { in: pendingParentIds } },
+        select: {
+          id: true,
+          kind: true,
+          parentTaskId: true,
+        },
+      })) as
+        | Array<{
+            id: string;
+            kind?: TaskKind | null;
+            parentTaskId?: string | null;
+          }>
+        | undefined) ?? [];
+    for (const parent of storedParents) {
+      graphTaskById.set(parent.id, {
+        activeChildTaskCount: 0,
+        hasMarginalEstimate: false,
+        id: parent.id,
+        kind: parent.kind ?? TaskKind.TASK,
+        parentTaskId: parent.parentTaskId ?? null,
+      });
+    }
+    pendingParentIds = Array.from(
+      new Set(
+        storedParents
+          .map((parent) => parent.parentTaskId)
+          .filter(
+            (id): id is string =>
+              Boolean(id) && !graphTaskById.has(id as string),
+          ),
+      ),
+    );
+  }
+  const graphTasks = Array.from(graphTaskById.values());
+  return {
+    graphTasks,
+    rootedTaskIds: getRootedTaskIds(graphTasks),
+  };
 }
 
 function isTaskTimeAvailable(task: PersonalQueueTaskRecord, now: Date) {
@@ -2076,9 +2551,11 @@ function buildPersonalQueueRows(
   },
   buybackRate?: number,
   options?: {
+    requireExecutable?: boolean;
     requireUnblocked?: boolean;
     limit?: number;
     now?: Date;
+    rootedTaskIds?: ReadonlySet<string>;
   },
 ) {
   const limit = parseQueueLimit(
@@ -2114,15 +2591,19 @@ function buildPersonalQueueRows(
   const ranked = filtered
     .map((task) => {
       const sourceTask = task as PersonalQueueTaskRecord;
+      const marginalImpactFrame = getMarginalImpactFrame(sourceTask);
       const score = ranking.computeTaskPriority(
-        sourceTask as TaskPriorityInput,
+        {
+          ...sourceTask,
+          selectedImpactFrame: marginalImpactFrame,
+        } as TaskPriorityInput,
         {
           buybackRate: parsedBuybackRate,
         },
       );
       const summary = summarizeTask(sourceTask);
       const context = getTaskContext(sourceTask);
-      const selectedImpactFrame = asObject(sourceTask.selectedImpactFrame);
+      const selectedImpactFrame = marginalImpactFrame;
       const hours = firstFiniteNumber([
         sourceTask.estimatedEffortHours,
         selectedImpactFrame?.estimatedEffortHoursBase,
@@ -2146,8 +2627,11 @@ function buildPersonalQueueRows(
       const deadline = computeDeadlineSummary(sourceTask, hours, now);
       return {
         ...summary,
+        activeChildTaskCount:
+          sourceTask.activeChildTaskCount ?? sourceTask.childTasks?.length ?? 0,
         assigneeOrganizationId: sourceTask.assigneeOrganizationId ?? null,
         assigneePersonId: sourceTask.assigneePersonId ?? null,
+        blockers: getPlanningBlockers(sourceTask),
         createdByUserId: sourceTask.createdByUserId ?? null,
         blockersCount: score.blockersCount,
         blockersResolved: score.blockersResolved,
@@ -2166,9 +2650,13 @@ function buildPersonalQueueRows(
         hours,
         latestStartAt: deadline.latestStartAt,
         executorType: getTaskExecutorType(sourceTask),
+        hasMarginalEstimate: hasMarginalEstimate(sourceTask),
         priority: score.priority,
         pSuccess,
         realEv: score.realEv,
+        rooted:
+          options?.rootedTaskIds?.has(sourceTask.id) ??
+          sourceTask.parentTaskId === OPTIMIZE_EARTH_ROOT_TASK_ID,
         timeUntilDueHours: deadline.timeUntilDueHours,
         unblockedBlockers: score.unblockedBlockers,
         unresolvedBlockers: Math.max(
@@ -2180,9 +2668,98 @@ function buildPersonalQueueRows(
         validationNotes: score.validationNotes,
       } as PersonalQueueTaskRecord & PersonalQueueRow;
     })
-    .sort((left, right) => right.priority - left.priority);
+    .filter(
+      (row) =>
+        !options?.requireExecutable ||
+        (isAtomicExecutionRecord(row) &&
+          row.rooted &&
+          row.hasMarginalEstimate &&
+          row.valid &&
+          row.realEv !== 0),
+    )
+    .sort((left, right) => {
+      if (right.priority !== left.priority) {
+        return right.priority - left.priority;
+      }
+      const leftDueAt = parseTaskDate(left.dueAt)?.getTime() ?? Infinity;
+      const rightDueAt = parseTaskDate(right.dueAt)?.getTime() ?? Infinity;
+      if (leftDueAt !== rightDueAt) return leftDueAt - rightDueAt;
+      return left.id.localeCompare(right.id);
+    });
 
   return ranked.slice(0, limit);
+}
+
+function toExecutionPlanningTask(row: PersonalQueueRow): ExecutionPlanningTask {
+  return {
+    activeChildTaskCount: row.activeChildTaskCount,
+    availableAt: row.availableAt ?? null,
+    blockers: row.blockers,
+    completionMilestone: isCompletionMilestone(
+      row as unknown as PersonalQueueTaskRecord,
+    ),
+    deadlinePolicy: row.deadlinePolicy,
+    deadlineStatus: row.deadlineStatus,
+    dueAt: row.dueAt ?? null,
+    executorType: row.executorType,
+    hasMarginalEstimate: row.hasMarginalEstimate,
+    hours: row.hours,
+    id: row.id,
+    kind: row.kind ?? TaskKind.TASK,
+    parentTaskId: row.parentTaskId ?? null,
+    priority: row.priority,
+    realEv: row.realEv,
+    rooted: row.rooted,
+    title: row.title,
+    valid: row.valid,
+    validationNotes: row.validationNotes,
+  };
+}
+
+type AuthorizedPlanningTarget =
+  | { kind: "self"; personId: string | null; userId: string }
+  | { kind: "person"; personId: string }
+  | { kind: "organization"; organizationId: string };
+
+async function resolveAuthorizedPlanningTarget(input: {
+  args: Record<string, unknown>;
+  isAdmin: boolean;
+  userId: string;
+}): Promise<AuthorizedPlanningTarget> {
+  const target = asObject(input.args.target) ?? {};
+  const kind = String(target.kind ?? target.type ?? "self").toLowerCase();
+  const targetId =
+    typeof target.id === "string" && target.id.trim() ? target.id.trim() : null;
+  const sessionPersonId = await loadSessionPersonId(input.userId);
+
+  if (kind === "self") {
+    return { kind: "self", personId: sessionPersonId, userId: input.userId };
+  }
+  if (kind === "person") {
+    if (!targetId)
+      throw new Error("target.id is required for a person target.");
+    if (!input.isAdmin && targetId !== sessionPersonId) {
+      throw new Error(
+        "Forbidden: you may only plan for your own Person record.",
+      );
+    }
+    return { kind: "person", personId: targetId };
+  }
+  if (kind === "organization") {
+    if (!targetId) {
+      throw new Error("target.id is required for an organization target.");
+    }
+    if (!input.isAdmin) {
+      const { canManageOrganization } = await import("./organization.server");
+      if (!(await canManageOrganization(input.userId, targetId))) {
+        throw new Error(
+          "Forbidden: organization planning requires an owner or admin membership.",
+        );
+      }
+    }
+    return { kind: "organization", organizationId: targetId };
+  }
+  throw new Error("target.kind must be self, person, or organization.");
 }
 
 function parseQueueLimit(value: unknown, fallback = 20, max = 100) {
@@ -3305,7 +3882,8 @@ const TASK_ROUTING_INPUT_PROPERTIES = {
   engagementKind: {
     type: "string",
     enum: Object.values(TaskEngagementKind),
-    description: "Commitment shape: ONE_OFF, ONGOING, PART_TIME, FULL_TIME, CONTRACT.",
+    description:
+      "Commitment shape: ONE_OFF, ONGOING, PART_TIME, FULL_TIME, CONTRACT.",
   },
   applicationPolicy: {
     type: "string",
@@ -3350,7 +3928,8 @@ const TASK_ROUTING_INPUT_PROPERTIES = {
   requiredAccessTags: {
     type: "array",
     items: { type: "string" },
-    description: "Accounts, clearance, location, network, or social access required.",
+    description:
+      "Accounts, clearance, location, network, or social access required.",
   },
   preferredAccessTags: {
     type: "array",
@@ -3854,6 +4433,89 @@ const TASK_TOOL_DEFINITIONS = [
     },
   },
   {
+    name: "getExecutionPlan",
+    description:
+      "Build a capacity-bounded execution plan for the authenticated user, their Person record, or an organization they administer. Uses frontier-replanning-v1: repeatedly chooses the highest-priority feasible atomic task, simulates completion to unlock dependencies, and never starts AI work or writes Calendar events.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        target: {
+          type: "object",
+          properties: {
+            kind: {
+              type: "string",
+              enum: ["self", "person", "organization"],
+              description: "Planning subject. Defaults to self.",
+            },
+            id: {
+              type: "string",
+              description:
+                "Person or organization ID. Omit for the self target.",
+            },
+          },
+        },
+        planningWindowStart: {
+          type: "string",
+          description: "ISO 8601 start. Defaults to now.",
+        },
+        planningWindowEnd: {
+          type: "string",
+          description: "ISO 8601 end. Defaults to 24 hours after start.",
+        },
+        fixedCommitments: {
+          type: "array",
+          description:
+            "Calendar meetings or invitations that consume capacity but are not imported as tasks.",
+          items: {
+            type: "object",
+            properties: {
+              title: { type: "string" },
+              startAt: { type: "string" },
+              endAt: { type: "string" },
+            },
+            required: ["startAt", "endAt"],
+          },
+        },
+        availableMinutes: {
+          type: "number",
+          description:
+            "Maximum work minutes. The planner also caps this at free time left after fixed commitments.",
+        },
+        maxResults: {
+          type: "number",
+          description:
+            "Maximum checklist and AI proposal items (default 20, max 100).",
+        },
+        buybackRate: {
+          type: "number",
+          description:
+            "USD per hour used to convert cash cost into time-equivalent penalty (default 1000).",
+        },
+      },
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        plannerVersion: {
+          type: "string",
+          description: "Transparent planner algorithm version.",
+        },
+        nextAction: { type: ["object", "null"] },
+        checklist: { type: "array", items: { type: "object" } },
+        proposedAiAssistedWork: {
+          type: "array",
+          items: { type: "object" },
+        },
+        blockedWork: { type: "array", items: { type: "object" } },
+        itemsNeedingEstimates: {
+          type: "array",
+          items: { type: "object" },
+        },
+        assumptions: { type: "array", items: { type: "string" } },
+      },
+    },
+  },
+  {
     name: "getNextAction",
     description:
       "Get the best next self-work action from available private tasks. Priority is pure expected net value per hour-equivalent: (P(success) * value - cash_cost) / (hours + cash_cost / buybackRate). Dependencies decide availability. REQUIRED and EXPIRES deadline tasks can override pure priority when they have reached latest-start time.",
@@ -3948,7 +4610,7 @@ const TASK_TOOL_DEFINITIONS = [
   {
     name: "recordTaskActuals",
     description:
-      "Record actual cash cost and effort on a task for non-claim execution paths.",
+      "Append an execution-history attempt and update aggregate actual cash cost and effort. Personal callers may record actuals only for their own private or assigned tasks; this does not create health measurements or run causal analysis.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -3964,6 +4626,10 @@ const TASK_TOOL_DEFINITIONS = [
         note: {
           type: "string",
           description: "Short execution note or procurement/funding rationale",
+        },
+        completedAt: {
+          type: "string",
+          description: "ISO 8601 completion time. Defaults to now.",
         },
       },
       required: ["taskId"],
@@ -4086,7 +4752,10 @@ const TASK_TOOL_DEFINITIONS = [
           description:
             "Optional target user ID. Admin-only unless it is the authenticated user.",
         },
-        limit: { type: "number", description: "Max results, default 20, max 50." },
+        limit: {
+          type: "number",
+          description: "Max results, default 20, max 50.",
+        },
         preferLeafExecution: {
           type: "boolean",
           description:
@@ -4119,8 +4788,14 @@ const TASK_TOOL_DEFINITIONS = [
           type: "string",
           description: "Optional applicant email snapshot.",
         },
-        originUrl: { type: "string", description: "Where the application started." },
-        utmJson: { type: ["object", "null"], description: "UTM/campaign metadata." },
+        originUrl: {
+          type: "string",
+          description: "Where the application started.",
+        },
+        utmJson: {
+          type: ["object", "null"],
+          description: "UTM/campaign metadata.",
+        },
       },
       required: ["taskId"],
     },
@@ -4176,7 +4851,10 @@ const TASK_TOOL_DEFINITIONS = [
       type: "object" as const,
       properties: {
         taskId: { type: "string", description: "Task ID." },
-        limit: { type: "number", description: "Max candidates, default 20, max 100." },
+        limit: {
+          type: "number",
+          description: "Max candidates, default 20, max 100.",
+        },
         includeAgents: {
           type: "boolean",
           description: "Include active AgentExecutor rows. Default true.",
@@ -4257,7 +4935,8 @@ const TASK_TOOL_DEFINITIONS = [
   },
   {
     name: "listAgentExecutors",
-    description: "Admin-only: list non-human executors addressable by task routing.",
+    description:
+      "Admin-only: list non-human executors addressable by task routing.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -5224,6 +5903,12 @@ const TASK_TOOL_DEFINITIONS = [
             type: "object",
             properties: {
               title: { type: "string", description: "Short imperative title" },
+              kind: {
+                type: "string",
+                enum: ["TASK", "PROJECT"],
+                description:
+                  "TASK for an atomic action or PROJECT for a non-executable grouping row.",
+              },
               description: {
                 type: "string",
                 description: "Action and acceptance criteria",
@@ -5241,12 +5926,64 @@ const TASK_TOOL_DEFINITIONS = [
                 description:
                   "IDs or taskKeys of tasks that must complete first",
               },
+              dependencies: {
+                type: "array",
+                description:
+                  "Prerequisites with optional explicit marginal probability or time contribution.",
+                items: {
+                  type: "object",
+                  properties: {
+                    taskRef: { type: "string" },
+                    probabilityDeltaBase: {
+                      type: "number",
+                      description: "Probability lift from 0 to 1.",
+                    },
+                    timeDeltaDaysBase: {
+                      type: "number",
+                      description: "Days accelerated by the prerequisite.",
+                    },
+                    assumptions: {
+                      type: "array",
+                      items: { type: "string" },
+                    },
+                    calculationVersion: { type: "string" },
+                  },
+                  required: ["taskRef"],
+                },
+              },
               parentTaskRef: {
                 type: "string",
                 description: "ID or taskKey of parent task",
               },
               estimatedEffortHours: { type: "number" },
               isPublic: { type: "boolean" },
+              executorType: {
+                type: "string",
+                enum: ["Self", "AI Agent"],
+              },
+              bestRoute: { type: "string" },
+              dueAt: { type: "string" },
+              deadlinePolicy: {
+                type: "string",
+                enum: ["NONE", "SOFT", "EXPIRES", "REQUIRED"],
+              },
+              acceptanceCriteria: {
+                type: "array",
+                items: { type: "string" },
+              },
+              source: {
+                type: "object",
+                description:
+                  "Stable Notion/manual/external provenance. Long source content stays linked rather than copied into the task body.",
+                properties: {
+                  sourceKey: { type: "string" },
+                  sourceHash: { type: "string" },
+                  sourceUrl: { type: "string" },
+                  sourceSystem: { type: "string" },
+                  title: { type: "string" },
+                },
+                required: ["sourceKey", "sourceSystem"],
+              },
               impact: {
                 type: "object",
                 properties: {
@@ -5269,6 +6006,28 @@ const TASK_TOOL_DEFINITIONS = [
                     type: "number",
                     description:
                       "Probability-weighted expected USD-equivalent welfare per hour, not gross conditional value",
+                  },
+                  expectedEconomicValueUsdLow: { type: "number" },
+                  expectedEconomicValueUsdBase: { type: "number" },
+                  expectedEconomicValueUsdHigh: { type: "number" },
+                  expectedDalysAvertedLow: { type: "number" },
+                  expectedDalysAvertedBase: { type: "number" },
+                  expectedDalysAvertedHigh: { type: "number" },
+                  medianHealthyLifeYearsEffectLow: { type: "number" },
+                  medianHealthyLifeYearsEffectBase: { type: "number" },
+                  medianHealthyLifeYearsEffectHigh: { type: "number" },
+                  medianIncomeGrowthEffectPpPerYearLow: { type: "number" },
+                  medianIncomeGrowthEffectPpPerYearBase: { type: "number" },
+                  medianIncomeGrowthEffectPpPerYearHigh: { type: "number" },
+                  successProbabilityLow: { type: "number" },
+                  successProbabilityBase: { type: "number" },
+                  successProbabilityHigh: { type: "number" },
+                  estimatedCashCostUsdLow: { type: "number" },
+                  estimatedCashCostUsdBase: { type: "number" },
+                  estimatedCashCostUsdHigh: { type: "number" },
+                  assumptions: {
+                    type: "array",
+                    items: { type: "string" },
                   },
                 },
               },
@@ -5714,7 +6473,8 @@ const TASK_TOOL_DEFINITIONS = [
         taskId: { type: "string", description: "Task this run worked on" },
         agentId: {
           type: "string",
-          description: "Stable agent identifier, usually matching the lease agentId",
+          description:
+            "Stable agent identifier, usually matching the lease agentId",
         },
         status: {
           type: "string",
@@ -6873,6 +7633,9 @@ export function createMcpServer(
               personId,
               visibility: "personal",
             });
+            const graph = await loadExecutionGraphContext(
+              personalTasks as PersonalQueueTaskRecord[],
+            );
             const selfTasks = (personalTasks as unknown[]).filter((task) =>
               isSelfExecutableTask(task as PersonalQueueTaskRecord),
             );
@@ -6882,7 +7645,9 @@ export function createMcpServer(
               buybackRate,
               {
                 limit: maxResults,
+                requireExecutable: true,
                 requireUnblocked: true,
+                rootedTaskIds: graph.rootedTaskIds,
               },
             );
 
@@ -6911,6 +7676,9 @@ export function createMcpServer(
               personId,
               visibility: "personal",
             });
+            const graph = await loadExecutionGraphContext(
+              personalTasks as PersonalQueueTaskRecord[],
+            );
             const assignedTasks = (personalTasks as unknown[]).filter((task) =>
               isAIExecutableTask(task as PersonalQueueTaskRecord),
             );
@@ -6920,11 +7688,99 @@ export function createMcpServer(
               buybackRate,
               {
                 limit: maxResults,
+                requireExecutable: true,
                 requireUnblocked: true,
+                rootedTaskIds: graph.rootedTaskIds,
               },
             );
 
             return ok({ buybackRate, queue });
+          }
+
+          // ── getExecutionPlan ───────────────────────────────────
+          case "getExecutionPlan": {
+            if (!userId) {
+              return authRequired(
+                "getExecutionPlan",
+                "It builds an authorized personal or organization execution plan.",
+              );
+            }
+            const target = await resolveAuthorizedPlanningTarget({
+              args: a,
+              isAdmin,
+              userId,
+            });
+            const { tasks, ranking } = await getTaskFunctions();
+            const buybackRate = parsePositiveNumber(
+              a.buybackRate,
+              DEFAULT_PERSONAL_BUYBACK_RATE,
+            );
+            const maxResults = parseQueueLimit(a.maxResults, 20, 100);
+            const targetTasks = (await (target.kind === "self"
+              ? tasks.listTasks({
+                  limit: 5000,
+                  personId: target.personId,
+                  status: TaskStatus.ACTIVE,
+                  userId: target.userId,
+                  visibility: "personal",
+                })
+              : target.kind === "person"
+                ? tasks.listTasks({
+                    assigneePersonId: target.personId,
+                    limit: 5000,
+                    status: TaskStatus.ACTIVE,
+                    visibility: "target",
+                  })
+                : tasks.listTasks({
+                    limit: 5000,
+                    status: TaskStatus.ACTIVE,
+                    targetOrganizationId: target.organizationId,
+                    visibility: "target",
+                  }))) as PersonalQueueTaskRecord[];
+            const graph = await loadExecutionGraphContext(targetTasks);
+            const rows = buildPersonalQueueRows(
+              targetTasks,
+              ranking,
+              buybackRate,
+              {
+                limit: targetTasks.length,
+                rootedTaskIds: graph.rootedTaskIds,
+              },
+            );
+            const planningWindowStart =
+              parseTaskDate(a.planningWindowStart) ?? new Date();
+            const planningWindowEnd =
+              parseTaskDate(a.planningWindowEnd) ??
+              new Date(planningWindowStart.getTime() + 24 * MS_PER_HOUR);
+            const fixedCommitments = Array.isArray(a.fixedCommitments)
+              ? (a.fixedCommitments as Array<Record<string, unknown>>).map(
+                  (commitment) => ({
+                    endAt: commitment.endAt as string,
+                    startAt: commitment.startAt as string,
+                    title:
+                      typeof commitment.title === "string"
+                        ? commitment.title
+                        : null,
+                  }),
+                )
+              : [];
+            const plan = buildExecutionPlan({
+              availableMinutes:
+                typeof a.availableMinutes === "number"
+                  ? a.availableMinutes
+                  : null,
+              commitments: fixedCommitments as PlanningCommitment[],
+              limit: maxResults,
+              planningWindowEnd,
+              planningWindowStart,
+              tasks: rows.map(toExecutionPlanningTask),
+            });
+
+            return ok({
+              ...plan,
+              buybackRate,
+              target,
+            });
           }
 
           // ── getQueueAudit ──────────────────────────────────────
@@ -6949,6 +7805,7 @@ export function createMcpServer(
               personId,
               visibility: "personal",
             })) as PersonalQueueTaskRecord[];
+            const graph = await loadExecutionGraphContext(personalTasks);
             const activeCreatedTasks = personalTasks.filter(
               (task) => task.createdByUserId === userId,
             ).length;
@@ -6958,17 +7815,21 @@ export function createMcpServer(
               buybackRate,
               {
                 limit: personalTasks.length,
+                rootedTaskIds: graph.rootedTaskIds,
               },
             );
-            const unblockedCount = buildPersonalQueueRows(
+            const executableRows = buildPersonalQueueRows(
               personalTasks,
               ranking,
               buybackRate,
               {
                 limit: personalTasks.length,
+                requireExecutable: true,
                 requireUnblocked: true,
+                rootedTaskIds: graph.rootedTaskIds,
               },
-            ).length;
+            );
+            const unblockedCount = executableRows.length;
 
             const rowById = new Map(rankedRows.map((row) => [row.id, row]));
             const issues: Array<{
@@ -6980,9 +7841,18 @@ export function createMcpServer(
 
             const taskIds = personalTasks.map((task) => task.id);
             const dependencyEdges = await prisma.taskEdge.findMany({
-              where: { toTaskId: { in: taskIds }, deletedAt: null },
+              where: {
+                OR: [
+                  { toTaskId: { in: taskIds } },
+                  { fromTaskId: { in: taskIds } },
+                ],
+                deletedAt: null,
+              },
               select: {
+                edgeType: true,
                 fromTaskId: true,
+                probabilityDeltaBase: true,
+                timeDeltaDaysBase: true,
                 toTaskId: true,
                 fromTask: {
                   select: { id: true, deletedAt: true, status: true },
@@ -6995,6 +7865,38 @@ export function createMcpServer(
                 orphanedDependencyTaskIds.add(edge.toTaskId);
               }
             }
+
+            const queueEligibleIds = new Set(
+              executableRows.map((row) => row.id),
+            );
+            const rowByGraphTaskId = new Map(
+              rankedRows.map((row) => [row.id, row]),
+            );
+            const graphFindings = auditExecutionGraph({
+              edges: dependencyEdges.map(
+                (edge) =>
+                  ({
+                    edgeType: edge.edgeType,
+                    fromTaskId: edge.fromTaskId,
+                    probabilityDeltaBase: edge.probabilityDeltaBase,
+                    timeDeltaDaysBase: edge.timeDeltaDaysBase,
+                    toTaskId: edge.toTaskId,
+                  }) satisfies ExecutionGraphEdge,
+              ),
+              tasks: graph.graphTasks.map((task) => {
+                const row = rowByGraphTaskId.get(task.id);
+                return {
+                  ...task,
+                  hasMarginalEstimate:
+                    row?.hasMarginalEstimate ?? task.hasMarginalEstimate,
+                  priority: row?.priority ?? null,
+                  queueEligible: queueEligibleIds.has(task.id),
+                } satisfies ExecutionGraphTask;
+              }),
+            }).filter(
+              (finding) => !finding.taskId || taskIds.includes(finding.taskId),
+            );
+            issues.push(...graphFindings);
 
             for (const task of personalTasks) {
               const row = rowById.get(task.id);
@@ -7114,6 +8016,9 @@ export function createMcpServer(
               personId,
               visibility: "personal",
             });
+            const graph = await loadExecutionGraphContext(
+              personalTasks as PersonalQueueTaskRecord[],
+            );
             const selfTasks = (personalTasks as unknown[]).filter((task) =>
               isSelfExecutableTask(task as PersonalQueueTaskRecord),
             );
@@ -7123,7 +8028,9 @@ export function createMcpServer(
               buybackRate,
               {
                 limit: selfTasks.length,
+                requireExecutable: true,
                 requireUnblocked: true,
+                rootedTaskIds: graph.rootedTaskIds,
               },
             );
             const selection = selectPersonalNextAction(queue);
@@ -7254,10 +8161,13 @@ export function createMcpServer(
                 requiredTags: parseStringArrayInput(a, "requiredTags"),
               };
             } catch (error) {
-              return err(error instanceof Error ? error.message : "Invalid filter.");
+              return err(
+                error instanceof Error ? error.message : "Invalid filter.",
+              );
             }
             const needsExtendedFiltering = Object.values(extendedFilters).some(
-              (value) => Array.isArray(value) ? value.length > 0 : value != null,
+              (value) =>
+                Array.isArray(value) ? value.length > 0 : value != null,
             );
             const parentTaskIdFilter =
               typeof a.parentTaskId === "string" && a.parentTaskId
@@ -7309,7 +8219,9 @@ export function createMcpServer(
                     ...asStringArray(task.preferredAccessTags),
                   ].map((tag) => tag.toLowerCase()),
                 );
-                if (!requiredTags.some((tag) => taskTags.has(tag.toLowerCase()))) {
+                if (
+                  !requiredTags.some((tag) => taskTags.has(tag.toLowerCase()))
+                ) {
                   return false;
                 }
               }
@@ -7608,7 +8520,9 @@ export function createMcpServer(
             }
             const targetUserId = optionalString(a.userId) ?? userId;
             if (targetUserId !== userId && !isAdmin) {
-              return err("Admin privileges are required to rank another user's tasks.");
+              return err(
+                "Admin privileges are required to rank another user's tasks.",
+              );
             }
             const prisma = await getPrisma();
             const { tasks, ranking } = await getTaskFunctions();
@@ -7642,7 +8556,10 @@ export function createMcpServer(
 
           case "applyToTask": {
             if (!userId) {
-              return authRequired(name, "This tool submits a task application.");
+              return authRequired(
+                name,
+                "This tool submits a task application.",
+              );
             }
             const taskId = requiredString(a.taskId, "taskId");
             if (typeof taskId !== "string") return taskId;
@@ -7676,7 +8593,9 @@ export function createMcpServer(
             }
 
             const answersJson =
-              "answersJson" in a ? normalizeJsonPatchValue(a.answersJson) : undefined;
+              "answersJson" in a
+                ? normalizeJsonPatchValue(a.answersJson)
+                : undefined;
             const application = await prisma.$transaction(async (tx) => {
               const existing = await tx.taskApplication.findFirst({
                 where: {
@@ -7697,7 +8616,9 @@ export function createMcpServer(
                 answersJson,
                 originUrl: optionalString(a.originUrl),
                 utmJson:
-                  "utmJson" in a ? normalizeJsonPatchValue(a.utmJson) : undefined,
+                  "utmJson" in a
+                    ? normalizeJsonPatchValue(a.utmJson)
+                    : undefined,
               };
               if (existing) {
                 const updated = await tx.taskApplication.update({
@@ -7742,7 +8663,10 @@ export function createMcpServer(
               });
               return created;
             });
-            return ok({ application, task: { id: task.id, title: task.title } });
+            return ok({
+              application,
+              task: { id: task.id, title: task.title },
+            });
           }
 
           case "listTaskApplications": {
@@ -7754,9 +8678,14 @@ export function createMcpServer(
             const applications = await import("./task-applications.server");
             if (!isAdmin) {
               try {
-                await applications.assertCanReviewTaskApplications(userId, taskId);
+                await applications.assertCanReviewTaskApplications(
+                  userId,
+                  taskId,
+                );
               } catch (error) {
-                return err(error instanceof Error ? error.message : "Forbidden");
+                return err(
+                  error instanceof Error ? error.message : "Forbidden",
+                );
               }
             }
             return ok({
@@ -7767,9 +8696,15 @@ export function createMcpServer(
 
           case "reviewTaskApplication": {
             if (!userId) {
-              return authRequired(name, "This tool reviews a task application.");
+              return authRequired(
+                name,
+                "This tool reviews a task application.",
+              );
             }
-            const applicationId = requiredString(a.applicationId, "applicationId");
+            const applicationId = requiredString(
+              a.applicationId,
+              "applicationId",
+            );
             if (typeof applicationId !== "string") return applicationId;
             const prisma = await getPrisma();
             const applications = await import("./task-applications.server");
@@ -7782,7 +8717,8 @@ export function createMcpServer(
                 taskId: true,
               },
             });
-            if (!existing || existing.deletedAt) return err("Application not found.");
+            if (!existing || existing.deletedAt)
+              return err("Application not found.");
             if (!isAdmin) {
               try {
                 await applications.assertCanReviewTaskApplications(
@@ -7790,7 +8726,9 @@ export function createMcpServer(
                   existing.taskId,
                 );
               } catch (error) {
-                return err(error instanceof Error ? error.message : "Forbidden");
+                return err(
+                  error instanceof Error ? error.message : "Forbidden",
+                );
               }
             }
             let status: TaskApplicationStatus | undefined;
@@ -7801,7 +8739,9 @@ export function createMcpServer(
                 "status",
               );
             } catch (error) {
-              return err(error instanceof Error ? error.message : "Invalid status.");
+              return err(
+                error instanceof Error ? error.message : "Invalid status.",
+              );
             }
             let reviewScore: number | null | undefined;
             try {
@@ -7823,7 +8763,9 @@ export function createMcpServer(
                     : undefined,
                 reviewerUserId: userId,
                 reviewNote:
-                  "reviewNote" in a ? (a.reviewNote as string | null) : undefined,
+                  "reviewNote" in a
+                    ? (a.reviewNote as string | null)
+                    : undefined,
                 reviewScore:
                   reviewScore === undefined ? undefined : reviewScore,
                 status,
@@ -7857,7 +8799,10 @@ export function createMcpServer(
             if (typeof taskId !== "string") return taskId;
             const prisma = await getPrisma();
             const { tasks, ranking } = await getTaskFunctions();
-            const detail = await tasks.getTaskDetailData(taskId, userId ?? null);
+            const detail = await tasks.getTaskDetailData(
+              taskId,
+              userId ?? null,
+            );
             if (!detail) return err("Task not found.");
             const task = detail.task as Record<string, unknown>;
             const limit = parseQueueLimit(a.limit, 20, 100);
@@ -7916,7 +8861,10 @@ export function createMcpServer(
             const candidates = [...userCandidates, ...agentCandidates]
               .sort((left, right) => right.score - left.score)
               .slice(0, limit);
-            return ok({ candidates, task: summarizeTask(task as SummarizableTask) });
+            return ok({
+              candidates,
+              task: summarizeTask(task as SummarizableTask),
+            });
           }
 
           case "saveTaskCandidateMatch": {
@@ -7940,17 +8888,17 @@ export function createMcpServer(
               if (!parsedKind) throw new Error("candidateKind is required.");
               candidateKind = parsedKind;
               status =
-                parseEnumInput(
-                  TaskCandidateMatchStatus,
-                  a.status,
-                  "status",
-                ) ?? TaskCandidateMatchStatus.SUGGESTED;
+                parseEnumInput(TaskCandidateMatchStatus, a.status, "status") ??
+                TaskCandidateMatchStatus.SUGGESTED;
             } catch (error) {
-              return err(error instanceof Error ? error.message : "Invalid candidate.");
+              return err(
+                error instanceof Error ? error.message : "Invalid candidate.",
+              );
             }
             const score = parseFiniteNumber(a.score);
             if (score == null) return err("score must be a finite number.");
-            const scoreVersion = optionalString(a.scoreVersion) ?? "mcp-match-v1";
+            const scoreVersion =
+              optionalString(a.scoreVersion) ?? "mcp-match-v1";
             const candidateUserId = optionalString(a.candidateUserId);
             const candidatePersonId = optionalString(a.candidatePersonId);
             const candidateOrganizationId = optionalString(
@@ -7968,7 +8916,11 @@ export function createMcpServer(
                 candidateUserId,
               });
             } catch (error) {
-              return err(error instanceof Error ? error.message : "Invalid candidate key.");
+              return err(
+                error instanceof Error
+                  ? error.message
+                  : "Invalid candidate key.",
+              );
             }
             let estimatedCostMinorUnits: bigint | null | undefined;
             let estimatedDurationSeconds: number | null | undefined;
@@ -8051,7 +9003,10 @@ export function createMcpServer(
 
           case "listTaskCandidateMatches": {
             if (!userId) {
-              return authRequired(name, "This tool lists task candidate matches.");
+              return authRequired(
+                name,
+                "This tool lists task candidate matches.",
+              );
             }
             const taskId = requiredString(a.taskId, "taskId");
             if (typeof taskId !== "string") return taskId;
@@ -8059,9 +9014,14 @@ export function createMcpServer(
             if (!isAdmin) {
               const applications = await import("./task-applications.server");
               try {
-                await applications.assertCanReviewTaskApplications(userId, taskId);
+                await applications.assertCanReviewTaskApplications(
+                  userId,
+                  taskId,
+                );
               } catch (error) {
-                return err(error instanceof Error ? error.message : "Forbidden");
+                return err(
+                  error instanceof Error ? error.message : "Forbidden",
+                );
               }
             }
             let status: TaskCandidateMatchStatus | undefined;
@@ -8072,7 +9032,9 @@ export function createMcpServer(
                 "status",
               );
             } catch (error) {
-              return err(error instanceof Error ? error.message : "Invalid status.");
+              return err(
+                error instanceof Error ? error.message : "Invalid status.",
+              );
             }
             const matches = await prisma.taskCandidateMatch.findMany({
               where: {
@@ -8088,7 +9050,12 @@ export function createMcpServer(
                   select: { id: true, name: true, slug: true, type: true },
                 },
                 candidatePerson: {
-                  select: { displayName: true, handle: true, id: true, image: true },
+                  select: {
+                    displayName: true,
+                    handle: true,
+                    id: true,
+                    image: true,
+                  },
                 },
                 candidateUser: {
                   select: {
@@ -8101,7 +9068,11 @@ export function createMcpServer(
                 },
               },
             });
-            return ok({ matches: matches.map((match) => summarizeCandidateMatch(match as any)) });
+            return ok({
+              matches: matches.map((match) =>
+                summarizeCandidateMatch(match as any),
+              ),
+            });
           }
 
           case "updateTaskCandidateMatchStatus": {
@@ -8116,7 +9087,9 @@ export function createMcpServer(
                 "status",
               );
             } catch (error) {
-              return err(error instanceof Error ? error.message : "Invalid status.");
+              return err(
+                error instanceof Error ? error.message : "Invalid status.",
+              );
             }
             if (!status) return err("status is required.");
             const prisma = await getPrisma();
@@ -8143,14 +9116,12 @@ export function createMcpServer(
             let status: AgentExecutorStatus | undefined;
             let capabilityTags: string[] | undefined;
             try {
-              status = parseEnumInput(
-                AgentExecutorStatus,
-                a.status,
-                "status",
-              );
+              status = parseEnumInput(AgentExecutorStatus, a.status, "status");
               capabilityTags = parseStringArrayInput(a, "capabilityTags");
             } catch (error) {
-              return err(error instanceof Error ? error.message : "Invalid filter.");
+              return err(
+                error instanceof Error ? error.message : "Invalid filter.",
+              );
             }
             const agents = await prisma.agentExecutor.findMany({
               where: {
@@ -8181,7 +9152,9 @@ export function createMcpServer(
                 parseEnumInput(AgentExecutorStatus, a.status, "status") ??
                 AgentExecutorStatus.ACTIVE;
             } catch (error) {
-              return err(error instanceof Error ? error.message : "Invalid status.");
+              return err(
+                error instanceof Error ? error.message : "Invalid status.",
+              );
             }
             const prisma = await getPrisma();
             let data: Record<string, unknown>;
@@ -8197,7 +9170,9 @@ export function createMcpServer(
                   parseStringArrayInput(a, "capabilityTags") ?? [],
                 displayName,
                 metadata:
-                  "metadata" in a ? normalizeJsonPatchValue(a.metadata) : undefined,
+                  "metadata" in a
+                    ? normalizeJsonPatchValue(a.metadata)
+                    : undefined,
                 modelName: optionalStringInput(a, "modelName"),
                 provider: optionalStringInput(a, "provider"),
                 status,
@@ -8206,7 +9181,11 @@ export function createMcpServer(
                 toolTags: parseStringArrayInput(a, "toolTags") ?? [],
               };
             } catch (error) {
-              return err(error instanceof Error ? error.message : "Invalid agent executor field.");
+              return err(
+                error instanceof Error
+                  ? error.message
+                  : "Invalid agent executor field.",
+              );
             }
             const agent = await prisma.agentExecutor.upsert({
               where: { agentKey },
@@ -8224,7 +9203,9 @@ export function createMcpServer(
             try {
               status = parseEnumInput(AgentExecutorStatus, a.status, "status");
             } catch (error) {
-              return err(error instanceof Error ? error.message : "Invalid status.");
+              return err(
+                error instanceof Error ? error.message : "Invalid status.",
+              );
             }
             if (!status) return err("status is required.");
             const prisma = await getPrisma();
@@ -9163,12 +10144,16 @@ export function createMcpServer(
               if (!profile) return err("User not found after update");
               const matchingPreferences =
                 Object.keys(matchingPatch).length > 0
-                  ? await (await getPrisma()).user.update({
+                  ? await (
+                      await getPrisma()
+                    ).user.update({
                       where: { id: userId },
                       data: matchingPatch as any,
                       select: USER_MATCHING_SELECT,
                     })
-                  : await (await getPrisma()).user.findUnique({
+                  : await (
+                      await getPrisma()
+                    ).user.findUnique({
                       where: { id: userId },
                       select: USER_MATCHING_SELECT,
                     });
@@ -9319,28 +10304,352 @@ export function createMcpServer(
 
           // ── proposeTaskBundle ───────────────────────────────────
           case "proposeTaskBundle": {
+            if (!userId) {
+              return authRequired(
+                "proposeTaskBundle",
+                "Draft proposals must be owned by an authenticated user.",
+              );
+            }
             const { endpoints } = await getTaskFunctions();
             const prisma = await getPrisma();
             const { reviewTaskProposalBundle } =
               await import("@optimitron/agent");
-            const { TaskEdgeType } = await import("@optimitron/db");
-            const candidates = a.candidates as Array<Record<string, unknown>>;
+            const rawCandidates = Array.isArray(a.candidates)
+              ? (a.candidates as Array<Record<string, unknown>>)
+              : [];
+            if (rawCandidates.length === 0) {
+              return err(
+                "candidates must contain at least one task or project.",
+              );
+            }
+            const sessionPersonId = await loadSessionPersonId(userId);
+            const candidates: Array<Record<string, unknown>> = [];
+            const planningBranches = new Map<
+              string,
+              { id: string; taskKey: string | null }
+            >();
+            const { canManageOrganization } =
+              await import("./organization.server");
 
+            for (const rawCandidate of rawCandidates) {
+              const candidate = normalizeProposalCandidate(rawCandidate);
+              if (
+                typeof candidate.taskKey === "string" &&
+                /^planner:(?:person|organization):/.test(candidate.taskKey)
+              ) {
+                return err(
+                  "taskKey uses a reserved execution-planning branch namespace.",
+                );
+              }
+              for (const dependency of (candidate.dependencies as Array<
+                Record<string, unknown>
+              >) ?? []) {
+                const probabilityDelta = parseFiniteNumber(
+                  dependency.probabilityDeltaBase,
+                );
+                if (
+                  dependency.probabilityDeltaBase !== undefined &&
+                  (probabilityDelta == null ||
+                    probabilityDelta < 0 ||
+                    probabilityDelta > 1)
+                ) {
+                  return err(
+                    "Dependency probabilityDeltaBase must be a finite number between 0 and 1.",
+                  );
+                }
+                const timeDeltaDays = parseFiniteNumber(
+                  dependency.timeDeltaDaysBase,
+                );
+                if (
+                  dependency.timeDeltaDaysBase !== undefined &&
+                  (timeDeltaDays == null || timeDeltaDays < 0)
+                ) {
+                  return err(
+                    "Dependency timeDeltaDaysBase must be a finite non-negative number.",
+                  );
+                }
+              }
+              const assigneeOrganizationId =
+                typeof candidate.assigneeOrganizationId === "string"
+                  ? candidate.assigneeOrganizationId
+                  : null;
+              let assigneePersonId =
+                typeof candidate.assigneePersonId === "string"
+                  ? candidate.assigneePersonId
+                  : null;
+
+              if (!isAdmin && candidate.isPublic) {
+                return err(
+                  "Non-admin task proposals must remain private drafts.",
+                );
+              }
+              if (assigneeOrganizationId) {
+                if (
+                  !isAdmin &&
+                  !(await canManageOrganization(userId, assigneeOrganizationId))
+                ) {
+                  return err(
+                    "Forbidden: organization proposals require an owner or admin membership.",
+                  );
+                }
+              } else if (!isAdmin) {
+                assigneePersonId ??= sessionPersonId;
+                if (assigneePersonId && assigneePersonId !== sessionPersonId) {
+                  return err(
+                    "Forbidden: personal proposals may only target your own Person record.",
+                  );
+                }
+              }
+
+              const branchKey = assigneeOrganizationId
+                ? `organization:${assigneeOrganizationId}`
+                : `person:${assigneePersonId ?? userId}`;
+              let branch = planningBranches.get(branchKey);
+              if (!branch) {
+                branch = await ensureExecutionPlanningBranch({
+                  organizationId: assigneeOrganizationId,
+                  personId: assigneeOrganizationId ? null : assigneePersonId,
+                  prisma,
+                  userId,
+                });
+                planningBranches.set(branchKey, branch);
+              }
+              candidates.push({
+                ...candidate,
+                assigneeOrganizationId,
+                assigneePersonId,
+                isPublic: isAdmin && candidate.isPublic === true,
+                parentTaskRef: (candidate.parentTaskRef as string) || branch.id,
+              });
+            }
+
+            const proposalOrganizationIds = Array.from(
+              new Set(
+                candidates.flatMap((candidate) =>
+                  typeof candidate.assigneeOrganizationId === "string"
+                    ? [candidate.assigneeOrganizationId]
+                    : [],
+                ),
+              ),
+            );
             const existingTasks = await prisma.task.findMany({
-              where: { deletedAt: null },
+              where: {
+                deletedAt: null,
+                ...(!isAdmin
+                  ? {
+                      OR: [
+                        { isPublic: true },
+                        { createdByUserId: userId },
+                        ...(sessionPersonId
+                          ? [{ assigneePersonId: sessionPersonId }]
+                          : []),
+                        ...(proposalOrganizationIds.length > 0
+                          ? [
+                              {
+                                assigneeOrganizationId: {
+                                  in: proposalOrganizationIds,
+                                },
+                              },
+                              {
+                                ownerOrganizationId: {
+                                  in: proposalOrganizationIds,
+                                },
+                              },
+                            ]
+                          : []),
+                      ],
+                    }
+                  : {}),
+              },
               select: {
                 assigneeOrganizationId: true,
                 assigneePersonId: true,
+                createdByUserId: true,
                 id: true,
+                isPublic: true,
+                ownerOrganizationId: true,
                 roleTitle: true,
+                sourceArtifacts: {
+                  where: { deletedAt: null },
+                  select: {
+                    sourceArtifact: {
+                      select: { contentHash: true, sourceKey: true },
+                    },
+                  },
+                },
                 status: true,
                 taskKey: true,
                 title: true,
               },
             });
+            const targetKeyForCandidate = (
+              candidate: Record<string, unknown>,
+            ) =>
+              typeof candidate.assigneeOrganizationId === "string"
+                ? `organization:${candidate.assigneeOrganizationId}`
+                : `person:${String(candidate.assigneePersonId ?? userId)}`;
+            const candidateByRef = new Map<string, Record<string, unknown>>();
+            for (const candidate of candidates) {
+              for (const ref of [candidate.id, candidate.taskKey]) {
+                if (typeof ref === "string" && ref) {
+                  candidateByRef.set(ref, candidate);
+                }
+              }
+            }
+            const existingTaskByRef = new Map<
+              string,
+              (typeof existingTasks)[number]
+            >();
+            for (const task of existingTasks) {
+              existingTaskByRef.set(task.id, task);
+              if (task.taskKey) existingTaskByRef.set(task.taskKey, task);
+            }
+
+            if (!isAdmin) {
+              const authorizedOrganizationIds = new Set(
+                candidates.flatMap((candidate) =>
+                  typeof candidate.assigneeOrganizationId === "string"
+                    ? [candidate.assigneeOrganizationId]
+                    : [],
+                ),
+              );
+              const canUsePrivateDependency = (
+                task: (typeof existingTasks)[number],
+              ) =>
+                task.isPublic ||
+                task.createdByUserId === userId ||
+                task.assigneePersonId === sessionPersonId ||
+                (task.assigneeOrganizationId != null &&
+                  authorizedOrganizationIds.has(task.assigneeOrganizationId)) ||
+                (task.ownerOrganizationId != null &&
+                  authorizedOrganizationIds.has(task.ownerOrganizationId));
+
+              for (const candidate of candidates) {
+                const targetKey = targetKeyForCandidate(candidate);
+                const branch = planningBranches.get(targetKey)!;
+                const parentRef = String(candidate.parentTaskRef ?? "");
+                const parentCandidate = candidateByRef.get(parentRef);
+                const parentTask = existingTaskByRef.get(parentRef);
+                const isBranch =
+                  parentRef === branch.id || parentRef === branch.taskKey;
+                const isSameTargetCandidate =
+                  parentCandidate != null &&
+                  targetKeyForCandidate(parentCandidate) === targetKey;
+                const isSameTargetTask =
+                  parentTask != null &&
+                  (typeof candidate.assigneeOrganizationId === "string"
+                    ? parentTask.assigneeOrganizationId ===
+                        candidate.assigneeOrganizationId ||
+                      parentTask.ownerOrganizationId ===
+                        candidate.assigneeOrganizationId
+                    : parentTask.assigneePersonId ===
+                        candidate.assigneePersonId ||
+                      parentTask.createdByUserId === userId);
+                if (!isBranch && !isSameTargetCandidate && !isSameTargetTask) {
+                  return err(
+                    `Invalid or unauthorized parentTaskRef ${JSON.stringify(parentRef)}. Personal drafts must stay in the caller's person or organization branch.`,
+                  );
+                }
+
+                for (const blockerRef of candidate.blockerRefs as string[]) {
+                  if (candidateByRef.has(blockerRef)) continue;
+                  const dependencyTask = existingTaskByRef.get(blockerRef);
+                  if (
+                    !dependencyTask ||
+                    !canUsePrivateDependency(dependencyTask)
+                  ) {
+                    return err(
+                      `Invalid or inaccessible dependency reference ${JSON.stringify(blockerRef)}.`,
+                    );
+                  }
+                }
+              }
+            }
+            const existingTaskByKey = new Map(
+              existingTasks.flatMap((task) =>
+                task.taskKey ? [[task.taskKey, task] as const] : [],
+              ),
+            );
+            const existingDrafts: Array<{
+              proposalRef: string;
+              status: TaskStatus;
+              taskId: string;
+              title: string;
+            }> = [];
+            const changedDrafts: Array<{
+              newSourceHash: string;
+              previousSourceHash: string | null;
+              proposalRef: string;
+              status: TaskStatus;
+              taskId: string;
+              title: string;
+            }> = [];
+            for (const candidate of candidates) {
+              const taskKey = candidate.taskKey as string | null;
+              const existingTask = taskKey
+                ? existingTaskByKey.get(taskKey)
+                : null;
+              if (!existingTask || !taskKey) continue;
+              const source = asObject(candidate.source);
+              const artifactKey = getPlannerSourceArtifactKey(source);
+              const newSourceHash =
+                typeof source?.sourceHash === "string"
+                  ? source.sourceHash
+                  : null;
+              const linkedArtifact = artifactKey
+                ? existingTask.sourceArtifacts.find(
+                    (link) => link.sourceArtifact.sourceKey === artifactKey,
+                  )?.sourceArtifact
+                : null;
+              if (
+                artifactKey &&
+                newSourceHash &&
+                linkedArtifact?.contentHash !== newSourceHash
+              ) {
+                changedDrafts.push({
+                  newSourceHash,
+                  previousSourceHash: linkedArtifact?.contentHash ?? null,
+                  proposalRef: taskKey,
+                  status: existingTask.status,
+                  taskId: existingTask.id,
+                  title: existingTask.title,
+                });
+              } else {
+                existingDrafts.push({
+                  proposalRef: taskKey,
+                  status: existingTask.status,
+                  taskId: existingTask.id,
+                  title: existingTask.title,
+                });
+              }
+            }
+            const newCandidates = candidates.filter((candidate) => {
+              const taskKey = candidate.taskKey as string | null;
+              return !taskKey || !existingTaskByKey.has(taskKey);
+            });
+
+            if (newCandidates.length === 0) {
+              return ok({
+                changedDrafts,
+                createdDrafts: [],
+                existingDrafts,
+                message:
+                  changedDrafts.length > 0
+                    ? `${changedDrafts.length} existing draft sources changed and require review; no duplicate drafts were created.`
+                    : "All source-identical proposals already exist.",
+                review: {
+                  decisions: [],
+                  promotableCount: 0,
+                  summary:
+                    changedDrafts.length > 0
+                      ? "Changed sources were reported without overwriting their reviewed drafts."
+                      : "No duplicate drafts were created.",
+                },
+              });
+            }
 
             const review = reviewTaskProposalBundle({
-              candidates: candidates.map((c) => ({
+              candidates: newCandidates.map((c) => ({
                 title: c.title as string,
                 description: (c.description as string) ?? null,
                 taskKey: (c.taskKey as string) ?? null,
@@ -9354,9 +10663,10 @@ export function createMcpServer(
                 blockerRefs: (c.blockerRefs as string[]) ?? [],
                 parentTaskRef: (c.parentTaskRef as string) ?? null,
                 estimatedEffortHours:
-                  (c.estimatedEffortHours as number) ?? null,
-                isPublic: (c.isPublic as boolean) ?? true,
-                impact: (c.impact as Record<string, number | null>) ?? null,
+                  (c.estimatedEffortHours as number) ??
+                  (c.kind === TaskKind.PROJECT ? 0.1 : null),
+                isPublic: (c.isPublic as boolean) ?? false,
+                impact: getProposalGovernanceImpact(c),
                 status: "DRAFT",
               })),
               existingTasks: existingTasks.map((t) => ({
@@ -9375,6 +10685,12 @@ export function createMcpServer(
               existingRefToTaskId.set(task.id, task.id);
               if (task.taskKey) existingRefToTaskId.set(task.taskKey, task.id);
             }
+            for (const branch of planningBranches.values()) {
+              existingRefToTaskId.set(branch.id, branch.id);
+              if (branch.taskKey) {
+                existingRefToTaskId.set(branch.taskKey, branch.id);
+              }
+            }
 
             const created: Array<{
               taskId: string;
@@ -9392,7 +10708,7 @@ export function createMcpServer(
 
             for (const decision of review.decisions) {
               if (!decision.promotable) continue;
-              const candidate = candidates.find((c) =>
+              const candidate = newCandidates.find((c) =>
                 matchCandidateToDecision(c, decision),
               );
               if (!candidate) continue;
@@ -9405,6 +10721,7 @@ export function createMcpServer(
                   taskKey: (candidate.taskKey as string) ?? null,
                   category: inferProposalCategory(candidate),
                   difficulty: inferProposalDifficulty(candidate),
+                  kind: candidate.kind as TaskKind,
                   assigneePersonId:
                     (candidate.assigneePersonId as string) ?? null,
                   assigneeOrganizationId:
@@ -9412,12 +10729,22 @@ export function createMcpServer(
                   roleTitle: (candidate.roleTitle as string) ?? null,
                   estimatedEffortHours:
                     (candidate.estimatedEffortHours as number) ?? null,
-                  isPublic: (candidate.isPublic as boolean) !== false,
+                  isPublic: candidate.isPublic === true,
                   impactStatement: (candidate.description as string) ?? null,
-                  contextJson: buildStoredProposalContext({
-                    candidate,
-                    decision,
-                  }),
+                  contextJson: {
+                    ...buildStoredProposalContext({ candidate, decision }),
+                    acceptanceCriteria:
+                      (candidate.acceptanceCriteria as string[]) ?? [],
+                    best_route: (candidate.bestRoute as string) ?? null,
+                    executor_type: normalizeExecutorType(
+                      candidate.executorType,
+                    ),
+                    sourceProvenance: asObject(candidate.source),
+                  },
+                  deadlinePolicy: normalizeDeadlinePolicy(
+                    candidate.deadlinePolicy,
+                  ),
+                  dueAt: parseTaskDate(candidate.dueAt),
                   status: TaskStatus.DRAFT,
                 } as any,
               });
@@ -9431,9 +10758,13 @@ export function createMcpServer(
               await attachProposalImpactEstimate({
                 estimatedEffortHours:
                   (candidate.estimatedEffortHours as number) ?? null,
-                impact:
-                  (candidate.impact as Record<string, number | null>) ?? null,
+                impact: (candidate.impact as Record<string, unknown>) ?? null,
                 prisma,
+                taskId: task.id,
+              });
+              await attachProposalSourceArtifact({
+                prisma,
+                source: asObject(candidate.source),
                 taskId: task.id,
               });
 
@@ -9477,42 +10808,74 @@ export function createMcpServer(
                   null;
                 if (!blockerTaskId) continue;
 
-                await prisma.taskEdge
-                  .create({
-                    data: {
-                      edgeType: TaskEdgeType.BLOCKS,
-                      fromTaskId: blockerTaskId,
-                      toTaskId: taskId,
-                    },
-                  })
-                  .catch((error) => {
-                    // Edge may already exist from a prior run — don't block draft
-                    // creation. Our own DB write though, so log as error so a real
-                    // schema/constraint bug surfaces instead of getting swallowed.
-                    console.error(
-                      "[mcp-server] taskEdge BLOCKS create failed",
-                      {
-                        blockerTaskId,
-                        taskId,
-                        error,
-                      },
-                    );
-                    return undefined;
-                  });
+                const dependency = (
+                  (candidate.dependencies as Array<Record<string, unknown>>) ??
+                  []
+                ).find((item) => item.taskRef === blockerRef);
+                const probabilityDeltaBase = parseFiniteNumber(
+                  dependency?.probabilityDeltaBase,
+                );
+                const timeDeltaDaysBase = parseFiniteNumber(
+                  dependency?.timeDeltaDaysBase,
+                );
+                if (
+                  probabilityDeltaBase != null &&
+                  (probabilityDeltaBase < 0 || probabilityDeltaBase > 1)
+                ) {
+                  throw new Error(
+                    `Dependency ${blockerRef} probabilityDeltaBase must be between 0 and 1.`,
+                  );
+                }
+                if (timeDeltaDaysBase != null && timeDeltaDaysBase < 0) {
+                  throw new Error(
+                    `Dependency ${blockerRef} timeDeltaDaysBase must be non-negative.`,
+                  );
+                }
+
+                await prisma.taskEdge.create({
+                  data: {
+                    assumptionsJson:
+                      asStringArray(dependency?.assumptions).length > 0
+                        ? toInputJsonValue({
+                            assumptions: asStringArray(dependency?.assumptions),
+                          })
+                        : undefined,
+                    calculationVersion:
+                      (dependency?.calculationVersion as string) ?? null,
+                    edgeType: TaskEdgeType.BLOCKS,
+                    fromTaskId: blockerTaskId,
+                    probabilityDeltaBase,
+                    timeDeltaDaysBase,
+                    toTaskId: taskId,
+                  },
+                });
               }
             }
 
             return ok({
               review,
+              changedDrafts,
               createdDrafts: created,
-              message: `${review.promotableCount} of ${review.decisions.length} candidates passed review. ${created.length} drafts created.`,
+              existingDrafts,
+              message: `${review.promotableCount} of ${review.decisions.length} new candidates passed review. ${created.length} drafts created; ${existingDrafts.length} source-identical tasks reused; ${changedDrafts.length} changed sources require review.`,
             });
           }
 
           // ── promoteTask ────────────────────────────────────────
           case "promoteTask": {
+            if (!userId) {
+              return authRequired(
+                "promoteTask",
+                "Promotion requires an authenticated owner reviewing their drafts.",
+              );
+            }
             const prisma = await getPrisma();
-            const refs = a.proposalRefs as string[];
+            const refs = asStringArray(a.proposalRefs);
+            if (refs.length === 0) {
+              return err(
+                "proposalRefs must contain at least one draft reference.",
+              );
+            }
             const promoted: Array<{ taskId: string; title: string }> = [];
             const rejected: Array<{ ref: string; reason: string }> = [];
             const { reviewTaskProposalBundle } =
@@ -9520,6 +10883,9 @@ export function createMcpServer(
 
             const draftTasks = await prisma.task.findMany({
               where: {
+                ...(!isAdmin
+                  ? { createdByUserId: userId, isPublic: false }
+                  : {}),
                 deletedAt: null,
                 status: TaskStatus.DRAFT,
                 OR: refs.flatMap((ref) => [{ id: ref }, { taskKey: ref }]),
@@ -9542,10 +10908,14 @@ export function createMcpServer(
                   },
                 },
                 contextJson: true,
+                createdByUserId: true,
                 description: true,
                 estimatedEffortHours: true,
                 id: true,
                 isPublic: true,
+                kind: true,
+                ownerOrganizationId: true,
+                parentTaskId: true,
                 roleTitle: true,
                 status: true,
                 taskKey: true,
@@ -9576,15 +10946,118 @@ export function createMcpServer(
               });
             }
 
+            if (!isAdmin) {
+              const { canManageOrganization } =
+                await import("./organization.server");
+              for (const task of draftTasks) {
+                const organizationId =
+                  task.ownerOrganizationId ?? task.assigneeOrganizationId;
+                if (
+                  organizationId &&
+                  !(await canManageOrganization(userId, organizationId))
+                ) {
+                  rejected.push({
+                    ref: task.taskKey ?? task.id,
+                    reason:
+                      "Organization promotion requires an owner or admin membership.",
+                  });
+                }
+              }
+            }
+
+            const graph = await loadExecutionGraphContext(
+              draftTasks as unknown as PersonalQueueTaskRecord[],
+            );
+            const dependencyEdges = await prisma.taskEdge.findMany({
+              where: {
+                deletedAt: null,
+                edgeType: {
+                  in: [TaskEdgeType.BLOCKS, TaskEdgeType.DEPENDS_ON],
+                },
+              },
+              select: {
+                edgeType: true,
+                fromTaskId: true,
+                probabilityDeltaBase: true,
+                timeDeltaDaysBase: true,
+                toTaskId: true,
+              },
+            });
+            const cycleFindings = auditExecutionGraph({
+              edges: dependencyEdges,
+              tasks: graph.graphTasks,
+            }).filter(
+              (finding) =>
+                finding.code === "DEPENDENCY_CYCLE" ||
+                finding.code === "PARENT_CYCLE",
+            );
+            if (cycleFindings.length > 0) {
+              const reason = cycleFindings
+                .map((finding) => finding.message)
+                .join(" ");
+              for (const task of draftTasks) {
+                const ref = task.taskKey ?? task.id;
+                if (!rejected.some((item) => item.ref === ref)) {
+                  rejected.push({ ref, reason });
+                }
+              }
+              return ok({
+                promoted,
+                rejected,
+                message: `${promoted.length} promoted, ${rejected.length} rejected.`,
+              });
+            }
+
+            const promotionOrganizationIds = Array.from(
+              new Set(
+                draftTasks.flatMap((task) =>
+                  (task.ownerOrganizationId ?? task.assigneeOrganizationId)
+                    ? [
+                        (task.ownerOrganizationId ??
+                          task.assigneeOrganizationId)!,
+                      ]
+                    : [],
+                ),
+              ),
+            );
+            const promotionPersonId = isAdmin
+              ? null
+              : await loadSessionPersonId(userId);
             const existingTasks = await prisma.task.findMany({
               where: {
                 deletedAt: null,
                 id: { notIn: draftTasks.map((task) => task.id) },
+                ...(!isAdmin
+                  ? {
+                      OR: [
+                        { isPublic: true },
+                        { createdByUserId: userId },
+                        ...(promotionPersonId
+                          ? [{ assigneePersonId: promotionPersonId }]
+                          : []),
+                        ...(promotionOrganizationIds.length > 0
+                          ? [
+                              {
+                                assigneeOrganizationId: {
+                                  in: promotionOrganizationIds,
+                                },
+                              },
+                              {
+                                ownerOrganizationId: {
+                                  in: promotionOrganizationIds,
+                                },
+                              },
+                            ]
+                          : []),
+                      ],
+                    }
+                  : {}),
               },
               select: {
                 assigneeOrganizationId: true,
                 assigneePersonId: true,
                 id: true,
+                kind: true,
                 roleTitle: true,
                 status: true,
                 taskKey: true,
@@ -9614,6 +11087,19 @@ export function createMcpServer(
             );
 
             for (const task of draftTasks) {
+              if (!graph.rootedTaskIds.has(task.id)) {
+                rejected.push({
+                  ref: task.taskKey ?? task.id,
+                  reason:
+                    "Task is not rooted under Optimize Earth through parentTaskId.",
+                });
+                continue;
+              }
+              if (
+                rejected.some((item) => item.ref === (task.taskKey ?? task.id))
+              ) {
+                continue;
+              }
               const decision = decisionByProposalRef.get(task.id);
               if (!decision?.promotable) {
                 rejected.push({
@@ -9769,6 +11255,48 @@ export function createMcpServer(
                     .map((id) => JSON.stringify(id))
                     .join(", ")}`,
                 );
+              }
+            }
+            if (dependencyPatchProvided) {
+              const dependencyEdges = await prisma.taskEdge.findMany({
+                where: {
+                  deletedAt: null,
+                  edgeType: {
+                    in: [TaskEdgeType.BLOCKS, TaskEdgeType.DEPENDS_ON],
+                  },
+                },
+                select: {
+                  edgeType: true,
+                  fromTaskId: true,
+                  toTaskId: true,
+                },
+              });
+              const proposedEdges = [
+                ...dependencyEdges.filter(
+                  (edge) => edge.toTaskId !== existingTask.id,
+                ),
+                ...blockerTaskIds
+                  .filter((blockerTaskId) => blockerTaskId !== existingTask.id)
+                  .map((blockerTaskId) => ({
+                    edgeType: TaskEdgeType.BLOCKS,
+                    fromTaskId: blockerTaskId,
+                    toTaskId: existingTask.id,
+                  })),
+              ];
+              const cycle = auditExecutionGraph({
+                edges: proposedEdges,
+                tasks: [
+                  {
+                    activeChildTaskCount: 0,
+                    hasMarginalEstimate: false,
+                    id: existingTask.id,
+                    kind: TaskKind.TASK,
+                    parentTaskId: OPTIMIZE_EARTH_ROOT_TASK_ID,
+                  },
+                ],
+              }).find((finding) => finding.code === "DEPENDENCY_CYCLE");
+              if (cycle) {
+                return err(`Dependency update rejected: ${cycle.message}`);
               }
             }
             const economicsPatch = hasEconomicsPatch(a);
@@ -10004,30 +11532,136 @@ export function createMcpServer(
 
           // ── recordTaskActuals ──────────────────────────────────
           case "recordTaskActuals": {
+            if (!userId) {
+              return authRequired(
+                "recordTaskActuals",
+                "Execution history must be attributed to an authenticated user.",
+              );
+            }
             const prisma = await getPrisma();
             const existing = await prisma.task.findUnique({
               where: { id: a.taskId as string },
               select: {
                 actualCashCostUsd: true,
                 actualEffortSeconds: true,
+                assigneeOrganizationId: true,
+                assigneePersonId: true,
                 contextJson: true,
+                createdByUserId: true,
                 id: true,
+                isPublic: true,
+                ownerOrganizationId: true,
                 title: true,
               },
             });
             if (!existing) return err("Task not found");
+            const personId = await loadSessionPersonId(userId);
+            const organizationId =
+              existing.ownerOrganizationId ??
+              existing.assigneeOrganizationId ??
+              null;
+            let canManageAssignedOrganization = false;
+            if (organizationId && !isAdmin) {
+              const { canManageOrganization } =
+                await import("./organization.server");
+              canManageAssignedOrganization = await canManageOrganization(
+                userId,
+                organizationId,
+              );
+            }
+            const ownsTask = existing.createdByUserId === userId;
+            const isAssignedPerson =
+              Boolean(personId) && existing.assigneePersonId === personId;
+            if (
+              !isAdmin &&
+              !ownsTask &&
+              !isAssignedPerson &&
+              !canManageAssignedOrganization
+            ) {
+              return err(
+                "Forbidden: execution actuals may only be recorded by the task owner, assignee, or an organization admin.",
+              );
+            }
 
             const context = asObject(existing.contextJson) ?? {};
             const executionV1 = asObject(context.executionV1) ?? {};
             const note = (a.note as string) ?? null;
+            const attemptCashCostUsd =
+              a.actualCashCostUsd === undefined
+                ? null
+                : parseFiniteNumber(a.actualCashCostUsd);
+            const attemptEffortSeconds =
+              a.actualEffortSeconds === undefined
+                ? null
+                : parseFiniteNumber(a.actualEffortSeconds);
+            if (
+              a.actualCashCostUsd !== undefined &&
+              attemptCashCostUsd == null
+            ) {
+              return err("actualCashCostUsd must be a finite number.");
+            }
+            if (
+              a.actualEffortSeconds !== undefined &&
+              attemptEffortSeconds == null
+            ) {
+              return err("actualEffortSeconds must be a finite number.");
+            }
             const actualCashCostUsd =
-              (a.actualCashCostUsd as number) ??
-              existing.actualCashCostUsd ??
-              null;
+              attemptCashCostUsd ?? existing.actualCashCostUsd ?? null;
             const actualEffortSeconds =
-              (a.actualEffortSeconds as number) ??
-              existing.actualEffortSeconds ??
-              null;
+              attemptEffortSeconds ?? existing.actualEffortSeconds ?? null;
+            if (attemptCashCostUsd != null && attemptCashCostUsd < 0) {
+              return err("actualCashCostUsd must be non-negative.");
+            }
+            if (attemptEffortSeconds != null && attemptEffortSeconds < 0) {
+              return err("actualEffortSeconds must be non-negative.");
+            }
+            if (
+              attemptEffortSeconds != null &&
+              !Number.isInteger(attemptEffortSeconds)
+            ) {
+              return err("actualEffortSeconds must be a whole number.");
+            }
+            const completedAt =
+              a.completedAt === undefined
+                ? new Date()
+                : parseTaskDate(a.completedAt);
+            if (!completedAt) {
+              return err("completedAt must be a valid ISO 8601 timestamp.");
+            }
+
+            const attempt = await prisma.taskExecutionAttempt.create({
+              data: {
+                actualCostCurrency: attemptCashCostUsd == null ? null : "usd",
+                actualCostMinorUnits:
+                  attemptCashCostUsd == null
+                    ? null
+                    : BigInt(Math.round(attemptCashCostUsd * 100)),
+                actualDurationSeconds: attemptEffortSeconds,
+                completedAt,
+                executorKey: `user:${userId}`,
+                executorKind: TaskCandidateKind.USER,
+                executorPersonId: personId,
+                executorUserId: userId,
+                metadata: note
+                  ? ({
+                      note,
+                      source: "mcp-record-task-actuals",
+                    } as Prisma.InputJsonValue)
+                  : ({
+                      source: "mcp-record-task-actuals",
+                    } as Prisma.InputJsonValue),
+                outputSummary: note,
+                startedAt:
+                  attemptEffortSeconds == null
+                    ? null
+                    : new Date(
+                        completedAt.getTime() - attemptEffortSeconds * 1000,
+                      ),
+                status: TaskExecutionAttemptStatus.COMPLETED,
+                taskId: existing.id,
+              },
+            });
 
             const task = await prisma.task.update({
               where: { id: a.taskId as string },
@@ -10052,6 +11686,7 @@ export function createMcpServer(
             return ok({
               actualCashCostUsd: task.actualCashCostUsd,
               actualEffortSeconds: task.actualEffortSeconds,
+              executionAttemptId: attempt.id,
               taskId: task.id,
               title: task.title,
             });
@@ -10392,6 +12027,9 @@ export function createMcpServer(
               (task) => task.id === blockerTaskId,
             );
             if (!blockedTask || !blockerTask) return err("Task not found");
+            if (blockedTaskId === blockerTaskId) {
+              return err("A task cannot depend on itself.");
+            }
             if (blockedTask.createdByUserId !== userId) {
               return err(
                 "Forbidden: blocked task was not created by current user",
@@ -10441,6 +12079,41 @@ export function createMcpServer(
               ...(calculationVersion ? { calculationVersion } : {}),
               ...(notes ? { notes } : {}),
             };
+            const dependencyEdges = await prisma.taskEdge.findMany({
+              where: {
+                deletedAt: null,
+                edgeType: {
+                  in: [TaskEdgeType.BLOCKS, TaskEdgeType.DEPENDS_ON],
+                },
+              },
+              select: {
+                edgeType: true,
+                fromTaskId: true,
+                toTaskId: true,
+              },
+            });
+            const cycle = auditExecutionGraph({
+              edges: [
+                ...dependencyEdges,
+                {
+                  edgeType: TaskEdgeType.BLOCKS,
+                  fromTaskId: blockerTaskId,
+                  toTaskId: blockedTaskId,
+                },
+              ],
+              tasks: [
+                {
+                  activeChildTaskCount: 0,
+                  hasMarginalEstimate: false,
+                  id: blockedTaskId,
+                  kind: TaskKind.TASK,
+                  parentTaskId: OPTIMIZE_EARTH_ROOT_TASK_ID,
+                },
+              ],
+            }).find((finding) => finding.code === "DEPENDENCY_CYCLE");
+            if (cycle) {
+              return err(`Dependency update rejected: ${cycle.message}`);
+            }
             await prisma.taskEdge.updateMany({
               where: {
                 fromTaskId: a.blockerTaskId as string,
@@ -10540,7 +12213,9 @@ export function createMcpServer(
               return err("costUsd must be a non-negative finite number.");
             }
             if (!status) {
-              return err("status must be RUNNING, COMPLETED, FAILED, or PARTIAL.");
+              return err(
+                "status must be RUNNING, COMPLETED, FAILED, or PARTIAL.",
+              );
             }
             const agentId = optionalString(a.agentId);
             const attempt = await prisma.taskExecutionAttempt.create({

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -2305,6 +2305,53 @@ async function loadExecutionGraphContext(tasks: PersonalQueueTaskRecord[]) {
   };
 }
 
+async function loadReachableDependencyEdges(
+  prisma: Awaited<ReturnType<typeof getPrisma>>,
+  seedTaskIds: string[],
+) {
+  const visitedSourceIds = new Set<string>();
+  const edgeByKey = new Map<string, ExecutionGraphEdge>();
+  let frontier = Array.from(new Set(seedTaskIds.filter(Boolean)));
+
+  while (frontier.length > 0) {
+    const sourceTaskIds = frontier.filter(
+      (taskId) => !visitedSourceIds.has(taskId),
+    );
+    if (sourceTaskIds.length === 0) break;
+    for (const taskId of sourceTaskIds) visitedSourceIds.add(taskId);
+
+    const edges = await prisma.taskEdge.findMany({
+      where: {
+        deletedAt: null,
+        edgeType: {
+          in: [TaskEdgeType.BLOCKS, TaskEdgeType.DEPENDS_ON],
+        },
+        fromTaskId: { in: sourceTaskIds },
+      },
+      select: {
+        edgeType: true,
+        fromTaskId: true,
+        probabilityDeltaBase: true,
+        timeDeltaDaysBase: true,
+        toTaskId: true,
+      },
+    });
+    const nextTaskIds = new Set<string>();
+    for (const edge of edges) {
+      edgeByKey.set(
+        `${edge.edgeType}:${edge.fromTaskId}:${edge.toTaskId}`,
+        edge,
+      );
+      if (!visitedSourceIds.has(edge.toTaskId)) {
+        nextTaskIds.add(edge.toTaskId);
+      }
+    }
+    frontier = Array.from(nextTaskIds);
+  }
+
+  return Array.from(edgeByKey.values());
+}
+
 function isTaskTimeAvailable(task: PersonalQueueTaskRecord, now: Date) {
   const availableAt = parseTaskDate(task.availableAt);
   return !availableAt || availableAt.getTime() <= now.getTime();
@@ -10970,21 +11017,10 @@ export function createMcpServer(
             const graph = await loadExecutionGraphContext(
               draftTasks as unknown as PersonalQueueTaskRecord[],
             );
-            const dependencyEdges = await prisma.taskEdge.findMany({
-              where: {
-                deletedAt: null,
-                edgeType: {
-                  in: [TaskEdgeType.BLOCKS, TaskEdgeType.DEPENDS_ON],
-                },
-              },
-              select: {
-                edgeType: true,
-                fromTaskId: true,
-                probabilityDeltaBase: true,
-                timeDeltaDaysBase: true,
-                toTaskId: true,
-              },
-            });
+            const dependencyEdges = await loadReachableDependencyEdges(
+              prisma,
+              draftTasks.map((task) => task.id),
+            );
             const cycleFindings = auditExecutionGraph({
               edges: dependencyEdges,
               tasks: graph.graphTasks,
@@ -11260,19 +11296,10 @@ export function createMcpServer(
               }
             }
             if (dependencyPatchProvided) {
-              const dependencyEdges = await prisma.taskEdge.findMany({
-                where: {
-                  deletedAt: null,
-                  edgeType: {
-                    in: [TaskEdgeType.BLOCKS, TaskEdgeType.DEPENDS_ON],
-                  },
-                },
-                select: {
-                  edgeType: true,
-                  fromTaskId: true,
-                  toTaskId: true,
-                },
-              });
+              const dependencyEdges = await loadReachableDependencyEdges(
+                prisma,
+                [existingTask.id],
+              );
               const proposedEdges = [
                 ...dependencyEdges.filter(
                   (edge) => edge.toTaskId !== existingTask.id,
@@ -12081,19 +12108,9 @@ export function createMcpServer(
               ...(calculationVersion ? { calculationVersion } : {}),
               ...(notes ? { notes } : {}),
             };
-            const dependencyEdges = await prisma.taskEdge.findMany({
-              where: {
-                deletedAt: null,
-                edgeType: {
-                  in: [TaskEdgeType.BLOCKS, TaskEdgeType.DEPENDS_ON],
-                },
-              },
-              select: {
-                edgeType: true,
-                fromTaskId: true,
-                toTaskId: true,
-              },
-            });
+            const dependencyEdges = await loadReachableDependencyEdges(prisma, [
+              blockedTaskId,
+            ]);
             const cycle = auditExecutionGraph({
               edges: [
                 ...dependencyEdges,

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -4759,7 +4759,7 @@ const TASK_TOOL_DEFINITIONS = [
         preferLeafExecution: {
           type: "boolean",
           description:
-            "Prefer executable leaf tasks over parent projects when possible.",
+            "When true, return only executable childless TASK rows; never fall back to parents or projects.",
         },
       },
     },
@@ -7737,6 +7737,11 @@ export function createMcpServer(
                     targetOrganizationId: target.organizationId,
                     visibility: "target",
                   }))) as PersonalQueueTaskRecord[];
+            const planningWindowStart =
+              parseTaskDate(a.planningWindowStart) ?? new Date();
+            const planningWindowEnd =
+              parseTaskDate(a.planningWindowEnd) ??
+              new Date(planningWindowStart.getTime() + 24 * MS_PER_HOUR);
             const graph = await loadExecutionGraphContext(targetTasks);
             const rows = buildPersonalQueueRows(
               targetTasks,
@@ -7744,14 +7749,10 @@ export function createMcpServer(
               buybackRate,
               {
                 limit: targetTasks.length,
+                now: planningWindowStart,
                 rootedTaskIds: graph.rootedTaskIds,
               },
             );
-            const planningWindowStart =
-              parseTaskDate(a.planningWindowStart) ?? new Date();
-            const planningWindowEnd =
-              parseTaskDate(a.planningWindowEnd) ??
-              new Date(planningWindowStart.getTime() + 24 * MS_PER_HOUR);
             const fixedCommitments = Array.isArray(a.fixedCommitments)
               ? (a.fixedCommitments as Array<Record<string, unknown>>).map(
                   (commitment) => ({
@@ -7771,6 +7772,7 @@ export function createMcpServer(
                   : null,
               commitments: fixedCommitments as PlanningCommitment[],
               limit: maxResults,
+              now: planningWindowStart,
               planningWindowEnd,
               planningWindowStart,
               tasks: rows.map(toExecutionPlanningTask),

--- a/packages/web/src/lib/tasks.server.ts
+++ b/packages/web/src/lib/tasks.server.ts
@@ -43,6 +43,7 @@ import {
   rankTasksForUser,
   scoreTaskForAccountability,
 } from "@/lib/tasks/rank-tasks";
+import { getExplicitEdgeMarginalFrames } from "@/lib/tasks/marginal-impact";
 import { grantWishes } from "@/lib/wishes.server";
 
 const log = createLogger("tasks-server");
@@ -731,7 +732,7 @@ function buildParentInheritedImpactFrame(
   });
 }
 
-function buildDownstreamUnlockedImpactFrame(
+function buildAnnotatedDownstreamMarginalImpactFrame(
   task: TaskListItem | TaskDetailItem,
   options?: {
     frameKey?: TaskImpactFrameKey | string | null;
@@ -747,87 +748,13 @@ function buildDownstreamUnlockedImpactFrame(
       return [];
     }
 
-    const weightedFrames: NonNullable<TaskImpactSelection["selectedFrame"]>[] =
-      [];
-    const probabilityDelta =
-      edge.probabilityDeltaBase != null && edge.probabilityDeltaBase > 0
-        ? edge.probabilityDeltaBase
-        : null;
-    const timeDeltaDays =
-      edge.timeDeltaDaysBase != null && edge.timeDeltaDaysBase > 0
-        ? edge.timeDeltaDaysBase
-        : null;
-
-    if (probabilityDelta != null) {
-      weightedFrames.push(
-        scaleImpactFrameSummary(frame, probabilityDelta, {
-          customFrameLabel: `Probability-weighted downstream value unlocked by ${task.title}`,
-          frameSlug: `${frame.frameSlug}-probability-delta-${task.id}`,
-          // A marginal-unlocked-value frame has no single success probability;
-          // leave it null rather than carrying the downstream task's.
-          successProbabilityBase: null,
-          successProbabilityHigh: null,
-          successProbabilityLow: null,
-          metrics: [],
-        }),
-      );
-    }
-
-    if (timeDeltaDays != null) {
-      weightedFrames.push({
-        ...frame,
-        customFrameLabel: `Time-accelerated downstream value unlocked by ${task.title}`,
-        successProbabilityBase: null,
-        successProbabilityHigh: null,
-        successProbabilityLow: null,
-        delayDalysLostPerDayBase: frame.delayDalysLostPerDayBase,
-        delayDalysLostPerDayHigh: frame.delayDalysLostPerDayHigh,
-        delayDalysLostPerDayLow: frame.delayDalysLostPerDayLow,
-        delayEconomicValueUsdLostPerDayBase:
-          frame.delayEconomicValueUsdLostPerDayBase,
-        delayEconomicValueUsdLostPerDayHigh:
-          frame.delayEconomicValueUsdLostPerDayHigh,
-        delayEconomicValueUsdLostPerDayLow:
-          frame.delayEconomicValueUsdLostPerDayLow,
-        estimatedCashCostUsdBase: null,
-        estimatedCashCostUsdHigh: null,
-        estimatedCashCostUsdLow: null,
-        estimatedEffortHoursBase:
-          task.estimatedEffortHours ?? frame.estimatedEffortHoursBase ?? null,
-        estimatedEffortHoursHigh:
-          task.estimatedEffortHours ?? frame.estimatedEffortHoursHigh ?? null,
-        estimatedEffortHoursLow:
-          task.estimatedEffortHours ?? frame.estimatedEffortHoursLow ?? null,
-        expectedDalysAvertedBase:
-          (frame.delayDalysLostPerDayBase ?? 0) * timeDeltaDays,
-        expectedDalysAvertedHigh:
-          frame.delayDalysLostPerDayHigh == null
-            ? null
-            : frame.delayDalysLostPerDayHigh * timeDeltaDays,
-        expectedDalysAvertedLow:
-          frame.delayDalysLostPerDayLow == null
-            ? null
-            : frame.delayDalysLostPerDayLow * timeDeltaDays,
-        expectedEconomicValueUsdBase:
-          (frame.delayEconomicValueUsdLostPerDayBase ?? 0) * timeDeltaDays,
-        expectedEconomicValueUsdHigh:
-          frame.delayEconomicValueUsdLostPerDayHigh == null
-            ? null
-            : frame.delayEconomicValueUsdLostPerDayHigh * timeDeltaDays,
-        expectedEconomicValueUsdLow:
-          frame.delayEconomicValueUsdLostPerDayLow == null
-            ? null
-            : frame.delayEconomicValueUsdLostPerDayLow * timeDeltaDays,
-        frameSlug: `${frame.frameSlug}-time-delta-${task.id}`,
-        metrics: [],
-      });
-    }
-
-    if (weightedFrames.length === 0) {
-      weightedFrames.push(frame);
-    }
-
-    return weightedFrames;
+    return getExplicitEdgeMarginalFrames({
+      downstreamFrame: frame,
+      edge,
+      estimatedEffortHours: task.estimatedEffortHours,
+      sourceTaskId: task.id,
+      sourceTaskTitle: task.title,
+    });
   });
 
   if (downstreamFrames.length === 0) {
@@ -867,6 +794,7 @@ function decorateTask<T extends TaskListItem | TaskDetailItem>(
   activeChildTaskCount: number;
   blockerStatuses: TaskStatus[];
   directImpactFrame: TaskImpactSelection["selectedFrame"];
+  marginalImpactFrame: TaskImpactSelection["selectedFrame"];
   impact: {
     availableFrames: TaskImpactSelection["availableFrames"];
     confidenceSummary: unknown;
@@ -891,15 +819,57 @@ function decorateTask<T extends TaskListItem | TaskDetailItem>(
     directImpactSelection.selectedFrame == null
       ? buildParentInheritedImpactFrame(task, options)
       : null;
-  const downstreamUnlockedFrame = buildDownstreamUnlockedImpactFrame(
+  const downstreamMarginalFrame = buildAnnotatedDownstreamMarginalImpactFrame(
     task,
     options,
+  );
+  const marginalImpactFrame = sumImpactFrameSummaries(
+    [directImpactSelection.selectedFrame, downstreamMarginalFrame].filter(
+      (frame): frame is NonNullable<typeof frame> => frame != null,
+    ),
+    directImpactSelection.selectedFrame
+      ? {
+          customFrameLabel:
+            directImpactSelection.selectedFrame.customFrameLabel,
+          estimatedCashCostUsdBase:
+            task.actualCashCostUsd ??
+            directImpactSelection.selectedFrame.estimatedCashCostUsdBase,
+          estimatedEffortHoursBase:
+            task.estimatedEffortHours ??
+            directImpactSelection.selectedFrame.estimatedEffortHoursBase,
+          frameKey: directImpactSelection.selectedFrame.frameKey,
+          frameSlug: directImpactSelection.selectedFrame.frameSlug,
+          metrics: directImpactSelection.selectedFrame.metrics,
+        }
+      : {
+          customFrameLabel: downstreamMarginalFrame?.customFrameLabel ?? null,
+          estimatedCashCostUsdBase: task.actualCashCostUsd ?? null,
+          estimatedCashCostUsdHigh: null,
+          estimatedCashCostUsdLow: null,
+          estimatedEffortHoursBase:
+            task.estimatedEffortHours ??
+            downstreamMarginalFrame?.estimatedEffortHoursBase ??
+            null,
+          estimatedEffortHoursHigh:
+            task.estimatedEffortHours ??
+            downstreamMarginalFrame?.estimatedEffortHoursHigh ??
+            null,
+          estimatedEffortHoursLow:
+            task.estimatedEffortHours ??
+            downstreamMarginalFrame?.estimatedEffortHoursLow ??
+            null,
+          frameKey:
+            downstreamMarginalFrame?.frameKey ?? DEFAULT_TASK_IMPACT_FRAME,
+          frameSlug:
+            downstreamMarginalFrame?.frameSlug ?? "explicit-marginal-impact",
+          metrics: [],
+        },
   );
   const selectedImpactFrame = sumImpactFrameSummaries(
     [
       directImpactSelection.selectedFrame,
       inheritedParentFrame,
-      downstreamUnlockedFrame,
+      downstreamMarginalFrame,
     ].filter((frame): frame is NonNullable<typeof frame> => frame != null),
     directImpactSelection.selectedFrame
       ? {
@@ -918,7 +888,7 @@ function decorateTask<T extends TaskListItem | TaskDetailItem>(
       : {
           customFrameLabel:
             inheritedParentFrame?.customFrameLabel ??
-            downstreamUnlockedFrame?.customFrameLabel ??
+            downstreamMarginalFrame?.customFrameLabel ??
             null,
           estimatedCashCostUsdBase: task.actualCashCostUsd ?? null,
           estimatedCashCostUsdHigh: null,
@@ -926,25 +896,25 @@ function decorateTask<T extends TaskListItem | TaskDetailItem>(
           estimatedEffortHoursBase:
             task.estimatedEffortHours ??
             inheritedParentFrame?.estimatedEffortHoursBase ??
-            downstreamUnlockedFrame?.estimatedEffortHoursBase ??
+            downstreamMarginalFrame?.estimatedEffortHoursBase ??
             null,
           estimatedEffortHoursHigh:
             task.estimatedEffortHours ??
             inheritedParentFrame?.estimatedEffortHoursHigh ??
-            downstreamUnlockedFrame?.estimatedEffortHoursHigh ??
+            downstreamMarginalFrame?.estimatedEffortHoursHigh ??
             null,
           estimatedEffortHoursLow:
             task.estimatedEffortHours ??
             inheritedParentFrame?.estimatedEffortHoursLow ??
-            downstreamUnlockedFrame?.estimatedEffortHoursLow ??
+            downstreamMarginalFrame?.estimatedEffortHoursLow ??
             null,
           frameKey:
             inheritedParentFrame?.frameKey ??
-            downstreamUnlockedFrame?.frameKey ??
+            downstreamMarginalFrame?.frameKey ??
             DEFAULT_TASK_IMPACT_FRAME,
           frameSlug:
             inheritedParentFrame?.frameSlug ??
-            downstreamUnlockedFrame?.frameSlug ??
+            downstreamMarginalFrame?.frameSlug ??
             "effective-impact",
           metrics: [],
         },
@@ -988,6 +958,7 @@ function decorateTask<T extends TaskListItem | TaskDetailItem>(
     ...(decoratedChildTasks ? { childTasks: decoratedChildTasks } : {}),
     contextJson: normalizeTaskContextJson(task.contextJson),
     directImpactFrame: directImpactSelection.selectedFrame,
+    marginalImpactFrame,
     primaryEndpoint,
     impact: {
       availableFrames: directImpactSelection.availableFrames,
@@ -1015,6 +986,7 @@ function decorateTask<T extends TaskListItem | TaskDetailItem>(
     activeChildTaskCount: number;
     blockerStatuses: TaskStatus[];
     directImpactFrame: TaskImpactSelection["selectedFrame"];
+    marginalImpactFrame: TaskImpactSelection["selectedFrame"];
     impact: {
       availableFrames: TaskImpactSelection["availableFrames"];
       confidenceSummary: unknown;
@@ -1069,9 +1041,10 @@ function getTaskVisibilityWhere(input?: {
   assigneePersonId?: string | null;
   personId?: string | null;
   status?: TaskStatus | null;
+  targetOrganizationId?: string | null;
   taskId?: string | null;
   userId?: string | null;
-  visibility?: "public" | "created" | "accessible" | "personal";
+  visibility?: "public" | "created" | "accessible" | "personal" | "target";
 }): Prisma.TaskWhereInput {
   const baseWhere: Prisma.TaskWhereInput = {
     assigneeOrganizationId: input?.assigneeOrganizationId ?? undefined,
@@ -1079,9 +1052,20 @@ function getTaskVisibilityWhere(input?: {
     deletedAt: null,
     id: input?.taskId ?? undefined,
     status: input?.status ?? undefined,
+    ...(input?.targetOrganizationId
+      ? {
+          OR: [
+            { assigneeOrganizationId: input.targetOrganizationId },
+            { ownerOrganizationId: input.targetOrganizationId },
+          ],
+        }
+      : {}),
   };
 
   const visibility = input?.visibility ?? "public";
+  if (visibility === "target") {
+    return baseWhere;
+  }
   if (visibility === "created") {
     if (!input?.userId) {
       return {
@@ -1383,14 +1367,16 @@ export async function listTasks(options?: {
   parentTaskId?: string | null;
   personId?: string | null;
   status?: TaskStatus | null;
+  targetOrganizationId?: string | null;
   userId?: string | null;
-  visibility?: "public" | "created" | "accessible" | "personal";
+  visibility?: "public" | "created" | "accessible" | "personal" | "target";
 }) {
   const visibilityWhere = getTaskVisibilityWhere({
     assigneeOrganizationId: options?.assigneeOrganizationId,
     assigneePersonId: options?.assigneePersonId,
     personId: options?.personId,
     status: options?.status,
+    targetOrganizationId: options?.targetOrganizationId,
     userId: options?.userId,
     visibility: options?.visibility,
   });

--- a/packages/web/src/lib/tasks/execution-planner-audit.test.ts
+++ b/packages/web/src/lib/tasks/execution-planner-audit.test.ts
@@ -1,0 +1,154 @@
+import { TaskKind } from "@optimitron/db";
+import { describe, expect, it } from "vitest";
+import {
+  auditExecutionGraph,
+  OPTIMIZE_EARTH_ROOT_TASK_ID,
+} from "./execution-planner-audit";
+
+function graphTask(id: string, parentTaskId: string | null, overrides = {}) {
+  return {
+    activeChildTaskCount: 0,
+    hasMarginalEstimate: true,
+    id,
+    kind: TaskKind.TASK,
+    parentTaskId,
+    queueEligible: false,
+    ...overrides,
+  };
+}
+
+describe("auditExecutionGraph", () => {
+  it("requires an actual PROJECT root row", () => {
+    const missing = auditExecutionGraph({
+      edges: [],
+      tasks: [graphTask("child", OPTIMIZE_EARTH_ROOT_TASK_ID)],
+    });
+    const wrongKind = auditExecutionGraph({
+      edges: [],
+      tasks: [graphTask(OPTIMIZE_EARTH_ROOT_TASK_ID, null)],
+    });
+
+    expect(missing.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining(["MISSING_ROOT", "UNROOTED_TASK"]),
+    );
+    expect(wrongKind.map((finding) => finding.code)).toContain(
+      "ROOT_NOT_PROJECT",
+    );
+  });
+
+  it("detects unrooted tasks and parent/dependency cycles", () => {
+    const findings = auditExecutionGraph({
+      edges: [
+        { edgeType: "BLOCKS", fromTaskId: "a", toTaskId: "b" },
+        { edgeType: "BLOCKS", fromTaskId: "b", toTaskId: "a" },
+      ],
+      tasks: [
+        graphTask(OPTIMIZE_EARTH_ROOT_TASK_ID, null, {
+          kind: TaskKind.PROJECT,
+        }),
+        graphTask("a", "b"),
+        graphTask("b", "a"),
+      ],
+    });
+
+    expect(findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining([
+        "DEPENDENCY_CYCLE",
+        "PARENT_CYCLE",
+        "UNROOTED_TASK",
+      ]),
+    );
+  });
+
+  it("flags projects, parents, and missing estimates when they pollute a queue", () => {
+    const findings = auditExecutionGraph({
+      edges: [],
+      tasks: [
+        graphTask(OPTIMIZE_EARTH_ROOT_TASK_ID, null, {
+          kind: TaskKind.PROJECT,
+        }),
+        graphTask("project", OPTIMIZE_EARTH_ROOT_TASK_ID, {
+          kind: TaskKind.PROJECT,
+          queueEligible: true,
+        }),
+        graphTask("parent", "project", {
+          activeChildTaskCount: 1,
+          queueEligible: true,
+        }),
+        graphTask("leaf", "parent", { hasMarginalEstimate: false }),
+      ],
+    });
+
+    expect(findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining([
+        "EXECUTABLE_PARENT",
+        "MISSING_MARGINAL_ESTIMATE",
+        "PROJECT_IN_QUEUE",
+      ]),
+    );
+  });
+
+  it("gives unannotated value edges no inherited value and reports them", () => {
+    const findings = auditExecutionGraph({
+      edges: [
+        {
+          edgeType: "INCREASES_PROBABILITY_OF",
+          fromTaskId: "research",
+          probabilityDeltaBase: null,
+          toTaskId: "treaty",
+        },
+        {
+          edgeType: "ACCELERATES",
+          fromTaskId: "lobby",
+          timeDeltaDaysBase: 4,
+          toTaskId: "treaty",
+        },
+      ],
+      tasks: [
+        graphTask(OPTIMIZE_EARTH_ROOT_TASK_ID, null, {
+          kind: TaskKind.PROJECT,
+        }),
+        graphTask("research", OPTIMIZE_EARTH_ROOT_TASK_ID),
+        graphTask("lobby", OPTIMIZE_EARTH_ROOT_TASK_ID),
+        graphTask("treaty", OPTIMIZE_EARTH_ROOT_TASK_ID),
+      ],
+    });
+
+    expect(
+      findings.filter((finding) => finding.code === "UNANNOTATED_VALUE_EDGE"),
+    ).toHaveLength(1);
+    expect(findings[0]?.taskId).toBe("research");
+  });
+
+  it("rejects impossible probability and time contributions", () => {
+    const findings = auditExecutionGraph({
+      edges: [
+        {
+          edgeType: "INCREASES_PROBABILITY_OF",
+          fromTaskId: "research",
+          probabilityDeltaBase: 1.2,
+          toTaskId: "treaty",
+        },
+        {
+          edgeType: "ACCELERATES",
+          fromTaskId: "lobby",
+          timeDeltaDaysBase: -1,
+          toTaskId: "treaty",
+        },
+      ],
+      tasks: [
+        graphTask(OPTIMIZE_EARTH_ROOT_TASK_ID, null, {
+          kind: TaskKind.PROJECT,
+        }),
+        graphTask("research", OPTIMIZE_EARTH_ROOT_TASK_ID),
+        graphTask("lobby", OPTIMIZE_EARTH_ROOT_TASK_ID),
+        graphTask("treaty", OPTIMIZE_EARTH_ROOT_TASK_ID),
+      ],
+    });
+
+    expect(
+      findings.filter((finding) => finding.code === "INVALID_VALUE_EDGE"),
+    ).toHaveLength(2);
+    expect(findings[0]?.severity).toBe("high");
+  });
+});

--- a/packages/web/src/lib/tasks/execution-planner-audit.ts
+++ b/packages/web/src/lib/tasks/execution-planner-audit.ts
@@ -1,0 +1,260 @@
+import { TaskKind } from "@optimitron/db";
+
+export const OPTIMIZE_EARTH_ROOT_TASK_ID = "optimize-earth";
+
+export interface ExecutionGraphTask {
+  activeChildTaskCount: number;
+  hasMarginalEstimate: boolean;
+  id: string;
+  kind: TaskKind | string | null;
+  parentTaskId: string | null;
+  priority?: number | null;
+  queueEligible?: boolean;
+}
+
+export interface ExecutionGraphEdge {
+  edgeType:
+    | "DEPENDS_ON"
+    | "BLOCKS"
+    | "INCREASES_PROBABILITY_OF"
+    | "ACCELERATES"
+    | string;
+  fromTaskId: string;
+  probabilityDeltaBase?: number | null;
+  timeDeltaDaysBase?: number | null;
+  toTaskId: string;
+}
+
+export interface ExecutionGraphFinding {
+  code: string;
+  message: string;
+  severity: "high" | "medium" | "low";
+  taskId?: string;
+}
+
+function findDirectedCycle(
+  nodeIds: readonly string[],
+  neighbors: (nodeId: string) => readonly string[],
+) {
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  function visit(nodeId: string): string | null {
+    if (visiting.has(nodeId)) return nodeId;
+    if (visited.has(nodeId)) return null;
+    visiting.add(nodeId);
+    for (const neighbor of neighbors(nodeId)) {
+      const cycleNode = visit(neighbor);
+      if (cycleNode) return cycleNode;
+    }
+    visiting.delete(nodeId);
+    visited.add(nodeId);
+    return null;
+  }
+
+  for (const nodeId of nodeIds) {
+    const cycleNode = visit(nodeId);
+    if (cycleNode) return cycleNode;
+  }
+  return null;
+}
+
+function reachesRoot(
+  taskId: string,
+  taskById: ReadonlyMap<string, ExecutionGraphTask>,
+  rootTaskId: string,
+) {
+  const seen = new Set<string>();
+  let currentId: string | null = taskId;
+  while (currentId) {
+    if (currentId === rootTaskId) return true;
+    if (seen.has(currentId)) return false;
+    seen.add(currentId);
+    currentId = taskById.get(currentId)?.parentTaskId ?? null;
+  }
+  return false;
+}
+
+export function getRootedTaskIds(
+  tasks: ExecutionGraphTask[],
+  rootTaskId = OPTIMIZE_EARTH_ROOT_TASK_ID,
+) {
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  if (taskById.get(rootTaskId)?.kind !== TaskKind.PROJECT) {
+    return new Set<string>();
+  }
+  return new Set(
+    tasks
+      .filter((task) => reachesRoot(task.id, taskById, rootTaskId))
+      .map((task) => task.id),
+  );
+}
+
+export function auditExecutionGraph(input: {
+  edges: ExecutionGraphEdge[];
+  rootTaskId?: string;
+  tasks: ExecutionGraphTask[];
+}) {
+  const rootTaskId = input.rootTaskId ?? OPTIMIZE_EARTH_ROOT_TASK_ID;
+  const taskById = new Map(input.tasks.map((task) => [task.id, task]));
+  const rootedTaskIds = getRootedTaskIds(input.tasks, rootTaskId);
+  const findings: ExecutionGraphFinding[] = [];
+  const rootTask = taskById.get(rootTaskId);
+  if (!rootTask) {
+    findings.push({
+      code: "MISSING_ROOT",
+      message: `The Optimize Earth root task ${rootTaskId} is missing.`,
+      severity: "high",
+      taskId: rootTaskId,
+    });
+  } else if (rootTask.kind !== TaskKind.PROJECT) {
+    findings.push({
+      code: "ROOT_NOT_PROJECT",
+      message: `The Optimize Earth root task ${rootTaskId} must be a PROJECT.`,
+      severity: "high",
+      taskId: rootTaskId,
+    });
+  }
+
+  const parentCycle = findDirectedCycle(
+    input.tasks.map((task) => task.id),
+    (taskId) => {
+      const parentTaskId = taskById.get(taskId)?.parentTaskId;
+      return parentTaskId ? [parentTaskId] : [];
+    },
+  );
+  if (parentCycle) {
+    findings.push({
+      code: "PARENT_CYCLE",
+      message: `Task ${parentCycle} participates in a parent-tree cycle.`,
+      severity: "high",
+      taskId: parentCycle,
+    });
+  }
+
+  const outgoingDependencies = new Map<string, string[]>();
+  for (const edge of input.edges) {
+    if (edge.edgeType !== "DEPENDS_ON" && edge.edgeType !== "BLOCKS") continue;
+    const neighbors = outgoingDependencies.get(edge.fromTaskId) ?? [];
+    neighbors.push(edge.toTaskId);
+    outgoingDependencies.set(edge.fromTaskId, neighbors);
+  }
+  const dependencyCycle = findDirectedCycle(
+    input.tasks.map((task) => task.id),
+    (taskId) => outgoingDependencies.get(taskId) ?? [],
+  );
+  if (dependencyCycle) {
+    findings.push({
+      code: "DEPENDENCY_CYCLE",
+      message: `Task ${dependencyCycle} participates in a dependency cycle.`,
+      severity: "high",
+      taskId: dependencyCycle,
+    });
+  }
+
+  for (const task of input.tasks) {
+    if (task.id !== rootTaskId && !rootedTaskIds.has(task.id)) {
+      findings.push({
+        code: "UNROOTED_TASK",
+        message: `Task ${task.id} does not reach the Optimize Earth root through parentTaskId.`,
+        severity: "high",
+        taskId: task.id,
+      });
+    }
+    if (task.queueEligible && task.activeChildTaskCount > 0) {
+      findings.push({
+        code: "EXECUTABLE_PARENT",
+        message: `Task ${task.id} has child tasks but entered an execution queue.`,
+        severity: "high",
+        taskId: task.id,
+      });
+    }
+    if (task.queueEligible && task.kind !== TaskKind.TASK) {
+      findings.push({
+        code: "PROJECT_IN_QUEUE",
+        message: `Non-TASK row ${task.id} entered an execution queue.`,
+        severity: "high",
+        taskId: task.id,
+      });
+    }
+    if (
+      task.kind === TaskKind.TASK &&
+      task.activeChildTaskCount === 0 &&
+      !task.hasMarginalEstimate
+    ) {
+      findings.push({
+        code: "MISSING_MARGINAL_ESTIMATE",
+        message: `Atomic task ${task.id} has no direct or explicitly edge-derived marginal estimate.`,
+        severity: "medium",
+        taskId: task.id,
+      });
+    }
+  }
+
+  for (const edge of input.edges) {
+    const invalidProbabilityDelta =
+      edge.edgeType === "INCREASES_PROBABILITY_OF" &&
+      typeof edge.probabilityDeltaBase === "number" &&
+      (!Number.isFinite(edge.probabilityDeltaBase) ||
+        edge.probabilityDeltaBase < 0 ||
+        edge.probabilityDeltaBase > 1);
+    const invalidTimeDelta =
+      edge.edgeType === "ACCELERATES" &&
+      typeof edge.timeDeltaDaysBase === "number" &&
+      (!Number.isFinite(edge.timeDeltaDaysBase) || edge.timeDeltaDaysBase < 0);
+    if (invalidProbabilityDelta || invalidTimeDelta) {
+      findings.push({
+        code: "INVALID_VALUE_EDGE",
+        message: `Value edge ${edge.fromTaskId} -> ${edge.toTaskId} has an invalid base contribution. Probability lifts must be at most 1 and all contributions must be finite.`,
+        severity: "high",
+        taskId: edge.fromTaskId,
+      });
+      continue;
+    }
+    const missingProbabilityDelta =
+      edge.edgeType === "INCREASES_PROBABILITY_OF" &&
+      !(
+        typeof edge.probabilityDeltaBase === "number" &&
+        edge.probabilityDeltaBase > 0
+      );
+    const missingTimeDelta =
+      edge.edgeType === "ACCELERATES" &&
+      !(
+        typeof edge.timeDeltaDaysBase === "number" && edge.timeDeltaDaysBase > 0
+      );
+    if (missingProbabilityDelta || missingTimeDelta) {
+      findings.push({
+        code: "UNANNOTATED_VALUE_EDGE",
+        message: `Value edge ${edge.fromTaskId} -> ${edge.toTaskId} has no positive base contribution and therefore inherits no value.`,
+        severity: "medium",
+        taskId: edge.fromTaskId,
+      });
+    }
+  }
+
+  const queueTasks = input.tasks.filter((task) => task.queueEligible);
+  const tieKeys = new Map<string, string>();
+  for (const task of queueTasks) {
+    if (!Number.isFinite(task.priority)) continue;
+    const key = `${task.priority}:${task.id}`;
+    const priorTaskId = tieKeys.get(key);
+    if (priorTaskId) {
+      findings.push({
+        code: "NONDETERMINISTIC_TIE",
+        message: `Tasks ${priorTaskId} and ${task.id} have the same priority and stable tie-break key.`,
+        severity: "high",
+        taskId: task.id,
+      });
+    }
+    tieKeys.set(key, task.id);
+  }
+
+  return findings.sort((left, right) => {
+    const severityRank = { high: 0, medium: 1, low: 2 } as const;
+    const severityDifference =
+      severityRank[left.severity] - severityRank[right.severity];
+    if (severityDifference !== 0) return severityDifference;
+    if (left.code !== right.code) return left.code.localeCompare(right.code);
+    return (left.taskId ?? "").localeCompare(right.taskId ?? "");
+  });
+}

--- a/packages/web/src/lib/tasks/execution-planner-pilot.test.ts
+++ b/packages/web/src/lib/tasks/execution-planner-pilot.test.ts
@@ -1,0 +1,236 @@
+import { TaskKind, TaskStatus } from "@optimitron/db";
+import { describe, expect, it } from "vitest";
+import {
+  auditExecutionGraph,
+  OPTIMIZE_EARTH_ROOT_TASK_ID,
+} from "./execution-planner-audit";
+import {
+  buildExecutionPlan,
+  type ExecutionPlanningTask,
+} from "./execution-planner";
+import {
+  findPilotDuplicateGroups,
+  normalizeCalendarForPlanning,
+  normalizeNotionPlanningItems,
+} from "./execution-source-normalization";
+
+function task(
+  id: string,
+  parentTaskId: string | null,
+  overrides: Partial<ExecutionPlanningTask> = {},
+): ExecutionPlanningTask {
+  return {
+    activeChildTaskCount: 0,
+    availableAt: null,
+    blockers: [],
+    deadlinePolicy: "NONE",
+    deadlineStatus: "none",
+    dueAt: null,
+    executorType: "Self",
+    hasMarginalEstimate: true,
+    hours: 0.5,
+    id,
+    kind: TaskKind.TASK,
+    parentTaskId,
+    priority: 500,
+    realEv: 1_000,
+    rooted: true,
+    title: id,
+    valid: true,
+    validationNotes: [],
+    ...overrides,
+  };
+}
+
+describe("Mike + EOS execution-planner pilot", () => {
+  it("deduplicates source material and returns a plausible reviewed frontier plan", () => {
+    const notionItems = [
+      {
+        actionContext: "Open the EOS bank account needed before funded work.",
+        estimatedEffortHours: 0.5,
+        id: "notion-bank",
+        title: "Open bank account for EOS Inc.",
+        url: "https://notion.so/notion-bank",
+      },
+      {
+        actionContext: "Complete the investor-facing pitch assets.",
+        estimatedEffortHours: 1,
+        id: "notion-pitch",
+        title: "Finish the pitch deck core",
+        url: "https://notion.so/notion-pitch",
+      },
+      {
+        actionContext: "Review the concise investor summary.",
+        estimatedEffortHours: 0.5,
+        id: "notion-one-pager",
+        title: "Investor One-Pager",
+        url: "https://notion.so/notion-one-pager",
+      },
+    ];
+    const calendarEvents = [
+      {
+        endAt: "2026-07-10T14:10:00.000Z",
+        id: "morning-meds-a",
+        kind: "routine" as const,
+        recurringSeriesId: "meds-series-a",
+        startAt: "2026-07-10T14:00:00.000Z",
+        title: "Morning meds/supplements",
+      },
+      {
+        endAt: "2026-07-10T15:25:00.000Z",
+        id: "morning-meds-b",
+        kind: "routine" as const,
+        recurringSeriesId: "meds-series-b",
+        startAt: "2026-07-10T15:15:00.000Z",
+        title: "Morning medication and supplements",
+      },
+      {
+        endAt: "2026-07-10T17:00:00.000Z",
+        id: "foundation-call",
+        kind: "commitment" as const,
+        startAt: "2026-07-10T16:00:00.000Z",
+        title: "Foundation call",
+      },
+      {
+        endAt: "2026-07-10T18:30:00.000Z",
+        id: "calendar-mercury",
+        kind: "task" as const,
+        startAt: "2026-07-10T18:00:00.000Z",
+        title: "Open Mercury bank account for EOS",
+      },
+    ];
+    const notion = normalizeNotionPlanningItems({ items: notionItems });
+    const calendar = normalizeCalendarForPlanning(calendarEvents);
+    const duplicateConcepts = findPilotDuplicateGroups([
+      ...notionItems,
+      ...calendarEvents,
+    ]).map((group) => group.concept);
+
+    expect(duplicateConcepts).toEqual([
+      "eos-pitch",
+      "medication-routine",
+      "mercury-account",
+    ]);
+    expect(notion.proposals).toHaveLength(3);
+    expect(calendar.fixedCommitments).toHaveLength(1);
+    expect(calendar.routineProposals).toHaveLength(1);
+    expect(calendar.taskProposals).toHaveLength(1);
+
+    const mikeProjectId = "project:mike";
+    const eosProjectId = "project:eos";
+    const tasks = [
+      task(OPTIMIZE_EARTH_ROOT_TASK_ID, null, {
+        activeChildTaskCount: 2,
+        hasMarginalEstimate: false,
+        hours: null,
+        kind: TaskKind.PROJECT,
+        realEv: 0,
+        title: "Optimize Earth",
+      }),
+      task(mikeProjectId, OPTIMIZE_EARTH_ROOT_TASK_ID, {
+        activeChildTaskCount: 2,
+        hasMarginalEstimate: false,
+        hours: null,
+        kind: TaskKind.PROJECT,
+        realEv: 0,
+        title: "Mike projects",
+      }),
+      task(eosProjectId, OPTIMIZE_EARTH_ROOT_TASK_ID, {
+        activeChildTaskCount: 4,
+        hasMarginalEstimate: false,
+        hours: null,
+        kind: TaskKind.PROJECT,
+        realEv: 0,
+        title: "EOS projects",
+      }),
+      task("mercury", eosProjectId, {
+        priority: 900,
+        title: "Open Mercury bank account for EOS",
+      }),
+      task("bank-dependent", eosProjectId, {
+        blockers: [{ status: TaskStatus.ACTIVE, taskId: "mercury" }],
+        priority: 2_000,
+        title: "Connect EOS banking to funded operations",
+      }),
+      task("formation-review", eosProjectId, {
+        hours: 0.75,
+        priority: 800,
+        title: "Review the corrected EOS formation record",
+      }),
+      task("draft-pitch", eosProjectId, {
+        executorType: "AI Agent",
+        hours: 1,
+        priority: 1_800,
+        title: "Prepare the EOS investor pitch draft",
+      }),
+      task("health-check-in", mikeProjectId, {
+        hours: 0.25,
+        priority: 300,
+        title: "Record daily symptoms and medication response",
+      }),
+      task("review-pitch", mikeProjectId, {
+        blockers: [{ status: TaskStatus.ACTIVE, taskId: "draft-pitch" }],
+        priority: 1_600,
+        title: "Review the EOS investor pitch",
+      }),
+    ];
+    const plan = buildExecutionPlan({
+      availableMinutes: 240,
+      commitments: calendar.fixedCommitments,
+      now: new Date("2026-07-10T14:00:00.000Z"),
+      planningWindowEnd: "2026-07-10T18:00:00.000Z",
+      planningWindowStart: "2026-07-10T14:00:00.000Z",
+      tasks,
+    });
+
+    expect(plan.fixedCommitmentMinutes).toBe(60);
+    expect(plan.availableMinutes).toBe(180);
+    expect(plan.nextAction?.id).toBe("mercury");
+    expect(plan.checklist.map((item) => item.id)).toEqual([
+      "mercury",
+      "bank-dependent",
+      "formation-review",
+      "health-check-in",
+    ]);
+    expect(plan.proposedAiAssistedWork.map((item) => item.id)).toEqual([
+      "draft-pitch",
+    ]);
+    expect(plan.blockedWork).toContainEqual(
+      expect.objectContaining({
+        blockerTaskIds: ["draft-pitch"],
+        id: "review-pitch",
+      }),
+    );
+    expect(plan.itemsNeedingEstimates).toEqual([]);
+    expect(plan.checklist.every((item) => item.realEv !== 0)).toBe(true);
+
+    const queueEligibleIds = new Set(plan.checklist.map((item) => item.id));
+    const findings = auditExecutionGraph({
+      edges: [
+        {
+          edgeType: "BLOCKS",
+          fromTaskId: "mercury",
+          toTaskId: "bank-dependent",
+        },
+        {
+          edgeType: "BLOCKS",
+          fromTaskId: "draft-pitch",
+          toTaskId: "review-pitch",
+        },
+      ],
+      tasks: tasks.map((item) => ({
+        activeChildTaskCount: item.activeChildTaskCount,
+        hasMarginalEstimate: item.hasMarginalEstimate,
+        id: item.id,
+        kind: item.kind,
+        parentTaskId: item.parentTaskId,
+        priority: item.priority,
+        queueEligible: queueEligibleIds.has(item.id),
+      })),
+    });
+
+    expect(findings.filter((finding) => finding.severity === "high")).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/web/src/lib/tasks/execution-planner.test.ts
+++ b/packages/web/src/lib/tasks/execution-planner.test.ts
@@ -1,0 +1,193 @@
+import { TaskKind, TaskStatus } from "@optimitron/db";
+import { describe, expect, it } from "vitest";
+import {
+  buildExecutionPlan,
+  EXECUTION_PLANNER_VERSION,
+  type ExecutionPlanningTask,
+} from "./execution-planner";
+
+const NOW = new Date("2026-07-10T14:00:00.000Z");
+
+function task(
+  id: string,
+  overrides: Partial<ExecutionPlanningTask> = {},
+): ExecutionPlanningTask {
+  return {
+    activeChildTaskCount: 0,
+    availableAt: null,
+    blockers: [],
+    deadlinePolicy: "NONE",
+    deadlineStatus: "none",
+    dueAt: null,
+    executorType: "Self",
+    hasMarginalEstimate: true,
+    hours: 1,
+    id,
+    kind: TaskKind.TASK,
+    parentTaskId: "mike-project",
+    priority: 100,
+    realEv: 100,
+    rooted: true,
+    title: id,
+    valid: true,
+    validationNotes: [],
+    ...overrides,
+  };
+}
+
+function plan(tasks: ExecutionPlanningTask[], overrides = {}) {
+  return buildExecutionPlan({
+    availableMinutes: 240,
+    now: NOW,
+    planningWindowEnd: "2026-07-10T22:00:00.000Z",
+    planningWindowStart: "2026-07-10T14:00:00.000Z",
+    tasks,
+    ...overrides,
+  });
+}
+
+describe("buildExecutionPlan", () => {
+  it("never places projects, parents, milestones, or unrooted rows in the checklist", () => {
+    const result = plan([
+      task("project", { kind: TaskKind.PROJECT, priority: 10_000 }),
+      task("parent", { activeChildTaskCount: 1, priority: 9_000 }),
+      task("milestone", { completionMilestone: true, priority: 8_000 }),
+      task("unrooted", { rooted: false, priority: 7_000 }),
+      task("atomic", { priority: 1 }),
+    ]);
+
+    expect(result.checklist.map((item) => item.id)).toEqual(["atomic"]);
+  });
+
+  it("simulates completion to unlock the next feasible dependency", () => {
+    const result = plan([
+      task("mercury", { hours: 1, priority: 100 }),
+      task("bank-dependent", {
+        blockers: [{ status: TaskStatus.ACTIVE, taskId: "mercury" }],
+        hours: 1,
+        priority: 1_000,
+      }),
+    ]);
+
+    expect(result.checklist.map((item) => item.id)).toEqual([
+      "mercury",
+      "bank-dependent",
+    ]);
+    expect(result.checklist[1]?.reason).toContain("unlocks");
+  });
+
+  it("keeps externally blocked work out of the checklist", () => {
+    const result = plan([
+      task("blocked", {
+        blockers: [{ status: TaskStatus.ACTIVE, taskId: "outside-window" }],
+      }),
+    ]);
+
+    expect(result.checklist).toEqual([]);
+    expect(result.blockedWork).toEqual([
+      {
+        blockerTaskIds: ["outside-window"],
+        id: "blocked",
+        title: "blocked",
+      },
+    ]);
+  });
+
+  it("uses stable IDs to order equal-priority tasks deterministically", () => {
+    const result = plan([task("z-task"), task("a-task")]);
+    expect(result.checklist.map((item) => item.id)).toEqual([
+      "a-task",
+      "z-task",
+    ]);
+  });
+
+  it("applies required latest-start guardrails before raw priority", () => {
+    const result = plan([
+      task("huge-upside", { priority: 1_000_000 }),
+      task("file-taxes", {
+        deadlinePolicy: "REQUIRED",
+        deadlineStatus: "start_now",
+        priority: 1,
+      }),
+    ]);
+    expect(result.nextAction?.id).toBe("file-taxes");
+  });
+
+  it("subtracts fixed commitments and stops at the remaining capacity", () => {
+    const result = plan(
+      [task("first", { hours: 1 }), task("second", { hours: 1 })],
+      {
+        availableMinutes: 180,
+        commitments: [
+          {
+            startAt: "2026-07-10T15:00:00.000Z",
+            endAt: "2026-07-10T17:30:00.000Z",
+            title: "Meetings",
+          },
+        ],
+        planningWindowEnd: "2026-07-10T17:00:00.000Z",
+      },
+    );
+
+    expect(result.fixedCommitmentMinutes).toBe(120);
+    expect(result.availableMinutes).toBe(60);
+    expect(result.checklist).toHaveLength(1);
+  });
+
+  it("counts overlapping fixed commitments only once", () => {
+    const result = plan([task("work", { hours: 2 })], {
+      commitments: [
+        {
+          startAt: "2026-07-10T15:00:00.000Z",
+          endAt: "2026-07-10T16:30:00.000Z",
+          title: "Meeting one",
+        },
+        {
+          startAt: "2026-07-10T16:00:00.000Z",
+          endAt: "2026-07-10T17:00:00.000Z",
+          title: "Meeting two",
+        },
+      ],
+      planningWindowEnd: "2026-07-10T18:00:00.000Z",
+    });
+
+    expect(result.fixedCommitmentMinutes).toBe(120);
+    expect(result.availableMinutes).toBe(120);
+    expect(result.checklist.map((item) => item.id)).toEqual(["work"]);
+  });
+
+  it("separates AI-routed work and never starts it automatically", () => {
+    const result = plan([
+      task("human-formation"),
+      task("draft-pitch", {
+        executorType: "AI Agent",
+        priority: 1_000,
+      }),
+    ]);
+
+    expect(result.checklist.map((item) => item.id)).toEqual([
+      "human-formation",
+    ]);
+    expect(result.proposedAiAssistedWork.map((item) => item.id)).toEqual([
+      "draft-pitch",
+    ]);
+    expect(result.proposedAiAssistedWork[0]?.reason).toContain(
+      "does not start",
+    );
+  });
+
+  it("reports zero or missing marginal estimates instead of ranking them", () => {
+    const result = plan([
+      task("unknown-value", {
+        hasMarginalEstimate: false,
+        realEv: 0,
+      }),
+    ]);
+
+    expect(result.checklist).toEqual([]);
+    expect(result.itemsNeedingEstimates[0]).toMatchObject({
+      id: "unknown-value",
+    });
+    expect(result.plannerVersion).toBe(EXECUTION_PLANNER_VERSION);
+  });
+});

--- a/packages/web/src/lib/tasks/execution-planner.ts
+++ b/packages/web/src/lib/tasks/execution-planner.ts
@@ -1,0 +1,367 @@
+import { TaskKind, TaskStatus } from "@optimitron/db";
+
+export const EXECUTION_PLANNER_VERSION = "frontier-replanning-v1" as const;
+
+const RESOLVED_STATUSES = new Set<string>([TaskStatus.VERIFIED]);
+const HUMAN_EXECUTOR = "Self";
+const AI_EXECUTOR = "AI Agent";
+
+export interface PlanningCommitment {
+  endAt: Date | string;
+  startAt: Date | string;
+  title?: string | null;
+}
+
+export interface PlanningBlocker {
+  status: TaskStatus | string;
+  taskId: string;
+}
+
+export interface ExecutionPlanningTask {
+  activeChildTaskCount: number;
+  availableAt: Date | string | null;
+  blockers: PlanningBlocker[];
+  completionMilestone?: boolean;
+  deadlinePolicy: "NONE" | "SOFT" | "EXPIRES" | "REQUIRED";
+  deadlineStatus:
+    | "none"
+    | "future"
+    | "start_now"
+    | "overdue"
+    | "missed"
+    | "expired";
+  dueAt: Date | string | null;
+  executorType: string;
+  hasMarginalEstimate: boolean;
+  hours: number | null;
+  id: string;
+  kind: TaskKind | string | null;
+  parentTaskId: string | null;
+  priority: number;
+  realEv: number;
+  rooted: boolean;
+  title: string;
+  valid: boolean;
+  validationNotes: string[];
+}
+
+export interface ExecutionPlanInput {
+  availableMinutes?: number | null;
+  commitments?: PlanningCommitment[];
+  limit?: number;
+  now?: Date;
+  planningWindowEnd: Date | string;
+  planningWindowStart: Date | string;
+  tasks: ExecutionPlanningTask[];
+}
+
+export interface PlannedAction extends ExecutionPlanningTask {
+  estimatedMinutes: number;
+  reason: string;
+}
+
+export interface ExecutionPlan {
+  assumptions: string[];
+  availableMinutes: number;
+  blockedWork: Array<{
+    blockerTaskIds: string[];
+    id: string;
+    title: string;
+  }>;
+  checklist: PlannedAction[];
+  fixedCommitmentMinutes: number;
+  itemsNeedingEstimates: Array<{
+    id: string;
+    reasons: string[];
+    title: string;
+  }>;
+  nextAction: PlannedAction | null;
+  plannerVersion: typeof EXECUTION_PLANNER_VERSION;
+  proposedAiAssistedWork: PlannedAction[];
+  unusedMinutes: number;
+}
+
+function asDate(value: Date | string | null | undefined) {
+  if (value == null) return null;
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}
+
+function clampLimit(value: number | undefined) {
+  if (!Number.isFinite(value)) return 20;
+  return Math.max(1, Math.min(100, Math.floor(value!)));
+}
+
+function overlapInterval(
+  commitment: PlanningCommitment,
+  windowStart: Date,
+  windowEnd: Date,
+) {
+  const start = asDate(commitment.startAt);
+  const end = asDate(commitment.endAt);
+  if (!start || !end || end <= start) return null;
+  const overlapStart = Math.max(start.getTime(), windowStart.getTime());
+  const overlapEnd = Math.min(end.getTime(), windowEnd.getTime());
+  return overlapEnd > overlapStart
+    ? ([overlapStart, overlapEnd] as const)
+    : null;
+}
+
+function totalCommitmentMinutes(
+  commitments: PlanningCommitment[],
+  windowStart: Date,
+  windowEnd: Date,
+) {
+  const intervals = commitments
+    .map((commitment) => overlapInterval(commitment, windowStart, windowEnd))
+    .filter(
+      (interval): interval is readonly [number, number] => interval != null,
+    )
+    .sort((left, right) => left[0] - right[0]);
+  let totalMilliseconds = 0;
+  let currentStart: number | null = null;
+  let currentEnd: number | null = null;
+
+  for (const [start, end] of intervals) {
+    if (currentStart == null || currentEnd == null) {
+      currentStart = start;
+      currentEnd = end;
+      continue;
+    }
+    if (start <= currentEnd) {
+      currentEnd = Math.max(currentEnd, end);
+      continue;
+    }
+    totalMilliseconds += currentEnd - currentStart;
+    currentStart = start;
+    currentEnd = end;
+  }
+  if (currentStart != null && currentEnd != null) {
+    totalMilliseconds += currentEnd - currentStart;
+  }
+  return totalMilliseconds / 60_000;
+}
+
+function taskMinutes(task: ExecutionPlanningTask) {
+  return task.hours == null || task.hours <= 0
+    ? null
+    : Math.ceil(task.hours * 60);
+}
+
+function isAtomicTask(task: ExecutionPlanningTask) {
+  return (
+    task.kind === TaskKind.TASK &&
+    task.activeChildTaskCount === 0 &&
+    task.completionMilestone !== true
+  );
+}
+
+function isTimeAvailable(task: ExecutionPlanningTask, now: Date) {
+  const availableAt = asDate(task.availableAt);
+  return availableAt == null || availableAt <= now;
+}
+
+function hasUsableEstimate(task: ExecutionPlanningTask) {
+  return (
+    task.hasMarginalEstimate &&
+    task.valid &&
+    Number.isFinite(task.priority) &&
+    Number.isFinite(task.realEv) &&
+    task.realEv !== 0 &&
+    taskMinutes(task) != null
+  );
+}
+
+function unresolvedBlockers(
+  task: ExecutionPlanningTask,
+  simulatedCompletedIds: ReadonlySet<string>,
+) {
+  return task.blockers
+    .filter(
+      (blocker) =>
+        !simulatedCompletedIds.has(blocker.taskId) &&
+        !RESOLVED_STATUSES.has(blocker.status),
+    )
+    .map((blocker) => blocker.taskId);
+}
+
+function deadlineRank(task: ExecutionPlanningTask) {
+  if (task.deadlinePolicy === "REQUIRED") {
+    if (task.deadlineStatus === "missed") return 0;
+    if (task.deadlineStatus === "start_now") return 1;
+  }
+  if (
+    task.deadlinePolicy === "EXPIRES" &&
+    task.deadlineStatus === "start_now"
+  ) {
+    return 2;
+  }
+  return 3;
+}
+
+export function compareExecutionTasks(
+  left: ExecutionPlanningTask,
+  right: ExecutionPlanningTask,
+) {
+  const leftDeadlineRank = deadlineRank(left);
+  const rightDeadlineRank = deadlineRank(right);
+  if (leftDeadlineRank !== rightDeadlineRank) {
+    return leftDeadlineRank - rightDeadlineRank;
+  }
+  if (left.priority !== right.priority) {
+    return right.priority - left.priority;
+  }
+  const leftDueAt = asDate(left.dueAt)?.getTime() ?? Number.POSITIVE_INFINITY;
+  const rightDueAt = asDate(right.dueAt)?.getTime() ?? Number.POSITIVE_INFINITY;
+  if (leftDueAt !== rightDueAt) return leftDueAt - rightDueAt;
+  return left.id.localeCompare(right.id);
+}
+
+function actionReason(task: ExecutionPlanningTask, unlocked: boolean) {
+  if (deadlineRank(task) < 3) {
+    return "Required or expiring work has reached its latest safe start.";
+  }
+  if (unlocked) {
+    return "The preceding planned action unlocks this task, which is then the highest-priority feasible frontier item.";
+  }
+  return "Highest-priority feasible atomic task on the current frontier.";
+}
+
+function planHumanChecklist(input: {
+  availableMinutes: number;
+  limit: number;
+  now: Date;
+  tasks: ExecutionPlanningTask[];
+}) {
+  const checklist: PlannedAction[] = [];
+  const completedIds = new Set<string>();
+  let remainingMinutes = input.availableMinutes;
+
+  while (checklist.length < input.limit && remainingMinutes > 0) {
+    const candidates = input.tasks
+      .filter((task) => task.executorType !== AI_EXECUTOR)
+      .filter((task) => !completedIds.has(task.id))
+      .filter((task) => isAtomicTask(task) && task.rooted)
+      .filter((task) => isTimeAvailable(task, input.now))
+      .filter((task) => task.deadlineStatus !== "expired")
+      .filter(hasUsableEstimate)
+      .filter((task) => unresolvedBlockers(task, completedIds).length === 0)
+      .filter(
+        (task) =>
+          (taskMinutes(task) ?? Number.POSITIVE_INFINITY) <= remainingMinutes,
+      )
+      .sort(compareExecutionTasks);
+
+    const next = candidates[0];
+    if (!next) break;
+    const estimatedMinutes = taskMinutes(next)!;
+    const unlocked = next.blockers.some((blocker) =>
+      completedIds.has(blocker.taskId),
+    );
+    checklist.push({
+      ...next,
+      estimatedMinutes,
+      reason: actionReason(next, unlocked),
+    });
+    completedIds.add(next.id);
+    remainingMinutes -= estimatedMinutes;
+  }
+
+  return { checklist, completedIds, remainingMinutes };
+}
+
+export function buildExecutionPlan(input: ExecutionPlanInput): ExecutionPlan {
+  const now = input.now ?? new Date();
+  const windowStart = asDate(input.planningWindowStart);
+  const windowEnd = asDate(input.planningWindowEnd);
+  if (!windowStart || !windowEnd || windowEnd <= windowStart) {
+    throw new Error("planningWindowEnd must be after planningWindowStart.");
+  }
+
+  const windowMinutes = Math.floor(
+    (windowEnd.getTime() - windowStart.getTime()) / 60_000,
+  );
+  const fixedCommitmentMinutes = Math.ceil(
+    totalCommitmentMinutes(input.commitments ?? [], windowStart, windowEnd),
+  );
+  const freeWindowMinutes = Math.max(0, windowMinutes - fixedCommitmentMinutes);
+  const requestedMinutes =
+    input.availableMinutes == null
+      ? freeWindowMinutes
+      : Math.max(0, Math.floor(input.availableMinutes));
+  const availableMinutes = Math.min(freeWindowMinutes, requestedMinutes);
+  const limit = clampLimit(input.limit);
+  const { checklist, completedIds, remainingMinutes } = planHumanChecklist({
+    availableMinutes,
+    limit,
+    now,
+    tasks: input.tasks,
+  });
+
+  const proposedAiAssistedWork = input.tasks
+    .filter((task) => task.executorType === AI_EXECUTOR)
+    .filter((task) => isAtomicTask(task) && task.rooted)
+    .filter((task) => isTimeAvailable(task, now))
+    .filter((task) => task.deadlineStatus !== "expired")
+    .filter(hasUsableEstimate)
+    .filter((task) => unresolvedBlockers(task, completedIds).length === 0)
+    .sort(compareExecutionTasks)
+    .slice(0, limit)
+    .map((task) => ({
+      ...task,
+      estimatedMinutes: taskMinutes(task)!,
+      reason:
+        "Feasible AI-routed work for review; this planner does not start it automatically.",
+    }));
+
+  const blockedWork = input.tasks
+    .map((task) => ({
+      blockerTaskIds: unresolvedBlockers(task, completedIds),
+      id: task.id,
+      title: task.title,
+    }))
+    .filter((task) => task.blockerTaskIds.length > 0)
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  const itemsNeedingEstimates = input.tasks
+    .filter((task) => isAtomicTask(task) && task.rooted)
+    .filter((task) => !hasUsableEstimate(task))
+    .map((task) => {
+      const reasons = [...task.validationNotes];
+      if (!task.hasMarginalEstimate || task.realEv === 0) {
+        reasons.push(
+          "Missing non-zero direct or explicitly edge-derived marginal value.",
+        );
+      }
+      if (taskMinutes(task) == null) {
+        reasons.push("Missing positive effort estimate.");
+      }
+      return {
+        id: task.id,
+        reasons: Array.from(new Set(reasons)),
+        title: task.title,
+      };
+    })
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  return {
+    assumptions: [
+      "This is repeated feasible-frontier selection, not a globally optimal finite schedule.",
+      "Only rooted, childless TASK rows with non-zero marginal estimates can enter the checklist.",
+      "Completing a checklist item is simulated only to test which dependency becomes feasible next.",
+      "Calendar commitments reduce capacity but are not imported as tasks.",
+      "AI-routed work is proposed for approval and is never started by this planner.",
+    ],
+    availableMinutes,
+    blockedWork,
+    checklist,
+    fixedCommitmentMinutes,
+    itemsNeedingEstimates,
+    nextAction: checklist[0] ?? null,
+    plannerVersion: EXECUTION_PLANNER_VERSION,
+    proposedAiAssistedWork,
+    unusedMinutes: remainingMinutes,
+  };
+}
+
+export { AI_EXECUTOR, HUMAN_EXECUTOR };

--- a/packages/web/src/lib/tasks/execution-source-normalization.test.ts
+++ b/packages/web/src/lib/tasks/execution-source-normalization.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import {
+  findPilotConceptGroups,
+  findPilotDuplicateGroups,
+  normalizeCalendarForPlanning,
+  normalizeNotionPlanningItems,
+} from "./execution-source-normalization";
+
+describe("normalizeNotionPlanningItems", () => {
+  it("is idempotent for source-identical items and keeps long documents linked", () => {
+    const first = normalizeNotionPlanningItems({
+      items: [
+        {
+          acceptanceCriteria: ["Account can receive funds."],
+          actionContext: "Open the Mercury account needed for EOS banking.",
+          estimatedEffortHours: 1,
+          id: "notion-mercury",
+          title: "Make a Mercury bank account for EOS",
+          url: "https://notion.so/mercury",
+        },
+      ],
+    });
+    const proposal = first.proposals[0]!;
+    const second = normalizeNotionPlanningItems({
+      existingSources: [
+        {
+          sourceHash: (proposal.source as { sourceHash: string }).sourceHash,
+          sourceKey: "notion:notion-mercury",
+          taskId: "task-mercury",
+        },
+      ],
+      items: [
+        {
+          acceptanceCriteria: ["Account can receive funds."],
+          actionContext: "Open the Mercury account needed for EOS banking.",
+          estimatedEffortHours: 1,
+          id: "notion-mercury",
+          title: "Make a Mercury bank account for EOS",
+          url: "https://notion.so/mercury",
+        },
+      ],
+    });
+
+    expect(first.proposals).toHaveLength(1);
+    expect(proposal.description).not.toContain("entire document");
+    expect(second.proposals).toEqual([]);
+    expect(second.unchanged).toEqual([
+      { sourceKey: "notion:notion-mercury", taskId: "task-mercury" },
+    ]);
+  });
+});
+
+describe("normalizeCalendarForPlanning", () => {
+  it("keeps meetings as commitments and collapses duplicate medication routines", () => {
+    const result = normalizeCalendarForPlanning([
+      {
+        endAt: "2026-07-10T14:15:00.000Z",
+        id: "meds-1",
+        isRoutine: true,
+        recurringSeriesId: "series-a",
+        startAt: "2026-07-10T14:00:00.000Z",
+        title: "Morning meds/supplements",
+      },
+      {
+        endAt: "2026-07-11T14:15:00.000Z",
+        id: "meds-2",
+        isRoutine: true,
+        recurringSeriesId: "series-b",
+        startAt: "2026-07-11T14:00:00.000Z",
+        title: "Morning medication and supplements",
+      },
+      {
+        endAt: "2026-07-10T22:40:00.000Z",
+        id: "night-meds-1",
+        isRoutine: true,
+        recurringSeriesId: "series-night",
+        startAt: "2026-07-10T22:30:00.000Z",
+        title: "Night meds/supplements",
+      },
+      {
+        endAt: "2026-07-10T17:00:00.000Z",
+        id: "meeting-1",
+        startAt: "2026-07-10T16:00:00.000Z",
+        title: "Foundation call",
+      },
+      {
+        endAt: "2026-07-10T18:00:00.000Z",
+        id: "mercury-1",
+        kind: "task",
+        startAt: "2026-07-10T17:30:00.000Z",
+        title: "Open Mercury bank account for EOS",
+      },
+    ]);
+
+    expect(result.fixedCommitments).toHaveLength(1);
+    expect(result.routineProposals).toHaveLength(2);
+    expect(result.taskProposals).toEqual([
+      expect.objectContaining({
+        estimatedEffortHours: 0.5,
+        title: "Open Mercury bank account for EOS",
+      }),
+    ]);
+    expect(result.routineProposals[0]?.trigger.sourceSeriesIds).toEqual([
+      "series-a",
+      "series-b",
+    ]);
+    expect(result.routineProposals[1]?.trigger.sourceSeriesIds).toEqual([
+      "series-night",
+    ]);
+    expect(
+      result.duplicateGroups.find(
+        (group) => group.concept === "medication-routine",
+      )?.items,
+    ).toHaveLength(2);
+  });
+
+  it("keeps a recurring template hash stable as the occurrence window moves", () => {
+    const occurrence = {
+      endAt: "2026-07-10T14:10:00.000Z",
+      id: "meds-1",
+      isRoutine: true,
+      recurringSeriesId: "series-a",
+      startAt: "2026-07-10T14:00:00.000Z",
+      title: "Morning meds/supplements",
+    };
+    const first = normalizeCalendarForPlanning([occurrence]);
+    const second = normalizeCalendarForPlanning([
+      occurrence,
+      {
+        ...occurrence,
+        endAt: "2026-07-11T14:10:00.000Z",
+        id: "meds-2",
+        startAt: "2026-07-11T14:00:00.000Z",
+      },
+    ]);
+
+    expect(first.routineProposals[0]?.source.sourceHash).toBe(
+      second.routineProposals[0]?.source.sourceHash,
+    );
+  });
+});
+
+describe("findPilotDuplicateGroups", () => {
+  it("explicitly detects Mercury, EOS pitch, and medication duplicates", () => {
+    const groups = findPilotDuplicateGroups([
+      { id: "m1", title: "Open Mercury account for EOS" },
+      { id: "m2", title: "Open bank account for EOS Inc." },
+      { id: "p1", title: "Make EOS investor pitch" },
+      { id: "p2", title: "Finish the pitch deck core" },
+      { id: "h1", title: "Morning meds" },
+      { id: "h2", title: "Take morning medications" },
+    ]);
+
+    expect(groups.map((group) => group.concept)).toEqual([
+      "eos-pitch",
+      "medication-routine",
+      "mercury-account",
+    ]);
+  });
+
+  it("reports singular pilot concepts before import as well as duplicates", () => {
+    const groups = findPilotConceptGroups([
+      { id: "m1", title: "Open Mercury bank account for EOS" },
+      { id: "p1", title: "Investor One-Pager" },
+      { id: "x1", title: "Unrelated task" },
+    ]);
+
+    expect(groups.map((group) => group.concept)).toEqual([
+      "eos-pitch",
+      "mercury-account",
+    ]);
+  });
+});

--- a/packages/web/src/lib/tasks/execution-source-normalization.test.ts
+++ b/packages/web/src/lib/tasks/execution-source-normalization.test.ts
@@ -133,10 +133,34 @@ describe("normalizeCalendarForPlanning", () => {
         startAt: "2026-07-11T14:00:00.000Z",
       },
     ]);
+    const dateInput = normalizeCalendarForPlanning([
+      {
+        ...occurrence,
+        endAt: new Date(occurrence.endAt),
+        startAt: new Date(occurrence.startAt),
+      },
+    ]);
 
     expect(first.routineProposals[0]?.source.sourceHash).toBe(
       second.routineProposals[0]?.source.sourceHash,
     );
+    expect(first.routineProposals[0]?.source.sourceHash).toBe(
+      dateInput.routineProposals[0]?.source.sourceHash,
+    );
+  });
+
+  it("uses a one-minute floor for malformed zero-duration task events", () => {
+    const result = normalizeCalendarForPlanning([
+      {
+        endAt: "2026-07-10T17:30:00.000Z",
+        id: "zero-duration-task",
+        kind: "task",
+        startAt: "2026-07-10T17:30:00.000Z",
+        title: "Open Mercury bank account for EOS",
+      },
+    ]);
+
+    expect(result.taskProposals[0]?.estimatedEffortHours).toBeCloseTo(1 / 60);
   });
 });
 

--- a/packages/web/src/lib/tasks/execution-source-normalization.ts
+++ b/packages/web/src/lib/tasks/execution-source-normalization.ts
@@ -1,0 +1,334 @@
+import { createHash } from "node:crypto";
+
+export interface NotionPlanningItem {
+  acceptanceCriteria?: string[];
+  actionContext?: string | null;
+  dependencySourceIds?: string[];
+  estimatedEffortHours?: number | null;
+  id: string;
+  kind?: "TASK" | "PROJECT";
+  parentSourceId?: string | null;
+  title: string;
+  url: string;
+}
+
+export interface ExistingPlanningSource {
+  sourceHash: string | null;
+  sourceKey: string;
+  taskId: string;
+}
+
+export interface CalendarPlanningEvent {
+  endAt: Date | string;
+  id: string;
+  isRoutine?: boolean;
+  kind?: "commitment" | "routine" | "task";
+  recurringSeriesId?: string | null;
+  startAt: Date | string;
+  title: string;
+  url?: string | null;
+}
+
+function normalizeWhitespace(value: string) {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function sourceClockTime(value: Date | string) {
+  if (typeof value === "string") {
+    const match = value.match(/T(\d{2}:\d{2})/);
+    if (match?.[1]) return match[1];
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
+export function normalizePlanningTitle(value: string) {
+  return normalizeWhitespace(value)
+    .toLowerCase()
+    .replace(/\b(the|a|an|my|our)\b/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function sourceHash(value: unknown) {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function notionTaskKey(sourceKey: string) {
+  return `planner-source:${sourceHash(sourceKey).slice(0, 32)}`;
+}
+
+export function normalizeNotionPlanningItems(input: {
+  existingSources?: ExistingPlanningSource[];
+  items: NotionPlanningItem[];
+}) {
+  const existingBySourceKey = new Map(
+    (input.existingSources ?? []).map((source) => [source.sourceKey, source]),
+  );
+  const proposals: Array<Record<string, unknown>> = [];
+  const unchanged: Array<{ sourceKey: string; taskId: string }> = [];
+  const changed: Array<{ sourceKey: string; taskId: string }> = [];
+
+  for (const item of input.items) {
+    const stableSourceKey = `notion:${item.id}`;
+    const hash = sourceHash({
+      acceptanceCriteria: item.acceptanceCriteria ?? [],
+      actionContext: item.actionContext ?? null,
+      dependencySourceIds: item.dependencySourceIds ?? [],
+      estimatedEffortHours: item.estimatedEffortHours ?? null,
+      kind: item.kind ?? "TASK",
+      parentSourceId: item.parentSourceId ?? null,
+      title: normalizeWhitespace(item.title),
+    });
+    const existing = existingBySourceKey.get(stableSourceKey);
+    if (existing?.sourceHash === hash) {
+      unchanged.push({ sourceKey: stableSourceKey, taskId: existing.taskId });
+      continue;
+    }
+    if (existing) {
+      changed.push({ sourceKey: stableSourceKey, taskId: existing.taskId });
+      continue;
+    }
+
+    proposals.push({
+      acceptanceCriteria: item.acceptanceCriteria ?? [],
+      blockerRefs: (item.dependencySourceIds ?? []).map((id) =>
+        notionTaskKey(`notion:${id}`),
+      ),
+      description:
+        item.actionContext ??
+        "Review this imported planning item and define its acceptance criteria.",
+      estimatedEffortHours: item.estimatedEffortHours ?? null,
+      kind: item.kind ?? "TASK",
+      parentTaskRef: item.parentSourceId
+        ? notionTaskKey(`notion:${item.parentSourceId}`)
+        : null,
+      source: {
+        sourceHash: hash,
+        sourceKey: stableSourceKey,
+        sourceSystem: "notion",
+        sourceUrl: item.url,
+        title: item.title,
+      },
+      sourceUrls: [item.url],
+      taskKey: notionTaskKey(stableSourceKey),
+      title: normalizeWhitespace(item.title),
+    });
+  }
+
+  return {
+    changed,
+    detectedPilotItems: findPilotConceptGroups(input.items),
+    proposals,
+    unchanged,
+  };
+}
+
+export type PilotConcept =
+  | "eos-pitch"
+  | "medication-routine"
+  | "mercury-account";
+
+function pilotConcept(title: string): PilotConcept | null {
+  const normalized = normalizePlanningTitle(title);
+  if (
+    /\b(med|meds|medication|medications|supplement|supplements)\b/.test(
+      normalized,
+    )
+  ) {
+    return "medication-routine";
+  }
+  const referencesEos =
+    normalized.includes("earth optimization services") ||
+    /\beos\b/.test(normalized);
+  if (
+    normalized.includes("account") &&
+    (normalized.includes("mercury") ||
+      (referencesEos && normalized.includes("bank")))
+  ) {
+    return "mercury-account";
+  }
+  if (
+    (referencesEos && /\b(pitch|deck)\b/.test(normalized)) ||
+    /\b(investor pitch|investor one pager|investor presentation|pitch deck)\b/.test(
+      normalized,
+    )
+  ) {
+    return "eos-pitch";
+  }
+  return null;
+}
+
+function pilotGroupingKey(title: string) {
+  const concept = pilotConcept(title);
+  if (concept !== "medication-routine") return concept;
+  const normalized = normalizePlanningTitle(title);
+  if (/\b(morning|am)\b/.test(normalized)) {
+    return `${concept}:morning`;
+  }
+  if (/\b(evening|night|nighttime|bedtime|pm)\b/.test(normalized)) {
+    return `${concept}:night`;
+  }
+  if (/\b(afternoon|midday|noon)\b/.test(normalized)) {
+    return `${concept}:afternoon`;
+  }
+  return `${concept}:unspecified`;
+}
+
+export function findPilotConceptGroups(
+  items: Array<{ id: string; title: string }>,
+) {
+  const groups = new Map<PilotConcept, Array<{ id: string; title: string }>>();
+  for (const item of items) {
+    const concept = pilotConcept(item.title);
+    if (!concept) continue;
+    const group = groups.get(concept) ?? [];
+    group.push(item);
+    groups.set(concept, group);
+  }
+  return Array.from(groups.entries())
+    .map(([concept, group]) => ({ concept, items: group }))
+    .sort((left, right) => left.concept.localeCompare(right.concept));
+}
+
+export function findPilotDuplicateGroups(
+  items: Array<{ id: string; title: string }>,
+) {
+  const groups = new Map<
+    string,
+    { concept: PilotConcept; items: Array<{ id: string; title: string }> }
+  >();
+  for (const item of items) {
+    const concept = pilotConcept(item.title);
+    const key = pilotGroupingKey(item.title);
+    if (!concept || !key) continue;
+    const group = groups.get(key) ?? { concept, items: [] };
+    group.items.push(item);
+    groups.set(key, group);
+  }
+  return Array.from(groups.values())
+    .filter((group) => group.items.length > 1)
+    .sort((left, right) => left.concept.localeCompare(right.concept));
+}
+
+export function normalizeCalendarForPlanning(events: CalendarPlanningEvent[]) {
+  const isRoutine = (event: CalendarPlanningEvent) =>
+    event.kind === "routine" || event.isRoutine === true;
+  const fixedCommitments = events
+    .filter((event) => !isRoutine(event) && event.kind !== "task")
+    .map((event) => ({
+      endAt: event.endAt,
+      sourceEventId: event.id,
+      startAt: event.startAt,
+      title: event.title,
+    }));
+  const routineGroups = new Map<string, CalendarPlanningEvent[]>();
+  for (const event of events.filter(isRoutine)) {
+    const key =
+      pilotGroupingKey(event.title) ?? normalizePlanningTitle(event.title);
+    const group = routineGroups.get(key) ?? [];
+    group.push(event);
+    routineGroups.set(key, group);
+  }
+  const routineProposals = Array.from(routineGroups.entries()).map(
+    ([concept, occurrences]) => {
+      const first = occurrences[0]!;
+      const stableSourceKey = `calendar-routine:${concept}`;
+      const sourceSeries = Array.from(
+        new Map(
+          occurrences.map((event) => {
+            const seriesKey = event.recurringSeriesId ?? event.id;
+            const start = new Date(event.startAt);
+            const end = new Date(event.endAt);
+            return [
+              seriesKey,
+              {
+                durationMinutes: Math.max(
+                  0,
+                  Math.round((end.getTime() - start.getTime()) / 60_000),
+                ),
+                recurringSeriesId: event.recurringSeriesId ?? null,
+                startTime: sourceClockTime(event.startAt),
+                title: normalizeWhitespace(event.title),
+              },
+            ] as const;
+          }),
+        ).values(),
+      ).sort((left, right) =>
+        `${left.recurringSeriesId}:${left.title}`.localeCompare(
+          `${right.recurringSeriesId}:${right.title}`,
+        ),
+      );
+      return {
+        acceptanceCriteria: [
+          "Complete the routine once when its trigger is due.",
+        ],
+        description:
+          "Create one recurring Optimitron task template for this routine; do not import each calendar occurrence.",
+        estimatedEffortHours:
+          Math.max(
+            1,
+            new Date(first.endAt).getTime() - new Date(first.startAt).getTime(),
+          ) / 3_600_000,
+        kind: "TASK",
+        source: {
+          sourceHash: sourceHash(sourceSeries),
+          sourceKey: stableSourceKey,
+          sourceSystem: "google-calendar",
+          sourceUrl: first.url ?? null,
+          title: first.title,
+        },
+        taskKey: notionTaskKey(stableSourceKey),
+        title: normalizeWhitespace(first.title),
+        trigger: {
+          kind: "recurring-template",
+          sourceSeriesIds: Array.from(
+            new Set(
+              sourceSeries
+                .map((series) => series.recurringSeriesId)
+                .filter((id): id is string => Boolean(id)),
+            ),
+          ).sort(),
+        },
+      };
+    },
+  );
+  const taskProposals = events
+    .filter((event) => event.kind === "task")
+    .map((event) => {
+      const stableSourceKey = `calendar-task:${event.id}`;
+      return {
+        acceptanceCriteria: ["Complete the scheduled action once."],
+        description:
+          "Migrate this one-off action from Calendar into Optimitron so Calendar remains a scheduling constraint rather than a second task database.",
+        estimatedEffortHours:
+          Math.max(
+            1,
+            new Date(event.endAt).getTime() - new Date(event.startAt).getTime(),
+          ) / 3_600_000,
+        kind: "TASK",
+        source: {
+          sourceHash: sourceHash({
+            endAt: new Date(event.endAt).toISOString(),
+            startAt: new Date(event.startAt).toISOString(),
+            title: event.title,
+          }),
+          sourceKey: stableSourceKey,
+          sourceSystem: "google-calendar",
+          sourceUrl: event.url ?? null,
+          title: event.title,
+        },
+        taskKey: notionTaskKey(stableSourceKey),
+        title: normalizeWhitespace(event.title),
+      };
+    });
+
+  return {
+    detectedPilotItems: findPilotConceptGroups(events),
+    duplicateGroups: findPilotDuplicateGroups(events),
+    fixedCommitments,
+    routineProposals,
+    taskProposals,
+  };
+}

--- a/packages/web/src/lib/tasks/execution-source-normalization.ts
+++ b/packages/web/src/lib/tasks/execution-source-normalization.ts
@@ -34,12 +34,18 @@ function normalizeWhitespace(value: string) {
 }
 
 function sourceClockTime(value: Date | string) {
-  if (typeof value === "string") {
-    const match = value.match(/T(\d{2}:\d{2})/);
-    if (match?.[1]) return match[1];
-  }
   const date = value instanceof Date ? value : new Date(value);
-  return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+  return `${String(date.getUTCHours()).padStart(2, "0")}:${String(date.getUTCMinutes()).padStart(2, "0")}`;
+}
+
+function calendarEventDurationHours(event: CalendarPlanningEvent) {
+  const durationMilliseconds =
+    new Date(event.endAt).getTime() - new Date(event.startAt).getTime();
+  const boundedDurationMilliseconds =
+    Number.isFinite(durationMilliseconds) && durationMilliseconds > 0
+      ? Math.max(60_000, durationMilliseconds)
+      : 60_000;
+  return boundedDurationMilliseconds / 3_600_000;
 }
 
 export function normalizePlanningTitle(value: string) {
@@ -266,11 +272,7 @@ export function normalizeCalendarForPlanning(events: CalendarPlanningEvent[]) {
         ],
         description:
           "Create one recurring Optimitron task template for this routine; do not import each calendar occurrence.",
-        estimatedEffortHours:
-          Math.max(
-            1,
-            new Date(first.endAt).getTime() - new Date(first.startAt).getTime(),
-          ) / 3_600_000,
+        estimatedEffortHours: calendarEventDurationHours(first),
         kind: "TASK",
         source: {
           sourceHash: sourceHash(sourceSeries),
@@ -302,11 +304,7 @@ export function normalizeCalendarForPlanning(events: CalendarPlanningEvent[]) {
         acceptanceCriteria: ["Complete the scheduled action once."],
         description:
           "Migrate this one-off action from Calendar into Optimitron so Calendar remains a scheduling constraint rather than a second task database.",
-        estimatedEffortHours:
-          Math.max(
-            1,
-            new Date(event.endAt).getTime() - new Date(event.startAt).getTime(),
-          ) / 3_600_000,
+        estimatedEffortHours: calendarEventDurationHours(event),
         kind: "TASK",
         source: {
           sourceHash: sourceHash({

--- a/packages/web/src/lib/tasks/marginal-impact.test.ts
+++ b/packages/web/src/lib/tasks/marginal-impact.test.ts
@@ -1,0 +1,88 @@
+import { TaskImpactFrameKey } from "@optimitron/db";
+import { describe, expect, it } from "vitest";
+import type { TaskImpactFrameSummary } from "./impact";
+import { getExplicitEdgeMarginalFrames } from "./marginal-impact";
+
+const downstreamFrame: TaskImpactFrameSummary = {
+  annualDiscountRate: 0.03,
+  adoptionRampYears: 0,
+  benefitDurationYears: 1,
+  customFrameLabel: null,
+  delayDalysLostPerDayBase: 2,
+  delayDalysLostPerDayHigh: 3,
+  delayDalysLostPerDayLow: 1,
+  delayEconomicValueUsdLostPerDayBase: 10,
+  delayEconomicValueUsdLostPerDayHigh: 15,
+  delayEconomicValueUsdLostPerDayLow: 5,
+  estimatedCashCostUsdBase: 0,
+  estimatedCashCostUsdHigh: 0,
+  estimatedCashCostUsdLow: 0,
+  estimatedEffortHoursBase: 10,
+  estimatedEffortHoursHigh: 12,
+  estimatedEffortHoursLow: 8,
+  evaluationHorizonYears: 1,
+  expectedDalysAvertedBase: 100,
+  expectedDalysAvertedHigh: 150,
+  expectedDalysAvertedLow: 50,
+  expectedEconomicValueUsdBase: 1_000,
+  expectedEconomicValueUsdHigh: 1_500,
+  expectedEconomicValueUsdLow: 500,
+  frameKey: TaskImpactFrameKey.ONE_YEAR,
+  frameSlug: "downstream",
+  medianHealthyLifeYearsEffectBase: 0.1,
+  medianHealthyLifeYearsEffectHigh: 0.15,
+  medianHealthyLifeYearsEffectLow: 0.05,
+  medianIncomeGrowthEffectPpPerYearBase: 0.1,
+  medianIncomeGrowthEffectPpPerYearHigh: 0.15,
+  medianIncomeGrowthEffectPpPerYearLow: 0.05,
+  metrics: [],
+  successProbabilityBase: 0.5,
+  successProbabilityHigh: 0.7,
+  successProbabilityLow: 0.3,
+  summaryStatsJson: null,
+  timeToImpactStartDays: 0,
+};
+
+describe("getExplicitEdgeMarginalFrames", () => {
+  it("gives an unannotated edge no inherited value", () => {
+    expect(
+      getExplicitEdgeMarginalFrames({
+        downstreamFrame,
+        edge: {},
+        sourceTaskId: "upstream",
+        sourceTaskTitle: "Do research",
+      }),
+    ).toEqual([]);
+  });
+
+  it("computes probability and time contributions explicitly", () => {
+    const frames = getExplicitEdgeMarginalFrames({
+      downstreamFrame,
+      edge: { probabilityDeltaBase: 0.2, timeDeltaDaysBase: 3 },
+      estimatedEffortHours: 2,
+      sourceTaskId: "upstream",
+      sourceTaskTitle: "Do research",
+    });
+
+    expect(frames[0]?.expectedEconomicValueUsdBase).toBe(400);
+    expect(frames[0]?.estimatedCashCostUsdBase).toBeNull();
+    expect(frames[0]?.estimatedEffortHoursBase).toBe(2);
+    expect(frames[1]?.expectedEconomicValueUsdBase).toBe(30);
+    expect(frames[1]?.expectedDalysAvertedBase).toBe(6);
+    expect(frames[1]?.estimatedEffortHoursBase).toBe(2);
+  });
+
+  it("does not invent gross value when downstream probability is unavailable", () => {
+    expect(
+      getExplicitEdgeMarginalFrames({
+        downstreamFrame: {
+          ...downstreamFrame,
+          successProbabilityBase: null,
+        },
+        edge: { probabilityDeltaBase: 0.2 },
+        sourceTaskId: "upstream",
+        sourceTaskTitle: "Do research",
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/web/src/lib/tasks/marginal-impact.ts
+++ b/packages/web/src/lib/tasks/marginal-impact.ts
@@ -1,0 +1,109 @@
+import { scaleImpactFrameSummary, type TaskImpactFrameSummary } from "./impact";
+
+export function getExplicitEdgeMarginalFrames(input: {
+  edge: {
+    probabilityDeltaBase?: number | null;
+    timeDeltaDaysBase?: number | null;
+  };
+  estimatedEffortHours?: number | null;
+  sourceTaskId: string;
+  sourceTaskTitle: string;
+  downstreamFrame: TaskImpactFrameSummary;
+}) {
+  const frames: TaskImpactFrameSummary[] = [];
+  const probabilityDelta =
+    typeof input.edge.probabilityDeltaBase === "number" &&
+    Number.isFinite(input.edge.probabilityDeltaBase) &&
+    input.edge.probabilityDeltaBase > 0 &&
+    input.edge.probabilityDeltaBase <= 1
+      ? input.edge.probabilityDeltaBase
+      : null;
+  const timeDeltaDays =
+    typeof input.edge.timeDeltaDaysBase === "number" &&
+    Number.isFinite(input.edge.timeDeltaDaysBase) &&
+    input.edge.timeDeltaDaysBase > 0
+      ? input.edge.timeDeltaDaysBase
+      : null;
+  const downstreamProbability =
+    typeof input.downstreamFrame.successProbabilityBase === "number" &&
+    Number.isFinite(input.downstreamFrame.successProbabilityBase) &&
+    input.downstreamFrame.successProbabilityBase > 0 &&
+    input.downstreamFrame.successProbabilityBase <= 1
+      ? input.downstreamFrame.successProbabilityBase
+      : null;
+
+  if (probabilityDelta != null && downstreamProbability != null) {
+    frames.push(
+      scaleImpactFrameSummary(
+        input.downstreamFrame,
+        probabilityDelta / downstreamProbability,
+        {
+          customFrameLabel: `Probability-weighted downstream value unlocked by ${input.sourceTaskTitle}`,
+          estimatedCashCostUsdBase: null,
+          estimatedCashCostUsdHigh: null,
+          estimatedCashCostUsdLow: null,
+          estimatedEffortHoursBase: input.estimatedEffortHours ?? null,
+          estimatedEffortHoursHigh: input.estimatedEffortHours ?? null,
+          estimatedEffortHoursLow: input.estimatedEffortHours ?? null,
+          frameSlug: `${input.downstreamFrame.frameSlug}-probability-delta-${input.sourceTaskId}`,
+          successProbabilityBase: null,
+          successProbabilityHigh: null,
+          successProbabilityLow: null,
+          metrics: [],
+        },
+      ),
+    );
+  }
+
+  if (timeDeltaDays != null) {
+    frames.push({
+      ...input.downstreamFrame,
+      customFrameLabel: `Time-accelerated downstream value unlocked by ${input.sourceTaskTitle}`,
+      successProbabilityBase: null,
+      successProbabilityHigh: null,
+      successProbabilityLow: null,
+      estimatedCashCostUsdBase: null,
+      estimatedCashCostUsdHigh: null,
+      estimatedCashCostUsdLow: null,
+      estimatedEffortHoursBase:
+        input.estimatedEffortHours ??
+        input.downstreamFrame.estimatedEffortHoursBase ??
+        null,
+      estimatedEffortHoursHigh:
+        input.estimatedEffortHours ??
+        input.downstreamFrame.estimatedEffortHoursHigh ??
+        null,
+      estimatedEffortHoursLow:
+        input.estimatedEffortHours ??
+        input.downstreamFrame.estimatedEffortHoursLow ??
+        null,
+      expectedDalysAvertedBase:
+        (input.downstreamFrame.delayDalysLostPerDayBase ?? 0) * timeDeltaDays,
+      expectedDalysAvertedHigh:
+        input.downstreamFrame.delayDalysLostPerDayHigh == null
+          ? null
+          : input.downstreamFrame.delayDalysLostPerDayHigh * timeDeltaDays,
+      expectedDalysAvertedLow:
+        input.downstreamFrame.delayDalysLostPerDayLow == null
+          ? null
+          : input.downstreamFrame.delayDalysLostPerDayLow * timeDeltaDays,
+      expectedEconomicValueUsdBase:
+        (input.downstreamFrame.delayEconomicValueUsdLostPerDayBase ?? 0) *
+        timeDeltaDays,
+      expectedEconomicValueUsdHigh:
+        input.downstreamFrame.delayEconomicValueUsdLostPerDayHigh == null
+          ? null
+          : input.downstreamFrame.delayEconomicValueUsdLostPerDayHigh *
+            timeDeltaDays,
+      expectedEconomicValueUsdLow:
+        input.downstreamFrame.delayEconomicValueUsdLostPerDayLow == null
+          ? null
+          : input.downstreamFrame.delayEconomicValueUsdLostPerDayLow *
+            timeDeltaDays,
+      frameSlug: `${input.downstreamFrame.frameSlug}-time-delta-${input.sourceTaskId}`,
+      metrics: [],
+    });
+  }
+
+  return frames;
+}

--- a/packages/web/src/lib/tasks/rank-tasks.test.ts
+++ b/packages/web/src/lib/tasks/rank-tasks.test.ts
@@ -139,6 +139,7 @@ describe("rankTasksForUser", () => {
     claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
     difficulty: TaskDifficulty.BEGINNER,
     estimatedEffortHours: 2,
+    id: "strong-fit",
     interestTags: ["tobacco-policy"],
     maxClaims: null,
     selectedImpactFrame: {
@@ -189,6 +190,7 @@ describe("rankTasksForUser", () => {
     claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
     difficulty: TaskDifficulty.ADVANCED,
     estimatedEffortHours: 8,
+    id: "weak-fit",
     interestTags: ["defi"],
     maxClaims: null,
     selectedImpactFrame: {
@@ -416,6 +418,28 @@ describe("rankTasksForUser", () => {
 
     expect(ranked).toHaveLength(1);
     expect(ranked[0]?.task).toBe(leafTask);
+  });
+
+  it("does not fall back to a parent when atomic execution is required", () => {
+    const parentTask = {
+      ...strongFitTask,
+      activeChildTaskCount: 1,
+    };
+
+    expect(
+      rankTasksForUser([parentTask], user, 10, {
+        preferLeafExecution: true,
+      }),
+    ).toEqual([]);
+  });
+
+  it("uses the required task ID as the deterministic final tie-breaker", () => {
+    const second = { ...strongFitTask, id: "task-b" };
+    const first = { ...strongFitTask, id: "task-a" };
+
+    expect(
+      rankTasksForUser([second, first], user, 10).map(({ task }) => task.id),
+    ).toEqual(["task-a", "task-b"]);
   });
 });
 

--- a/packages/web/src/lib/tasks/rank-tasks.ts
+++ b/packages/web/src/lib/tasks/rank-tasks.ts
@@ -1,6 +1,7 @@
 import {
   TaskClaimPolicy,
   TaskDifficulty,
+  TaskKind,
   TaskStatus,
 } from "@optimitron/db";
 import {
@@ -10,6 +11,7 @@ import {
 } from "@/lib/tasks/impact";
 
 export interface RankableTask {
+  id?: string;
   activeClaimCount?: number;
   activeChildTaskCount?: number;
   blockerStatuses?: TaskStatus[];
@@ -20,6 +22,8 @@ export interface RankableTask {
   estimatedHoursPerWeekMin?: number | null;
   interestTags: string[];
   maxClaims?: number | null;
+  kind?: TaskKind | null;
+  marginalImpactFrame?: TaskImpactFrameSummary | null;
   compensationPaymentRails?: string[] | null;
   preferredAccessTags?: string[] | null;
   preferredCredentialTags?: string[] | null;
@@ -438,6 +442,19 @@ export function hasActiveChildTasks(task: Pick<RankableTask, "activeChildTaskCou
   return (task.activeChildTaskCount ?? 0) > 0;
 }
 
+export function isAtomicExecutionTask(
+  task: Pick<RankableTask, "activeChildTaskCount" | "kind">,
+) {
+  return (
+    (task.kind == null || task.kind === TaskKind.TASK) &&
+    !hasActiveChildTasks(task)
+  );
+}
+
+function getExecutionImpactFrame(task: RankableTask) {
+  return task.marginalImpactFrame ?? task.selectedImpactFrame ?? null;
+}
+
 export function scoreTaskForUser(task: RankableTask, user: RankableUser) {
   const skillScore =
     requiredPreferredFit(task.skillTags, task.preferredSkillTags, user.skillTags) ??
@@ -493,14 +510,17 @@ export function scoreTaskForUser(task: RankableTask, user: RankableUser) {
     0.02,
   );
   const fitScore = scoreWeightedComponents(fitComponents);
-  const impactScore = scoreTaskForAccountability(task);
+  const impactScore = scoreImpactFrame(getExecutionImpactFrame(task));
   const capabilityMultiplier = 0.65 + 0.35 * fitScore;
 
   return impactScore * capabilityMultiplier;
 }
 
 export function scoreTaskForAccountability(task: RankableTask) {
-  const frame = task.selectedImpactFrame;
+  return scoreImpactFrame(task.selectedImpactFrame ?? null);
+}
+
+function scoreImpactFrame(frame: TaskImpactFrameSummary | null) {
   if (!frame) {
     return 0;
   }
@@ -526,12 +546,9 @@ export function rankTasksForUser<T extends RankableTask>(
   );
   const executionPool =
     options?.preferLeafExecution === true
-      ? actionableTasks.filter((task) => !hasActiveChildTasks(task))
+      ? actionableTasks.filter(isAtomicExecutionTask)
       : actionableTasks;
-  const selectionPool =
-    options?.preferLeafExecution === true && executionPool.length > 0
-      ? executionPool
-      : actionableTasks;
+  const selectionPool = executionPool;
 
   return selectionPool
     .map((task) => ({
@@ -550,10 +567,14 @@ export function rankTasksForUser<T extends RankableTask>(
       }
 
       const rightValuePerHour =
-        deriveImpactRatios(right.task.selectedImpactFrame).expectedValuePerHourUsd ?? 0;
+        deriveImpactRatios(getExecutionImpactFrame(right.task)).expectedValuePerHourUsd ?? 0;
       const leftValuePerHour =
-        deriveImpactRatios(left.task.selectedImpactFrame).expectedValuePerHourUsd ?? 0;
-      return rightValuePerHour - leftValuePerHour;
+        deriveImpactRatios(getExecutionImpactFrame(left.task)).expectedValuePerHourUsd ?? 0;
+      if (rightValuePerHour !== leftValuePerHour) {
+        return rightValuePerHour - leftValuePerHour;
+      }
+
+      return (left.task.id ?? "").localeCompare(right.task.id ?? "");
     })
     .slice(0, limit);
 }

--- a/packages/web/src/lib/tasks/rank-tasks.ts
+++ b/packages/web/src/lib/tasks/rank-tasks.ts
@@ -11,7 +11,7 @@ import {
 } from "@/lib/tasks/impact";
 
 export interface RankableTask {
-  id?: string;
+  id: string;
   activeClaimCount?: number;
   activeChildTaskCount?: number;
   blockerStatuses?: TaskStatus[];
@@ -60,6 +60,7 @@ export interface RankableUser {
 }
 
 export interface RankTasksOptions {
+  /** When true, return only atomic TASK rows; parent/project fallback is forbidden. */
   preferLeafExecution?: boolean;
 }
 
@@ -391,7 +392,7 @@ export function isTaskClaimable(task: Pick<RankableTask, "claimPolicy" | "status
   );
 }
 
-export function canTaskAcceptMoreClaims(task: RankableTask) {
+export function canTaskAcceptMoreClaims(task: Omit<RankableTask, "id">) {
   if (!isTaskClaimable(task)) {
     return false;
   }
@@ -574,7 +575,7 @@ export function rankTasksForUser<T extends RankableTask>(
         return rightValuePerHour - leftValuePerHour;
       }
 
-      return (left.task.id ?? "").localeCompare(right.task.id ?? "");
+      return left.task.id.localeCompare(right.task.id);
     })
     .slice(0, limit);
 }


### PR DESCRIPTION
## Summary

- add the `frontier-replanning-v1` execution planner for authorized personal and organization targets
- require actionable work to be a rooted, childless `TASK` with a direct or explicitly edge-derived marginal estimate
- make `getNextAction`, personal queues, queue audit, and `getExecutionPlan` share the same eligibility and marginal-value rules
- add private, caller-owned draft proposal and promotion flows with source provenance, idempotency, dependency metadata, cycle checks, and organization authorization
- normalize Notion planning inputs and Calendar commitments/routines without writing to either external system
- record durable task execution attempts without copying prior recurring-task actuals into new attempts
- make the managed Optimize Earth root a `PROJECT`

## Why

Personal and organization queues previously mixed inherited project value with executable work and could disagree about what should happen next. This introduces a deterministic, auditable feasible-frontier planner without claiming a globally optimal schedule or starting AI work automatically.

## Pilot evidence

A read-only Mike + EOS pilot covered the Mercury account dependency, EOS pitch work, human formation work, recurring medication and health routines, fixed meetings, and cross-branch dependencies. The reviewed fixture produces a plausible checklist with no projects, blocked work, or zero-estimate actions in the actionable queue. No Notion, Calendar, or production database writes were made.

The current data audit also identified existing unrooted personal N-of-1 work and missing Optimitron EOS/Mercury/pitch records. Those remain explicit migration/review work rather than being silently imported.

## Validation

- `pnpm --filter @optimitron/web run typecheck:fast`
- `pnpm --filter @optimitron/db exec tsc --noEmit`
- 197 focused MCP/planner/ranking tests
- 413 broader task-domain tests
- 20 managed-data tests
- `git diff --check`

No Prisma schema changes and no user-interface changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added execution planning that creates prioritized human checklists, AI-assisted work suggestions, blocked-work details, and estimate reminders.
  * Added planning imports from Notion and calendars, including duplicate detection and recurring routine handling.
  * Added safeguards for task dependencies, cycles, authorization, and execution recording.
  * Improved task impact calculations, queue ranking, and support for project versus atomic tasks.
  * Added targeted task visibility and refined access to planning tools.

* **Bug Fixes**
  * Improved deterministic task ordering and prevented invalid or unrooted tasks from entering execution queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->