### PR TITLE
Visual review: stop dimension-delta diff noise + consolidate preview-shot helper

### DIFF
--- a/packages/web/scripts/build-visual-review.mjs
+++ b/packages/web/scripts/build-visual-review.mjs
@@ -15,6 +15,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { extractHunksAndAlignment } from "./visual-review-hunks.mjs";
+import { isSignificantDimensionChange } from "./visual-review-diff.mjs";
 import { renderReviewHtml } from "./visual-review-page.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -59,6 +60,18 @@ const diffPixelRatioThreshold = parseNumberEnv(
   0.002,
 );
 const pixelmatchThreshold = parseNumberEnv("VISUAL_REVIEW_PIXEL_THRESHOLD", 0.12);
+// Full-page height deltas below this are treated as rendering drift, not a
+// change, so a sub-pixel reflow in shared chrome stops force-flagging every
+// route with "0% overlap". See isSignificantDimensionChange in
+// visual-review-diff.mjs. Width stays exact (fixed viewport).
+const dimensionTolerancePx = parseNumberEnv(
+  "VISUAL_REVIEW_DIMENSION_TOLERANCE_PX",
+  12,
+);
+const dimensionToleranceRatio = parseNumberEnv(
+  "VISUAL_REVIEW_DIMENSION_TOLERANCE_RATIO",
+  0.004,
+);
 const allowIncompleteReview =
   process.env.VISUAL_REVIEW_ALLOW_INCOMPLETE === "1";
 const reviewCommitSha =
