### PR TITLE
Collection tables: Notion-style column header menu, CSV export, mobile

### DIFF
--- a/packages/web/src/app/collections/[id]/page.tsx
+++ b/packages/web/src/app/collections/[id]/page.tsx
@@ -115,6 +115,7 @@ export default async function CollectionPage({
         canEdit={result.viewerCanEditContent}
         canSaveView={result.viewerCanEditSchema}
         collectionId={id}
+        collectionName={dto.name}
         fields={dto.fields}
         initialNextCursor={records.nextCursor}
         initialRecords={initialRecords}

--- a/packages/web/src/components/collections/collection-column-header.tsx
+++ b/packages/web/src/components/collections/collection-column-header.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import type { IHeaderParams } from "ag-grid-community";
+import { ArrowDown, ArrowUp, Check, MoreVertical } from "lucide-react";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import type {
+  ColumnAlign,
+  ColumnDisplaySettings,
+} from "@/components/collections/collection-column-settings";
+import { Menu } from "@/components/retroui/Menu";
+import { cn } from "@/lib/utils";
+
+// The channel the grid uses to read/write per-column display settings. Passed
+// through the AG Grid `context` prop (a stable object) rather than via
+// headerComponentParams closures, so header memoization stays intact.
+export interface CollectionGridContext {
+  getColumnSetting: (colId: string) => ColumnDisplaySettings | undefined;
+  onColumnSetting: (colId: string, patch: ColumnDisplaySettings | null) => void;
+}
+
+interface CollectionHeaderParams
+  extends IHeaderParams<unknown, CollectionGridContext> {
+  fieldType: string;
+}
+
+const ALIGNMENTS: Array<{ label: string; value: ColumnAlign }> = [
+  { label: "Left", value: "left" },
+  { label: "Center", value: "center" },
+  { label: "Right", value: "right" },
+];
+
+const NUMBER_FORMATS: Array<{ label: string; value: string }> = [
+  { label: "Plain", value: "plain" },
+  { label: "Comma (1,000)", value: "comma" },
+  { label: "Currency (USD)", value: "currency" },
+  { label: "Percent", value: "percent" },
+];
+
+const DATE_FORMATS: Array<{ label: string; value: string }> = [
+  { label: "ISO (YYYY-MM-DD)", value: "iso" },
+  { label: "Local date", value: "local" },
+  { label: "Mon D, YYYY", value: "medium" },
+];
+
+function MenuIndicator({ active }: { active: boolean }) {
+  return active ? (
+    <Check aria-hidden className="h-4 w-4 shrink-0" />
+  ) : (
+    <span aria-hidden className="h-4 w-4 shrink-0" />
+  );
+}
+
+function MenuSeparator() {
+  return <DropdownMenuPrimitive.Separator className="my-1 h-px bg-border" />;
+}
+
+function MenuLabel({ children }: { children: ReactNode }) {
+  return (
+    <DropdownMenuPrimitive.Label className="px-2 py-1 text-xs font-medium text-muted-foreground">
+      {children}
+    </DropdownMenuPrimitive.Label>
+  );
+}
+
+export function CollectionColumnHeader(params: CollectionHeaderParams) {
+  const { column, context, displayName, fieldType } = params;
+  const colId = column.getColId();
+  const [sort, setSortState] = useState<"asc" | "desc" | null>(
+    () => column.getSort() ?? null,
+  );
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const onSortChanged = () => setSortState(column.getSort() ?? null);
+    column.addEventListener("sortChanged", onSortChanged);
+    return () => column.removeEventListener("sortChanged", onSortChanged);
+  }, [column]);
+
+  // Read latest settings on every render. Opening the menu flips `menuOpen`,
+  // forcing a render, so the check marks reflect the current settings.
+  const setting = context.getColumnSetting(colId) ?? {};
+  const align: ColumnAlign = setting.align ?? "left";
+  const activeFormat = setting.format ?? "plain";
+  const formatOptions =
+    fieldType === "NUMBER"
+      ? NUMBER_FORMATS
+      : fieldType === "DATE"
+        ? DATE_FORMATS
+        : null;
+
+  function cycleSort() {
+    const next = sort === "asc" ? "desc" : sort === "desc" ? null : "asc";
+    params.setSort(next, false);
+  }
+
+  return (
+    <div className="flex h-full w-full items-center gap-1">
+      <button
+        className={cn(
+          "flex min-w-0 flex-1 items-center gap-1 bg-transparent font-bold",
+          align === "center" && "justify-center text-center",
+          align === "right" && "justify-end text-right",
+        )}
+        onClick={(event) => {
+          event.stopPropagation();
+          cycleSort();
+        }}
+        title={`Sort by ${displayName}`}
+        type="button"
+      >
+        <span className="truncate">{displayName}</span>
+        {sort === "asc" ? (
+          <ArrowUp aria-label="Sorted ascending" className="h-3 w-3 shrink-0" />
+        ) : sort === "desc" ? (
+          <ArrowDown
+            aria-label="Sorted descending"
+            className="h-3 w-3 shrink-0"
+          />
+        ) : null}
+      </button>
+
+      <Menu onOpenChange={setMenuOpen} open={menuOpen}>
+        <Menu.Trigger asChild>
+          <button
+            aria-label={`Column options for ${displayName}`}
+            className="flex h-8 w-8 shrink-0 items-center justify-center text-foreground hover:bg-muted"
+            onClick={(event) => event.stopPropagation()}
+            type="button"
+          >
+            <MoreVertical className="h-4 w-4" />
+          </button>
+        </Menu.Trigger>
+        <Menu.Content
+          align="end"
+          className="relative top-0 z-50 w-56 rounded-none border-foreground p-1"
+          sideOffset={4}
+        >
+          <Menu.Item
+            className="gap-2"
+            onSelect={() => params.setSort("asc", false)}
+          >
+            <MenuIndicator active={sort === "asc"} />
+            Sort ascending
+          </Menu.Item>
+          <Menu.Item
+            className="gap-2"
+            onSelect={() => params.setSort("desc", false)}
+          >
+            <MenuIndicator active={sort === "desc"} />
+            Sort descending
+          </Menu.Item>
+          <Menu.Item
+            className="gap-2"
+            onSelect={() => params.setSort(null, false)}
+          >
+            <MenuIndicator active={sort === null} />
+            Clear sort
+          </Menu.Item>
+
+          <MenuSeparator />
+          <Menu.Item
+            className="gap-2"
+            onSelect={() =>
+              context.onColumnSetting(colId, { wrapText: !setting.wrapText })
+            }
+          >
+            <MenuIndicator active={Boolean(setting.wrapText)} />
+            Wrap text
+          </Menu.Item>
+
+          <MenuSeparator />
+          <MenuLabel>Align</MenuLabel>
+          {ALIGNMENTS.map((option) => (
+            <Menu.Item
+              className="gap-2"
+              key={option.value}
+              onSelect={() =>
+                context.onColumnSetting(colId, { align: option.value })
+              }
+            >
+              <MenuIndicator active={align === option.value} />
+              {option.label}
+            </Menu.Item>
+          ))}
+
+          {formatOptions ? (
+            <>
+              <MenuSeparator />
+              <MenuLabel>Format</MenuLabel>
+              {formatOptions.map((option) => (
+                <Menu.Item
+                  className="gap-2"
+                  key={option.value}
+                  onSelect={() =>
+                    context.onColumnSetting(colId, { format: option.value })
+                  }
+                >
+                  <MenuIndicator active={activeFormat === option.value} />
+                  {option.label}
+                </Menu.Item>
+              ))}
+            </>
+          ) : null}
+
+          <MenuSeparator />
+          <MenuLabel>Pin</MenuLabel>
+          <Menu.Item
+            className="gap-2"
+            onSelect={() => params.api.setColumnsPinned([colId], "left")}
+          >
+            <MenuIndicator active={column.isPinnedLeft()} />
+            Left
+          </Menu.Item>
+          <Menu.Item
+            className="gap-2"
+            onSelect={() => params.api.setColumnsPinned([colId], "right")}
+          >
+            <MenuIndicator active={column.isPinnedRight()} />
+            Right
+          </Menu.Item>
+          <Menu.Item
+            className="gap-2"
+            onSelect={() => params.api.setColumnsPinned([colId], null)}
+          >
+            <MenuIndicator active={!column.isPinned()} />
+            None
+          </Menu.Item>
+
+          <MenuSeparator />
+          <Menu.Item
+            className="gap-2"
+            onSelect={() => params.api.setColumnsVisible([colId], false)}
+          >
+            <span aria-hidden className="h-4 w-4 shrink-0" />
+            Hide column
+          </Menu.Item>
+        </Menu.Content>
+      </Menu>
+    </div>
+  );
+}

