### PR TITLE
Make the MCP API learnable: server instructions + generated tool reference

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -79,9 +79,22 @@ Recommended OAuth scope for a personal life-planning AI:
 tasks:personal
 ```
 
-Do not request `tasks:admin` for personal planning. `tasks:admin` is reserved for admin users managing public Earth-level tasks. Public manual search and public task reads do not require OAuth permissions.
+The full scope vocabulary (live-rendered on `/developers` and in `/api/mcp/tools`):
 
-Add `tasks:organization` only for work in organizations where the user is an explicit member. Human approval clients may receive `actions:approve`; agent tokens may not.
+| Scope | Grants |
+| --- | --- |
+| `tasks:personal` | Create, update, prioritize, and comment on the user's private tasks; personal planning roots. |
+| `tasks:organization` | The same for organizations where the user is an explicit member; org planning roots. |
+| `tasks:admin` | Public Earth-level task management. Admin users only. |
+| `actions:approve` | Approve proposed external actions. Human approval clients only; agent tokens may not hold it. |
+| `earthdata:write` | Public Earth-data writes — court cases, memorials, evidence, corrections, measurements/tracking. Gates roughly a third of all tools. |
+| `earthdata:admin` | Administrative Earth-data operations. |
+| `agent:run` | Agent run logging and lease coordination. |
+| `github` | Repo search/read and GitHub API passthrough. |
+
+Do not request `tasks:admin` for personal planning. Public manual search and public task reads do not require OAuth permissions. Add `tasks:organization` only for work in organizations where the user is an explicit member.
+
+Task-listing tools take `visibility: "all" | "public" | "private"` — signed-in callers default to `all` (public plus their own private work); `scope: "accessible"` survives as a deprecated alias.
 
 Example private task:
 
@@ -166,21 +179,30 @@ are specified in [TASK_COMMUNICATION_MODEL.md](./TASK_COMMUNICATION_MODEL.md)
 
 ## Tool Groups
 
-- Queue discovery: `listTasks`, `getTask`, `getBlockers`, `getQueueAudit`, `getNextAction`, `getMyQueue`, `getAIQueue`, `evaluateTaskEconomics`.
-- Personal task management: `createTask`, `updateTask`, `deleteTask`.
-- Reviewed private import: `reviewPrivateTaskBundle`, `applyPrivateTaskBundle`, `deletePrivateSourceSelection` (target contract; see OPT-INTG-03 status).
-- Private execution: `startTaskExecution`, `submitTaskArtifact`, `submitTaskForVerification`, `verifyTaskExecution`, `getTaskAuditTrail` (target contract; see OPT-TASK-08 status).
-- External approval: `proposeExternalAction`, `recordExternalActionResult`; human approval is performed only by an `actions:approve` client (target contract; see OPT-AGENT-02 status).
-- Portability: `exportPrivateWork` (target contract; see OPT-TASK-08 status).
-- Public Earth task management, admin-only: `proposeTaskBundle`, `setTaskImpact`, `addDependency`, `promoteTask`, `updateMilestone`, `recordTaskActuals`.
-- Referendums: `listReferendums` for public active referendum inventory; `createReferendum` for admin-created draft referendum rows.
-- Agent coordination: `acquireLease`, `heartbeatLease`, `releaseLease`, `logAgentRun`.
-- Comments and comment notifications: `postTaskComment`, `getTaskComments`, `voteTaskComment`, `deleteTaskComment`.
-- Knowledge: `searchManual`, `askWishonia`, `searchRepo`, `getFileContent`, `listRepoFiles`, `listSitePages`, `getPageContent`.
-- Claims and actuals: `claimTask`, `completeTaskClaim`, `recordTaskActuals`.
-- Task triggers (data-driven blueprints): `createTaskTrigger`, `updateTaskTrigger`, `disableTaskTrigger`, `listTaskTriggers`, `getTaskTrigger`, `fireTaskTrigger`. See "Task Trigger Framework" below.
+This is an orientation map, not an inventory. The complete, generated,
+cannot-drift reference — every tool with parameters, required scopes, and
+admin gating — is the **[MCP Tool Reference](https://optimitron.com/developers/tools)**
+(human) and `/api/mcp/tools` (machine). When this section and those sources
+disagree, those sources win.
 
-Detailed tool schemas are exposed at `/api/mcp/tools`.
+- Queue discovery: `listTasks`, `getTask`, `getBlockers`, `getQueueAudit`, `getNextAction`, `getMyQueue`, `getAIQueue`, `evaluateTaskEconomics`.
+- Personal task management: `createTask`, `updateTask`, `deleteTask`, `proposeTaskBundle` (multi-task drafts with duplicate review), `promoteTask` (DRAFT → ACTIVE after review).
+- Reviewed private import: `reviewPrivateTaskBundle`, `applyPrivateTaskBundle`, `deletePrivateSourceSelection`.
+- Private execution (admin/agent-gated; not exposed to ordinary third-party tokens): `startTaskExecution`, `submitTaskArtifact`, `submitTaskForVerification`, `verifyTaskExecution`, `getTaskAuditTrail`.
+- External approval: `proposeExternalAction`, `recordExternalActionResult`; human approval is performed only by an `actions:approve` client.
+- Portability: `exportPrivateWork`.
+- Admin-only public task management: `setTaskImpact`, `addDependency`, `recordTaskActuals`, `createReferendum`.
+- Referendums: `listReferendums`, `castReferendumVote`, `signReferendumAsOrganization`.
+- Agent coordination (`agent:run`): `acquireLease`, `heartbeatLease`, `releaseLease`, `logAgentRun`, `getNextTask`.
+- Comments: `postTaskComment`, `getTaskComments`, `voteTaskComment`, `deleteTaskComment`.
+- Documents (versioned markdown): `createDocument`, `updateDocument`, `getDocument`, `listDocuments`.
+- Collections (structured records): `createCollection`, `updateCollection`, `getCollection`, `listCollections`, `createCollectionRecord`, `updateCollectionRecord`, `queryCollectionRecords`, `upsertCollectionRecordsBatch`, `saveCollectionView`.
+- Content: `searchContent`, `exportContent`, `manageContentAccess`, `manageContentFiles`, `reportContent`.
+- Health tracking (`earthdata:write`, companion-loop stage 1): `recordMeasurement`, `upsertTrackingReminder`, `listTrackingReminders`, `listDueTrackingReminders`, `respondToTrackingReminder`, `recordInterventionExperience`.
+- Task templates: `getTaskTemplate`, `listTaskTemplates`, `previewTaskTemplate`.
+- Knowledge: `searchManual`, `askWishonia`, `searchRepo`, `getFileContent`, `listRepoFiles`, `listSitePages`, `getPageContent`.
+- Claims: `claimTask`, `completeTaskClaim`.
+- Task triggers (data-driven blueprints): `createTaskTrigger`, `updateTaskTrigger`, `disableTaskTrigger`, `listTaskTriggers`, `getTaskTrigger`, `fireTaskTrigger`. See "Task Trigger Framework" below.
 
 ## Task Trigger Framework
 

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -94,7 +94,7 @@ The full scope vocabulary (live-rendered on `/developers` and in `/api/mcp/tools
 
 Do not request `tasks:admin` for personal planning. Public manual search and public task reads do not require OAuth permissions. Add `tasks:organization` only for work in organizations where the user is an explicit member.
 
