### PR TITLE
Document model v1 + private-comment visibility gate + single GA ID

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,6 +65,13 @@ referendum — 32 doubling rounds at 2 recruits per voter reaches ~4.3B. Sites:
 
 Bugs and concrete debt:
 
+- [x] Private-task comment leak (task `optimitron:dev:comment-visibility-gate`):
+      anonymous GET `/api/tasks/<id>/comments` returned comments for PRIVATE
+      tasks. Feed, activity timeline, comment votes, and comment posting now
+      reuse the /tasks/[id] predicate (`lib/tasks/task-visibility.server.ts`);
+      private tasks 404 like missing ones. Note: org-member access is not in
+      the page predicate, so it is not in the comment gate either — extend the
+      shared predicate deliberately if ever wanted.
 - [ ] MCP `getTask` double-escapes nested child descriptions (contamination
       vector; bug report a063947f, no fix commit found).
 - [ ] Task-payout hardening remainder: cron reconciliation for VERIFIED claims

--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,47 @@ referendum — 32 doubling rounds at 2 recruits per voter reaches ~4.3B. Sites:
 `optimitron.com` (app/proof engine). Every task roots under
 `OPTIMIZE_EARTH_ROOT_TASK_ID` (`program:optimize-earth`).
 
+## Agent handoff — 2026-07-12 evening (session ending)
+
+- **This PR (`feature/docs-model-comment-privacy`):** comment-privacy gate
+  (0607410f — fixes anonymous reads of private-task comments, verified leak on
+  prod) + single GA ID (6b35688d — `NEXT_PUBLIC_GA_MEASUREMENT_ID` for all
+  sites; Mike still owes the GA4 Admin "Configure your domains" click for
+  cross-domain sessions) + Document model v1 (Prisma `Document` + versions,
+  MCP createDocument/updateDocument/getDocument/listDocuments,
+  `/documents/[id]`, task-page doc list). After merge, re-mirror grant drafts
+  as task comments (they're PUBLIC-readable until this deploys).
+- **Next dev tasks (specs in Optimitron, EV-ranked):**
+  `optimitron:dev:llms-txt-comprehensive` (cmridzl5n — llms.txt is
+  campaign-only; must expose MCP/API/directories, generate from `routes.ts`);
+  `optimitron:dev:person-capability-profile` (cmridvdbt —
+  GitHub-profile-style redesign of `/people/[handle]`; full spec + Mike's
+  critique in task comments; bio/headline currently DON'T render on the page —
+  worst defect); `optimitron:dev:createtask-deadline-policy` (cmri8tcvz —
+  EXPIRES silently downgraded to SOFT);
+  `optimitron:dev:task-tree-visualization` (cmri3k975); extension OAuth
+  end-to-end live verification (PR #113 merged, untested against prod).
+- **Funding/prizes:** task tree under `funding:prizes-2026-q3` (cmri80ldt) —
+  Coefficient Giving due Aug 21 (top priority), Schmidt go/no-go Jul 25,
+  XPRIZE Future Vision due Aug 15, Build with Gemini decide Jul 20; every
+  Apply task has a Review-&-SUBMIT child for Mike with an embedded
+  browser-agent prompt; drafts in Notion under "Grant Applications Q3 2026" +
+  mirrored as task comments.
+- **Binding content rules (Mike, 2026-07-12):** never name QuantiModo/CureDAO
+  in application narratives (claim the work: 10+ yrs open-source health
+  infra, studies.dfda.earth); never claim cures are known-but-withheld (95%
+  of diseases have no treatment — the machine FINDS cures); "but the economy"
+  always paired with the math-error counter
+  (`war_counterfactual_income_multiple`); Optimitron = OPG/OBG optimal
+  policies+budgets, not just "move 1%"; canonical bio =
+  optimitron.com/people/mike; film/script/public-argument content lives in
+  the manual repo (canonical educational film:
+  `manual/knowledge/educational-film.qmd`), Notion only for private drafts.
+- **Mike's open decisions:** icon pick (64 candidates, sheets in
+  chat/scratchpad), Coefficient applicant entity (AMF 501c3 vs EOS PBC —
+  rec: AMF), bio scale figure (10M+ data points vs 50k+ studies), merge this
+  PR.
+
 ## In Flight
 
 - [ ] Execution-planner audit follow-through (`feature/mcp-execution-plan-audit`):
@@ -62,6 +103,15 @@ referendum — 32 doubling rounds at 2 recruits per voter reaches ~4.3B. Sites:
       history; sovereign-compute program task under `optimize-earth` +
       basement-node MCP client spec (getAIQueue worker loop); install-lead
       handling beyond the mailto CTA.
+
+- [x] Document model v1 (task `optimitron:dev:document-model`): versioned
+      markdown `Document` rows (new version = new row, `isCurrent` flips in a
+      transaction), private by default; MCP createDocument / updateDocument /
+      getDocument / listDocuments; `/documents/[id]` page with version list +
+      creator-only editor; task page lists attached documents.
+- [ ] Document model follow-ups: `/documents` index page; delete/archive (no
+      deletedAt in v1); visibility levels beyond PUBLIC/PRIVATE (org-shared);
+      move a Notion working doc across as the first dogfood.
 
 Bugs and concrete debt:
 

--- a/TODO.md
+++ b/TODO.md
@@ -19,8 +19,11 @@ referendum — 32 doubling rounds at 2 recruits per voter reaches ~4.3B. Sites:
   sites; Mike still owes the GA4 Admin "Configure your domains" click for
   cross-domain sessions) + Document model v1 (Prisma `Document` + versions,
   MCP createDocument/updateDocument/getDocument/listDocuments,
-  `/documents/[id]`, task-page doc list). After merge, re-mirror grant drafts
-  as task comments (they're PUBLIC-readable until this deploys).
+  `/documents/[id]`, task-page doc list). Re-mirror grant drafts as task
+  comments only once the comment-privacy fix is confirmed LIVE IN PRODUCTION
+  (not just merged — a merge can lag deploy) and a smoke test confirms
+  anonymous GET on a private task returns no comments; they're
+  PUBLIC-readable until this actually deploys.
 - **Next dev tasks (specs in Optimitron, EV-ranked):**
   `optimitron:dev:llms-txt-comprehensive` (cmridzl5n — llms.txt is
   campaign-only; must expose MCP/API/directories, generate from `routes.ts`);
@@ -109,9 +112,11 @@ referendum — 32 doubling rounds at 2 recruits per voter reaches ~4.3B. Sites:
       transaction), private by default; MCP createDocument / updateDocument /
       getDocument / listDocuments; `/documents/[id]` page with version list +
       creator-only editor; task page lists attached documents.
-- [ ] Document model follow-ups: `/documents` index page; delete/archive (no
-      deletedAt in v1); visibility levels beyond PUBLIC/PRIVATE (org-shared);
-      move a Notion working doc across as the first dogfood.
+- [ ] Document model follow-ups: `/documents` index page; delete/archive
+      endpoint (schema has `deletedAt` as of 2026-07-12 per Mike's call on PR
+      #114 review — reads already filter it out — but no delete/archive API
+      or UI wired to set it yet); visibility levels beyond PUBLIC/PRIVATE
+      (org-shared); move a Notion working doc across as the first dogfood.
 
 Bugs and concrete debt:
 

--- a/TODO.md
+++ b/TODO.md
@@ -72,6 +72,10 @@ Bugs and concrete debt:
       private tasks 404 like missing ones. Note: org-member access is not in
       the page predicate, so it is not in the comment gate either — extend the
       shared predicate deliberately if ever wanted.