--- a/packages/web/src/components/collections/collection-column-settings.test.ts
+++ b/packages/web/src/components/collections/collection-column-settings.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { formatCellValue } from "./collection-column-settings";
+
+describe("formatCellValue", () => {
+  it("keeps a date-only value on its own calendar day regardless of time zone", () => {
+    // Regression: new Date("2026-07-19") is UTC midnight, which renders as
+    // 2026-07-18 west of UTC. All three date formats must show the 19th.
+    expect(formatCellValue("DATE", "iso", "2026-07-19")).toBe("2026-07-19");
+    expect(formatCellValue("DATE", "medium", "2026-07-19")).toBe(
+      "Jul 19, 2026",
+    );
+    // toLocaleDateString output varies by runner locale, but must contain the
+    // correct day, never the 18th.
+    const local = formatCellValue("DATE", "local", "2026-07-19");
+    expect(local).toMatch(/19/);
+    expect(local).not.toMatch(/18/);
+  });
+
+  it("falls back to the raw string for an unparseable date", () => {
+    expect(formatCellValue("DATE", "medium", "not-a-date")).toBe("not-a-date");
+  });
+
+  it("formats numbers per the chosen format", () => {
+    expect(formatCellValue("NUMBER", "comma", 125000)).toBe("125,000");
+    expect(formatCellValue("NUMBER", "currency", 8000)).toBe("$8,000.00");
+    expect(formatCellValue("NUMBER", "percent", 0.65)).toBe("65%");
+    expect(formatCellValue("NUMBER", "plain", 42)).toBe("42");
+  });
+
+  it("preserves the original null / array / string fallbacks", () => {
+    expect(formatCellValue("TEXT", undefined, null)).toBe("");
+    expect(formatCellValue("MULTI_SELECT", undefined, ["a", "b"])).toBe("a, b");
+    expect(formatCellValue("TEXT", undefined, "hello")).toBe("hello");
+  });
+
+  it("does not throw on a non-finite number", () => {
+    expect(formatCellValue("NUMBER", "currency", "abc")).toBe("abc");
+  });
+});