-Task-listing tools take `visibility: "all" | "public" | "private"` — signed-in callers default to `all` (public plus their own private work); `scope: "accessible"` survives as a deprecated alias.
+Task-listing tools take `visibility: "all" | "public" | "private"` — signed-in callers default to `all` (public plus their own private work). On the tools that previously exposed `scope`/`taskScope`, `"accessible"` survives as a deprecated alias for `"all"`; `listTasks` never had the alias and takes only `visibility`.
 
 Example private task:
 
@@ -191,7 +191,8 @@ disagree, those sources win.
 - Private execution (admin/agent-gated; not exposed to ordinary third-party tokens): `startTaskExecution`, `submitTaskArtifact`, `submitTaskForVerification`, `verifyTaskExecution`, `getTaskAuditTrail`.
 - External approval: `proposeExternalAction`, `recordExternalActionResult`; human approval is performed only by an `actions:approve` client.
 - Portability: `exportPrivateWork`.
-- Admin-only public task management: `setTaskImpact`, `addDependency`, `recordTaskActuals`, `createReferendum`.
+- Admin-only public task management: `setTaskImpact`, `createReferendum` (the complete admin set is labeled on the generated reference).
+- Dependencies and actuals (personal/org callers): `addDependency`, `recordTaskActuals`.
 - Referendums: `listReferendums`, `castReferendumVote`, `signReferendumAsOrganization`.
 - Agent coordination (`agent:run`): `acquireLease`, `heartbeatLease`, `releaseLease`, `logAgentRun`, `getNextTask`.
 - Comments: `postTaskComment`, `getTaskComments`, `voteTaskComment`, `deleteTaskComment`.