+- [x] Single GA measurement ID: `site.ts` read `NEXT_PUBLIC_GA_DFDA_ID` /
+      `NEXT_PUBLIC_GA_DIH_ID` / `NEXT_PUBLIC_GA_WAR_ON_DISEASE_ID`, none of
+      which were set — warondisease.org served no GA tag. All sites now use
+      `NEXT_PUBLIC_GA_MEASUREMENT_ID` (Mike's call, 2026-07-12).
 - [ ] MCP `getTask` double-escapes nested child descriptions (contamination
       vector; bug report a063947f, no fix commit found).
 - [ ] Task-payout hardening remainder: cron reconciliation for VERIFIED claims

--- a/packages/db/prisma/migrations/20260712120000_add_document_model/migration.sql
+++ b/packages/db/prisma/migrations/20260712120000_add_document_model/migration.sql
@@ -15,6 +15,7 @@ CREATE TABLE "Document" (
     "createdByUserId" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
 
     CONSTRAINT "Document_pkey" PRIMARY KEY ("id")
 );
@@ -30,6 +31,9 @@ CREATE INDEX "Document_jurisdictionId_idx" ON "Document"("jurisdictionId");
 
 -- CreateIndex
 CREATE INDEX "Document_visibility_isCurrent_idx" ON "Document"("visibility", "isCurrent");
+
+-- CreateIndex
+CREATE INDEX "Document_deletedAt_idx" ON "Document"("deletedAt");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Document_documentKey_version_key" ON "Document"("documentKey", "version");

--- a/packages/db/prisma/migrations/20260712120000_add_document_model/migration.sql
+++ b/packages/db/prisma/migrations/20260712120000_add_document_model/migration.sql
@@ -1,0 +1,44 @@
+-- CreateEnum
+CREATE TYPE "DocumentVisibility" AS ENUM ('PUBLIC', 'PRIVATE');
+
+-- CreateTable
+CREATE TABLE "Document" (
+    "id" TEXT NOT NULL,
+    "jurisdictionId" TEXT,
+    "documentKey" TEXT NOT NULL,
+    "taskId" TEXT,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "isCurrent" BOOLEAN NOT NULL DEFAULT true,
+    "visibility" "DocumentVisibility" NOT NULL DEFAULT 'PRIVATE',
+    "createdByUserId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Document_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Document_taskId_isCurrent_idx" ON "Document"("taskId", "isCurrent");
+
+-- CreateIndex
+CREATE INDEX "Document_createdByUserId_isCurrent_idx" ON "Document"("createdByUserId", "isCurrent");
+
+-- CreateIndex
+CREATE INDEX "Document_jurisdictionId_idx" ON "Document"("jurisdictionId");
+
+-- CreateIndex
+CREATE INDEX "Document_visibility_isCurrent_idx" ON "Document"("visibility", "isCurrent");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Document_documentKey_version_key" ON "Document"("documentKey", "version");
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_jurisdictionId_fkey" FOREIGN KEY ("jurisdictionId") REFERENCES "Jurisdiction"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1869,6 +1869,7 @@ model User {
   taskComments                       TaskComment[]                    @relation("TaskCommentAuthor")
   moderatedTaskComments              TaskComment[]                    @relation("TaskCommentModerator")
   taskCommentVotes                   TaskCommentVote[]                @relation("TaskCommentVoter")
+  createdDocuments                   Document[]                       @relation("DocumentCreator")
   oauthAuthCodes                     OAuthAuthCode[]                  @relation("UserOAuthAuthCodes")
   oauthGrants                        OAuthGrant[]                     @relation("UserOAuthGrants")
   mcpToolCallAudits                  McpToolCallAudit[]               @relation("UserMcpToolCallAudits")
@@ -3752,6 +3753,7 @@ model Jurisdiction {
   conflicts                     Conflict[]                       @relation("ConflictPrimaryJurisdiction")
   memorialResponsibleParties    PersonMemorialResponsibleParty[] @relation("JurisdictionPersonMemorialResponsibleParties")
   interventionApprovalTimelines InterventionApprovalTimeline[]   @relation("JurisdictionInterventionApprovalTimelines")
+  documents                     Document[]                       @relation("JurisdictionDocuments")
 
   @@index([type])
   @@index([parentJurisdictionId])
@@ -5820,6 +5822,7 @@ model Task {
   fundingTarget             TaskFundingTarget?          @relation("TaskFundingTargetTask")
   fundingPayments           TaskFundingPayment[]        @relation("TaskFundingPaymentTask")
   payouts                   TaskPayout[]                @relation("TaskPayoutTask")
+  documents                 Document[]                  @relation("TaskDocuments")
 
   @@index([jurisdictionId, status])
   @@index([parentTaskId])
@@ -5896,6 +5899,65 @@ model TaskManager {
   @@index([userId, role])
   @@index([createdByUserId])
   @@index([deletedAt])
+}
+
+/// Who can see a Document.
+enum DocumentVisibility {
+  PUBLIC
+  PRIVATE
+}
+
+/// Versioned markdown document, optionally attached to a task. Working docs
+/// live here instead of Notion. One row per version: every version of a
+/// logical document shares documentKey, and exactly one row per documentKey
+/// has isCurrent = true (enforced in the update transaction).
+model Document {
+  /// Unique identifier for this version row
+  id String @id @default(cuid())
+
+  /// Optional jurisdiction this document belongs to
+  jurisdictionId String?
+
+  /// Stable identity shared by every version of this logical document
+  documentKey String @default(cuid())
+
+  /// Optional task this document is attached to
+  taskId String?
+
+  /// Document title
+  title String
+
+  /// Markdown body
+  body String
+
+  /// Monotonic version number within a documentKey, starting at 1
+  version Int @default(1)
+
+  /// Whether this row is the version readers see by default
+  isCurrent Boolean @default(true)
+
+  /// Who can see this document. Private by default.
+  visibility DocumentVisibility @default(PRIVATE)
+
+  /// User who created this version
+  createdByUserId String
+
+  /// When this record was created
+  createdAt DateTime @default(now())
+
+  /// When this record was last updated
+  updatedAt DateTime @updatedAt
+
+  // -- Relations --
+  jurisdiction  Jurisdiction? @relation("JurisdictionDocuments", fields: [jurisdictionId], references: [id])
+  task          Task?         @relation("TaskDocuments", fields: [taskId], references: [id], onDelete: SetNull)
+  createdByUser User          @relation("DocumentCreator", fields: [createdByUserId], references: [id], onDelete: Restrict)
+
+  @@unique([documentKey, version])
+  @@index([taskId, isCurrent])
+  @@index([createdByUserId, isCurrent])
+  @@index([jurisdictionId])
+  @@index([visibility, isCurrent])
 }
 
 /// Non-human executor that can be matched to tasks by agents.

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -5948,6 +5948,9 @@ model Document {
   /// When this record was last updated
   updatedAt DateTime @updatedAt
 
+  /// Soft-delete timestamp
+  deletedAt DateTime?
+
   // -- Relations --
   jurisdiction  Jurisdiction? @relation("JurisdictionDocuments", fields: [jurisdictionId], references: [id])
   task          Task?         @relation("TaskDocuments", fields: [taskId], references: [id], onDelete: SetNull)
@@ -5958,6 +5961,7 @@ model Document {
   @@index([createdByUserId, isCurrent])
   @@index([jurisdictionId])
   @@index([visibility, isCurrent])
+  @@index([deletedAt])
 }
 
 /// Non-human executor that can be matched to tasks by agents.

--- a/packages/web/src/app/api/documents/[id]/route.test.ts
+++ b/packages/web/src/app/api/documents/[id]/route.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  getDocumentForViewer: vi.fn(),
+  updateDocument: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-utils", () => ({
+  getCurrentUser: mocks.getCurrentUser,
+}));
+
+vi.mock("@/lib/documents.server", () => ({
+  DOCUMENT_NOT_FOUND_MESSAGE: "Document not found",
+  getDocumentForViewer: mocks.getDocumentForViewer,
+  toDocumentDto: (row: unknown) => row,
+  updateDocument: mocks.updateDocument,
+}));
+
+import { GET, POST } from "./route";
+
+beforeEach(() => {
+  for (const fn of Object.values(mocks)) {
+    fn.mockReset();
+  }
+});
+
+describe("GET /api/documents/[id]", () => {
+  it("returns 404 for an anonymous viewer on a private document", async () => {
+    mocks.getCurrentUser.mockResolvedValue(null);
+    mocks.getDocumentForViewer.mockResolvedValue(null);
+
+    const response = await GET(
+      new Request("http://localhost/api/documents/doc_1"),
+      { params: Promise.resolve({ id: "doc_1" }) },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Document not found.",
+    });
+  });
+
+  it("returns the document for a permitted viewer", async () => {
+    mocks.getCurrentUser.mockResolvedValue({ id: "creator_1" });
+    mocks.getDocumentForViewer.mockResolvedValue({
+      document: { id: "doc_1" },
+      versions: [],
+      viewerCanEdit: true,
+    });
+
+    const response = await GET(
+      new Request("http://localhost/api/documents/doc_1"),
+      { params: Promise.resolve({ id: "doc_1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.getDocumentForViewer).toHaveBeenCalledWith(
+      "doc_1",
+      "creator_1",
+    );
+  });
+});
+
+describe("POST /api/documents/[id]", () => {
+  it("requires authentication", async () => {
+    mocks.getCurrentUser.mockResolvedValue(null);
+
+    const response = await POST(
+      new Request("http://localhost/api/documents/doc_1", {
+        method: "POST",
+        body: JSON.stringify({ body: "new" }),
+      }),
+      { params: Promise.resolve({ id: "doc_1" }) },
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.updateDocument).not.toHaveBeenCalled();
+  });
+
+  it("maps the not-found error from non-creator edits to 404", async () => {
+    mocks.getCurrentUser.mockResolvedValue({ id: "stranger_1" });
+    mocks.updateDocument.mockRejectedValue(new Error("Document not found"));
+
+    const response = await POST(
+      new Request("http://localhost/api/documents/doc_1", {
+        method: "POST",
+        body: JSON.stringify({ body: "hijack" }),
+      }),
+      { params: Promise.resolve({ id: "doc_1" }) },
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/web/src/app/api/documents/[id]/route.test.ts
+++ b/packages/web/src/app/api/documents/[id]/route.test.ts
@@ -11,7 +11,11 @@ vi.mock("@/lib/auth-utils", () => ({
 }));
 
 vi.mock("@/lib/documents.server", () => ({
+  DOCUMENT_EMPTY_PATCH_MESSAGE:
+    "At least one of title, body, or visibility must be provided",
   DOCUMENT_NOT_FOUND_MESSAGE: "Document not found",
+  DOCUMENT_PRIVATE_TASK_MESSAGE:
+    "Cannot make a document attached to a private task public",
   getDocumentForViewer: mocks.getDocumentForViewer,
   toDocumentDto: (row: unknown) => row,
   updateDocument: mocks.updateDocument,
@@ -91,5 +95,41 @@ describe("POST /api/documents/[id]", () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it("maps the empty-patch rejection to 400", async () => {
+    mocks.getCurrentUser.mockResolvedValue({ id: "creator_1" });
+    mocks.updateDocument.mockRejectedValue(
+      new Error(
+        "At least one of title, body, or visibility must be provided",
+      ),
+    );
+
+    const response = await POST(
+      new Request("http://localhost/api/documents/doc_1", {
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+      { params: Promise.resolve({ id: "doc_1" }) },
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("maps the public-visibility-on-a-private-task rejection to 400", async () => {
+    mocks.getCurrentUser.mockResolvedValue({ id: "creator_1" });
+    mocks.updateDocument.mockRejectedValue(
+      new Error("Cannot make a document attached to a private task public"),
+    );
+
+    const response = await POST(
+      new Request("http://localhost/api/documents/doc_1", {
+        method: "POST",
+        body: JSON.stringify({ visibility: "PUBLIC" }),
+      }),
+      { params: Promise.resolve({ id: "doc_1" }) },
+    );
+
+    expect(response.status).toBe(400);
   });
 });

--- a/packages/web/src/app/api/documents/[id]/route.ts
+++ b/packages/web/src/app/api/documents/[id]/route.ts
@@ -1,0 +1,116 @@
+/**
+ * GET  /api/documents/[id] — read one document version + version list.
+ * POST /api/documents/[id] — append a new version (creator only).
+ *
+ * Private documents return 404 for everyone but their creator (and admins on
+ * GET) — indistinguishable from missing ones.
+ */
+
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth-utils";
+import { McpScope } from "@/lib/mcp-scopes";
+import {
+  DOCUMENT_NOT_FOUND_MESSAGE,
+  getDocumentForViewer,
+  toDocumentDto,
+  updateDocument,
+} from "@/lib/documents.server";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await context.params;
+    const currentUser = await getCurrentUser(request, [
+      McpScope.TASKS_PERSONAL,
+      McpScope.TASKS_ADMIN,
+    ]);
+
+    const result = await getDocumentForViewer(id, currentUser?.id ?? null);
+    if (!result) {
+      return NextResponse.json({ error: "Document not found." }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      document: toDocumentDto(result.document),
+      versions: result.versions,
+      viewerCanEdit: result.viewerCanEdit,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    console.error("[DOCUMENTS] Failed to fetch document:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch document." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const currentUser = await getCurrentUser(request, [
+      McpScope.TASKS_PERSONAL,
+      McpScope.TASKS_ADMIN,
+    ]);
+    if (!currentUser) {
+      return NextResponse.json(
+        { error: "Authentication required." },
+        { status: 401 },
+      );
+    }
+
+    const { id } = await context.params;
+    const body = (await request.json().catch(() => null)) as {
+      title?: unknown;
+      body?: unknown;
+      visibility?: unknown;
+    } | null;
+
+    const title = typeof body?.title === "string" ? body.title : null;
+    const markdown = typeof body?.body === "string" ? body.body : null;
+    const visibility =
+      body?.visibility === "PUBLIC" || body?.visibility === "PRIVATE"
+        ? body.visibility
+        : null;
+
+    const updated = await updateDocument({
+      documentId: id,
+      editorUserId: currentUser.id,
+      title,
+      body: markdown,
+      visibility,
+    });
+
+    return NextResponse.json({ document: toDocumentDto(updated) });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (
+      error instanceof Error &&
+      error.message === DOCUMENT_NOT_FOUND_MESSAGE
+    ) {
+      return NextResponse.json({ error: "Document not found." }, { status: 404 });
+    }
+    if (
+      error instanceof Error &&
+      (error.message.includes("cannot be empty") ||
+        error.message.includes("character limit"))
+    ) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    console.error("[DOCUMENTS] Failed to update document:", error);
+    return NextResponse.json(
+      { error: "Failed to update document." },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/src/app/api/documents/[id]/route.ts
+++ b/packages/web/src/app/api/documents/[id]/route.ts
@@ -10,7 +10,9 @@ import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth-utils";
 import { McpScope } from "@/lib/mcp-scopes";
 import {
+  DOCUMENT_EMPTY_PATCH_MESSAGE,
   DOCUMENT_NOT_FOUND_MESSAGE,
+  DOCUMENT_PRIVATE_TASK_MESSAGE,
   getDocumentForViewer,
   toDocumentDto,
   updateDocument,
@@ -103,7 +105,9 @@ export async function POST(
     if (
       error instanceof Error &&
       (error.message.includes("cannot be empty") ||
-        error.message.includes("character limit"))
+        error.message.includes("character limit") ||
+        error.message === DOCUMENT_EMPTY_PATCH_MESSAGE ||
+        error.message === DOCUMENT_PRIVATE_TASK_MESSAGE)
     ) {
       return NextResponse.json({ error: error.message }, { status: 400 });
     }

--- a/packages/web/src/app/api/tasks/[id]/comments/route.test.ts
+++ b/packages/web/src/app/api/tasks/[id]/comments/route.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  canUserViewTask: vi.fn(),
+  countUserCommentsInWindow: vi.fn(),
+  getCurrentUser: vi.fn(),
+  getTaskActivityTimeline: vi.fn(),
+  getTaskCommentFeed: vi.fn(),
+  postComment: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-utils", () => ({
+  getCurrentUser: mocks.getCurrentUser,
+}));
+
+vi.mock("@/lib/tasks/task-comments.server", () => ({
+  countUserCommentsInWindow: mocks.countUserCommentsInWindow,
+  getTaskActivityTimeline: mocks.getTaskActivityTimeline,
+  getTaskCommentFeed: mocks.getTaskCommentFeed,
+  postComment: mocks.postComment,
+}));
+
+vi.mock("@/lib/tasks/task-visibility.server", () => ({
+  TASK_NOT_FOUND_MESSAGE: "Task not found",
+  canUserViewTask: mocks.canUserViewTask,
+}));
+
+vi.mock("@/lib/tasks/task-comment-notifications.server", () => ({
+  notifyTaskCommentRecipients: vi.fn(),
+}));
+
+vi.mock("@/lib/tasks/wishonia-task-reply.server", () => ({
+  buildCitationsJson: vi.fn(),
+  generateAndPostWishoniaReply: vi.fn(),
+  prepareWishoniaReply: vi.fn(),
+  streamWishoniaReplyText: vi.fn(),
+}));
+
+import { GET, POST } from "./route";
+
+const FEED = { comments: [], nextCursor: null, total: 0 };
+
+function getRequest(taskId: string) {
+  return GET(new Request(`http://localhost/api/tasks/${taskId}/comments`), {
+    params: Promise.resolve({ id: taskId }),
+  });
+}
+
+beforeEach(() => {
+  for (const fn of Object.values(mocks)) {
+    fn.mockReset();
+  }
+});
+
+describe("GET /api/tasks/[id]/comments", () => {
+  it("returns 404 for an anonymous viewer on a private task", async () => {
+    mocks.getCurrentUser.mockResolvedValue(null);
+    mocks.getTaskCommentFeed.mockRejectedValue(new Error("Task not found"));
+    mocks.getTaskActivityTimeline.mockRejectedValue(
+      new Error("Task not found"),
+    );
+
+    const response = await getRequest("private_task");
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Task not found.",
+    });
+  });
+
+  it("returns 200 with the feed for the task owner", async () => {
+    mocks.getCurrentUser.mockResolvedValue({ id: "owner_1" });
+    mocks.getTaskCommentFeed.mockResolvedValue(FEED);
+    mocks.getTaskActivityTimeline.mockResolvedValue([]);
+
+    const response = await getRequest("private_task");
+
+    expect(response.status).toBe(200);
+    expect(mocks.getTaskCommentFeed).toHaveBeenCalledWith(
+      expect.objectContaining({ currentUserId: "owner_1" }),
+    );
+    expect(mocks.getTaskActivityTimeline).toHaveBeenCalledWith(
+      "private_task",
+      50,
+      "owner_1",
+    );
+  });
+
+  it("returns 200 for an anonymous viewer on a public task", async () => {
+    mocks.getCurrentUser.mockResolvedValue(null);
+    mocks.getTaskCommentFeed.mockResolvedValue(FEED);
+    mocks.getTaskActivityTimeline.mockResolvedValue([]);
+
+    const response = await getRequest("public_task");
+
+    expect(response.status).toBe(200);
+    expect(mocks.getTaskCommentFeed).toHaveBeenCalledWith(
+      expect.objectContaining({ currentUserId: null }),
+    );
+    expect(mocks.getTaskActivityTimeline).toHaveBeenCalledWith(
+      "public_task",
+      50,
+      null,
+    );
+  });
+});
+
+describe("POST /api/tasks/[id]/comments", () => {
+  it("returns 404 when the author cannot view the task", async () => {
+    mocks.getCurrentUser.mockResolvedValue({ id: "stranger_1" });
+    mocks.canUserViewTask.mockResolvedValue(false);
+
+    const response = await POST(
+      new Request("http://localhost/api/tasks/private_task/comments", {
+        method: "POST",
+        body: JSON.stringify({ message: "hello" }),
+      }),
+      { params: Promise.resolve({ id: "private_task" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(mocks.postComment).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/app/api/tasks/[id]/comments/route.ts
+++ b/packages/web/src/app/api/tasks/[id]/comments/route.ts
@@ -15,6 +15,10 @@ import {
   type CommentSortKey,
 } from "@/lib/tasks/task-comments.server";
 import {
+  canUserViewTask,
+  TASK_NOT_FOUND_MESSAGE,
+} from "@/lib/tasks/task-visibility.server";
+import {
   buildCitationsJson,
   generateAndPostWishoniaReply,
   prepareWishoniaReply,
@@ -56,7 +60,9 @@ export async function GET(
       }),
       // Only fetch activities on the first page load (no cursor) — they're
       // not paginated, they're just a supplementary timeline.
-      cursor ? Promise.resolve([]) : getTaskActivityTimeline(taskId, 50),
+      cursor
+        ? Promise.resolve([])
+        : getTaskActivityTimeline(taskId, 50, currentUser?.id ?? null),
     ]);
 
     return NextResponse.json({
@@ -68,6 +74,10 @@ export async function GET(
   } catch (error) {
     if (error instanceof Error && error.message === "Unauthorized") {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof Error && error.message === TASK_NOT_FOUND_MESSAGE) {
+      // Private tasks 404 exactly like missing ones — same as /tasks/[id].
+      return NextResponse.json({ error: "Task not found." }, { status: 404 });
     }
 
     console.error("[TASKS] Failed to fetch comment feed:", error);
@@ -114,6 +124,13 @@ export async function POST(
         : null;
     const mediaUrl =
       typeof body?.mediaUrl === "string" && body.mediaUrl.length > 0 ? body.mediaUrl : null;
+
+    // Same visibility gate as GET: you can only write where you can read.
+    // (postComment itself stays ungated so server-initiated Wishonia replies
+    // can land on private tasks.)
+    if (!(await canUserViewTask(taskId, currentUser.id))) {
+      return NextResponse.json({ error: "Task not found." }, { status: 404 });
+    }
 
     // Rate limit: 5 comments per user per task per hour
     const recentCount = await countUserCommentsInWindow(

--- a/packages/web/src/app/api/tasks/comments/[id]/vote/route.ts
+++ b/packages/web/src/app/api/tasks/comments/[id]/vote/route.ts
@@ -48,6 +48,11 @@ export async function POST(
 
     return NextResponse.json(result);
   } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message === "Task not found" || message === "Comment not found") {
+      // Comments on private tasks are indistinguishable from missing ones.
+      return NextResponse.json({ error: "Comment not found." }, { status: 404 });
+    }
     console.error("[TASKS] Failed to vote on comment:", error);
     return NextResponse.json({ error: "Failed to vote." }, { status: 500 });
   }

--- a/packages/web/src/app/documents/[id]/page.tsx
+++ b/packages/web/src/app/documents/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getDocumentForViewer } from "@/lib/documents.server";
+import { canUserViewTask } from "@/lib/tasks/task-visibility.server";
 import { RichMarkdown } from "@/components/markdown/rich-markdown";
 import { DocumentEditForm } from "@/components/documents/document-edit-form";
 
@@ -49,6 +50,14 @@ export default async function DocumentPage({
 
   const { document, versions, viewerCanEdit } = result;
   const currentVersion = versions.find((v) => v.isCurrent) ?? null;
+  // A public document can (still) be attached to a task the viewer can't
+  // see — e.g. the task was made private after the document was attached.
+  // Only render the link when the viewer can actually view that task, so a
+  // public document page never leaks a private task's id to anyone who
+  // couldn't otherwise find it.
+  const canViewAttachedTask = document.taskId
+    ? await canUserViewTask(document.taskId, userId)
+    : false;
 
   return (
     <main className="mx-auto w-full max-w-3xl px-4 py-8">
@@ -62,7 +71,7 @@ export default async function DocumentPage({
           {document.visibility === "PRIVATE" ? "Private." : "Public."}{" "}
           {document.createdAt.toLocaleDateString("en-US", DOCUMENT_DATE_FORMAT)}.
         </p>
-        {document.taskId ? (
+        {document.taskId && canViewAttachedTask ? (
           <p className="mt-1 text-sm font-bold">
             <Link
               className="underline underline-offset-4"

--- a/packages/web/src/app/documents/[id]/page.tsx
+++ b/packages/web/src/app/documents/[id]/page.tsx
@@ -1,0 +1,135 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getDocumentForViewer } from "@/lib/documents.server";
+import { RichMarkdown } from "@/components/markdown/rich-markdown";
+import { DocumentEditForm } from "@/components/documents/document-edit-form";
+
+export const dynamic = "force-dynamic";
+
+const DOCUMENT_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  day: "numeric",
+  month: "long",
+  timeZone: "UTC",
+  year: "numeric",
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const session = await getServerSession(authOptions);
+  const result = await getDocumentForViewer(id, session?.user.id ?? null);
+  if (!result) {
+    return { title: "Document not found" };
+  }
+  return {
+    title: result.document.title,
+    robots: { index: false },
+  };
+}
+
+export default async function DocumentPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await getServerSession(authOptions);
+  const userId = session?.user.id ?? null;
+
+  const result = await getDocumentForViewer(id, userId);
+  if (!result) {
+    notFound();
+  }
+
+  const { document, versions, viewerCanEdit } = result;
+  const currentVersion = versions.find((v) => v.isCurrent) ?? null;
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8">
+      <header className="border-b-2 border-foreground pb-4">
+        <h1 className="text-4xl font-black uppercase tracking-tight sm:text-5xl">
+          {document.title}
+        </h1>
+        <p className="mt-2 text-sm font-bold text-muted-foreground">
+          Version {document.version}
+          {document.isCurrent ? " (current)" : ""}.{" "}
+          {document.visibility === "PRIVATE" ? "Private." : "Public."}{" "}
+          {document.createdAt.toLocaleDateString("en-US", DOCUMENT_DATE_FORMAT)}.
+        </p>
+        {document.taskId ? (
+          <p className="mt-1 text-sm font-bold">
+            <Link
+              className="underline underline-offset-4"
+              href={`/tasks/${document.taskId}`}
+            >
+              Attached task.
+            </Link>
+          </p>
+        ) : null}
+        {!document.isCurrent && currentVersion ? (
+          <p className="mt-1 text-sm font-bold">
+            This is an old version.{" "}
+            <Link
+              className="underline underline-offset-4"
+              href={`/documents/${currentVersion.id}`}
+            >
+              Read the current version.
+            </Link>
+          </p>
+        ) : null}
+      </header>
+
+      <section className="border-b border-foreground py-6">
+        <RichMarkdown markdown={document.body} />
+      </section>
+
+      {viewerCanEdit && document.isCurrent ? (
+        <details className="border-b border-foreground py-5">
+          <summary className="cursor-pointer text-sm font-black uppercase tracking-[0.12em]">
+            Edit
+          </summary>
+          <div className="mt-4">
+            <DocumentEditForm
+              documentId={document.id}
+              initialTitle={document.title}
+              initialBody={document.body}
+            />
+          </div>
+        </details>
+      ) : null}
+
+      {versions.length > 1 ? (
+        <section className="py-5">
+          <h2 className="text-sm font-black uppercase tracking-[0.12em]">
+            Versions
+          </h2>
+          <ul className="mt-3 space-y-1">
+            {versions.map((version) => (
+              <li key={version.id} className="text-sm font-bold">
+                {version.id === document.id ? (
+                  <span>
+                    v{version.version} — {version.title} (you are here)
+                  </span>
+                ) : (
+                  <Link
+                    className="underline underline-offset-4"
+                    href={`/documents/${version.id}`}
+                  >
+                    v{version.version} — {version.title}
+                    {version.isCurrent ? " (current)" : ""}
+                  </Link>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </main>
+  );
+}

--- a/packages/web/src/app/tasks/[id]/page.tsx
+++ b/packages/web/src/app/tasks/[id]/page.tsx
@@ -44,13 +44,20 @@ import {
 import { getTaskFundingStatus } from "@/lib/task-funding/status.server";
 import { normalizeTaskCommunicationEndpointUrl } from "@/lib/tasks/task-communication-endpoints.server";
 import { TREATY_PARENT_TASK_ID } from "@/lib/tasks/task-keys";
+import { TASK_NOT_FOUND_MESSAGE } from "@/lib/tasks/task-visibility.server";
 import { getStripeConnectStatus } from "@/lib/stripe-connect.server";
 import { getWishoniaUserId } from "@/lib/wishonia.server";
 
 // The feed/timeline helpers throw the shared "Task not found" for tasks the
 // viewer can't see. The page already renders TaskAccessGate when `data` is
-// null, so swallow the throw into an empty feed instead of a 500.
+// null, so swallow ONLY that specific throw into an empty feed — any other
+// rejection (DB error, bug in assertUserCanViewTask) should surface as a 500
+// instead of a silent, indistinguishable "no comments yet".
 const EMPTY_COMMENT_FEED = { comments: [], nextCursor: null, total: 0 };
+
+function isTaskNotFoundError(error: unknown): boolean {
+  return error instanceof Error && error.message === TASK_NOT_FOUND_MESSAGE;
+}
 
 async function getPublicTaskPageData(id: string) {
   const [data, commentFeed, activityTimeline, ancestors] = await Promise.all([
@@ -60,8 +67,14 @@ async function getPublicTaskPageData(id: string) {
       sort: "new",
       limit: 100,
       currentUserId: null,
-    }).catch(() => EMPTY_COMMENT_FEED),
-    getTaskActivityTimeline(id, 50, null).catch(() => []),
+    }).catch((error) => {
+      if (isTaskNotFoundError(error)) return EMPTY_COMMENT_FEED;
+      throw error;
+    }),
+    getTaskActivityTimeline(id, 50, null).catch((error) => {
+      if (isTaskNotFoundError(error)) return [];
+      throw error;
+    }),
     getTaskAncestors(id),
   ]);
 
@@ -376,8 +389,14 @@ export default async function TaskDetailPage({
           sort: "new",
           limit: 100,
           currentUserId: userId,
-        }).catch(() => EMPTY_COMMENT_FEED),
-        getTaskActivityTimeline(id, 50, userId).catch(() => []),
+        }).catch((error) => {
+          if (isTaskNotFoundError(error)) return EMPTY_COMMENT_FEED;
+          throw error;
+        }),
+        getTaskActivityTimeline(id, 50, userId).catch((error) => {
+          if (isTaskNotFoundError(error)) return [];
+          throw error;
+        }),
         getWishoniaUserId().catch(() => null),
         getTaskAncestors(id),
         prisma.user

--- a/packages/web/src/app/tasks/[id]/page.tsx
+++ b/packages/web/src/app/tasks/[id]/page.tsx
@@ -14,6 +14,7 @@ import { TaskFundingProgress } from "@/components/task-funding/TaskFundingProgre
 import { type TaskCardTask } from "@/components/tasks/task-card";
 import { TaskCommentFeed } from "@/components/tasks/task-comment-feed";
 import { TaskDescription } from "@/components/tasks/task-description";
+import { TaskDocumentsList } from "@/components/documents/task-documents-list";
 import { SortableTaskList } from "@/components/tasks/task-list-controls";
 import { StripeConnectStatusPanel } from "@/components/tasks/StripeConnectStatusPanel";
 import { TaskClaimButton } from "@/components/tasks/TaskClaimButton";
@@ -675,6 +676,8 @@ export default async function TaskDetailPage({
             <TaskDescription markdown={task.description} />
           </article>
         </section>
+
+        <TaskDocumentsList taskId={task.id} userId={userId} />
 
         <TaskDependenciesSection task={task} viewer={viewer} />
 

--- a/packages/web/src/app/tasks/[id]/page.tsx
+++ b/packages/web/src/app/tasks/[id]/page.tsx
@@ -46,6 +46,11 @@ import { TREATY_PARENT_TASK_ID } from "@/lib/tasks/task-keys";
 import { getStripeConnectStatus } from "@/lib/stripe-connect.server";
 import { getWishoniaUserId } from "@/lib/wishonia.server";
 
+// The feed/timeline helpers throw the shared "Task not found" for tasks the
+// viewer can't see. The page already renders TaskAccessGate when `data` is
+// null, so swallow the throw into an empty feed instead of a 500.
+const EMPTY_COMMENT_FEED = { comments: [], nextCursor: null, total: 0 };
+
 async function getPublicTaskPageData(id: string) {
   const [data, commentFeed, activityTimeline, ancestors] = await Promise.all([
     getTaskDetailData(id, null),
@@ -54,8 +59,8 @@ async function getPublicTaskPageData(id: string) {
       sort: "new",
       limit: 100,
       currentUserId: null,
-    }),
-    getTaskActivityTimeline(id, 50),
+    }).catch(() => EMPTY_COMMENT_FEED),
+    getTaskActivityTimeline(id, 50, null).catch(() => []),
     getTaskAncestors(id),
   ]);
 
@@ -370,8 +375,8 @@ export default async function TaskDetailPage({
           sort: "new",
           limit: 100,
           currentUserId: userId,
-        }),
-        getTaskActivityTimeline(id, 50),
+        }).catch(() => EMPTY_COMMENT_FEED),
+        getTaskActivityTimeline(id, 50, userId).catch(() => []),
         getWishoniaUserId().catch(() => null),
         getTaskAncestors(id),
         prisma.user

--- a/packages/web/src/components/documents/document-edit-form.tsx
+++ b/packages/web/src/components/documents/document-edit-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import { Button } from "@/components/retroui/Button";
 import { Input } from "@/components/retroui/Input";
 import { Textarea } from "@/components/retroui/Textarea";
@@ -26,42 +26,46 @@ export function DocumentEditForm({
   const [title, setTitle] = useState(initialTitle);
   const [body, setBody] = useState(initialBody);
   const [error, setError] = useState<string | null>(null);
-  const [isPending, startTransition] = useTransition();
+  // Tracks the in-flight POST itself (not just the transition callback) so a
+  // fast double-click can't fire two saves before the first response lands
+  // and trips the (documentKey, version) unique constraint server-side.
+  const [isSaving, setIsSaving] = useState(false);
 
   return (
     <form
       className="space-y-3"
       onSubmit={(event) => {
         event.preventDefault();
+        if (isSaving) return;
         setError(null);
-        startTransition(() => {
-          void fetch(API_ROUTES.documents.document(documentId), {
-            body: JSON.stringify({ title, body }),
-            headers: { "Content-Type": "application/json" },
-            method: "POST",
+        setIsSaving(true);
+        void fetch(API_ROUTES.documents.document(documentId), {
+          body: JSON.stringify({ title, body }),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+        })
+          .then(async (response) => {
+            const payload = (await response.json().catch(() => null)) as {
+              document?: { id?: string };
+              error?: string;
+            } | null;
+
+            if (!response.ok) {
+              throw new Error(payload?.error ?? "Save failed.");
+            }
+
+            const newId = payload?.document?.id;
+            if (newId && newId !== documentId) {
+              router.push(`/documents/${newId}`);
+            }
+            router.refresh();
           })
-            .then(async (response) => {
-              const payload = (await response.json().catch(() => null)) as {
-                document?: { id?: string };
-                error?: string;
-              } | null;
-
-              if (!response.ok) {
-                throw new Error(payload?.error ?? "Save failed.");
-              }
-
-              const newId = payload?.document?.id;
-              if (newId && newId !== documentId) {
-                router.push(`/documents/${newId}`);
-              }
-              router.refresh();
-            })
-            .catch((saveError) => {
-              setError(
-                saveError instanceof Error ? saveError.message : "Save failed.",
-              );
-            });
-        });
+          .catch((saveError) => {
+            setError(
+              saveError instanceof Error ? saveError.message : "Save failed.",
+            );
+          })
+          .finally(() => setIsSaving(false));
       }}
     >
       <label className="block text-sm font-black uppercase tracking-[0.12em]">
@@ -80,8 +84,8 @@ export function DocumentEditForm({
           onChange={(event) => setBody(event.target.value)}
         />
       </label>
-      <Button className="font-black uppercase" disabled={isPending} type="submit">
-        {isPending ? "Saving..." : "Save."}
+      <Button className="font-black uppercase" disabled={isSaving} type="submit">
+        {isSaving ? "Saving..." : "Save."}
       </Button>
       <p className="text-sm font-bold text-muted-foreground">
         Saving makes a new version. Old versions stay.

--- a/packages/web/src/components/documents/document-edit-form.tsx
+++ b/packages/web/src/components/documents/document-edit-form.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { Button } from "@/components/retroui/Button";
+import { Input } from "@/components/retroui/Input";
+import { Textarea } from "@/components/retroui/Textarea";
+import { API_ROUTES } from "@/lib/api-routes";
+
+interface DocumentEditFormProps {
+  documentId: string;
+  initialTitle: string;
+  initialBody: string;
+}
+
+/**
+ * Creator-only editor. Saving writes a NEW version row server-side; the old
+ * version stays readable in the version list.
+ */
+export function DocumentEditForm({
+  documentId,
+  initialTitle,
+  initialBody,
+}: DocumentEditFormProps) {
+  const router = useRouter();
+  const [title, setTitle] = useState(initialTitle);
+  const [body, setBody] = useState(initialBody);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <form
+      className="space-y-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        setError(null);
+        startTransition(() => {
+          void fetch(API_ROUTES.documents.document(documentId), {
+            body: JSON.stringify({ title, body }),
+            headers: { "Content-Type": "application/json" },
+            method: "POST",
+          })
+            .then(async (response) => {
+              const payload = (await response.json().catch(() => null)) as {
+                document?: { id?: string };
+                error?: string;
+              } | null;
+
+              if (!response.ok) {
+                throw new Error(payload?.error ?? "Save failed.");
+              }
+
+              const newId = payload?.document?.id;
+              if (newId && newId !== documentId) {
+                router.push(`/documents/${newId}`);
+              }
+              router.refresh();
+            })
+            .catch((saveError) => {
+              setError(
+                saveError instanceof Error ? saveError.message : "Save failed.",
+              );
+            });
+        });
+      }}
+    >
+      <label className="block text-sm font-black uppercase tracking-[0.12em]">
+        Title
+        <Input
+          className="mt-1"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+        />
+      </label>
+      <label className="block text-sm font-black uppercase tracking-[0.12em]">
+        Body
+        <Textarea
+          className="mt-1 min-h-64 font-mono text-sm"
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+        />
+      </label>
+      <Button className="font-black uppercase" disabled={isPending} type="submit">
+        {isPending ? "Saving..." : "Save."}
+      </Button>
+      <p className="text-sm font-bold text-muted-foreground">
+        Saving makes a new version. Old versions stay.
+      </p>
+      {error ? (
+        <p className="text-sm font-bold text-foreground">{error}</p>
+      ) : null}
+    </form>
+  );
+}

--- a/packages/web/src/components/documents/task-documents-list.tsx
+++ b/packages/web/src/components/documents/task-documents-list.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
-import { listDocumentsForViewer } from "@/lib/documents.server";
+import { listDocumentSummariesForViewer } from "@/lib/documents.server";
 
 /**
  * Small list of documents attached to a task, shown under the description.
- * Renders nothing when the viewer can see no documents on the task.
+ * Renders nothing when the viewer can see no documents on the task. Fetches
+ * id/title/version only — not the (up to 500k char) markdown body every
+ * DocumentRow carries, which this list never renders.
  */
 export async function TaskDocumentsList({
   taskId,
@@ -14,7 +16,7 @@ export async function TaskDocumentsList({
 }) {
   // Swallow query errors (e.g. code deployed ahead of the Document migration)
   // instead of taking down the whole task page for a side list.
-  const documents = await listDocumentsForViewer({
+  const documents = await listDocumentSummariesForViewer({
     taskId,
     userId,
     limit: 50,

--- a/packages/web/src/components/documents/task-documents-list.tsx
+++ b/packages/web/src/components/documents/task-documents-list.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { listDocumentsForViewer } from "@/lib/documents.server";
+
+/**
+ * Small list of documents attached to a task, shown under the description.
+ * Renders nothing when the viewer can see no documents on the task.
+ */
+export async function TaskDocumentsList({
+  taskId,
+  userId,
+}: {
+  taskId: string;
+  userId: string | null;
+}) {
+  // Swallow query errors (e.g. code deployed ahead of the Document migration)
+  // instead of taking down the whole task page for a side list.
+  const documents = await listDocumentsForViewer({
+    taskId,
+    userId,
+    limit: 50,
+  }).catch(() => []);
+  if (documents.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="border-b border-foreground py-5">
+      <h2 className="text-sm font-black uppercase tracking-[0.12em] text-foreground">
+        Documents
+      </h2>
+      <ul className="mt-3 space-y-1">
+        {documents.map((document) => (
+          <li key={document.id} className="text-sm font-bold">
+            <Link
+              className="underline underline-offset-4"
+              href={`/documents/${document.id}`}
+            >
+              {document.title}
+            </Link>{" "}
+            <span className="text-muted-foreground">v{document.version}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/packages/web/src/lib/__tests__/documents.server.test.ts
+++ b/packages/web/src/lib/__tests__/documents.server.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  assertUserCanViewTask: vi.fn(),
+  prisma: {
+    documentCreate: vi.fn(),
+    documentFindMany: vi.fn(),
+    documentFindUnique: vi.fn(),
+    taskFindUnique: vi.fn(),
+    transaction: vi.fn(),
+    userFindUnique: vi.fn(),
+  },
+  tx: {
+    documentCreate: vi.fn(),
+    documentFindFirst: vi.fn(),
+    documentFindUnique: vi.fn(),
+    documentUpdate: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $transaction: mocks.prisma.transaction,
+    document: {
+      create: mocks.prisma.documentCreate,
+      findMany: mocks.prisma.documentFindMany,
+      findUnique: mocks.prisma.documentFindUnique,
+    },
+    task: {
+      findUnique: mocks.prisma.taskFindUnique,
+    },
+    user: {
+      findUnique: mocks.prisma.userFindUnique,
+    },
+  },
+}));
+
+vi.mock("@/lib/tasks/task-visibility.server", () => ({
+  assertUserCanViewTask: mocks.assertUserCanViewTask,
+}));
+
+import {
+  createDocument,
+  getDocumentForViewer,
+  toDocumentDto,
+  updateDocument,
+} from "../documents.server";
+
+function createTxClient() {
+  return {
+    document: {
+      create: mocks.tx.documentCreate,
+      findFirst: mocks.tx.documentFindFirst,
+      findUnique: mocks.tx.documentFindUnique,
+      update: mocks.tx.documentUpdate,
+    },
+  };
+}
+
+const CURRENT_ROW = {
+  id: "doc_v3",
+  documentKey: "key_1",
+  jurisdictionId: "jur_1",
+  taskId: "task_1",
+  title: "Plan",
+  body: "# Plan\n\nold body",
+  version: 3,
+  isCurrent: true,
+  visibility: "PRIVATE" as const,
+  createdByUserId: "creator_1",
+  createdAt: new Date("2026-07-01T00:00:00Z"),
+  updatedAt: new Date("2026-07-01T00:00:00Z"),
+};
+
+beforeEach(() => {
+  for (const group of [mocks.prisma, mocks.tx]) {
+    for (const fn of Object.values(group)) {
+      fn.mockReset();
+    }
+  }
+  mocks.assertUserCanViewTask.mockReset();
+  mocks.assertUserCanViewTask.mockResolvedValue(undefined);
+  mocks.prisma.transaction.mockImplementation(
+    async (cb: (tx: ReturnType<typeof createTxClient>) => unknown) =>
+      cb(createTxClient()),
+  );
+});
+
+describe("updateDocument version transition", () => {
+  it("flips the current row and appends version + 1 in one transaction", async () => {
+    mocks.tx.documentFindUnique.mockResolvedValue({
+      documentKey: "key_1",
+      createdByUserId: "creator_1",
+    });
+    mocks.tx.documentFindFirst.mockResolvedValue(CURRENT_ROW);
+    mocks.tx.documentCreate.mockImplementation(
+      async ({ data }: { data: Record<string, unknown> }) => ({
+        ...CURRENT_ROW,
+        ...data,
+        id: "doc_v4",
+      }),
+    );
+
+    const result = await updateDocument({
+      documentId: "doc_v3",
+      editorUserId: "creator_1",
+      body: "# Plan\n\nnew body",
+    });
+
+    expect(mocks.prisma.transaction).toHaveBeenCalledTimes(1);
+    expect(mocks.tx.documentUpdate).toHaveBeenCalledWith({
+      where: { id: "doc_v3" },
+      data: { isCurrent: false },
+    });
+    expect(mocks.tx.documentCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        documentKey: "key_1",
+        version: 4,
+        isCurrent: true,
+        body: "# Plan\n\nnew body",
+        // Untouched fields carry forward from the current version.
+        title: "Plan",
+        taskId: "task_1",
+        jurisdictionId: "jur_1",
+        visibility: "PRIVATE",
+        createdByUserId: "creator_1",
+      }),
+    });
+    expect(result.version).toBe(4);
+  });
+
+  it("rejects non-creators with the 404-mapped error and writes nothing", async () => {
+    mocks.tx.documentFindUnique.mockResolvedValue({
+      documentKey: "key_1",
+      createdByUserId: "creator_1",
+    });
+
+    await expect(
+      updateDocument({
+        documentId: "doc_v3",
+        editorUserId: "stranger_1",
+        body: "hijack",
+      }),
+    ).rejects.toThrow("Document not found");
+
+    expect(mocks.tx.documentUpdate).not.toHaveBeenCalled();
+    expect(mocks.tx.documentCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the document does not exist", async () => {
+    mocks.tx.documentFindUnique.mockResolvedValue(null);
+
+    await expect(
+      updateDocument({
+        documentId: "missing",
+        editorUserId: "creator_1",
+        body: "x",
+      }),
+    ).rejects.toThrow("Document not found");
+  });
+
+  it("rejects an empty replacement body before writing", async () => {
+    mocks.tx.documentFindUnique.mockResolvedValue({
+      documentKey: "key_1",
+      createdByUserId: "creator_1",
+    });
+    mocks.tx.documentFindFirst.mockResolvedValue(CURRENT_ROW);
+
+    await expect(
+      updateDocument({
+        documentId: "doc_v3",
+        editorUserId: "creator_1",
+        body: "   ",
+      }),
+    ).rejects.toThrow("Body cannot be empty");
+
+    expect(mocks.tx.documentUpdate).not.toHaveBeenCalled();
+    expect(mocks.tx.documentCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("createDocument", () => {
+  it("defaults to PRIVATE and gates task attachment on task visibility", async () => {
+    mocks.prisma.taskFindUnique.mockResolvedValue({ jurisdictionId: "jur_9" });
+    mocks.prisma.documentCreate.mockImplementation(
+      async ({ data }: { data: Record<string, unknown> }) => ({
+        ...CURRENT_ROW,
+        ...data,
+        id: "doc_new",
+      }),
+    );
+
+    await createDocument({
+      title: "Notes",
+      body: "text",
+      createdByUserId: "creator_1",
+      taskId: "task_9",
+    });
+
+    expect(mocks.assertUserCanViewTask).toHaveBeenCalledWith(
+      "task_9",
+      "creator_1",
+    );
+    expect(mocks.prisma.documentCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        visibility: "PRIVATE",
+        taskId: "task_9",
+        // Inherits the task's jurisdiction when none is given.
+        jurisdictionId: "jur_9",
+      }),
+    });
+  });
+
+  it("refuses to attach to a task the creator cannot view", async () => {
+    mocks.assertUserCanViewTask.mockRejectedValue(new Error("Task not found"));
+
+    await expect(
+      createDocument({
+        title: "Notes",
+        body: "text",
+        createdByUserId: "stranger_1",
+        taskId: "private_task",
+      }),
+    ).rejects.toThrow("Task not found");
+
+    expect(mocks.prisma.documentCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("getDocumentForViewer visibility gate", () => {
+  it("returns null for anonymous viewers on a private document", async () => {
+    mocks.prisma.documentFindUnique.mockResolvedValue(CURRENT_ROW);
+
+    await expect(getDocumentForViewer("doc_v3", null)).resolves.toBeNull();
+
+    // No version list leaks when the gate denies.
+    expect(mocks.prisma.documentFindMany).not.toHaveBeenCalled();
+  });
+
+  it("returns the document and versions for its creator", async () => {
+    mocks.prisma.documentFindUnique.mockResolvedValue(CURRENT_ROW);
+    mocks.prisma.userFindUnique.mockResolvedValue({
+      id: "creator_1",
+      isAdmin: false,
+    });
+    mocks.prisma.documentFindMany.mockResolvedValue([
+      {
+        id: "doc_v3",
+        version: 3,
+        isCurrent: true,
+        title: "Plan",
+        createdAt: CURRENT_ROW.createdAt,
+      },
+    ]);
+
+    const result = await getDocumentForViewer("doc_v3", "creator_1");
+
+    expect(result?.document.id).toBe("doc_v3");
+    expect(result?.viewerCanEdit).toBe(true);
+    expect(result?.versions).toHaveLength(1);
+  });
+
+  it("returns public documents to anonymous viewers without edit rights", async () => {
+    mocks.prisma.documentFindUnique.mockResolvedValue({
+      ...CURRENT_ROW,
+      visibility: "PUBLIC",
+    });
+    mocks.prisma.documentFindMany.mockResolvedValue([]);
+
+    const result = await getDocumentForViewer("doc_v3", null);
+
+    expect(result?.document.visibility).toBe("PUBLIC");
+    expect(result?.viewerCanEdit).toBe(false);
+  });
+
+  it("lets admins read private documents they did not create", async () => {
+    mocks.prisma.documentFindUnique.mockResolvedValue(CURRENT_ROW);
+    mocks.prisma.userFindUnique.mockResolvedValue({
+      id: "admin_1",
+      isAdmin: true,
+    });
+    mocks.prisma.documentFindMany.mockResolvedValue([]);
+
+    const result = await getDocumentForViewer("doc_v3", "admin_1");
+
+    expect(result?.document.id).toBe("doc_v3");
+    expect(result?.viewerCanEdit).toBe(false);
+  });
+});
+
+describe("toDocumentDto boundary", () => {
+  it("serializes dates to ISO strings and passes scalars through", () => {
+    const dto = toDocumentDto(CURRENT_ROW);
+
+    expect(dto).toEqual({
+      id: "doc_v3",
+      documentKey: "key_1",
+      jurisdictionId: "jur_1",
+      taskId: "task_1",
+      title: "Plan",
+      body: "# Plan\n\nold body",
+      version: 3,
+      isCurrent: true,
+      visibility: "PRIVATE",
+      createdByUserId: "creator_1",
+      createdAt: "2026-07-01T00:00:00.000Z",
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    });
+  });
+});

--- a/packages/web/src/lib/__tests__/documents.server.test.ts
+++ b/packages/web/src/lib/__tests__/documents.server.test.ts
@@ -2,10 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   assertUserCanViewTask: vi.fn(),
+  canUserViewTask: vi.fn(),
   prisma: {
     documentCreate: vi.fn(),
+    documentFindFirst: vi.fn(),
     documentFindMany: vi.fn(),
-    documentFindUnique: vi.fn(),
     taskFindUnique: vi.fn(),
     transaction: vi.fn(),
     userFindUnique: vi.fn(),
@@ -13,8 +14,8 @@ const mocks = vi.hoisted(() => ({
   tx: {
     documentCreate: vi.fn(),
     documentFindFirst: vi.fn(),
-    documentFindUnique: vi.fn(),
     documentUpdate: vi.fn(),
+    taskFindUnique: vi.fn(),
   },
 }));
 
@@ -23,8 +24,8 @@ vi.mock("@/lib/prisma", () => ({
     $transaction: mocks.prisma.transaction,
     document: {
       create: mocks.prisma.documentCreate,
+      findFirst: mocks.prisma.documentFindFirst,
       findMany: mocks.prisma.documentFindMany,
-      findUnique: mocks.prisma.documentFindUnique,
     },
     task: {
       findUnique: mocks.prisma.taskFindUnique,
@@ -37,11 +38,16 @@ vi.mock("@/lib/prisma", () => ({
 
 vi.mock("@/lib/tasks/task-visibility.server", () => ({
   assertUserCanViewTask: mocks.assertUserCanViewTask,
+  canUserViewTask: mocks.canUserViewTask,
 }));
 
 import {
   createDocument,
+  DOCUMENT_EMPTY_PATCH_MESSAGE,
+  DOCUMENT_PRIVATE_TASK_MESSAGE,
   getDocumentForViewer,
+  listDocumentsForViewer,
+  listDocumentSummariesForViewer,
   toDocumentDto,
   updateDocument,
 } from "../documents.server";
@@ -51,13 +57,31 @@ function createTxClient() {
     document: {
       create: mocks.tx.documentCreate,
       findFirst: mocks.tx.documentFindFirst,
-      findUnique: mocks.tx.documentFindUnique,
       update: mocks.tx.documentUpdate,
+    },
+    task: {
+      findUnique: mocks.tx.taskFindUnique,
     },
   };
 }
 
-const CURRENT_ROW = {
+interface TestDocumentRow {
+  id: string;
+  documentKey: string;
+  jurisdictionId: string | null;
+  taskId: string | null;
+  title: string;
+  body: string;
+  version: number;
+  isCurrent: boolean;
+  visibility: "PUBLIC" | "PRIVATE";
+  createdByUserId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+const CURRENT_ROW: TestDocumentRow = {
   id: "doc_v3",
   documentKey: "key_1",
   jurisdictionId: "jur_1",
@@ -66,11 +90,26 @@ const CURRENT_ROW = {
   body: "# Plan\n\nold body",
   version: 3,
   isCurrent: true,
-  visibility: "PRIVATE" as const,
+  visibility: "PRIVATE",
   createdByUserId: "creator_1",
   createdAt: new Date("2026-07-01T00:00:00Z"),
   updatedAt: new Date("2026-07-01T00:00:00Z"),
+  deletedAt: null,
 };
+
+/** Wires prisma.document.findFirst so the "specific requested row" call
+ * (filtered by id) and the "current row for the chain" call (filtered by
+ * isCurrent) can return different rows, matching getDocumentForViewer's two
+ * lookups. */
+function mockDocumentLookup(
+  requested: TestDocumentRow | null,
+  current: TestDocumentRow | null = requested,
+) {
+  mocks.prisma.documentFindFirst.mockImplementation(
+    async ({ where }: { where: Record<string, unknown> }) =>
+      "isCurrent" in where ? current : requested,
+  );
+}
 
 beforeEach(() => {
   for (const group of [mocks.prisma, mocks.tx]) {
@@ -80,6 +119,8 @@ beforeEach(() => {
   }
   mocks.assertUserCanViewTask.mockReset();
   mocks.assertUserCanViewTask.mockResolvedValue(undefined);
+  mocks.canUserViewTask.mockReset();
+  mocks.canUserViewTask.mockResolvedValue(true);
   mocks.prisma.transaction.mockImplementation(
     async (cb: (tx: ReturnType<typeof createTxClient>) => unknown) =>
       cb(createTxClient()),
@@ -88,11 +129,12 @@ beforeEach(() => {
 
 describe("updateDocument version transition", () => {
   it("flips the current row and appends version + 1 in one transaction", async () => {
-    mocks.tx.documentFindUnique.mockResolvedValue({
-      documentKey: "key_1",
-      createdByUserId: "creator_1",
-    });
-    mocks.tx.documentFindFirst.mockResolvedValue(CURRENT_ROW);
+    mocks.tx.documentFindFirst
+      .mockResolvedValueOnce({
+        documentKey: "key_1",
+        createdByUserId: "creator_1",
+      })
+      .mockResolvedValueOnce(CURRENT_ROW);
     mocks.tx.documentCreate.mockImplementation(
       async ({ data }: { data: Record<string, unknown> }) => ({
         ...CURRENT_ROW,
@@ -127,10 +169,12 @@ describe("updateDocument version transition", () => {
       }),
     });
     expect(result.version).toBe(4);
+    // Visibility didn't change, so the private-task guard never queries it.
+    expect(mocks.tx.taskFindUnique).not.toHaveBeenCalled();
   });
 
   it("rejects non-creators with the 404-mapped error and writes nothing", async () => {
-    mocks.tx.documentFindUnique.mockResolvedValue({
+    mocks.tx.documentFindFirst.mockResolvedValueOnce({
       documentKey: "key_1",
       createdByUserId: "creator_1",
     });
@@ -148,7 +192,7 @@ describe("updateDocument version transition", () => {
   });
 
   it("rejects when the document does not exist", async () => {
-    mocks.tx.documentFindUnique.mockResolvedValue(null);
+    mocks.tx.documentFindFirst.mockResolvedValueOnce(null);
 
     await expect(
       updateDocument({
@@ -160,11 +204,12 @@ describe("updateDocument version transition", () => {
   });
 
   it("rejects an empty replacement body before writing", async () => {
-    mocks.tx.documentFindUnique.mockResolvedValue({
-      documentKey: "key_1",
-      createdByUserId: "creator_1",
-    });
-    mocks.tx.documentFindFirst.mockResolvedValue(CURRENT_ROW);
+    mocks.tx.documentFindFirst
+      .mockResolvedValueOnce({
+        documentKey: "key_1",
+        createdByUserId: "creator_1",
+      })
+      .mockResolvedValueOnce(CURRENT_ROW);
 
     await expect(
       updateDocument({
@@ -177,11 +222,68 @@ describe("updateDocument version transition", () => {
     expect(mocks.tx.documentUpdate).not.toHaveBeenCalled();
     expect(mocks.tx.documentCreate).not.toHaveBeenCalled();
   });
+
+  it("rejects a patch touching none of title/body/visibility before opening a transaction", async () => {
+    await expect(
+      updateDocument({ documentId: "doc_v3", editorUserId: "creator_1" }),
+    ).rejects.toThrow(DOCUMENT_EMPTY_PATCH_MESSAGE);
+
+    expect(mocks.prisma.transaction).not.toHaveBeenCalled();
+  });
+
+  it("refuses to flip visibility to PUBLIC while the attached task is private", async () => {
+    mocks.tx.documentFindFirst
+      .mockResolvedValueOnce({
+        documentKey: "key_1",
+        createdByUserId: "creator_1",
+      })
+      .mockResolvedValueOnce(CURRENT_ROW); // taskId: "task_1"
+    mocks.tx.taskFindUnique.mockResolvedValue({ isPublic: false });
+
+    await expect(
+      updateDocument({
+        documentId: "doc_v3",
+        editorUserId: "creator_1",
+        visibility: "PUBLIC",
+      }),
+    ).rejects.toThrow(DOCUMENT_PRIVATE_TASK_MESSAGE);
+
+    expect(mocks.tx.documentUpdate).not.toHaveBeenCalled();
+    expect(mocks.tx.documentCreate).not.toHaveBeenCalled();
+  });
+
+  it("allows flipping visibility to PUBLIC when the attached task is public", async () => {
+    mocks.tx.documentFindFirst
+      .mockResolvedValueOnce({
+        documentKey: "key_1",
+        createdByUserId: "creator_1",
+      })
+      .mockResolvedValueOnce(CURRENT_ROW);
+    mocks.tx.taskFindUnique.mockResolvedValue({ isPublic: true });
+    mocks.tx.documentCreate.mockImplementation(
+      async ({ data }: { data: Record<string, unknown> }) => ({
+        ...CURRENT_ROW,
+        ...data,
+        id: "doc_v4",
+      }),
+    );
+
+    const result = await updateDocument({
+      documentId: "doc_v3",
+      editorUserId: "creator_1",
+      visibility: "PUBLIC",
+    });
+
+    expect(result.visibility).toBe("PUBLIC");
+  });
 });
 
 describe("createDocument", () => {
   it("defaults to PRIVATE and gates task attachment on task visibility", async () => {
-    mocks.prisma.taskFindUnique.mockResolvedValue({ jurisdictionId: "jur_9" });
+    mocks.prisma.taskFindUnique.mockResolvedValue({
+      jurisdictionId: "jur_9",
+      isPublic: false,
+    });
     mocks.prisma.documentCreate.mockImplementation(
       async ({ data }: { data: Record<string, unknown> }) => ({
         ...CURRENT_ROW,
@@ -225,11 +327,54 @@ describe("createDocument", () => {
 
     expect(mocks.prisma.documentCreate).not.toHaveBeenCalled();
   });
+
+  it("refuses a PUBLIC document attached to a private task", async () => {
+    mocks.prisma.taskFindUnique.mockResolvedValue({
+      jurisdictionId: "jur_9",
+      isPublic: false,
+    });
+
+    await expect(
+      createDocument({
+        title: "Notes",
+        body: "text",
+        createdByUserId: "creator_1",
+        taskId: "task_9",
+        visibility: "PUBLIC",
+      }),
+    ).rejects.toThrow(DOCUMENT_PRIVATE_TASK_MESSAGE);
+
+    expect(mocks.prisma.documentCreate).not.toHaveBeenCalled();
+  });
+
+  it("allows a PUBLIC document attached to a public task", async () => {
+    mocks.prisma.taskFindUnique.mockResolvedValue({
+      jurisdictionId: "jur_9",
+      isPublic: true,
+    });
+    mocks.prisma.documentCreate.mockImplementation(
+      async ({ data }: { data: Record<string, unknown> }) => ({
+        ...CURRENT_ROW,
+        ...data,
+        id: "doc_new",
+      }),
+    );
+
+    const result = await createDocument({
+      title: "Notes",
+      body: "text",
+      createdByUserId: "creator_1",
+      taskId: "task_9",
+      visibility: "PUBLIC",
+    });
+
+    expect(result.visibility).toBe("PUBLIC");
+  });
 });
 
 describe("getDocumentForViewer visibility gate", () => {
   it("returns null for anonymous viewers on a private document", async () => {
-    mocks.prisma.documentFindUnique.mockResolvedValue(CURRENT_ROW);
+    mockDocumentLookup(CURRENT_ROW);
 
     await expect(getDocumentForViewer("doc_v3", null)).resolves.toBeNull();
 
@@ -238,7 +383,7 @@ describe("getDocumentForViewer visibility gate", () => {
   });
 
   it("returns the document and versions for its creator", async () => {
-    mocks.prisma.documentFindUnique.mockResolvedValue(CURRENT_ROW);
+    mockDocumentLookup(CURRENT_ROW);
     mocks.prisma.userFindUnique.mockResolvedValue({
       id: "creator_1",
       isAdmin: false,
@@ -261,10 +406,7 @@ describe("getDocumentForViewer visibility gate", () => {
   });
 
   it("returns public documents to anonymous viewers without edit rights", async () => {
-    mocks.prisma.documentFindUnique.mockResolvedValue({
-      ...CURRENT_ROW,
-      visibility: "PUBLIC",
-    });
+    mockDocumentLookup({ ...CURRENT_ROW, visibility: "PUBLIC" });
     mocks.prisma.documentFindMany.mockResolvedValue([]);
 
     const result = await getDocumentForViewer("doc_v3", null);
@@ -274,7 +416,7 @@ describe("getDocumentForViewer visibility gate", () => {
   });
 
   it("lets admins read private documents they did not create", async () => {
-    mocks.prisma.documentFindUnique.mockResolvedValue(CURRENT_ROW);
+    mockDocumentLookup(CURRENT_ROW);
     mocks.prisma.userFindUnique.mockResolvedValue({
       id: "admin_1",
       isAdmin: true,
@@ -286,10 +428,132 @@ describe("getDocumentForViewer visibility gate", () => {
     expect(result?.document.id).toBe("doc_v3");
     expect(result?.viewerCanEdit).toBe(false);
   });
+
+  it("denies an old PUBLIC version once the chain's current version is PRIVATE", async () => {
+    // Regression test: visibility is a chain-level property. A version that
+    // was PUBLIC when written must NOT stay independently readable once a
+    // later version in the same documentKey flips the chain PRIVATE.
+    const oldPublicRow: TestDocumentRow = {
+      ...CURRENT_ROW,
+      id: "doc_v1",
+      version: 1,
+      isCurrent: false,
+      visibility: "PUBLIC",
+    };
+    const currentPrivateRow: TestDocumentRow = {
+      ...CURRENT_ROW,
+      id: "doc_v2",
+      version: 2,
+      isCurrent: true,
+      visibility: "PRIVATE",
+    };
+    mockDocumentLookup(oldPublicRow, currentPrivateRow);
+
+    await expect(getDocumentForViewer("doc_v1", null)).resolves.toBeNull();
+    expect(mocks.prisma.documentFindMany).not.toHaveBeenCalled();
+  });
+
+  it("treats a soft-deleted document as not found", async () => {
+    // Mimics Prisma's WHERE filtering: only "find" the row when the caller
+    // actually asked for deletedAt: null, so this fails if that filter is
+    // ever dropped from the query.
+    mocks.prisma.documentFindFirst.mockImplementation(
+      async ({ where }: { where: { deletedAt?: null } }) =>
+        where.deletedAt === null
+          ? null
+          : { ...CURRENT_ROW, deletedAt: new Date("2026-07-10T00:00:00Z") },
+    );
+
+    await expect(
+      getDocumentForViewer("doc_v3", "creator_1"),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("listDocumentsForViewer", () => {
+  it("returns [] without querying documents when the viewer can't view the task", async () => {
+    mocks.canUserViewTask.mockResolvedValue(false);
+
+    const result = await listDocumentsForViewer({
+      userId: "stranger_1",
+      taskId: "private_task",
+    });
+
+    expect(result).toEqual([]);
+    expect(mocks.prisma.documentFindMany).not.toHaveBeenCalled();
+  });
+
+  it("includes private documents from any creator for admin viewers", async () => {
+    mocks.prisma.userFindUnique.mockResolvedValue({
+      id: "admin_1",
+      isAdmin: true,
+    });
+    mocks.prisma.documentFindMany.mockResolvedValue([CURRENT_ROW]);
+
+    await listDocumentsForViewer({ userId: "admin_1" });
+
+    expect(mocks.prisma.documentFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            { visibility: "PUBLIC" },
+            { visibility: "PRIVATE" },
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("excludes soft-deleted rows", async () => {
+    mocks.prisma.userFindUnique.mockResolvedValue(null);
+    mocks.prisma.documentFindMany.mockImplementation(
+      async ({ where }: { where: { deletedAt?: null } }) =>
+        where.deletedAt === null
+          ? []
+          : [{ ...CURRENT_ROW, visibility: "PUBLIC", deletedAt: new Date() }],
+    );
+
+    await expect(listDocumentsForViewer({ userId: null })).resolves.toEqual(
+      [],
+    );
+  });
+});
+
+describe("listDocumentSummariesForViewer", () => {
+  it("returns id/title/version only, gated by task visibility", async () => {
+    mocks.prisma.documentFindMany.mockResolvedValue([
+      { id: "doc_v3", title: "Plan", version: 3 },
+    ]);
+
+    const result = await listDocumentSummariesForViewer({
+      userId: null,
+      taskId: "task_1",
+    });
+
+    expect(mocks.canUserViewTask).toHaveBeenCalledWith("task_1", null);
+    expect(mocks.prisma.documentFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: { id: true, title: true, version: true },
+      }),
+    );
+    expect(result).toEqual([{ id: "doc_v3", title: "Plan", version: 3 }]);
+  });
+
+  it("returns [] when the viewer can't view the task", async () => {
+    mocks.canUserViewTask.mockResolvedValue(false);
+
+    const result = await listDocumentSummariesForViewer({
+      userId: "stranger_1",
+      taskId: "private_task",
+    });
+
+    expect(result).toEqual([]);
+    expect(mocks.prisma.documentFindMany).not.toHaveBeenCalled();
+  });
 });
 
 describe("toDocumentDto boundary", () => {
-  it("serializes dates to ISO strings and passes scalars through", () => {
+  it("serializes dates to ISO strings, passes scalars through, and omits createdByUserId", () => {
     const dto = toDocumentDto(CURRENT_ROW);
 
     expect(dto).toEqual({
@@ -302,9 +566,9 @@ describe("toDocumentDto boundary", () => {
       version: 3,
       isCurrent: true,
       visibility: "PRIVATE",
-      createdByUserId: "creator_1",
       createdAt: "2026-07-01T00:00:00.000Z",
       updatedAt: "2026-07-01T00:00:00.000Z",
     });
+    expect(dto).not.toHaveProperty("createdByUserId");
   });
 });

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -84,6 +84,7 @@ const mocks = vi.hoisted(() => ({
   upsertPrimaryTaskCommunicationEndpoint: vi.fn(),
   countUserCommentsInWindow: vi.fn(),
   postComment: vi.fn(),
+  canUserViewTask: vi.fn(),
   notifyTaskCommentRecipients: vi.fn(),
   generateAndPostWishoniaReply: vi.fn(),
   getProfileIdentityData: vi.fn(),
@@ -166,6 +167,12 @@ vi.mock("../tasks/task-communication-endpoints.server", () => ({
 vi.mock("../tasks/task-comments.server", () => ({
   countUserCommentsInWindow: mocks.countUserCommentsInWindow,
   postComment: mocks.postComment,
+}));
+vi.mock("../tasks/task-visibility.server", () => ({
+  TASK_NOT_FOUND_MESSAGE: "Task not found",
+  canUserViewTask: mocks.canUserViewTask,
+  assertUserCanViewTask: vi.fn(),
+  getTaskVisibilityWhere: vi.fn(),
 }));
 vi.mock("../tasks/task-comment-notifications.server", () => ({
   notifyTaskCommentRecipients: mocks.notifyTaskCommentRecipients,
@@ -536,6 +543,8 @@ function makePriority(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   for (const fn of Object.values(mocks)) fn.mockReset();
+  // Default: the caller can view the task. Visibility-denial cases override.
+  mocks.canUserViewTask.mockResolvedValue(true);
   vi.unstubAllGlobals();
   delete process.env.GITHUB_PAT;
   delete process.env.GITHUB_TOKEN;
@@ -4975,6 +4984,23 @@ describe("MCP server tool dispatch", () => {
         message: "Owner/assignee update",
         taskId: "task-1",
       });
+    });
+
+    it("postTaskComment 404s tasks the caller cannot view without writing", async () => {
+      mocks.canUserViewTask.mockResolvedValue(false);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "postTaskComment",
+        arguments: {
+          taskId: "private-task",
+          message: "should not land",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).error).toBe("Task not found");
+      expect(mocks.postComment).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/web/src/lib/__tests__/task-comments.server.test.ts
+++ b/packages/web/src/lib/__tests__/task-comments.server.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  assertUserCanViewTask: vi.fn(),
   prisma: {
+    activityFindMany: vi.fn(),
+    taskCommentCount: vi.fn(),
+    taskCommentFindMany: vi.fn(),
     taskCommentFindUnique: vi.fn(),
     taskCommentUpdate: vi.fn(),
+    taskCommentVoteFindMany: vi.fn(),
     transaction: vi.fn(),
   },
   tx: {
@@ -15,14 +20,32 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     $transaction: mocks.prisma.transaction,
+    activity: {
+      findMany: mocks.prisma.activityFindMany,
+    },
     taskComment: {
+      count: mocks.prisma.taskCommentCount,
+      findMany: mocks.prisma.taskCommentFindMany,
       findUnique: mocks.prisma.taskCommentFindUnique,
       update: mocks.prisma.taskCommentUpdate,
+    },
+    taskCommentVote: {
+      findMany: mocks.prisma.taskCommentVoteFindMany,
     },
   },
 }));
 
-import { deleteComment } from "../tasks/task-comments.server";
+vi.mock("@/lib/tasks/task-visibility.server", () => ({
+  TASK_NOT_FOUND_MESSAGE: "Task not found",
+  assertUserCanViewTask: mocks.assertUserCanViewTask,
+}));
+
+import {
+  deleteComment,
+  getTaskActivityTimeline,
+  getTaskCommentFeed,
+  voteComment,
+} from "../tasks/task-comments.server";
 
 function createTxClient() {
   return {
@@ -39,6 +62,9 @@ function resetAllMocks() {
       fn.mockReset();
     }
   }
+  mocks.assertUserCanViewTask.mockReset();
+  // Default: caller may view the task. Denial tests override per-case.
+  mocks.assertUserCanViewTask.mockResolvedValue(undefined);
 }
 
 describe("deleteComment", () => {
@@ -208,5 +234,123 @@ describe("deleteComment", () => {
         }),
       ).rejects.toThrow("Comment not found");
     });
+  });
+});
+
+describe("getTaskCommentFeed visibility gate", () => {
+  beforeEach(() => {
+    resetAllMocks();
+    mocks.prisma.taskCommentFindMany.mockResolvedValue([]);
+    mocks.prisma.taskCommentCount.mockResolvedValue(0);
+    mocks.prisma.taskCommentVoteFindMany.mockResolvedValue([]);
+  });
+
+  it("rejects with Task not found when the viewer cannot see the task", async () => {
+    mocks.assertUserCanViewTask.mockRejectedValue(new Error("Task not found"));
+
+    await expect(
+      getTaskCommentFeed({ taskId: "private_task", currentUserId: null }),
+    ).rejects.toThrow("Task not found");
+
+    expect(mocks.assertUserCanViewTask).toHaveBeenCalledWith(
+      "private_task",
+      null,
+    );
+    // Nothing leaks: no comment query runs when the gate denies.
+    expect(mocks.prisma.taskCommentFindMany).not.toHaveBeenCalled();
+    expect(mocks.prisma.taskCommentCount).not.toHaveBeenCalled();
+  });
+
+  it("returns the feed when the gate passes for the owner", async () => {
+    const row = {
+      id: "c1",
+      createdAt: new Date("2026-07-01T00:00:00Z"),
+      authorUser: null,
+    };
+    mocks.prisma.taskCommentFindMany.mockResolvedValue([row]);
+    mocks.prisma.taskCommentCount.mockResolvedValue(1);
+    mocks.prisma.taskCommentVoteFindMany.mockResolvedValue([]);
+
+    const result = await getTaskCommentFeed({
+      taskId: "private_task",
+      currentUserId: "owner_1",
+    });
+
+    expect(mocks.assertUserCanViewTask).toHaveBeenCalledWith(
+      "private_task",
+      "owner_1",
+    );
+    expect(result.total).toBe(1);
+    expect(result.comments).toHaveLength(1);
+  });
+
+  it("returns the feed for an anonymous viewer on a public task", async () => {
+    const result = await getTaskCommentFeed({
+      taskId: "public_task",
+      currentUserId: null,
+    });
+
+    expect(mocks.assertUserCanViewTask).toHaveBeenCalledWith(
+      "public_task",
+      null,
+    );
+    expect(result.comments).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});
+
+describe("getTaskActivityTimeline visibility gate", () => {
+  beforeEach(() => {
+    resetAllMocks();
+    mocks.prisma.activityFindMany.mockResolvedValue([]);
+  });
+
+  it("rejects for viewers who cannot see the task and skips the query", async () => {
+    mocks.assertUserCanViewTask.mockRejectedValue(new Error("Task not found"));
+
+    await expect(
+      getTaskActivityTimeline("private_task", 50, null),
+    ).rejects.toThrow("Task not found");
+
+    expect(mocks.prisma.activityFindMany).not.toHaveBeenCalled();
+  });
+
+  it("passes the caller identity through to the gate", async () => {
+    await getTaskActivityTimeline("task_1", 50, "user_1");
+
+    expect(mocks.assertUserCanViewTask).toHaveBeenCalledWith(
+      "task_1",
+      "user_1",
+    );
+  });
+});
+
+describe("voteComment visibility gate", () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  it("rejects when the comment's task is not visible to the voter", async () => {
+    mocks.prisma.taskCommentFindUnique.mockResolvedValue({
+      taskId: "private_task",
+    });
+    mocks.assertUserCanViewTask.mockRejectedValue(new Error("Task not found"));
+
+    await expect(
+      voteComment({ commentId: "c1", userId: "stranger_1", value: 1 }),
+    ).rejects.toThrow("Task not found");
+
+    expect(mocks.prisma.transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the comment does not exist", async () => {
+    mocks.prisma.taskCommentFindUnique.mockResolvedValue(null);
+
+    await expect(
+      voteComment({ commentId: "missing", userId: "user_1", value: 1 }),
+    ).rejects.toThrow("Comment not found");
+
+    expect(mocks.assertUserCanViewTask).not.toHaveBeenCalled();
+    expect(mocks.prisma.transaction).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/lib/__tests__/task-visibility.server.test.ts
+++ b/packages/web/src/lib/__tests__/task-visibility.server.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    taskFindFirst: vi.fn(),
+    userFindUnique: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    task: {
+      findFirst: mocks.prisma.taskFindFirst,
+    },
+    user: {
+      findUnique: mocks.prisma.userFindUnique,
+    },
+  },
+}));
+
+import {
+  assertUserCanViewTask,
+  canUserViewTask,
+  getTaskVisibilityWhere,
+} from "../tasks/task-visibility.server";
+
+beforeEach(() => {
+  mocks.prisma.taskFindFirst.mockReset();
+  mocks.prisma.userFindUnique.mockReset();
+});
+
+describe("getTaskVisibilityWhere", () => {
+  it("restricts anonymous 'accessible' viewers to public tasks", () => {
+    const where = getTaskVisibilityWhere({
+      taskId: "task_1",
+      visibility: "accessible",
+    });
+
+    expect(where).toMatchObject({
+      deletedAt: null,
+      id: "task_1",
+      isPublic: true,
+    });
+    expect(where.OR).toBeUndefined();
+  });
+
+  it("lets signed-in viewers reach public, own, and assigned tasks", () => {
+    const where = getTaskVisibilityWhere({
+      taskId: "task_1",
+      userId: "user_1",
+      personId: "person_1",
+      visibility: "accessible",
+    });
+
+    expect(where.OR).toEqual([
+      { isPublic: true },
+      { createdByUserId: "user_1" },
+      { assigneePersonId: "person_1" },
+    ]);
+    expect(where.isPublic).toBeUndefined();
+  });
+
+  it("defaults to public-only when no visibility is given", () => {
+    const where = getTaskVisibilityWhere({ taskId: "task_1" });
+
+    expect(where).toMatchObject({ id: "task_1", isPublic: true });
+  });
+});
+
+describe("canUserViewTask", () => {
+  it("returns false for anonymous viewers when the public lookup misses", async () => {
+    mocks.prisma.taskFindFirst.mockResolvedValue(null);
+
+    await expect(canUserViewTask("private_task", null)).resolves.toBe(false);
+
+    expect(mocks.prisma.userFindUnique).not.toHaveBeenCalled();
+    const where = mocks.prisma.taskFindFirst.mock.calls[0]?.[0]?.where;
+    expect(where).toMatchObject({ id: "private_task", isPublic: true });
+  });
+
+  it("checks creator/assignee access for signed-in non-admins", async () => {
+    mocks.prisma.userFindUnique.mockResolvedValue({
+      isAdmin: false,
+      personId: "person_1",
+    });
+    mocks.prisma.taskFindFirst.mockResolvedValue({ id: "task_1" });
+
+    await expect(canUserViewTask("task_1", "user_1")).resolves.toBe(true);
+
+    const where = mocks.prisma.taskFindFirst.mock.calls[0]?.[0]?.where;
+    expect(where.OR).toEqual([
+      { isPublic: true },
+      { createdByUserId: "user_1" },
+      { assigneePersonId: "person_1" },
+    ]);
+  });
+
+  it("lets admins view any non-deleted task", async () => {
+    mocks.prisma.userFindUnique.mockResolvedValue({
+      isAdmin: true,
+      personId: null,
+    });
+    mocks.prisma.taskFindFirst.mockResolvedValue({ id: "task_1" });
+
+    await expect(canUserViewTask("task_1", "admin_1")).resolves.toBe(true);
+
+    expect(mocks.prisma.taskFindFirst).toHaveBeenCalledWith({
+      where: { id: "task_1", deletedAt: null },
+      select: { id: true },
+    });
+  });
+
+  it("returns false for a blank task id without querying", async () => {
+    await expect(canUserViewTask("  ", "user_1")).resolves.toBe(false);
+
+    expect(mocks.prisma.taskFindFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertUserCanViewTask", () => {
+  it("throws the 404-mapped message when access is denied", async () => {
+    mocks.prisma.taskFindFirst.mockResolvedValue(null);
+
+    await expect(assertUserCanViewTask("private_task", null)).rejects.toThrow(
+      "Task not found",
+    );
+  });
+});

--- a/packages/web/src/lib/api-routes.ts
+++ b/packages/web/src/lib/api-routes.ts
@@ -30,6 +30,9 @@ export const API_ROUTES = {
     application: (id: string, applicationId: string) =>
       `/api/tasks/${id}/applications/${applicationId}`,
   },
+  documents: {
+    document: (id: string) => `/api/documents/${id}`,
+  },
   push: {
     vapidKey: "/api/push/vapid-key",
     subscribe: "/api/push/subscribe",

--- a/packages/web/src/lib/documents.server.ts
+++ b/packages/web/src/lib/documents.server.ts
@@ -1,0 +1,302 @@
+/**
+ * Document server helpers. A logical document is a chain of immutable version
+ * rows sharing one documentKey; exactly one row per chain has isCurrent.
+ * Updates never mutate a version — they append a new row and flip isCurrent
+ * inside a transaction.
+ *
+ * Visibility: PRIVATE by default. Private documents are readable by their
+ * creator (and admins) only, and 404 for everyone else — same principle as
+ * private tasks.
+ */
+
+import type { Prisma } from "@optimitron/db";
+import { DocumentVisibility } from "@optimitron/db/enums";
+import { prisma } from "@/lib/prisma";
+
+export const DOCUMENT_NOT_FOUND_MESSAGE = "Document not found";
+
+const MAX_TITLE_LENGTH = 300;
+const MAX_BODY_LENGTH = 500_000;
+
+export interface DocumentRow {
+  id: string;
+  documentKey: string;
+  jurisdictionId: string | null;
+  taskId: string | null;
+  title: string;
+  body: string;
+  version: number;
+  isCurrent: boolean;
+  visibility: DocumentVisibility;
+  createdByUserId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Wire shape for API/MCP responses: dates as ISO strings. */
+export interface DocumentDto {
+  id: string;
+  documentKey: string;
+  jurisdictionId: string | null;
+  taskId: string | null;
+  title: string;
+  body: string;
+  version: number;
+  isCurrent: boolean;
+  visibility: DocumentVisibility;
+  createdByUserId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function toDocumentDto(row: DocumentRow): DocumentDto {
+  return {
+    id: row.id,
+    documentKey: row.documentKey,
+    jurisdictionId: row.jurisdictionId,
+    taskId: row.taskId,
+    title: row.title,
+    body: row.body,
+    version: row.version,
+    isCurrent: row.isCurrent,
+    visibility: row.visibility,
+    createdByUserId: row.createdByUserId,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function normalizeVisibility(
+  value: unknown,
+  fallback: DocumentVisibility,
+): DocumentVisibility {
+  return value === DocumentVisibility.PUBLIC ||
+    value === DocumentVisibility.PRIVATE
+    ? value
+    : fallback;
+}
+
+function validateTitleAndBody(title: string, body: string): void {
+  if (!title.trim()) {
+    throw new Error("Title cannot be empty");
+  }
+  if (title.length > MAX_TITLE_LENGTH) {
+    throw new Error(`Title exceeds ${MAX_TITLE_LENGTH} character limit`);
+  }
+  if (!body.trim()) {
+    throw new Error("Body cannot be empty");
+  }
+  if (body.length > MAX_BODY_LENGTH) {
+    throw new Error(`Body exceeds ${MAX_BODY_LENGTH} character limit`);
+  }
+}
+
+async function getViewerFlags(
+  userId?: string | null,
+): Promise<{ id: string; isAdmin: boolean } | null> {
+  if (!userId) return null;
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, isAdmin: true },
+  });
+  return user ? { id: user.id, isAdmin: user.isAdmin ?? false } : null;
+}
+
+/** Pure visibility rule: public docs are readable by anyone; private docs by
+ * their creator or an admin. */
+export function canViewDocument(
+  document: Pick<DocumentRow, "visibility" | "createdByUserId">,
+  viewer: { id: string; isAdmin: boolean } | null,
+): boolean {
+  if (document.visibility === DocumentVisibility.PUBLIC) return true;
+  if (!viewer) return false;
+  return viewer.isAdmin || document.createdByUserId === viewer.id;
+}
+
+/**
+ * Create version 1 of a new document. Private by default. When taskId is
+ * given, the creator must be able to view that task (same predicate as
+ * /tasks/[id]) so documents can't be attached to tasks the author can't see.
+ */
+export async function createDocument(input: {
+  title: string;
+  body: string;
+  createdByUserId: string;
+  taskId?: string | null;
+  jurisdictionId?: string | null;
+  visibility?: DocumentVisibility | null;
+}): Promise<DocumentRow> {
+  const title = input.title.trim();
+  const body = input.body;
+  validateTitleAndBody(title, body);
+
+  const taskId = input.taskId?.trim() || null;
+  let jurisdictionId = input.jurisdictionId?.trim() || null;
+
+  if (taskId) {
+    const { assertUserCanViewTask } = await import(
+      "@/lib/tasks/task-visibility.server"
+    );
+    await assertUserCanViewTask(taskId, input.createdByUserId);
+    if (!jurisdictionId) {
+      const task = await prisma.task.findUnique({
+        where: { id: taskId },
+        select: { jurisdictionId: true },
+      });
+      jurisdictionId = task?.jurisdictionId ?? null;
+    }
+  }
+
+  return prisma.document.create({
+    data: {
+      title,
+      body,
+      taskId,
+      jurisdictionId,
+      visibility: normalizeVisibility(
+        input.visibility,
+        DocumentVisibility.PRIVATE,
+      ),
+      createdByUserId: input.createdByUserId,
+    },
+  });
+}
+
+/**
+ * Append a new version. Only the document's creator may update. Runs in one
+ * transaction: the current row loses isCurrent, the new row (version + 1)
+ * gains it. Untouched fields carry forward.
+ */
+export async function updateDocument(input: {
+  documentId: string;
+  editorUserId: string;
+  title?: string | null;
+  body?: string | null;
+  visibility?: DocumentVisibility | null;
+}): Promise<DocumentRow> {
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.document.findUnique({
+      where: { id: input.documentId },
+      select: { documentKey: true, createdByUserId: true },
+    });
+    if (!existing) {
+      throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
+    }
+    if (existing.createdByUserId !== input.editorUserId) {
+      // Non-creators get the same 404 as a missing document so private
+      // documents stay indistinguishable from nonexistent ones.
+      throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
+    }
+
+    const current = await tx.document.findFirst({
+      where: { documentKey: existing.documentKey, isCurrent: true },
+      orderBy: { version: "desc" },
+    });
+    if (!current) {
+      throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
+    }
+
+    const title = input.title?.trim() || current.title;
+    const body = input.body ?? current.body;
+    validateTitleAndBody(title, body);
+
+    await tx.document.update({
+      where: { id: current.id },
+      data: { isCurrent: false },
+    });
+
+    return tx.document.create({
+      data: {
+        documentKey: current.documentKey,
+        title,
+        body,
+        taskId: current.taskId,
+        jurisdictionId: current.jurisdictionId,
+        version: current.version + 1,
+        isCurrent: true,
+        visibility: normalizeVisibility(input.visibility, current.visibility),
+        createdByUserId: current.createdByUserId,
+      },
+    });
+  });
+}
+
+export interface DocumentVersionSummary {
+  id: string;
+  version: number;
+  isCurrent: boolean;
+  title: string;
+  createdAt: Date;
+}
+
+/**
+ * Load one version row plus the version list for its chain, gated by
+ * visibility. Returns null (callers 404) when missing or not viewable.
+ */
+export async function getDocumentForViewer(
+  documentId: string,
+  userId?: string | null,
+): Promise<{
+  document: DocumentRow;
+  versions: DocumentVersionSummary[];
+  viewerCanEdit: boolean;
+} | null> {
+  const normalizedId = documentId?.trim();
+  if (!normalizedId) return null;
+
+  const document = await prisma.document.findUnique({
+    where: { id: normalizedId },
+  });
+  if (!document) return null;
+
+  const viewer = await getViewerFlags(userId);
+  if (!canViewDocument(document, viewer)) return null;
+
+  const versions = await prisma.document.findMany({
+    where: { documentKey: document.documentKey },
+    orderBy: { version: "desc" },
+    select: {
+      id: true,
+      version: true,
+      isCurrent: true,
+      title: true,
+      createdAt: true,
+    },
+  });
+
+  return {
+    document,
+    versions,
+    viewerCanEdit: viewer != null && document.createdByUserId === viewer.id,
+  };
+}
+
+/**
+ * List current versions the viewer can see: public documents plus the
+ * viewer's own. Anonymous viewers see public documents only.
+ */
+export async function listDocumentsForViewer(input: {
+  userId?: string | null;
+  taskId?: string | null;
+  limit?: number | null;
+}): Promise<DocumentRow[]> {
+  const limit = Math.min(Math.max(input.limit ?? 100, 1), 500);
+  const taskId = input.taskId?.trim() || null;
+
+  const visibilityOr: Prisma.DocumentWhereInput[] = [
+    { visibility: DocumentVisibility.PUBLIC },
+  ];
+  if (input.userId) {
+    visibilityOr.push({ createdByUserId: input.userId });
+  }
+
+  return prisma.document.findMany({
+    where: {
+      isCurrent: true,
+      ...(taskId ? { taskId } : {}),
+      OR: visibilityOr,
+    },
+    orderBy: { updatedAt: "desc" },
+    take: limit,
+  });
+}

--- a/packages/web/src/lib/documents.server.ts
+++ b/packages/web/src/lib/documents.server.ts
@@ -6,7 +6,10 @@
  *
  * Visibility: PRIVATE by default. Private documents are readable by their
  * creator (and admins) only, and 404 for everyone else — same principle as
- * private tasks.
+ * private tasks. Visibility is enforced at the CHAIN level: every read gates
+ * on the documentKey's current row, not the requested row's own (possibly
+ * stale) visibility field, so an old PUBLIC version can't outlive a later
+ * PRIVATE one and a downgrade can't be bypassed by linking an old version id.
  */
 
 import type { Prisma } from "@optimitron/db";
@@ -14,26 +17,19 @@ import { DocumentVisibility } from "@optimitron/db/enums";
 import { prisma } from "@/lib/prisma";
 
 export const DOCUMENT_NOT_FOUND_MESSAGE = "Document not found";
+export const DOCUMENT_EMPTY_PATCH_MESSAGE =
+  "At least one of title, body, or visibility must be provided";
+export const DOCUMENT_PRIVATE_TASK_MESSAGE =
+  "Cannot make a document attached to a private task public";
 
 const MAX_TITLE_LENGTH = 300;
 const MAX_BODY_LENGTH = 500_000;
 
-export interface DocumentRow {
-  id: string;
-  documentKey: string;
-  jurisdictionId: string | null;
-  taskId: string | null;
-  title: string;
-  body: string;
-  version: number;
-  isCurrent: boolean;
-  visibility: DocumentVisibility;
-  createdByUserId: string;
-  createdAt: Date;
-  updatedAt: Date;
-}
+export type DocumentRow = Prisma.DocumentGetPayload<Record<string, never>>;
 
-/** Wire shape for API/MCP responses: dates as ISO strings. */
+/** Wire shape for API/MCP responses: dates as ISO strings. Omits
+ * createdByUserId — raw User ids don't go to anonymous readers; route
+ * creator attribution through Person if this ever needs a byline. */
 export interface DocumentDto {
   id: string;
   documentKey: string;
@@ -44,9 +40,14 @@ export interface DocumentDto {
   version: number;
   isCurrent: boolean;
   visibility: DocumentVisibility;
-  createdByUserId: string;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface DocumentSummary {
+  id: string;
+  title: string;
+  version: number;
 }
 
 export function toDocumentDto(row: DocumentRow): DocumentDto {
@@ -60,7 +61,6 @@ export function toDocumentDto(row: DocumentRow): DocumentDto {
     version: row.version,
     isCurrent: row.isCurrent,
     visibility: row.visibility,
-    createdByUserId: row.createdByUserId,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   };
@@ -113,10 +113,30 @@ export function canViewDocument(
   return viewer.isAdmin || document.createdByUserId === viewer.id;
 }
 
+/** Public + creator/admin visibility OR, shared by both list helpers below. */
+async function buildDocumentVisibilityWhere(
+  userId?: string | null,
+): Promise<Prisma.DocumentWhereInput> {
+  const viewer = await getViewerFlags(userId);
+  const visibilityOr: Prisma.DocumentWhereInput[] = [
+    { visibility: DocumentVisibility.PUBLIC },
+  ];
+  if (viewer?.isAdmin) {
+    // Admins get the same private read access canViewDocument grants them.
+    visibilityOr.push({ visibility: DocumentVisibility.PRIVATE });
+  } else if (viewer) {
+    visibilityOr.push({ createdByUserId: viewer.id });
+  }
+  return { OR: visibilityOr };
+}
+
 /**
  * Create version 1 of a new document. Private by default. When taskId is
  * given, the creator must be able to view that task (same predicate as
  * /tasks/[id]) so documents can't be attached to tasks the author can't see.
+ * A document can only be made PUBLIC on a task that is itself public —
+ * otherwise the document would leak the private task's existence/id to
+ * anyone who can read the document.
  */
 export async function createDocument(input: {
   title: string;
@@ -132,18 +152,26 @@ export async function createDocument(input: {
 
   const taskId = input.taskId?.trim() || null;
   let jurisdictionId = input.jurisdictionId?.trim() || null;
+  const visibility = normalizeVisibility(
+    input.visibility,
+    DocumentVisibility.PRIVATE,
+  );
 
   if (taskId) {
     const { assertUserCanViewTask } = await import(
       "@/lib/tasks/task-visibility.server"
     );
     await assertUserCanViewTask(taskId, input.createdByUserId);
+
+    const task = await prisma.task.findUnique({
+      where: { id: taskId },
+      select: { jurisdictionId: true, isPublic: true },
+    });
     if (!jurisdictionId) {
-      const task = await prisma.task.findUnique({
-        where: { id: taskId },
-        select: { jurisdictionId: true },
-      });
       jurisdictionId = task?.jurisdictionId ?? null;
+    }
+    if (visibility === DocumentVisibility.PUBLIC && !task?.isPublic) {
+      throw new Error(DOCUMENT_PRIVATE_TASK_MESSAGE);
     }
   }
 
@@ -153,10 +181,7 @@ export async function createDocument(input: {
       body,
       taskId,
       jurisdictionId,
-      visibility: normalizeVisibility(
-        input.visibility,
-        DocumentVisibility.PRIVATE,
-      ),
+      visibility,
       createdByUserId: input.createdByUserId,
     },
   });
@@ -165,7 +190,10 @@ export async function createDocument(input: {
 /**
  * Append a new version. Only the document's creator may update. Runs in one
  * transaction: the current row loses isCurrent, the new row (version + 1)
- * gains it. Untouched fields carry forward.
+ * gains it. Untouched fields carry forward. Rejects patches that touch none
+ * of title/body/visibility instead of appending a no-op version, and — same
+ * rule as createDocument — refuses to flip an attached document PUBLIC while
+ * its task is private.
  */
 export async function updateDocument(input: {
   documentId: string;
@@ -174,9 +202,13 @@ export async function updateDocument(input: {
   body?: string | null;
   visibility?: DocumentVisibility | null;
 }): Promise<DocumentRow> {
+  if (input.title == null && input.body == null && input.visibility == null) {
+    throw new Error(DOCUMENT_EMPTY_PATCH_MESSAGE);
+  }
+
   return prisma.$transaction(async (tx) => {
-    const existing = await tx.document.findUnique({
-      where: { id: input.documentId },
+    const existing = await tx.document.findFirst({
+      where: { id: input.documentId, deletedAt: null },
       select: { documentKey: true, createdByUserId: true },
     });
     if (!existing) {
@@ -189,7 +221,11 @@ export async function updateDocument(input: {
     }
 
     const current = await tx.document.findFirst({
-      where: { documentKey: existing.documentKey, isCurrent: true },
+      where: {
+        documentKey: existing.documentKey,
+        isCurrent: true,
+        deletedAt: null,
+      },
       orderBy: { version: "desc" },
     });
     if (!current) {
@@ -199,6 +235,17 @@ export async function updateDocument(input: {
     const title = input.title?.trim() || current.title;
     const body = input.body ?? current.body;
     validateTitleAndBody(title, body);
+
+    const visibility = normalizeVisibility(input.visibility, current.visibility);
+    if (visibility === DocumentVisibility.PUBLIC && current.taskId) {
+      const task = await tx.task.findUnique({
+        where: { id: current.taskId },
+        select: { isPublic: true },
+      });
+      if (!task?.isPublic) {
+        throw new Error(DOCUMENT_PRIVATE_TASK_MESSAGE);
+      }
+    }
 
     await tx.document.update({
       where: { id: current.id },
@@ -214,7 +261,7 @@ export async function updateDocument(input: {
         jurisdictionId: current.jurisdictionId,
         version: current.version + 1,
         isCurrent: true,
-        visibility: normalizeVisibility(input.visibility, current.visibility),
+        visibility,
         createdByUserId: current.createdByUserId,
       },
     });
@@ -230,8 +277,10 @@ export interface DocumentVersionSummary {
 }
 
 /**
- * Load one version row plus the version list for its chain, gated by
- * visibility. Returns null (callers 404) when missing or not viewable.
+ * Load one version row plus the version list for its chain, gated by the
+ * CHAIN's current visibility (not the requested row's own field — see file
+ * header). Returns null (callers 404) when missing, soft-deleted, or not
+ * viewable.
  */
 export async function getDocumentForViewer(
   documentId: string,
@@ -244,16 +293,26 @@ export async function getDocumentForViewer(
   const normalizedId = documentId?.trim();
   if (!normalizedId) return null;
 
-  const document = await prisma.document.findUnique({
-    where: { id: normalizedId },
+  const document = await prisma.document.findFirst({
+    where: { id: normalizedId, deletedAt: null },
   });
   if (!document) return null;
 
+  const current = await prisma.document.findFirst({
+    where: {
+      documentKey: document.documentKey,
+      isCurrent: true,
+      deletedAt: null,
+    },
+    orderBy: { version: "desc" },
+  });
+  if (!current) return null;
+
   const viewer = await getViewerFlags(userId);
-  if (!canViewDocument(document, viewer)) return null;
+  if (!canViewDocument(current, viewer)) return null;
 
   const versions = await prisma.document.findMany({
-    where: { documentKey: document.documentKey },
+    where: { documentKey: document.documentKey, deletedAt: null },
     orderBy: { version: "desc" },
     select: {
       id: true,
@@ -267,13 +326,16 @@ export async function getDocumentForViewer(
   return {
     document,
     versions,
-    viewerCanEdit: viewer != null && document.createdByUserId === viewer.id,
+    viewerCanEdit: viewer != null && current.createdByUserId === viewer.id,
   };
 }
 
 /**
- * List current versions the viewer can see: public documents plus the
- * viewer's own. Anonymous viewers see public documents only.
+ * List current versions the viewer can see: public documents, the viewer's
+ * own, and (for admins) every private document too — same access
+ * canViewDocument grants. Anonymous viewers see public documents only. When
+ * taskId is given, the viewer must be able to view that task itself — a
+ * document-list query can't become a way to probe private task ids.
  */
 export async function listDocumentsForViewer(input: {
   userId?: string | null;
@@ -283,20 +345,57 @@ export async function listDocumentsForViewer(input: {
   const limit = Math.min(Math.max(input.limit ?? 100, 1), 500);
   const taskId = input.taskId?.trim() || null;
 
-  const visibilityOr: Prisma.DocumentWhereInput[] = [
-    { visibility: DocumentVisibility.PUBLIC },
-  ];
-  if (input.userId) {
-    visibilityOr.push({ createdByUserId: input.userId });
+  if (taskId) {
+    const { canUserViewTask } = await import(
+      "@/lib/tasks/task-visibility.server"
+    );
+    if (!(await canUserViewTask(taskId, input.userId ?? null))) return [];
   }
+
+  const visibilityWhere = await buildDocumentVisibilityWhere(input.userId);
 
   return prisma.document.findMany({
     where: {
       isCurrent: true,
+      deletedAt: null,
       ...(taskId ? { taskId } : {}),
-      OR: visibilityOr,
+      ...visibilityWhere,
     },
     orderBy: { updatedAt: "desc" },
     take: limit,
+  });
+}
+
+/**
+ * Minimal id/title/version list for a task's attached documents — used by
+ * TaskDocumentsList, which never renders the body. Avoids shipping full
+ * markdown bodies (up to 500k chars each) on every task page load.
+ */
+export async function listDocumentSummariesForViewer(input: {
+  userId?: string | null;
+  taskId: string;
+  limit?: number | null;
+}): Promise<DocumentSummary[]> {
+  const taskId = input.taskId?.trim();
+  if (!taskId) return [];
+  const limit = Math.min(Math.max(input.limit ?? 50, 1), 500);
+
+  const { canUserViewTask } = await import(
+    "@/lib/tasks/task-visibility.server"
+  );
+  if (!(await canUserViewTask(taskId, input.userId ?? null))) return [];
+
+  const visibilityWhere = await buildDocumentVisibilityWhere(input.userId);
+
+  return prisma.document.findMany({
+    where: {
+      isCurrent: true,
+      deletedAt: null,
+      taskId,
+      ...visibilityWhere,
+    },
+    orderBy: { updatedAt: "desc" },
+    take: limit,
+    select: { id: true, title: true, version: true },
   });
 }

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -79,6 +79,12 @@ import {
   handleTaskTemplateToolCall,
   isTaskTemplateToolName,
 } from "./mcp-tools/task-templates";
+import {
+  DOCUMENT_TOOL_DEFINITIONS,
+  DOCUMENT_TOOL_SCOPES,
+  handleDocumentToolCall,
+  isDocumentToolName,
+} from "./mcp-tools/documents";
 import { stringifyJsonSafe } from "./json-safe";
 import { normalizeTaskTextLineBreaks } from "./task-text";
 import { slugify } from "./slugify";
@@ -213,6 +219,7 @@ const TOOL_SCOPES: Record<string, McpScope[]> = {
   githubApi: [McpScope.GITHUB],
   ...TASK_TEMPLATE_TOOL_SCOPES,
   ...TASK_TRIGGER_TOOL_SCOPES,
+  ...DOCUMENT_TOOL_SCOPES,
 };
 
 const ADMIN_ONLY_TOOLS = new Set([
@@ -8376,6 +8383,7 @@ Posting a comment automatically sends comment notifications to task recipients a
   },
   ...TASK_TEMPLATE_TOOL_DEFINITIONS,
   ...TASK_TRIGGER_TOOL_DEFINITIONS,
+  ...DOCUMENT_TOOL_DEFINITIONS,
 ];
 
 // ---------------------------------------------------------------------------
@@ -8448,6 +8456,13 @@ export function createMcpServer(
         }
         if (isTaskTemplateToolName(name)) {
           return handleTaskTemplateToolCall({
+            args: a,
+            name,
+            userId: userId ?? null,
+          });
+        }
+        if (isDocumentToolName(name)) {
+          return handleDocumentToolCall({
             args: a,
             name,
             userId: userId ?? null,

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -14303,6 +14303,15 @@ export function createMcpServer(
                 ? (a.mediaUrl as string)
                 : null;
 
+            // Same gate as the comment feed: you can only write where you
+            // can read. Private tasks look identical to missing ones.
+            const { canUserViewTask } = await import(
+              "./tasks/task-visibility.server"
+            );
+            if (!(await canUserViewTask(taskId, userId))) {
+              return err("Task not found");
+            }
+
             // Rate limit: 5 per user per task per hour
             const recentCount = await countUserCommentsInWindow(
               taskId,
@@ -14400,7 +14409,7 @@ export function createMcpServer(
               }),
               cursor
                 ? Promise.resolve([])
-                : getTaskActivityTimeline(taskId, 50),
+                : getTaskActivityTimeline(taskId, 50, userId ?? null),
             ]);
 
             return ok({

--- a/packages/web/src/lib/mcp-tools/documents.ts
+++ b/packages/web/src/lib/mcp-tools/documents.ts
@@ -82,7 +82,7 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
   {
     name: "getDocument",
     description:
-      "Read one document version plus its version list. Private documents 404 unless you created them.",
+      "Read one document version plus its version list. Private documents 404 unless you created them or are an administrator.",
     inputSchema: {
       type: "object" as const,
       properties: {

--- a/packages/web/src/lib/mcp-tools/documents.ts
+++ b/packages/web/src/lib/mcp-tools/documents.ts
@@ -1,0 +1,189 @@
+/**
+ * MCP document tools: versioned markdown documents, optionally attached to
+ * tasks. Personal-scope gated like personal tasks; private by default.
+ */
+
+import { stringifyJsonSafe } from "../json-safe";
+import { McpScope } from "../mcp-scopes";
+
+type ToolResponse = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+function ok(data: unknown): ToolResponse {
+  return { content: [{ type: "text", text: stringifyJsonSafe(data, 2) }] };
+}
+
+function err(message: string): ToolResponse {
+  return {
+    content: [{ type: "text", text: JSON.stringify({ error: message }) }],
+    isError: true,
+  };
+}
+
+export const DOCUMENT_TOOL_SCOPES = {
+  createDocument: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
+  updateDocument: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
+  getDocument: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
+  listDocuments: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
+} satisfies Record<string, McpScope[]>;
+
+export type DocumentToolName = keyof typeof DOCUMENT_TOOL_SCOPES;
+
+const VISIBILITY_SCHEMA = {
+  type: "string",
+  description: "PRIVATE (default) or PUBLIC.",
+  enum: ["PRIVATE", "PUBLIC"],
+};
+
+export const DOCUMENT_TOOL_DEFINITIONS = [
+  {
+    name: "createDocument",
+    description:
+      "Create a markdown document (version 1). Private by default. Optionally attach it to a task you can view.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        title: { type: "string", description: "Document title" },
+        body: { type: "string", description: "Markdown body" },
+        taskId: {
+          type: "string",
+          description: "Optional task to attach the document to",
+        },
+        jurisdictionId: {
+          type: "string",
+          description:
+            "Optional jurisdiction. Defaults to the attached task's jurisdiction.",
+        },
+        visibility: VISIBILITY_SCHEMA,
+      },
+      required: ["title", "body"],
+    },
+  },
+  {
+    name: "updateDocument",
+    description:
+      "Update a document you created. Writes a NEW version row and flips isCurrent — old versions stay readable. Omitted fields carry forward.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        documentId: {
+          type: "string",
+          description: "Any version row id of the document",
+        },
+        title: { type: "string" },
+        body: { type: "string", description: "Full replacement markdown body" },
+        visibility: VISIBILITY_SCHEMA,
+      },
+      required: ["documentId"],
+    },
+  },
+  {
+    name: "getDocument",
+    description:
+      "Read one document version plus its version list. Private documents 404 unless you created them.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        documentId: { type: "string", description: "Document version row id" },
+      },
+      required: ["documentId"],
+    },
+  },
+  {
+    name: "listDocuments",
+    description:
+      "List current document versions you can see: public documents plus your own. Filter by taskId to see a task's documents.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        taskId: { type: "string", description: "Only documents on this task" },
+        limit: { type: "number", description: "Default 100, max 500" },
+      },
+    },
+  },
+] as const;
+
+const DOCUMENT_TOOL_NAME_SET = new Set<string>(
+  Object.keys(DOCUMENT_TOOL_SCOPES),
+);
+
+export function isDocumentToolName(name: string): name is DocumentToolName {
+  return DOCUMENT_TOOL_NAME_SET.has(name);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+export async function handleDocumentToolCall({
+  args,
+  name,
+  userId,
+}: {
+  args: Record<string, unknown>;
+  name: DocumentToolName;
+  userId: string | null | undefined;
+}): Promise<ToolResponse> {
+  const documents = await import("../documents.server");
+
+  switch (name) {
+    case "createDocument": {
+      if (!userId) return err("createDocument requires an identified user");
+      const title = readString(args.title);
+      const body = readString(args.body);
+      if (!title || !body) return err("title and body are required");
+      const row = await documents.createDocument({
+        title,
+        body,
+        createdByUserId: userId,
+        taskId: readString(args.taskId) ?? null,
+        jurisdictionId: readString(args.jurisdictionId) ?? null,
+        visibility:
+          args.visibility === "PUBLIC" || args.visibility === "PRIVATE"
+            ? args.visibility
+            : null,
+      });
+      return ok({ document: documents.toDocumentDto(row) });
+    }
+
+    case "updateDocument": {
+      if (!userId) return err("updateDocument requires an identified user");
+      const documentId = readString(args.documentId);
+      if (!documentId) return err("documentId is required");
+      const row = await documents.updateDocument({
+        documentId,
+        editorUserId: userId,
+        title: readString(args.title) ?? null,
+        body: typeof args.body === "string" ? args.body : null,
+        visibility:
+          args.visibility === "PUBLIC" || args.visibility === "PRIVATE"
+            ? args.visibility
+            : null,
+      });
+      return ok({ document: documents.toDocumentDto(row) });
+    }
+
+    case "getDocument": {
+      const documentId = readString(args.documentId);
+      if (!documentId) return err("documentId is required");
+      const result = await documents.getDocumentForViewer(documentId, userId);
+      if (!result) return err(documents.DOCUMENT_NOT_FOUND_MESSAGE);
+      return ok({
+        document: documents.toDocumentDto(result.document),
+        versions: result.versions,
+        viewerCanEdit: result.viewerCanEdit,
+      });
+    }
+
+    case "listDocuments": {
+      const rows = await documents.listDocumentsForViewer({
+        userId: userId ?? null,
+        taskId: readString(args.taskId) ?? null,
+        limit: typeof args.limit === "number" ? args.limit : null,
+      });
+      return ok({ documents: rows.map(documents.toDocumentDto) });
+    }
+  }
+}

--- a/packages/web/src/lib/site.ts
+++ b/packages/web/src/lib/site.ts
@@ -668,7 +668,7 @@ const DFDA_CONFIG: SiteConfig = {
   description:
     "Find conditions, treatments, outcomes, and clinical trials in one evidence system.",
   ogImage: "/site-assets/dfda/dfda-og-1200x630.png",
-  analyticsId: process.env.NEXT_PUBLIC_GA_DFDA_ID,
+  analyticsId: process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
   contentKey: null,
   organizationName: ORGANIZATION_NAME,
   organizationUrl: ORGANIZATION_URL,
@@ -777,7 +777,7 @@ const DIH_CONFIG: SiteConfig = {
   description:
     "Create and fund disease-focused research institutes, then allocate resources by verified public priorities.",
   ogImage: "/site-assets/dih/dih-og-social-70s-utopian-1280x640.png",
-  analyticsId: process.env.NEXT_PUBLIC_GA_DIH_ID,
+  analyticsId: process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
   contentKey: null,
   organizationName: ORGANIZATION_NAME,
   organizationUrl: ORGANIZATION_URL,
@@ -897,7 +897,7 @@ const WAR_ON_DISEASE_CONFIG: SiteConfig = {
   ],
   description: WAR_ON_DISEASE_APOCALYPSE_DESCRIPTION,
   ogImage: "/site-assets/warondisease/war-on-disease-og-1200x630.png",
-  analyticsId: process.env.NEXT_PUBLIC_GA_WAR_ON_DISEASE_ID,
+  analyticsId: process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
   contentKey: "onePercentTreaty",
   // Public-facing campaign brand on WoD; compliance surfaces name the
   // nonprofit legal entity and campaign DBA.

--- a/packages/web/src/lib/task-applications.server.ts
+++ b/packages/web/src/lib/task-applications.server.ts
@@ -4,6 +4,7 @@ import {
   TaskApplicationStatus,
 } from "@optimitron/db/enums";
 import { prisma } from "@/lib/prisma";
+import { canUserViewTask } from "@/lib/tasks/task-visibility.server";
 
 export const applicationSelect = {
   id: true,
@@ -153,6 +154,11 @@ export async function assertCanReviewTaskApplications(
   }
 
   if (!(await canReviewTaskApplications(userId, taskId))) {
+    // A private task the caller can't even view must stay indistinguishable
+    // from a missing one — same predicate as /tasks/[id].
+    if (!(await canUserViewTask(taskId, userId))) {
+      throw new Error("Task not found");
+    }
     throw new Error("Forbidden");
   }
 }

--- a/packages/web/src/lib/tasks.server.ts
+++ b/packages/web/src/lib/tasks.server.ts
@@ -44,6 +44,7 @@ import {
   scoreTaskForAccountability,
 } from "@/lib/tasks/rank-tasks";
 import { getExplicitEdgeMarginalFrames } from "@/lib/tasks/marginal-impact";
+import { getTaskVisibilityWhere } from "@/lib/tasks/task-visibility.server";
 import { grantWishes } from "@/lib/wishes.server";
 
 const log = createLogger("tasks-server");
@@ -1030,86 +1031,8 @@ async function requireTaskReviewer(userId: string) {
   return reviewer;
 }
 
-function getTaskVisibilityWhere(input?: {
-  assigneeOrganizationId?: string | null;
-  assigneePersonId?: string | null;
-  personId?: string | null;
-  status?: TaskStatus | null;
-  targetOrganizationId?: string | null;
-  taskId?: string | null;
-  userId?: string | null;
-  visibility?: "public" | "created" | "accessible" | "personal" | "target";
-}): Prisma.TaskWhereInput {
-  const baseWhere: Prisma.TaskWhereInput = {
-    assigneeOrganizationId: input?.assigneeOrganizationId ?? undefined,
-    assigneePersonId: input?.assigneePersonId ?? undefined,
-    deletedAt: null,
-    id: input?.taskId ?? undefined,
-    status: input?.status ?? undefined,
-    ...(input?.targetOrganizationId
-      ? {
-          OR: [
-            { assigneeOrganizationId: input.targetOrganizationId },
-            { ownerOrganizationId: input.targetOrganizationId },
-          ],
-        }
-      : {}),
-  };
-
-  const visibility = input?.visibility ?? "public";
-  if (visibility === "target") {
-    return baseWhere;
-  }
-  if (visibility === "created") {
-    if (!input?.userId) {
-      return {
-        ...baseWhere,
-        createdByUserId: "__unreachable__",
-      };
-    }
-
-    return {
-      ...baseWhere,
-      createdByUserId: input.userId,
-    };
-  }
-
-  // "personal" = anything I created OR anything assigned to my Person.
-  // Used by the MCP getMyQueue / getNextAction / getQueueAudit handlers
-  // so trigger-spawned tasks (assignee = me, creator = system) surface
-  // alongside tasks I authored myself.
-  if (visibility === "personal") {
-    if (!input?.userId) {
-      return { ...baseWhere, createdByUserId: "__unreachable__" };
-    }
-    const ors: Prisma.TaskWhereInput[] = [{ createdByUserId: input.userId }];
-    if (input.personId) {
-      ors.push({ assigneePersonId: input.personId });
-    }
-    return { ...baseWhere, OR: ors };
-  }
-
-  if (visibility === "accessible" && input?.userId) {
-    // A task is "accessible" to a signed-in viewer if it is public, the
-    // viewer created it, OR it is assigned to the viewer's Person. The last
-    // clause matters for private trigger-spawned tasks (assignee = me,
-    // creator = system) so they don't 404 when their assignee clicks them
-    // from /tasks "Your Tasks" → /tasks/[id].
-    const ors: Prisma.TaskWhereInput[] = [
-      { isPublic: true },
-      { createdByUserId: input.userId },
-    ];
-    if (input.personId) {
-      ors.push({ assigneePersonId: input.personId });
-    }
-    return { ...baseWhere, OR: ors };
-  }
-
-  return {
-    ...baseWhere,
-    isPublic: true,
-  };
-}
+// getTaskVisibilityWhere moved to @/lib/tasks/task-visibility.server so the
+// comment/vote/application surfaces can reuse the exact /tasks/[id] predicate.
 
 function sortTasksForAccountability<T extends ReturnType<typeof decorateTask>>(
   tasks: T[],

--- a/packages/web/src/lib/tasks/task-comments.server.ts
+++ b/packages/web/src/lib/tasks/task-comments.server.ts
@@ -5,6 +5,7 @@
 
 import { Prisma } from "@optimitron/db";
 import { prisma } from "@/lib/prisma";
+import { assertUserCanViewTask } from "@/lib/tasks/task-visibility.server";
 import { userDisplaySelect } from "@/lib/user-display";
 
 const MAX_MESSAGE_LENGTH = 20_000;
@@ -183,6 +184,18 @@ export async function voteComment(input: {
   downvoteCount: number;
   userVote: 1 | -1 | 0;
 }> {
+  // Voting requires the same task access as reading the feed — otherwise a
+  // signed-in user could interact with (and confirm the existence of)
+  // comments on private tasks.
+  const target = await prisma.taskComment.findUnique({
+    where: { id: input.commentId },
+    select: { taskId: true },
+  });
+  if (!target) {
+    throw new Error("Comment not found");
+  }
+  await assertUserCanViewTask(target.taskId, input.userId);
+
   return prisma.$transaction(async (tx) => {
     const existing = await tx.taskCommentVote.findUnique({
       where: { commentId_userId: { commentId: input.commentId, userId: input.userId } },
@@ -319,6 +332,11 @@ export async function getTaskCommentFeed(input: {
   nextCursor: Date | null;
   total: number;
 }> {
+  // Same predicate as /tasks/[id]: a task whose page 404s for this viewer
+  // must 404 its comment feed too (private tasks stay indistinguishable
+  // from missing ones — never a 401/403).
+  await assertUserCanViewTask(input.taskId, input.currentUserId);
+
   const sort = input.sort ?? "new";
   const limit = Math.min(Math.max(input.limit ?? 50, 1), 100);
 
@@ -384,7 +402,12 @@ export async function getTaskCommentFeed(input: {
 export async function getTaskActivityTimeline(
   taskId: string,
   limit = 50,
+  currentUserId?: string | null,
 ): Promise<TaskActivityRow[]> {
+  // Same visibility gate as the comment feed: activity on a private task is
+  // as sensitive as its comments.
+  await assertUserCanViewTask(taskId, currentUserId);
+
   const rows = await prisma.activity.findMany({
     where: {
       entityType: "Task",

--- a/packages/web/src/lib/tasks/task-visibility.server.ts
+++ b/packages/web/src/lib/tasks/task-visibility.server.ts
@@ -1,0 +1,146 @@
+/**
+ * Task visibility predicate shared by every surface that reads a task or its
+ * children (comments, activity, votes, applications). This is THE access rule
+ * for /tasks/[id] — moved here verbatim from tasks.server.ts so API routes and
+ * MCP handlers can reuse it without importing the whole tasks module. Do not
+ * write a second predicate; extend this one.
+ */
+
+import type { Prisma, TaskStatus } from "@optimitron/db";
+import { prisma } from "@/lib/prisma";
+
+/** Error message API routes map to HTTP 404. Private tasks throw the same
+ * message as missing ones so they stay indistinguishable. */
+export const TASK_NOT_FOUND_MESSAGE = "Task not found";
+
+export function getTaskVisibilityWhere(input?: {
+  assigneeOrganizationId?: string | null;
+  assigneePersonId?: string | null;
+  personId?: string | null;
+  status?: TaskStatus | null;
+  targetOrganizationId?: string | null;
+  taskId?: string | null;
+  userId?: string | null;
+  visibility?: "public" | "created" | "accessible" | "personal" | "target";
+}): Prisma.TaskWhereInput {
+  const baseWhere: Prisma.TaskWhereInput = {
+    assigneeOrganizationId: input?.assigneeOrganizationId ?? undefined,
+    assigneePersonId: input?.assigneePersonId ?? undefined,
+    deletedAt: null,
+    id: input?.taskId ?? undefined,
+    status: input?.status ?? undefined,
+    ...(input?.targetOrganizationId
+      ? {
+          OR: [
+            { assigneeOrganizationId: input.targetOrganizationId },
+            { ownerOrganizationId: input.targetOrganizationId },
+          ],
+        }
+      : {}),
+  };
+
+  const visibility = input?.visibility ?? "public";
+  if (visibility === "target") {
+    return baseWhere;
+  }
+  if (visibility === "created") {
+    if (!input?.userId) {
+      return {
+        ...baseWhere,
+        createdByUserId: "__unreachable__",
+      };
+    }
+
+    return {
+      ...baseWhere,
+      createdByUserId: input.userId,
+    };
+  }
+
+  // "personal" = anything I created OR anything assigned to my Person.
+  // Used by the MCP getMyQueue / getNextAction / getQueueAudit handlers
+  // so trigger-spawned tasks (assignee = me, creator = system) surface
+  // alongside tasks I authored myself.
+  if (visibility === "personal") {
+    if (!input?.userId) {
+      return { ...baseWhere, createdByUserId: "__unreachable__" };
+    }
+    const ors: Prisma.TaskWhereInput[] = [{ createdByUserId: input.userId }];
+    if (input.personId) {
+      ors.push({ assigneePersonId: input.personId });
+    }
+    return { ...baseWhere, OR: ors };
+  }
+
+  if (visibility === "accessible" && input?.userId) {
+    // A task is "accessible" to a signed-in viewer if it is public, the
+    // viewer created it, OR it is assigned to the viewer's Person. The last
+    // clause matters for private trigger-spawned tasks (assignee = me,
+    // creator = system) so they don't 404 when their assignee clicks them
+    // from /tasks "Your Tasks" → /tasks/[id].
+    const ors: Prisma.TaskWhereInput[] = [
+      { isPublic: true },
+      { createdByUserId: input.userId },
+    ];
+    if (input.personId) {
+      ors.push({ assigneePersonId: input.personId });
+    }
+    return { ...baseWhere, OR: ors };
+  }
+
+  return {
+    ...baseWhere,
+    isPublic: true,
+  };
+}
+
+/**
+ * True when the viewer can see the task — the same "accessible" predicate
+ * /tasks/[id] uses (public, creator, or assignee Person), plus an admin
+ * override. Missing/deleted tasks return false so callers 404 uniformly.
+ */
+export async function canUserViewTask(
+  taskId: string,
+  userId?: string | null,
+): Promise<boolean> {
+  const normalizedTaskId = typeof taskId === "string" ? taskId.trim() : "";
+  if (!normalizedTaskId) {
+    return false;
+  }
+
+  const viewer = userId
+    ? await prisma.user.findUnique({
+        where: { id: userId },
+        select: { isAdmin: true, personId: true },
+      })
+    : null;
+
+  if (viewer?.isAdmin) {
+    const existing = await prisma.task.findFirst({
+      where: { id: normalizedTaskId, deletedAt: null },
+      select: { id: true },
+    });
+    return existing != null;
+  }
+
+  const task = await prisma.task.findFirst({
+    where: getTaskVisibilityWhere({
+      taskId: normalizedTaskId,
+      userId: userId ?? undefined,
+      personId: viewer?.personId ?? null,
+      visibility: "accessible",
+    }),
+    select: { id: true },
+  });
+  return task != null;
+}
+
+/** Throw the 404-mapped error unless the viewer can see the task. */
+export async function assertUserCanViewTask(
+  taskId: string,
+  userId?: string | null,
+): Promise<void> {
+  if (!(await canUserViewTask(taskId, userId))) {
+    throw new Error(TASK_NOT_FOUND_MESSAGE);
+  }
+}


### PR DESCRIPTION
Three items, one commit each.

## 1. Security: private-task comment visibility gate (0607410f)

**Repro (confirmed on production):** an anonymous `GET /api/tasks/<id>/comments` for a task whose page correctly 404s (private task) returned the full comment feed, activity timeline, and vote counts.

**Fix:** `getTaskCommentFeed` and `getTaskActivityTimeline` now enforce the same visibility predicate the `/tasks/[id]` page uses. The predicate (`getTaskVisibilityWhere`) moved verbatim to `lib/tasks/task-visibility.server.ts` with new `canUserViewTask` / `assertUserCanViewTask` wrappers, so there is exactly one predicate. Private tasks throw the 404-mapped "Task not found" — indistinguishable from missing tasks, never a 401/403 existence oracle.

Also gated in the same pass:
- `voteComment` (web route + MCP) — resolves the comment's task and applies the same gate.
- Comment **posting** (web POST + MCP `postTaskComment`) — the human caller must be able to view the task; server-initiated Wishonia replies still land on private tasks.
- `assertCanReviewTaskApplications` — a private task the caller can't view now 404s instead of leaking existence via 403.
- `/tasks/[id]` page swallows the gate error into an empty feed; the existing TaskAccessGate renders as before.

Tests: predicate where-clause behavior, feed/timeline/vote gating at the lib boundary, route-level anon-private → 404 / owner → 200 / anon-public → 200.

## 2. Single GA measurement ID (6b35688d)

`site.ts` read `NEXT_PUBLIC_GA_DFDA_ID` / `NEXT_PUBLIC_GA_DIH_ID` / `NEXT_PUBLIC_GA_WAR_ON_DISEASE_ID` — none were set, so those sites (including warondisease.org) served **no GA tag at all**. Every `SiteConfig` now uses `NEXT_PUBLIC_GA_MEASUREMENT_ID` (Mike's decision, 2026-07-12). No other references to the dead vars exist in the repo. Follow-up outside this repo: the GA4 Admin "Configure your domains" step for cross-domain sessions.

## 3. Document model v1 (8acb0c0d)

Start of "do this in Optimitron instead of Notion" (`optimitron:dev:document-model`).

- **Prisma:** `Document` rows are immutable versions sharing a `documentKey`; updating appends `version + 1` and flips `isCurrent` in one transaction. PRIVATE by default; `jurisdictionId` follows the Task pattern. Migration `20260712120000_add_document_model`.
- **MCP:** `createDocument` / `updateDocument` / `getDocument` / `listDocuments`, personal-scope gated like personal tasks. `createDocument` refuses to attach to tasks the author can't view (same shared predicate).
- **Web:** `/documents/[id]` renders markdown via the shared `RichMarkdown`, lists versions, creator-only textarea editor posting to `POST /api/documents/[id]`. Task pages list attached documents under the description; the list tolerates a code-before-migration deploy without 500ing task pages.
- **Tests:** version-transition transaction, DTO date serialization, visibility gating (private doc anon → 404), route auth mapping. No UI snapshots.

## Verification

- `pnpm check` green (typecheck + lint + full test suite; 2038 web tests + package suites).
- Migration applied cleanly to the local dev Postgres; smoke-tested on the dev server: existing doc API 200, missing doc 404, `/documents/<id>` page renders markdown.
- `copy:preview` (smart) run — no snapshot diffs.

Deploy note: run migrations before or with this deploy so `Document` exists; the task-page list degrades gracefully if code lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added versioned Markdown documents with public/private visibility, creator-only editing, and version history.
  - Added document viewing pages plus task-linked document lists.
  - Enabled document access and updates via new document API and document-related MCP tools.

- **Bug Fixes**
  - Strengthened access controls so private tasks’ comments, activity, votes, and related surfaces properly return not-found when unauthorized.
  - Improved missing-resource handling for documents and comments (consistent 404/401 behavior).
  - Standardized analytics measurement tracking across sites.

- **Tests**
  - Added/expanded coverage for document permissions, versioning rules, privacy gates, task visibility, and API behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->