@@ -484,8 +497,10 @@ async function comparePair(pair) {
     const { PNG, pixelmatch } = await loadImageDiffDependencies();
     const before = PNG.sync.read(readFileSync(pair.before.assetPath));
     const after = PNG.sync.read(readFileSync(pair.after.assetPath));
-    const dimensionChanged =
-      before.width !== after.width || before.height !== after.height;
+    const dimensionChanged = isSignificantDimensionChange(before, after, {
+      tolerancePx: dimensionTolerancePx,
+      toleranceRatio: dimensionToleranceRatio,
+    });
     const compareWidth = Math.min(before.width, after.width);
     const compareHeight = Math.min(before.height, after.height);
     const beforeData = getComparableImageData(before, compareWidth, compareHeight);

--- a/packages/web/scripts/preview-shot.mjs
+++ b/packages/web/scripts/preview-shot.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * preview-shot.mjs — capture screenshots of routes on a live Vercel PREVIEW
+ * deploy. Fills the gap the visual-review toolchain doesn't cover: it targets
+ * a deployed preview (not local dev, not the full before/after variant matrix),
+ * handling the preview's auth + protection.
+ *
+ * Local dev often can't run here (no root .env / DB), so previews are the only
+ * way to render a branch. A preview is (a) protected by Vercel deployment
+ * protection — pass the `_vercel_share` token from
+ * `get_access_to_vercel_url` / the Vercel dashboard; (b) served as the
+ * warondisease variant by default — the `optimitron_site_key` cookie forces the
+ * optimitron variant; (c) gated by auth — `?login=demo` signs in the demo user.
+ *
+ * Usage:
+ *   node scripts/preview-shot.mjs \
+ *     --origin https://optimitron-web-git-<branch>-<team>.vercel.app \
+ *     --route /dashboard --route /collections \
+ *     --share <vercel-share-token> \
+ *     [--login demo] [--site optimitron] [--viewports desktop,mobile] [--out <dir>]
+ *
+ * Screenshots land in output/playwright/review/<out> (out defaults to "preview").
+ * Requires @playwright/test (already a dev dependency; run from packages/web).
+ */
+import { chromium } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const VIEWPORTS = {
+  desktop: { height: 900, width: 1440 },
+  mobile: { height: 844, width: 390 },
+};
+
+function parseArgs(argv) {
+  const opts = { routes: [], viewports: ["desktop", "mobile"], login: null, share: null, site: "optimitron", out: "preview", origin: null };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => argv[++i];
+    if (arg === "--origin") opts.origin = next();
+    else if (arg === "--route") opts.routes.push(next());
+    else if (arg === "--share") opts.share = next();
+    else if (arg === "--login") opts.login = next();
+    else if (arg === "--site") opts.site = next();
+    else if (arg === "--out") opts.out = next();
+    else if (arg === "--viewports") opts.viewports = next().split(",").map((v) => v.trim()).filter(Boolean);
+  }
+  return opts;
+}
+
+const opts = parseArgs(process.argv.slice(2));
+if (!opts.origin || opts.routes.length === 0) {
+  console.error("usage: node scripts/preview-shot.mjs --origin <url> --route <path> [--route ...] [--share TOKEN] [--login demo] [--site optimitron] [--viewports desktop,mobile] [--out <dir>]");
+  process.exit(1);
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const outDir = path.resolve(scriptDir, "..", "output", "playwright", "review", opts.out);
+fs.mkdirSync(outDir, { recursive: true });
+
+function routeSlug(route) {
+  return route.replace(/^\/+|\/+$/g, "").replace(/[^\w.-]+/g, "-") || "home";
+}
+
+function withParams(route) {
+  const params = [];
+  if (opts.login) params.push(`login=${encodeURIComponent(opts.login)}`);
+  const sep = route.includes("?") ? "&" : "?";
+  return params.length ? `${route}${sep}${params.join("&")}` : route;
+}
+
+(async () => {
+  const hostname = new URL(opts.origin).hostname;
+  const browser = await chromium.launch();
+  try {
+    for (const vpName of opts.viewports) {
+      const viewport = VIEWPORTS[vpName];
+      if (!viewport) {
+        console.error(`unknown viewport "${vpName}" (use desktop|mobile)`);
+        continue;
+      }
+      const context = await browser.newContext({ viewport });
+      if (opts.site) {
+        await context.addCookies([
+          { domain: hostname, name: "optimitron_site_key", path: "/", value: opts.site },
+        ]);
+      }
+      const page = await context.newPage();
+      // Visiting with the share token sets the deployment-protection cookie.
+      if (opts.share) {
+        await page.goto(`${opts.origin}/?_vercel_share=${opts.share}`, { timeout: 90000, waitUntil: "domcontentloaded" });
+      }
+      for (const route of opts.routes) {
+        const url = `${opts.origin}${withParams(route)}`;
+        console.log(`[${vpName}] ${url}`);
+        await page.goto(url, { timeout: 90000, waitUntil: "networkidle" });
+        await page.waitForTimeout(1200);
+        const file = path.join(outDir, `${routeSlug(route)}-${vpName}.png`);
+        await page.screenshot({ path: file, fullPage: vpName === "desktop" });
+      }
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+  console.log("done:", outDir);
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/web/scripts/preview-shot.mjs
+++ b/packages/web/scripts/preview-shot.mjs
@@ -36,7 +36,14 @@ function parseArgs(argv) {
   const opts = { routes: [], viewports: ["desktop", "mobile"], login: null, share: null, site: "optimitron", out: "preview", origin: null };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    const next = () => argv[++i];
+    const next = () => {
+      const value = argv[++i];
+      if (value === undefined) {
+        console.error(`missing value for ${arg}`);
+        process.exit(1);
+      }
+      return value;
+    };
     if (arg === "--origin") opts.origin = next();
     else if (arg === "--route") opts.routes.push(next());
     else if (arg === "--share") opts.share = next();
@@ -59,14 +66,17 @@ const outDir = path.resolve(scriptDir, "..", "output", "playwright", "review", o
 fs.mkdirSync(outDir, { recursive: true });
 
 function routeSlug(route) {
-  return route.replace(/^\/+|\/+$/g, "").replace(/[^\w.-]+/g, "-") || "home";
+  // Slug from the path only, so query/hash don't leak into filenames.
+  const pathname = new URL(route, opts.origin).pathname;
+  return pathname.replace(/^\/+|\/+$/g, "").replace(/[^\w.-]+/g, "-") || "home";
 }
 
-function withParams(route) {
-  const params = [];
-  if (opts.login) params.push(`login=${encodeURIComponent(opts.login)}`);
-  const sep = route.includes("?") ? "&" : "?";
-  return params.length ? `${route}${sep}${params.join("&")}` : route;
+// Build the target URL with the URL API so a route with/without a leading
+// slash, an existing query, or a hash all resolve correctly against origin.
+function targetUrl(route) {
+  const url = new URL(route, opts.origin);
+  if (opts.login) url.searchParams.set("login", opts.login);
+  return url.toString();
 }
 
 (async () => {
@@ -88,10 +98,12 @@ function withParams(route) {
       const page = await context.newPage();
       // Visiting with the share token sets the deployment-protection cookie.
       if (opts.share) {
-        await page.goto(`${opts.origin}/?_vercel_share=${opts.share}`, { timeout: 90000, waitUntil: "domcontentloaded" });
+        const shareUrl = new URL("/", opts.origin);
+        shareUrl.searchParams.set("_vercel_share", opts.share);
+        await page.goto(shareUrl.toString(), { timeout: 90000, waitUntil: "domcontentloaded" });
       }
       for (const route of opts.routes) {
-        const url = `${opts.origin}${withParams(route)}`;
+        const url = targetUrl(route);
         console.log(`[${vpName}] ${url}`);
         await page.goto(url, { timeout: 90000, waitUntil: "networkidle" });
         await page.waitForTimeout(1200);

--- a/packages/web/scripts/visual-review-diff.mjs
+++ b/packages/web/scripts/visual-review-diff.mjs
@@ -1,0 +1,42 @@
+/**
+ * visual-review-diff.mjs
+ *
+ * Pure classifiers for the screenshot review's before/after comparison.
+ * Dependency-free ESM so it can be unit-tested with `node --test`.
+ */
+
+/**
+ * Whether two full-page screenshots differ in dimensions enough to count as a
+ * real change.
+ *
+ * Screenshots are captured full-page, so `height` is the whole document
+ * height. Across a tall page, sub-pixel font-hinting drift between the
+ * "before" (a baseline run, possibly a different Chromium build) and the
+ * "after" accumulates into a multi-pixel height delta even when nothing
+ * visibly changed. Flagging that forces the route — and every route sharing
+ * header/nav/footer chrome, so a whole batch at once — to render as "changed"
+ * with "0% overlap", which is the noise the review is known for.
+ *
+ * So a small height delta whose overlapping pixels are otherwise identical is
+ * treated as unchanged; a genuinely inserted/removed component far exceeds the
+ * tolerance and still flags (and its overlap pixel diff flags it anyway).
+ * Width stays exact — the viewport width is fixed, so any width change is real.
+ *
+ * @param {{ width: number, height: number }} before
+ * @param {{ width: number, height: number }} after
+ * @param {{ tolerancePx?: number, toleranceRatio?: number }} [options]
+ *   tolerancePx: absolute floor (px); toleranceRatio: fraction of the taller
+ *   image, so tall pages (which accrue more drift) get proportionally more slack.
+ * @returns {boolean}
+ */
+export function isSignificantDimensionChange(
+  before,
+  after,
+  { tolerancePx = 12, toleranceRatio = 0.004 } = {},
+) {
+  if (before.width !== after.width) return true;
+  const heightDelta = Math.abs(before.height - after.height);
+  const maxHeight = Math.max(before.height, after.height);
+  const tolerance = Math.max(tolerancePx, maxHeight * toleranceRatio);
+  return heightDelta > tolerance;
+}

--- a/packages/web/scripts/visual-review-diff.test.mjs
+++ b/packages/web/scripts/visual-review-diff.test.mjs
@@ -1,0 +1,74 @@
+/**
+ * Tests for visual-review-diff.mjs.
+ * Run: cd packages/web && pnpm exec node --test scripts/visual-review-diff.test.mjs
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isSignificantDimensionChange } from "./visual-review-diff.mjs";
+
+test("identical dimensions are not a change", () => {
+  assert.equal(
+    isSignificantDimensionChange({ width: 1440, height: 4000 }, { width: 1440, height: 4000 }),
+    false,
+  );
+});
+
+test("any width difference is a real change (fixed viewport)", () => {
+  assert.equal(
+    isSignificantDimensionChange({ width: 1440, height: 4000 }, { width: 1441, height: 4000 }),
+    true,
+  );
+});
+
+test("a few-pixel height delta below the floor is noise, not a change", () => {
+  // The reported bug: a sub-pixel reflow shifts total height by a handful of
+  // px and force-flags every route sharing chrome.
+  assert.equal(
+    isSignificantDimensionChange({ width: 1440, height: 2000 }, { width: 1440, height: 2005 }),
+    false,
+  );
+  assert.equal(
+    isSignificantDimensionChange({ width: 1440, height: 2000 }, { width: 1440, height: 1995 }),
+    false,
+  );
+});
+
+test("a large height delta (a real inserted/removed component) still flags", () => {
+  assert.equal(
+    isSignificantDimensionChange({ width: 1440, height: 2000 }, { width: 1440, height: 2200 }),
+    true,
+  );
+});
+
+test("the tolerance scales with page height", () => {
+  // Tall page: 0.4% of 5000 = 20px, so a 15px delta is still noise...
+  assert.equal(
+    isSignificantDimensionChange({ width: 1440, height: 5000 }, { width: 1440, height: 5015 }),
+    false,
+  );
+  // ...but a 25px delta exceeds it.
+  assert.equal(
+    isSignificantDimensionChange({ width: 1440, height: 5000 }, { width: 1440, height: 5025 }),
+    true,
+  );
+  // Short page uses the absolute floor (12px), not the ratio.
+  assert.equal(
+    isSignificantDimensionChange({ width: 1440, height: 800 }, { width: 1440, height: 810 }),
+    false,
+  );
+  assert.equal(
+    isSignificantDimensionChange({ width: 1440, height: 800 }, { width: 1440, height: 815 }),
+    true,
+  );
+});
+
+test("options override the defaults", () => {
+  assert.equal(
+    isSignificantDimensionChange(
+      { width: 1440, height: 2000 },
+      { width: 1440, height: 2005 },
+      { tolerancePx: 2, toleranceRatio: 0 },
+    ),
+    true,
+  );
+});


### PR DESCRIPTION
## What you were seeing

The review flags "changes on several pages" that have no visible difference — the panels show a `WxH -> WxH; 0% overlap` label, meaning the overlapping pixels are identical and only the total page height moved by a hair.

## Root cause

`comparePair` (build-visual-review.mjs) did:
```js
const dimensionChanged = before.width !== after.width || before.height !== after.height; // zero tolerance
const changed = dimensionChanged || changedByPixels; // OR bypasses the pixel-ratio floor
```
Screenshots are **full-page**, so `height` is the whole document. Sub-pixel font-hinting drift between the baseline run and the PR run (they can use different Chromium builds / managed-data snapshots) shifts total height a few px even when nothing visibly changed — and since every route shares header/nav/footer chrome, **one reflow force-flags the whole batch at once** (plus each variant home route re-flags). The pixel-ratio floor never got a chance to say "unchanged."

This was pre-existing; PR #120 didn't touch this gate — it just widened the captured surface (more routes + variants) subject to the same noise.

## Fix

`isSignificantDimensionChange` (new dependency-free `visual-review-diff.mjs`, mirroring the tested `visual-review-hunks.mjs`): a small height delta whose overlap is otherwise identical is treated as **unchanged**. Tolerance = `max(12px, 0.4% of the taller image)` so tall pages get proportional slack; **width stays exact** (fixed viewport). A real inserted/removed component far exceeds the tolerance and still flags — and if it shifts content in the overlap, the pixel diff flags it anyway. Tunable via `VISUAL_REVIEW_DIMENSION_TOLERANCE_PX` / `_RATIO`. 6 unit tests (`node --test scripts/visual-review-diff.test.mjs`, green).

**Not touched** (already handled per the diagnosis): pixelmatch AA suppression (`includeAA` off → AA excluded), the 0.2% pixel-ratio floor, the `data-volatile`/`freezeClock` dynamic-content masking. Two optional follow-ups if noise persists: pin Playwright's bundled Chromium instead of the auto-updating `chrome` channel, and annotate any still-unmasked relative-timestamp/counter elements.

## The two side scripts (your other question)

Yes, I created `queue-preview-shots.js` and `collection-preview-shots.js` this session for ad-hoc screenshots of Vercel **preview** deploys (local dev can't run here). They were untracked throwaways with ~40 lines of duplicated boilerplate. Replaced by one committed, general **`scripts/preview-shot.mjs`** — targeted screenshots of a live preview (share-token bypass + `optimitron_site_key` cookie + `?login=demo`), which the official toolchain (local-dev-only, full before/after matrix) genuinely doesn't do. If you'd rather not keep a preview helper at all, say so and I'll drop it.

## Verification

`node --test scripts/visual-review-diff.test.mjs` 6/6; all edited/new scripts `node --check` clean. No app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to capture route screenshots from live preview deployments across multiple viewports, with optional protected preview access and configurable output.
  * Added a reusable utility for classifying whether screenshot dimension differences are significant.
* **Bug Fixes**
  * Visual review comparison now treats dimension changes as significant only when width differs or when height deltas exceed configurable pixel/ratio tolerances.
* **Tests**
  * Added unit tests covering significant-dimension classification, scaling behavior across page sizes, and custom tolerance overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->