--- a/packages/web/src/app/api/mcp/tools/route.ts
+++ b/packages/web/src/app/api/mcp/tools/route.ts
@@ -1,8 +1,17 @@
-import { getToolDefinitions } from "@/lib/mcp-server";
+import { getToolCatalog } from "@/lib/mcp-server";
 import { ALL_SCOPES, MCP_SCOPE_DESCRIPTIONS, scopeToWire } from "@/lib/mcp-scopes";
 
 export async function GET() {
-  const tools = getToolDefinitions();
+  // Access-aware catalog: same registry/scope-map/admin-set the live server
+  // enforces, with wire-format scope keys. Additive relative to the previous
+  // raw-definitions payload, so existing consumers keep working.
+  const tools = getToolCatalog().map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    requiredScopes: (tool.scopes ?? []).map((scope) => scopeToWire(scope)),
+    adminOnly: tool.adminOnly,
+  }));
 
   // Public API — emit OAuth wire-format scope keys clients expect.
   const scopes = Object.fromEntries(

--- a/packages/web/src/app/developers/page.tsx
+++ b/packages/web/src/app/developers/page.tsx
@@ -213,6 +213,9 @@ export default function DevelopersPage() {
             <Link className={primaryButtonClassName} href="/openapi.json">
               Open OpenAPI
             </Link>
+            <Link className={defaultButtonClassName} href="/developers/tools">
+              MCP Tool Reference
+            </Link>
             <Link className={defaultButtonClassName} href={mcpLink.href}>
               Install MCP
             </Link>

--- a/packages/web/src/app/developers/tools/page.tsx
+++ b/packages/web/src/app/developers/tools/page.tsx
@@ -1,0 +1,181 @@
+import Link from "next/link";
+import { getToolCatalog } from "@/lib/mcp-server";
+import {
+  ALL_SCOPES,
+  MCP_SCOPE_DESCRIPTIONS,
+  scopeToWire,
+  type McpScope,
+} from "@/lib/mcp-scopes";
+import { ROUTES } from "@/lib/routes";
+
+export const metadata = {
+  title: "MCP Tool Reference | Optimitron Developers",
+  description:
+    "Every tool the Optimitron MCP server exposes — parameters, required scopes, and admin gating — generated from the live registry.",
+};
+
+type CatalogTool = ReturnType<typeof getToolCatalog>[number];
+
+type SchemaProperty = {
+  type?: string | string[];
+  description?: string;
+  enum?: unknown[];
+};
+
+function toolGroupLabel(tool: CatalogTool): string {
+  if (tool.adminOnly) return "Admin-only";
+  if (!tool.scopes || tool.scopes.length === 0) return "Public (no scope)";
+  return scopeToWire(tool.scopes[0]);
+}
+
+function requiredParams(tool: CatalogTool): Set<string> {
+  const schema = tool.inputSchema as { required?: string[] } | undefined;
+  return new Set(schema?.required ?? []);
+}
+
+function schemaProperties(
+  tool: CatalogTool,
+): Array<[string, SchemaProperty]> {
+  const schema = tool.inputSchema as
+    | { properties?: Record<string, SchemaProperty> }
+    | undefined;
+  return Object.entries(schema?.properties ?? {});
+}
+
+function typeLabel(property: SchemaProperty): string {
+  if (property.enum) return "enum";
+  if (Array.isArray(property.type)) return property.type.join(" | ");
+  return property.type ?? "any";
+}
+
+export default function McpToolReferencePage() {
+  const catalog = getToolCatalog();
+  const groups = new Map<string, CatalogTool[]>();
+  for (const tool of catalog) {
+    const label = toolGroupLabel(tool);
+    groups.set(label, [...(groups.get(label) ?? []), tool]);
+  }
+  const orderedLabels = [
+    "Public (no scope)",
+    ...ALL_SCOPES.map((scope: McpScope) => scopeToWire(scope)),
+    "Admin-only",
+  ].filter((label) => groups.has(label));
+  const adminCount = catalog.filter((tool) => tool.adminOnly).length;
+
+  return (
+    <main className="min-h-screen bg-background px-4 py-10 text-foreground sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-4xl">
+        <p className="mb-3 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          Developers
+        </p>
+        <h1 className="text-3xl font-black uppercase leading-tight sm:text-4xl">
+          MCP Tool Reference
+        </h1>
+        <p className="mt-4 max-w-2xl text-base leading-relaxed text-foreground">
+          Every tool the Optimitron MCP server exposes — {catalog.length} tools
+          ({adminCount} admin-gated) — generated from the same registry the
+          live server enforces, so this page cannot drift from reality. The
+          machine-readable version is{" "}
+          <Link className="underline underline-offset-4" href="/api/mcp/tools">
+            /api/mcp/tools
+          </Link>
+          ; connection instructions live at{" "}
+          <Link className="underline underline-offset-4" href={ROUTES.mcp}>
+            /mcp
+          </Link>
+          .
+        </p>
+
+        <section className="mt-8 border-2 border-foreground p-4">
+          <h2 className="text-sm font-black uppercase tracking-[0.16em]">
+            OAuth scopes
+          </h2>
+          <dl className="mt-3 space-y-2">
+            {ALL_SCOPES.map((scope: McpScope) => (
+              <div key={scope} className="text-sm leading-relaxed">
+                <dt className="inline font-mono font-bold">
+                  {scopeToWire(scope)}
+                </dt>
+                <dd className="inline text-muted-foreground">
+                  {" "}
+                  — {MCP_SCOPE_DESCRIPTIONS[scope]}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        {orderedLabels.map((label) => (
+          <section key={label} className="mt-10">
+            <h2 className="border-b-2 border-foreground pb-2 text-xl font-black uppercase leading-tight">
+              {label}{" "}
+              <span className="text-sm font-bold text-muted-foreground">
+                ({groups.get(label)!.length})
+              </span>
+            </h2>
+            <div className="mt-4 space-y-6">
+              {groups.get(label)!.map((tool) => {
+                const required = requiredParams(tool);
+                const properties = schemaProperties(tool);
+                return (
+                  <article
+                    key={tool.name}
+                    className="border border-foreground p-4"
+                    id={tool.name}
+                  >
+                    <h3 className="font-mono text-base font-black">
+                      {tool.name}
+                      {tool.adminOnly ? (
+                        <span className="ml-2 border border-foreground px-1.5 py-0.5 text-[10px] font-black uppercase">
+                          admin
+                        </span>
+                      ) : null}
+                      {tool.scopes && tool.scopes.length > 0 ? (
+                        <span className="ml-2 text-xs font-bold text-muted-foreground">
+                          {tool.scopes
+                            .map((scope) => scopeToWire(scope))
+                            .join(" or ")}
+                        </span>
+                      ) : null}
+                    </h3>
+                    <p className="mt-2 whitespace-pre-line text-sm leading-relaxed text-foreground">
+                      {tool.description}
+                    </p>
+                    {properties.length > 0 ? (
+                      <details className="mt-3">
+                        <summary className="cursor-pointer text-xs font-black uppercase tracking-[0.14em]">
+                          Parameters ({properties.length})
+                        </summary>
+                        <ul className="mt-2 space-y-1.5">
+                          {properties.map(([name, property]) => (
+                            <li key={name} className="text-sm leading-snug">
+                              <span className="font-mono font-bold">
+                                {name}
+                              </span>
+                              <span className="text-muted-foreground">
+                                {" "}
+                                ({typeLabel(property)}
+                                {required.has(name) ? ", required" : ""})
+                                {property.description
+                                  ? ` — ${property.description}`
+                                  : ""}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </details>
+                    ) : (
+                      <p className="mt-2 text-xs font-bold uppercase text-muted-foreground">
+                        No parameters
+                      </p>
+                    )}
+                  </article>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/packages/web/src/app/developers/tools/page.tsx
+++ b/packages/web/src/app/developers/tools/page.tsx
@@ -6,13 +6,10 @@ import {
   scopeToWire,
   type McpScope,
 } from "@/lib/mcp-scopes";
-import { ROUTES } from "@/lib/routes";
+import { getRouteMetadata } from "@/lib/metadata";
+import { developersToolsLink, ROUTES } from "@/lib/routes";
 
-export const metadata = {
-  title: "MCP Tool Reference | Optimitron Developers",
-  description:
-    "Every tool the Optimitron MCP server exposes — parameters, required scopes, and admin gating — generated from the live registry.",
-};
+export const metadata = getRouteMetadata(developersToolsLink);
 
 type CatalogTool = ReturnType<typeof getToolCatalog>[number];
 
@@ -84,6 +81,11 @@ export default function McpToolReferencePage() {
             /mcp
           </Link>
           .
+        </p>
+        <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+          Each tool is listed once, under its primary scope; many accept more
+          than one scope, so the badges on a tool name every scope that can
+          call it.
         </p>
 
         <section className="mt-8 border-2 border-foreground p-4">

--- a/packages/web/src/lib/__tests__/mcp-tool-catalog.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-tool-catalog.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { getToolCatalog, getToolDefinitions } from "../mcp-server";
+import { MCP_SERVER_INSTRUCTIONS } from "../mcp-instructions";
+
+describe("MCP tool catalog", () => {
+  it("assigns every exposed tool an explicit scope entry", () => {
+    // hasScope denies tools missing from TOOL_SCOPES, so a null here means a
+    // registered tool no client can ever call — a registry error.
+    const unmapped = getToolCatalog()
+      .filter((tool) => tool.scopes === null)
+      .map((tool) => tool.name);
+
+    expect(unmapped).toEqual([]);
+  });
+
+  it("keeps catalog names unique and within the registered definitions", () => {
+    const catalogNames = getToolCatalog().map((tool) => tool.name);
+    const registered = new Set(getToolDefinitions().map((tool) => tool.name));
+
+    expect(new Set(catalogNames).size).toBe(catalogNames.length);
+    for (const name of catalogNames) {
+      expect(registered.has(name)).toBe(true);
+    }
+  });
+
+  it("only references real tools in the server instructions", () => {
+    // The docs-drift class this prevents: MCP_SERVER.md once documented a
+    // phantom updateMilestone tool. Instructions ship to every client on
+    // initialize, so every backticked-or-bare tool mention must exist.
+    const registered = new Set(getToolDefinitions().map((tool) => tool.name));
+    const mentioned = MCP_SERVER_INSTRUCTIONS.match(/\bget[A-Z]\w+|\b[a-z]+[A-Z]\w+/g) ?? [];
+    const phantom = [...new Set(mentioned)].filter(
+      (word) =>
+        /^(get|list|create|update|propose|post|claim|complete|search|record|upsert|respond|fire|evaluate)[A-Z]/.test(
+          word,
+        ) && !registered.has(word),
+    );
+
+    expect(phantom).toEqual([]);
+  });
+});

--- a/packages/web/src/lib/mcp-instructions.ts
+++ b/packages/web/src/lib/mcp-instructions.ts
@@ -1,0 +1,18 @@
+/**
+ * Server instructions sent to MCP clients on initialize. Clients like Claude
+ * surface this text to the model when the connector loads, so this is the
+ * first (often only) usage guidance an agent sees. Keep it dense and
+ * imperative; tool descriptions carry the details.
+ */
+export const MCP_SERVER_INSTRUCTIONS = `Optimitron is the live task graph for optimizing Earth and the humans on it: one tree rooted at "Optimize Earth", where every task carries expected-value estimates (value, p_success, hours) and the queue ranks work by expected net value per hour with deadline overrides.
+
+START HERE (in order):
+1. getMe — your identity, granted scopes, and personal/organization planning roots (created on first call).
+2. getQueueAudit — data-health check of the personal queue; repair high-severity issues before trusting rankings.
+3. getNextAction or getMyQueue — the user's own ranked next actions. getAIQueue — tasks marked for autonomous agent execution. getNextTask — best public task for an anonymous agent.
+
+CREATING WORK: always searchTasks first (visibility defaults to 'all' — public plus your private work — when signed in; pass 'public' or 'private' to narrow). createTask requires an explicit parentTaskId — choose the closest existing objective; never attach directly to Optimize Earth. Estimate value/p_success/hours honestly; a calibrated guess beats omission. Use proposeTaskBundle for multi-task drafts (it runs duplicate review).
+
+COORDINATING: postTaskComment for threaded discussion (markdown, math, mermaid); claimTask → completeTaskClaim for execution with evidence; updateTask to fix estimates, parents, or dependencies as scope changes.
+
+EXAMPLE ASKS: "I can write TypeScript for two hours — what should I do next?" · "Audit my queue and fix what's wrong." · "Create tasks for this project under the right parent." · "What is the highest-EV thing humanity should do today?"`;

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -110,6 +110,7 @@ import { IMAGE_UPLOAD_KINDS, isImageUploadKind } from "./image-upload-types";
 import { ensureSubjectForUser } from "./subject.server";
 import type { RankableTask } from "./tasks/rank-tasks";
 import { resolveTaskVisibilityParam } from "./tasks/task-visibility-param";
+import { MCP_SERVER_INSTRUCTIONS } from "./mcp-instructions";
 import {
   canUserManageTask,
   getTaskAccessWhere,
@@ -7873,7 +7874,10 @@ export function createMcpServer(
 
   const server = new Server(
     { name: "optimitron-tasks", version: "1.0.0" },
-    { capabilities: { tools: {} } },
+    {
+      capabilities: { tools: {} },
+      instructions: MCP_SERVER_INSTRUCTIONS,
+    },
   );
 
   // -- Tool listing (filtered by granted scopes) --
@@ -14226,4 +14230,22 @@ export function createMcpServer(
  */
 export function getToolDefinitions() {
   return TASK_TOOL_DEFINITIONS;
+}
+
+/**
+ * Full tool catalog with access metadata, for the generated developer
+ * reference (/developers/tools). Single source of truth: the same
+ * definitions, scope map, and admin set the live server enforces — a tool
+ * cannot appear here in a state the server would not honor.
+ */
+export function getToolCatalog() {
+  return TASK_TOOL_DEFINITIONS.filter(
+    (tool) => !DISABLED_TOOLS.has(tool.name),
+  ).map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    scopes: TOOL_SCOPES[tool.name] ?? null,
+    adminOnly: ADMIN_ONLY_TOOLS.has(tool.name),
+  }));
 }

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -156,6 +156,7 @@ export const ROUTES = {
   declaration: "/declaration",
   mcp: "/mcp",
   developers: "/developers",
+  developersTools: "/developers/tools",
   demo: "/demo",
   search: "/search",
   video: "/video",
@@ -702,6 +703,16 @@ export const developersLink: NavItem = {
   copyPreview: true,
   screenshot: true,
   cta: "Read API Docs",
+};
+
+export const developersToolsLink: NavItem = {
+  href: ROUTES.developersTools,
+  label: "MCP Tool Reference",
+  emoji: "{}",
+  description:
+    "Every tool the Optimitron MCP server exposes — parameters, required scopes, and admin gating — generated from the live registry so it cannot drift.",
+  tagline: "The complete MCP tool reference",
+  cta: "Browse the tools",
 };
 
 export const efficiencyLink: NavItem = {


### PR DESCRIPTION
## What

Closes the two top gaps from the API-docs audit (tasks `optimitron:dev:api-docs-refresh` and `optimitron:dev:mcp-onboarding-instructions`):

1. **Server instructions on initialize** (`mcp-instructions.ts`) — every MCP client now receives the start-here tool path (getMe → getQueueAudit → getNextAction/getMyQueue/getAIQueue), the search-first createTask discipline, the visibility vocabulary, and example asks. Previously clients connected into silence.
2. **`/developers/tools` — generated MCP Tool Reference** — every non-disabled tool with parameters, required scopes, and admin gating, rendered from a new `getToolCatalog()` that reuses the exact registry/scope-map/admin-set the live server enforces. Cannot drift. Linked from `/developers`.
3. **MCP_SERVER.md truth-up** — phantom `updateMilestone` removed; all 8 OAuth scopes documented (was 4; `earthdata:write`, which gates ~⅓ of tools, was never mentioned); missing tool families (Documents, Collections, Content, Tracking, Templates) mapped; private-execution tools labeled admin/agent-gated; generated reference declared canonical over prose.
4. **Drift guards as tests** — every exposed tool must have an explicit scope entry (missing = uncallable dead tool), and every tool named in the server instructions must exist in the registry. The phantom-tool class of doc rot now fails tests instead of shipping.

## Verification

- 3/3 new drift-guard tests; full app + tests typecheck green.
- `/developers` has no copy snapshot enrollment — no snapshot drift.
- New page renders from the registry server-side; review the live page on the preview deployment: `/developers/tools?logout=1` and `/developers?logout=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an MCP Tool Reference page listing available tools, required OAuth scopes, administrative access, and parameters.
  * Added a direct link to the MCP Tool Reference from the Developers page.
  * MCP clients now receive built-in setup and task-coordination guidance.
  * Added a machine-readable tool catalog with scope and availability details.

* **Documentation**
  * Expanded OAuth scope guidance and clarified visibility defaults and deprecated scope behavior.
  * Updated MCP tool group documentation with current categories and reference links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->