--- a/packages/web/src/components/collections/collection-column-settings.ts
+++ b/packages/web/src/components/collections/collection-column-settings.ts
@@ -100,22 +100,34 @@ export function formatCellValue(
 
   if (fieldType === "DATE" && format) {
     const raw = String(value);
-    const parsed = new Date(raw);
-    const valid = !Number.isNaN(parsed.getTime());
+    // Date-only values (the editor/filters store YYYY-MM-DD) must parse in
+    // LOCAL time: new Date("2026-07-19") is UTC midnight, which renders as the
+    // previous calendar day west of UTC. Full timestamps parse as-is.
+    const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(raw);
+    const parsed = dateOnly
+      ? new Date(
+          Number(raw.slice(0, 4)),
+          Number(raw.slice(5, 7)) - 1,
+          Number(raw.slice(8, 10)),
+        )
+      : new Date(raw);
+    if (Number.isNaN(parsed.getTime())) return raw;
     try {
       switch (format) {
-        case "iso":
-          return valid ? parsed.toISOString().slice(0, 10) : raw.slice(0, 10);
+        case "iso": {
+          const y = parsed.getFullYear();
+          const m = String(parsed.getMonth() + 1).padStart(2, "0");
+          const d = String(parsed.getDate()).padStart(2, "0");
+          return `${y}-${m}-${d}`;
+        }
         case "local":
-          return valid ? parsed.toLocaleDateString() : raw;
+          return parsed.toLocaleDateString();
         case "medium":
-          return valid
-            ? parsed.toLocaleDateString("en-US", {
-                day: "numeric",
-                month: "short",
-                year: "numeric",
-              })
-            : raw;
+          return parsed.toLocaleDateString("en-US", {
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+          });
         default:
           return raw;
       }

--- a/packages/web/src/components/collections/collection-column-settings.ts
+++ b/packages/web/src/components/collections/collection-column-settings.ts
@@ -1,0 +1,128 @@
+// Per-column display settings for the collection records grid.
+//
+// TODO(persistence): durable per-view persistence needs a
+// `CollectionView.columnSettingsJson` column + migration (owner approval
+// pending). Until that lands, these per-column display settings live only in
+// localStorage on the current browser. `loadColumnSettings`/`saveColumnSettings`
+// below are the single swap point: replace their bodies with server reads/writes
+// once the migration exists, and callers keep working unchanged.
+
+export type ColumnAlign = "center" | "left" | "right";
+
+export interface ColumnDisplaySettings {
+  align?: ColumnAlign;
+  format?: string;
+  wrapText?: boolean;
+}
+
+export type ColumnSettingsMap = Record<string, ColumnDisplaySettings>;
+
+const KEY_PREFIX = "optimitron:collection-columns";
+
+function storageKey(collectionId: string, viewId: string | null): string {
+  return `${KEY_PREFIX}:${collectionId}:${viewId ?? "default"}`;
+}
+
+export function loadColumnSettings(
+  collectionId: string,
+  viewId: string | null,
+): ColumnSettingsMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(storageKey(collectionId, viewId));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as ColumnSettingsMap;
+  } catch {
+    return {};
+  }
+}
+
+export function saveColumnSettings(
+  collectionId: string,
+  viewId: string | null,
+  settings: ColumnSettingsMap,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    const key = storageKey(collectionId, viewId);
+    if (!settings || Object.keys(settings).length === 0) {
+      window.localStorage.removeItem(key);
+      return;
+    }
+    window.localStorage.setItem(key, JSON.stringify(settings));
+  } catch {
+    // Non-fatal: private-mode, quota, or disabled storage. Settings simply do
+    // not persist across reloads in that browser.
+  }
+}
+
+// Formats a grid cell for display. Extends the grid's original null/array/string
+// fallback with optional number/date formatting. Never throws: any bad value or
+// formatter error falls back to the raw string so the grid keeps rendering.
+export function formatCellValue(
+  fieldType: string,
+  format: string | undefined,
+  value: unknown,
+): string {
+  if (value == null) return "";
+  if (Array.isArray(value)) return value.join(", ");
+
+  if (fieldType === "NUMBER" && format && format !== "plain") {
+    const numeric = typeof value === "number" ? value : Number(value);
+    if (Number.isFinite(numeric)) {
+      try {
+        switch (format) {
+          case "comma":
+            return new Intl.NumberFormat("en-US").format(numeric);
+          case "currency":
+            return new Intl.NumberFormat("en-US", {
+              currency: "USD",
+              style: "currency",
+            }).format(numeric);
+          case "percent":
+            return new Intl.NumberFormat("en-US", {
+              maximumFractionDigits: 2,
+              style: "percent",
+            }).format(numeric);
+          default:
+            break;
+        }
+      } catch {
+        return String(value);
+      }
+    }
+    return String(value);
+  }
+
+  if (fieldType === "DATE" && format) {
+    const raw = String(value);
+    const parsed = new Date(raw);
+    const valid = !Number.isNaN(parsed.getTime());
+    try {
+      switch (format) {
+        case "iso":
+          return valid ? parsed.toISOString().slice(0, 10) : raw.slice(0, 10);
+        case "local":
+          return valid ? parsed.toLocaleDateString() : raw;
+        case "medium":
+          return valid
+            ? parsed.toLocaleDateString("en-US", {
+                day: "numeric",
+                month: "short",
+                year: "numeric",
+              })
+            : raw;
+        default:
+          return raw;
+      }
+    } catch {
+      return raw;
+    }
+  }
+
+  return String(value);
+}

