### PR TITLE
Fix R2 backup upload with scoped credentials

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -136,13 +136,6 @@ jobs:
       - name: Upload to R2
         run: |
           set -euo pipefail
-          # First-run bootstrap. Advisory error-swallow rule: ONLY the
-          # already-exists/owned errors are tolerated — anything else fails.
-          if ! aws s3api create-bucket --bucket "$R2_BUCKET" --endpoint-url "$R2_ENDPOINT" 2> create-bucket.err; then
-            grep -qE "BucketAlreadyOwnedByYou|BucketAlreadyExists" create-bucket.err \
-              || { cat create-bucket.err; exit 1; }
-          fi
-
           prefix="backups/$(date -u +%Y/%m/%d)"
           sha=$(cat dump.sha256)
           aws s3 cp dump.zst.enc "s3://$R2_BUCKET/$prefix/dump.zst.enc" \

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -136,6 +136,7 @@ jobs:
       - name: Upload to R2
         run: |
           set -euo pipefail
+          # The bucket is provisioned separately; this token has object access only.
           prefix="backups/$(date -u +%Y/%m/%d)"
           sha=$(cat dump.sha256)
           aws s3 cp dump.zst.enc "s3://$R2_BUCKET/$prefix/dump.zst.enc" \


### PR DESCRIPTION
## Summary
- stop calling `CreateBucket` during every backup run
- keep the R2 credential scoped to object read/write on the pre-provisioned private bucket

## Verification
- `pnpm exec prettier --check .github/workflows/db-backup.yml`
- manual `DB Backup` workflow run completed successfully
- dump verification, encryption, R2 upload, and retention pruning all passed

Successful run: https://github.com/mikepsinn/optimitron/actions/runs/29276217749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database backup uploads by removing unnecessary bucket initialization.
  * Backups now proceed directly to upload while preserving encryption and checksum metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->