--- a/packages/web/src/components/collections/collection-records-client.tsx
+++ b/packages/web/src/components/collections/collection-records-client.tsx
@@ -184,6 +184,7 @@ export function CollectionRecordsClient({
   canEdit,
   canSaveView,
   collectionId,
+  collectionName,
   fields,
   focusedRecordId,
   initialNextCursor,
@@ -194,6 +195,7 @@ export function CollectionRecordsClient({
   canEdit: boolean;
   canSaveView: boolean;
   collectionId: string;
+  collectionName?: string;
   fields: CollectionField[];
   focusedRecordId: string | null;
   initialNextCursor: string | null;
@@ -351,6 +353,7 @@ export function CollectionRecordsClient({
         canEdit={canEdit}
         canSaveView={canSaveView}
         collectionId={collectionId}
+        collectionName={collectionName}
         fields={orderedFields}
         focusedRecordId={focusedRecordId}
         initialNextCursor={initialNextCursor}

--- a/packages/web/src/components/collections/collection-records-grid.tsx
+++ b/packages/web/src/components/collections/collection-records-grid.tsx
@@ -420,6 +420,7 @@ export function CollectionRecordsGrid({
   const queryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const requestSequence = useRef(0);
   const [error, setError] = useState<string | null>(null);
+  const [isExportingCsv, setIsExportingCsv] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isSavingView, setIsSavingView] = useState(false);
   const [newViewName, setNewViewName] = useState("");
@@ -701,7 +702,7 @@ export function CollectionRecordsGrid({
       nextCursor?: unknown;
       records?: unknown;
     } | null;
-    if (sequence !== requestSequence.current) return;
+    if (sequence !== requestSequence.current) return null;
     if (!response.ok || !Array.isArray(payload?.records)) {
       throw new Error(
         typeof payload?.error === "string"
@@ -712,10 +713,11 @@ export function CollectionRecordsGrid({
     const loaded = payload.records as CollectionRecord[];
     if (input.append) onRecordsAdded(loaded);
     else onRecordsReplaced(loaded);
-    setNextCursor(
-      typeof payload.nextCursor === "string" ? payload.nextCursor : null,
-    );
+    const cursor =
+      typeof payload.nextCursor === "string" ? payload.nextCursor : null;
+    setNextCursor(cursor);
     lastLoadedQuery.current = querySignature(input.query);
+    return cursor;
   }
 
   function scheduleQueryReload(query: RecordQuery) {
@@ -822,17 +824,40 @@ export function CollectionRecordsGrid({
     }
   }
 
-  function exportCsv() {
+  async function exportCsv() {
     const api = gridApi.current;
-    if (!api) return;
-    const base = (collectionName ?? collectionId)
-      .replace(/[^\w.-]+/g, "-")
-      .replace(/^-+|-+$/g, "")
-      .slice(0, 80);
-    api.exportDataAsCsv({
-      columnKeys: visibleFieldIds,
-      fileName: `${base || collectionId}.csv`,
-    });
+    if (!api || isExportingCsv) return;
+    setError(null);
+    setIsExportingCsv(true);
+    try {
+      // The grid holds only the loaded pages; pull every remaining page first
+      // so the CSV covers the whole (filtered) result set, not just the rows
+      // scrolled into view.
+      let cursor = nextCursor;
+      while (cursor) {
+        cursor = await fetchRows({
+          append: true,
+          cursor,
+          query: activeQuery.current,
+        });
+      }
+      const base = (collectionName ?? collectionId)
+        .replace(/[^\w.-]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 80);
+      api.exportDataAsCsv({
+        columnKeys: visibleFieldIds,
+        fileName: `${base || collectionId}.csv`,
+      });
+    } catch (exportError) {
+      setError(
+        exportError instanceof Error
+          ? exportError.message
+          : "Could not export the rows.",
+      );
+    } finally {
+      setIsExportingCsv(false);
+    }
   }
 
   async function loadMore() {
@@ -936,13 +961,14 @@ export function CollectionRecordsGrid({
         </Popover>
         <Button
           className="gap-2 shadow-none"
-          onClick={exportCsv}
+          disabled={isExportingCsv}
+          onClick={() => void exportCsv()}
           size="sm"
           type="button"
           variant="outline"
         >
           <Download className="h-4 w-4" />
-          Export CSV
+          {isExportingCsv ? "Exporting" : "Export CSV"}
         </Button>
         {canSaveView ? (
           <>

--- a/packages/web/src/components/collections/collection-records-grid.tsx
+++ b/packages/web/src/components/collections/collection-records-grid.tsx
@@ -11,9 +11,27 @@ import {
   type ICellRendererParams,
 } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
-import { Check, Columns3, Pencil, Plus, Save, Search } from "lucide-react";
+import {
+  Check,
+  Columns3,
+  Download,
+  Pencil,
+  Plus,
+  Save,
+  Search,
+} from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  CollectionColumnHeader,
+  type CollectionGridContext,
+} from "@/components/collections/collection-column-header";
+import {
+  type ColumnSettingsMap,
+  formatCellValue,
+  loadColumnSettings,
+  saveColumnSettings,
+} from "@/components/collections/collection-column-settings";
 import { Button } from "@/components/retroui/Button";
 import { Checkbox } from "@/components/retroui/Checkbox";
 import { Input } from "@/components/retroui/Input";
@@ -352,6 +370,7 @@ export function CollectionRecordsGrid({
   canEdit,
   canSaveView,
   collectionId,
+  collectionName,
   fields,
   focusedRecordId,
   initialNextCursor,
@@ -366,6 +385,7 @@ export function CollectionRecordsGrid({
   canEdit: boolean;
   canSaveView: boolean;
   collectionId: string;
+  collectionName?: string;
   fields: CollectionField[];
   focusedRecordId: string | null;
   initialNextCursor: string | null;
@@ -415,6 +435,35 @@ export function CollectionRecordsGrid({
       ? initialView.visibleFieldIds
       : fields.map((field) => field.id),
   );
+  const persistenceViewId = initialView?.id ?? null;
+  const [columnSettings, setColumnSettings] = useState<ColumnSettingsMap>(() =>
+    loadColumnSettings(collectionId, persistenceViewId),
+  );
+  const columnSettingsRef = useRef(columnSettings);
+  columnSettingsRef.current = columnSettings;
+  const applyColumnSetting = useCallback<CollectionGridContext["onColumnSetting"]>(
+    (colId, patch) => {
+      setColumnSettings((current) => {
+        const next: ColumnSettingsMap = { ...current };
+        if (patch === null) {
+          delete next[colId];
+        } else {
+          next[colId] = { ...current[colId], ...patch };
+        }
+        columnSettingsRef.current = next;
+        saveColumnSettings(collectionId, persistenceViewId, next);
+        return next;
+      });
+    },
+    [collectionId, persistenceViewId],
+  );
+  const gridContext = useMemo<CollectionGridContext>(
+    () => ({
+      getColumnSetting: (colId) => columnSettingsRef.current[colId],
+      onColumnSetting: applyColumnSetting,
+    }),
+    [applyColumnSetting],
+  );
   const orderedFields = useMemo(
     () => [...fields].sort((left, right) => left.position - right.position),
     [fields],
@@ -440,12 +489,19 @@ export function CollectionRecordsGrid({
     [],
   );
 
+  // Wrap-text toggles switch autoHeight on/off; recompute row heights so rows
+  // grow or snap back to the fixed height. No-op before the grid is ready.
+  useEffect(() => {
+    gridApi.current?.resetRowHeights();
+  }, [columnSettings]);
+
   const columnDefs = useMemo<ColDef<CollectionRecord>[]>(() => {
     const columns = orderedFields.map((field) => {
       const options = optionValues(field.options);
       const type = filterType(field);
       const expression = formulaText(field.options);
       const editable = canEdit && EDITABLE_TYPES.has(field.type);
+      const setting = columnSettings[field.id] ?? {};
       const column: ColDef<CollectionRecord> = {
         cellDataType:
           field.type === "BOOLEAN"
@@ -480,18 +536,27 @@ export function CollectionRecordsGrid({
           }
           return gridValue(value, field);
         },
+        headerComponent: CollectionColumnHeader,
+        headerComponentParams: { fieldType: field.type },
         headerName: field.name,
         headerTooltip: expression ? `${field.name}: ${expression}` : field.name,
         minWidth: field.type === "RICH_TEXT" ? 260 : 160,
+        suppressHeaderMenuButton: true,
         tooltipValueGetter: ({ value }) => (value == null ? "" : String(value)),
         valueFormatter: ({ value }) =>
-          value == null
-            ? ""
-            : Array.isArray(value)
-              ? value.join(", ")
-              : String(value),
+          formatCellValue(field.type, setting.format, value),
         valueGetter: ({ data }) => gridValue(data?.values[field.key], field),
       };
+      if (setting.wrapText) {
+        column.wrapText = true;
+        column.autoHeight = true;
+      }
+      if (setting.align) {
+        column.cellStyle = {
+          ...(typeof column.cellStyle === "object" ? column.cellStyle : {}),
+          textAlign: setting.align,
+        };
+      }
       if (field.type === "BOOLEAN") {
         column.cellEditor = "agCheckboxCellEditor";
         column.cellRenderer = ({
@@ -567,7 +632,7 @@ export function CollectionRecordsGrid({
       });
     }
     return columns;
-  }, [canEdit, onEditRecord, orderedFields]);
+  }, [canEdit, columnSettings, onEditRecord, orderedFields]);
 
   async function saveCell(event: CellEditRequestEvent<CollectionRecord>) {
     const field = fieldsById.get(event.column.getColId());
@@ -757,6 +822,19 @@ export function CollectionRecordsGrid({
     }
   }
 
+  function exportCsv() {
+    const api = gridApi.current;
+    if (!api) return;
+    const base = (collectionName ?? collectionId)
+      .replace(/[^\w.-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80);
+    api.exportDataAsCsv({
+      columnKeys: visibleFieldIds,
+      fileName: `${base || collectionId}.csv`,
+    });
+  }
+
   async function loadMore() {
     if (!nextCursor || isLoadingMore) return;
     setError(null);
@@ -781,7 +859,7 @@ export function CollectionRecordsGrid({
   return (
     <>
       <div className="mt-3 flex flex-wrap items-center gap-2">
-        <label className="relative min-w-52 flex-1 sm:max-w-sm">
+        <label className="relative w-full sm:max-w-sm sm:flex-1">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
           <span className="sr-only">Search rows</span>
           <Input
@@ -856,6 +934,16 @@ export function CollectionRecordsGrid({
             </div>
           </Popover.Content>
         </Popover>
+        <Button
+          className="gap-2 shadow-none"
+          onClick={exportCsv}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          <Download className="h-4 w-4" />
+          Export CSV
+        </Button>
         {canSaveView ? (
           <>
             <Button
@@ -929,10 +1017,13 @@ export function CollectionRecordsGrid({
         <AgGridReact<CollectionRecord>
           animateRows={false}
           columnDefs={columnDefs}
+          context={gridContext}
           defaultColDef={GRID_DEFAULT_COLUMN}
           enableCellTextSelection
           getRowId={({ data }) => data.id}
+          headerHeight={40}
           initialState={initialState}
+          maintainColumnOrder
           onCellEditRequest={(event) => void saveCell(event)}
           onColumnMoved={({ api, finished }) => {
             if (finished) {


### PR DESCRIPTION
## What

Increment 1 of making the collection tables Notion-grade (`optimitron:dev:collection-tables-notion-parity`). **AG Grid Community only — no paid license, no Prisma schema change.**

- **Column-header menu** — a kebab (⋮) on every column header, always visible so it works by tap on mobile (no right-click on touch). Opens: sort asc/desc/clear, **wrap text**, align left/center/right, **value formatting** (number: comma/currency/percent; date: ISO/local/medium), pin left/right/none, hide column. Replaces AG Grid's filter-only header button; floating filters unchanged.
- **Per-column display settings** applied live to the grid (wrap+auto-height, alignment, `Intl` formatting) and persisted in **localStorage** keyed by collection+view. A `// TODO(persistence)` marks the pending `CollectionView.columnSettingsJson` migration for durable per-view server persistence (owner approval — see below).
- **Export CSV** toolbar button (visible columns only).
- **Mobile:** full-width search, always-visible header kebab, touch-sized targets, horizontal scroll.

New files: `collection-column-header.tsx` (the header component) and `collection-column-settings.ts` (settings types + localStorage helpers + `formatCellValue`). All existing behavior preserved (cell edit, saved views, move/hide/filter/sort reload, pinned actions column).

## Open decision for the human

Durable per-view column settings across devices need a one-line additive migration (`CollectionView.columnSettingsJson Json?`). Not done here (schema changes need explicit approval). localStorage is the interim; the load/save helpers are the single swap point.

## Verification

- `pnpm --filter @optimitron/web typecheck:app` clean; `collections.server.test.ts` 11/11.
- Screenshots (desktop menu-open / wrap-on / currency-format, mobile default + menu) captured from the branch preview and inspected locally; not attached here. Data was seeded on the preview as the demo user via the REST API — synthetic, no personal info.
- Owner said "don't worry about custom styling" — the menu inherits the AG Grid theme; no neobrutalist chrome added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)