### PR TITLE
Make production tasks the canonical development queue

### DIFF
--- a/.claude/agents/pr-comment-triager.md
+++ b/.claude/agents/pr-comment-triager.md
@@ -10,16 +10,21 @@ You are the pr-comment-triager agent. Your job: review all unresolved inline com
 
 Take a PR number as input (or look it up from the current branch if none is given).
 
-## Step 0: Read TODO.md for prior decisions (do this BEFORE classifying)
+## Step 0: Inspect canonical prior decisions (do this BEFORE classifying)
 
-Before triaging anything, grep `TODO.md` for entries related to the areas this PR touches. The team often agrees on architectural fixes that are deferred — if a bot is asking for a symptomatic patch in code the team has already decided to migrate / restructure, the right answer is usually the deferred plan, not the bot's patch.
+Before triaging anything, read `docs/ROADMAP.md` and search the production
+`optimitron:dev` task tree for the areas the PR touches. The team often records
+deferred architectural fixes there. If a bot asks for a symptomatic patch in
+code already scheduled for migration or removal, prefer the canonical task's
+direction.
 
 ```bash
 gh pr diff <N> --name-only | xargs -I{} basename {} | sort -u  # files touched by PR
-grep -i -E "treaty|referendum|managed-data|<area-from-PR>" TODO.md  # context
 ```
 
-If TODO.md has a relevant entry (e.g. "add Referendums to managed-data sync"), prefer fixes consistent with that direction. Don't paper over a known-broken-state with a defensive patch that masks the planned migration. If the bot's comment can't be addressed without contradicting an open TODO, mark the thread resolved with: "TODO.md entry '<title>' covers this; defensive patch would mask the planned upstream fix."
+When rejecting a bot suggestion because it conflicts with planned work, cite
+the production task key and explain why the defensive patch would mask the
+planned upstream fix.
 
 ## Step 1: Enumerate
 

--- a/.claude/agents/test-auditor.md
+++ b/.claude/agents/test-auditor.md
@@ -11,13 +11,15 @@ You are the test-auditor agent. You walk the test suite with two questions:
 
 You do NOT write tests yourself. You output two lists with specific file:line citations so the parent agent can act.
 
-## Before you audit: read TODO.md
+## Before you audit: inspect planned work
 
-Grep `TODO.md` for entries that name areas you're about to audit (e.g. "migrate referendums to managed-data", "split tests when X lands"). Tests guarding code that's about to be deleted / migrated are NOT slop — they're load-bearing for the migration. Flag those with "keep until <TODO entry>" instead of "delete." Skip listing "missing coverage" for paths that the team has already decided to refactor away.
-
-```bash
-grep -i -E "<area-keyword>|test|coverage" TODO.md
-```
+Read `docs/ROADMAP.md`, then search the production `optimitron:dev` task tree
+for the areas you are about to audit. Tests guarding code with an active
+removal or migration task are not slop; they are load-bearing for that change.
+Flag those with "keep until <production task key>" instead of "delete." Skip
+listing missing coverage for paths the canonical task already retires. If the
+production MCP is unavailable, use the roadmap and current branch history as
+the explicit fallback; do not infer active plans from `TODO.md`.
 
 # The "delete on sight" rubric
 

--- a/.claude/hooks/verify-ui-changes.mjs
+++ b/.claude/hooks/verify-ui-changes.mjs
@@ -125,37 +125,6 @@ try {
     violations.push({ name, count, message, blocking: options.blocking !== false });
   }
 
-  // --- TODO.md drift gate -------------------------------------------------
-  // Per CLAUDE.md "Update TODO.md in the same commit as the work it covers"
-  // — but the rule was rotting silently before this hook. If a commit
-  // touches packages/web/src/ and the message body doesn't claim
-  // `todo-touched:` or `todo-skipped: <reason>`, and TODO.md isn't in the
-  // staged set, advisory-flag it. Forces the next session to resolve
-  // whether the in-flight work closes any TODO.md items. Advisory only —
-  // never blocks the commit.
-  const touchesWebSrc = allChanged.some((f) =>
-    /^packages\/web\/src\//.test(f),
-  );
-  const todoStaged = allChanged.includes("TODO.md");
-  if (
-    touchesWebSrc &&
-    !todoStaged &&
-    hookData?.tool_name === "Bash"
-  ) {
-    const cmd = hookData?.tool_input?.command ?? "";
-    const hasTodoMarker = /todo[-\s]?(touched|skipped|none)\s*:/i.test(cmd);
-    if (!hasTodoMarker) {
-      pushViolation(
-        "TODO_DRIFT",
-        1,
-        `TODO DRIFT GATE (advisory): commit touches packages/web/src/ but does not stage TODO.md and the message has no \`todo-touched:\` / \`todo-skipped: <reason>\` marker.
-
-  If this work resolves a TODO.md item, edit TODO.md in the same commit and add \`todo-touched: <item summary>\` to the message. If it doesn't, add \`todo-skipped: <reason>\` so future audits know it was intentional. This is the rule from CLAUDE.md "Update TODO.md in the same commit as the work it covers" — silent drift is what made today's TODO.md 60%+ stale.`,
-        { blocking: false },
-      );
-    }
-  }
-
   // --- Check 1: UI changes without a fresh screenshot ---------------------
   if (uiFiles.length) {
     let lastUiMtime = 0;

--- a/.codex/agents/test-auditor.toml
+++ b/.codex/agents/test-auditor.toml
@@ -7,13 +7,15 @@ You are the test-auditor agent. You walk the test suite with two questions:
 
 You do NOT write tests yourself. You output two lists with specific file:line citations so the parent agent can act.
 
-## Before you audit: read TODO.md
+## Before you audit: inspect planned work
 
-Grep `TODO.md` for entries that name areas you're about to audit (e.g. "migrate referendums to managed-data", "split tests when X lands"). Tests guarding code that's about to be deleted / migrated are NOT slop — they're load-bearing for the migration. Flag those with "keep until <TODO entry>" instead of "delete." Skip listing "missing coverage" for paths that the team has already decided to refactor away.
-
-```bash
-grep -i -E "<area-keyword>|test|coverage" TODO.md
-```
+Read `docs/ROADMAP.md`, then search the production `optimitron:dev` task tree
+for the areas you are about to audit. Tests guarding code with an active
+removal or migration task are not slop; they are load-bearing for that change.
+Flag those with "keep until <production task key>" instead of "delete." Skip
+listing missing coverage for paths the canonical task already retires. If the
+production MCP is unavailable, use the roadmap and current branch history as
+the explicit fallback; do not infer active plans from `TODO.md`.
 
 # The "delete on sight" rubric
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -13,7 +13,7 @@ auth = "oauth"
 scopes = ["tasks:personal"]
 enabled = true
 required = false
-default_tools_approval_mode = "writes"
+default_tools_approval_mode = "approve"
 startup_timeout_sec = 20
 tool_timeout_sec = 120
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 - For user-facing copy, call `mcp__optimitron-tasks__searchManual` before drafting. Use `askWishonia` only when synthesis is needed. If MCP is unavailable, search `https://manual.warondisease.org/assets/json/search-index.json` and say the fallback was used.
 - Never hand-edit `page.logged-out.md` or `*.email.md`. Generate them with `pnpm --filter @optimitron/web copy:preview` or `email:preview-md`.
-- Update `TODO.md` in the commit that closes or creates its work. Commit messages include `todo-touched: <item>` or `todo-skipped: <reason>`.
+- Use the production `optimitron:dev` task tree as the operational queue. Update the owning task's comments/status and link the implementation PR; do not maintain a parallel Markdown checklist.
 - Ask the human owner only for copy approval, a strategic fork, or a ship/redraft/abandon decision. Decide ordinary engineering details from code and tests.
 - For a non-trivial cross-system change, show the current and proposed flow before editing.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,253 +1,29 @@
-# Optimitron TODO — Tactical Queue
+# Development Queue
 
-Tactical queue only. Priorities and mission order: `AGENTS.md` §Mission Focus.
-Product spec: `docs/PRD.md`. Feature status: `docs/FEATURES.md`. Sequencing and
-cleanup backlog: `docs/ROADMAP.md`. Full history:
-`docs/archive/TODO-history-2026-07.md` and `git show <sha>:TODO.md`.
+Production Task rows are the canonical operational development queue. This
+file intentionally contains no checklist, status, handoff, or standing policy.
 
-**North star:** verified majority of humanity (~4B) voting YES on the 1% Treaty
-referendum — 32 doubling rounds at 2 recruits per voter reaches ~4.3B. Sites:
-`warondisease.org` (campaign), `1percenttreaty.org` (treaty text),
-`optimitron.com` (app/proof engine). Every task roots under
-`OPTIMIZE_EARTH_ROOT_TASK_ID` (`program:optimize-earth`).
+Root: [Optimize Optimitron: engineering
+program](https://optimitron.com/tasks/cmrh79s7h000604jtqfckws4t)
+(`optimitron:dev`, `cmrh79s7h000604jtqfckws4t`).
 
-## Agent handoff — 2026-07-12 evening (session ending)
+Use the Codex-registered production Optimitron MCP server, not the local site
+or repository environment variables:
 
-- **This PR (`feature/docs-model-comment-privacy`):** comment-privacy gate
-  (0607410f — fixes anonymous reads of private-task comments, verified leak on
-  prod) + single GA ID (6b35688d — `NEXT_PUBLIC_GA_MEASUREMENT_ID` for all
-  sites; Mike still owes the GA4 Admin "Configure your domains" click for
-  cross-domain sessions) + Document model v1 (Prisma `Document` + versions,
-  MCP createDocument/updateDocument/getDocument/listDocuments,
-  `/documents/[id]`, task-page doc list). Comment-privacy fix CONFIRMED
-  LIVE IN PRODUCTION 2026-07-17 (post-#119 deploy): anonymous GET
-  `/api/tasks/<privateTaskId>/comments` returns 404 "Task not found";
-  `/tasks/<privateTaskId>` serves the not-found shell with no task
-  content. Re-mirroring grant drafts as task comments is now UNBLOCKED —
-  drafts live in Notion "Grant Applications Q3 2026 (drafts —
-  2026-07-12)".
-- **Next dev tasks (specs in Optimitron, EV-ranked):**
-  `optimitron:dev:llms-txt-comprehensive` (cmridzl5n — llms.txt is
-  campaign-only; must expose MCP/API/directories, generate from `routes.ts`);
-  `optimitron:dev:person-capability-profile` (cmridvdbt —
-  GitHub-profile-style redesign of `/people/[handle]`; full spec + Mike's
-  critique in task comments; bio/headline currently DON'T render on the page —
-  worst defect); `optimitron:dev:createtask-deadline-policy` (cmri8tcvz —
-  EXPIRES silently downgraded to SOFT);
-  `optimitron:dev:task-tree-visualization` (cmri3k975); extension OAuth
-  end-to-end live verification (PR #113 merged, untested against prod).
-- **Funding/prizes:** task tree under `funding:prizes-2026-q3` (cmri80ldt) —
-  Coefficient Giving due Aug 21 (top priority), Schmidt go/no-go Jul 25,
-  XPRIZE Future Vision due Aug 15, Build with Gemini decide Jul 20; every
-  Apply task has a Review-&-SUBMIT child for Mike with an embedded
-  browser-agent prompt; drafts in Notion under "Grant Applications Q3 2026" +
-  mirrored as task comments.
-- **Binding content rules (Mike, 2026-07-12):** never name QuantiModo/CureDAO
-  in application narratives (claim the work: 10+ yrs open-source health
-  infra, studies.dfda.earth); never claim cures are known-but-withheld (95%
-  of diseases have no treatment — the machine FINDS cures); "but the economy"
-  always paired with the math-error counter
-  (`war_counterfactual_income_multiple`); Optimitron = OPG/OBG optimal
-  policies+budgets, not just "move 1%"; canonical bio =
-  optimitron.com/people/mike; film/script/public-argument content lives in
-  the manual repo (canonical educational film:
-  `manual/knowledge/educational-film.qmd`), Notion only for private drafts.
-- **Mike's open decisions:** icon pick (64 candidates, sheets in
-  chat/scratchpad), Coefficient applicant entity (AMF 501c3 vs EOS PBC —
-  rec: AMF), bio scale figure (10M+ data points vs 50k+ studies), merge this
-  PR.
+1. Call `getMe` to confirm the authenticated identity.
+2. Call `getQueueAudit` before trusting queue rankings.
+3. Call `listTasks` with `parentTaskId` set to
+   `cmrh79s7h000604jtqfckws4t` and `visibility: "all"` to inspect development
+   children.
+4. Call `searchTasks` by stable task key and title before creating work.
+5. Use `getTask`, `getBlockers`, and `getNextAction` for current scope,
+   dependencies, and priority.
+6. Record dependencies with `TaskEdge`; link plans, comments, commits, and
+   pull requests to the owning production task.
 
-## In Flight
+Planning ownership remains intentionally separate:
 
-- [ ] Execution-planner audit follow-through (`feature/mcp-execution-plan-audit`):
-      TaskDifficulty removal, executionMode capability wiring, MCP output fixes.
-      (Other agent; do not duplicate.)
-- [x] Documentation consolidation: `docs/PRD.md`, `docs/FEATURES.md`, ROADMAP
-      rewrite, doc dedup, `docs/archive/` (committed b9834f37).
-- [x] dFDA tracking MCP tools (companion-loop stage 1 capture): recordMeasurement,
-      upsertTrackingReminder, listTrackingReminders, listDueTrackingReminders,
-      respondToTrackingReminder — applied from stash, response-shape bug fixed,
-      7 behavioral tests added (OPT-HEALTH-02/06 groundwork). Deploy unlocks
-      measurement writes + re-parenting (updateTask parentTaskId ships too).
-- [ ] Post-deploy: execute the 77-task re-parenting plan (clusters approved in
-      session 2026-07-11), re-parent personal:health:* tasks from `dfda` to the
-      health container, create Optimize Optimitron dev branch + edges.
-
-## Next Up
-
-- [ ] EOS retro landing Phase B (`feature/eos-landing-retro` shipped Phase A;
-      round 2 restructured it exhibits-first, money-last):
-      homepage variant flip pending Mike approval (one-liner in `app/page.tsx`);
-      extend sanctioned dark theme to `/fund`; add parameters for numbers now
-      copy-only (Engine No. 1 facts, dFDA 12M datapoints / 10K contributors,
-      use-of-proceeds $500K/$1M/$2M ladder, model parameter count "670");
-      spec §9 "thirteen channels" upside passage not in manual — used canonical
-      flywheel passage instead, restore if Mike supplies the source.
-- [ ] EOS landing round-2 follow-ups: dFDA exhibit card is an illustrative
-      statin sample (labeled) — wire to a real studies.dfda.earth feed;
-      collapse-clock parasitic-base calibration (11.5% @ 2020) copied from the
-      Sierra slide — promote to a parameter; pavilion grid "expand" is
-      anchor-scroll, revisit if Mike wants in-place expansion.
-
-- [ ] Door-to-door YES sheet follow-ups (`/door-to-door` shipped on
-      `feature/eos-landing-retro`): optional full-treaty-text back page;
-      per-referendum sheet generalization (3 referendums configured; only the
-      treaty has a live vote flow today); phase-2 canvass upload flow (sheet
-      photo → sourceArtifact → represented votes — needs `ReferendumVote`
-      provenance field + paper-pending vote source, schema change requires
-      Mike's approval); canvass mission task under the campaign branch once
-      the optimitron MCP connector is re-authed.
-- [ ] OPG generated-data quality: 18 of 23 US policy rows are templated
-      "Category: Adopt Country X's Approach" benchmark transplants with
-      copy-pasted effect pairs. Landing exhibit now filters them
-      (`PolicyGradeTable.topDistinctPolicies`) — fix the generator to emit
-      distinct defensible per-category estimates, then drop the filter.
-- [ ] /compute "Basement Professor" follow-ups (Phase 1 shipped on
-      `feature/eos-landing-retro`): scheduled price-snapshot refresh
-      (eBay/vast.ai) instead of hand-curated asOf dates; per-card price
-      history; sovereign-compute program task under `optimize-earth` +
-      basement-node MCP client spec (getAIQueue worker loop); install-lead
-      handling beyond the mailto CTA.
-
-- [x] Document model v1 (task `optimitron:dev:document-model`): versioned
-      markdown `Document` rows (new version = new row, `isCurrent` flips in a
-      transaction), private by default; MCP createDocument / updateDocument /
-      getDocument / listDocuments; `/documents/[id]` page with version list +
-      creator-only editor; task page lists attached documents.
-- [ ] Document model follow-ups: `/documents` index page; delete/archive
-      endpoint (schema has `deletedAt` as of 2026-07-12 per Mike's call on PR
-      #114 review — reads already filter it out — but no delete/archive API
-      or UI wired to set it yet); visibility levels beyond PUBLIC/PRIVATE
-      (org-shared); move a Notion working doc across as the first dogfood.
-
-Bugs and concrete debt:
-
-- [x] Private-task comment leak (task `optimitron:dev:comment-visibility-gate`):
-      anonymous GET `/api/tasks/<id>/comments` returned comments for PRIVATE
-      tasks. Feed, activity timeline, comment votes, and comment posting now
-      reuse the /tasks/[id] predicate (`lib/tasks/task-visibility.server.ts`);
-      private tasks 404 like missing ones. Note: org-member access is not in
-      the page predicate, so it is not in the comment gate either — extend the
-      shared predicate deliberately if ever wanted.
-- [x] Single GA measurement ID: `site.ts` read `NEXT_PUBLIC_GA_DFDA_ID` /
-      `NEXT_PUBLIC_GA_DIH_ID` / `NEXT_PUBLIC_GA_WAR_ON_DISEASE_ID`, none of
-      which were set — warondisease.org served no GA tag. All sites now use
-      `NEXT_PUBLIC_GA_MEASUREMENT_ID` (Mike's call, 2026-07-12).
-- [ ] MCP `getTask` double-escapes nested child descriptions (contamination
-      vector; bug report a063947f, no fix commit found).
-- [ ] Task-payout hardening remainder: cron reconciliation for VERIFIED claims
-      with no `TaskPayout`; Stripe idempotency key on connected-account create;
-      `AbortController` timeout on `stripeV2Request`; schema CHECK/FK hardening
-      (needs Mike's schema approval).
-- [ ] Backfill `jurisdictionId` on the 25 models added in PR #86, plus
-      `TaskExecutionArtifact`, `TaskVerification`, and `ExternalActionRequest`
-      added in PR #119 (needs Mike's schema approval).
-- [ ] Login page: slider-to-submit spacing pushes CTA below the fold on mobile.
-- [ ] Min-font-size enforcement remainder: email render-and-walk test, ESLint
-      rule for `text-xs`/inline small fonts, named-token refactor of
-      `email-styles.ts`.
-- [ ] Email/template validation test: banned-phrase list, length cap, required
-      tokens, single-primary-CTA assertion.
-- [ ] `share-templates.ts` migration remainder: `post-vote-share` still builds
-      from `share-message.ts`; final audit of `task-comment-notification`.
-- [ ] "magic link" → "sign-in link" user-facing copy sweep.
-- [ ] Apocalypse-phrasing standardization sweep (copy gate).
-- [ ] Task-execution UX batch: whole-row click, `/tasks` heading/chip
-      redundancy, hide empty columns, impact-inheritance "—" display policy,
-      task-detail declutter, "Claim Task" → "Do this.", enum-label reframing,
-      E2E regression for private-task access.
-- [ ] Dashboard command-surface cleanup: dedupe embedded surfaces; Humanity
-      Manager panel only if it adds a next-action.
-- [ ] Referral: transitive chain counts on Humanity Manager status; copyable
-      overdue-human/president messages on dashboard.
-- [ ] Organization grant/application workflow persistence — first check overlap
-      with the 2026-07-09 foundations share-letter calculator rewrite.
-- [ ] AEOSP partner-org framing on `/join` — verify against PR #96 rewrites
-      before treating as open.
-- [ ] `/humanity-v-government` plaintiff-first rework: hero CTA, running
-      plaintiff count, public death/plaintiff stream, counterfactual damages.
-- [ ] `/court` operational surface: case caption, plaintiff/juror/defendant
-      status, 193-government respondent parties.
-- [ ] Represented-people pre-search + co-next-of-kin join flow.
-- [ ] `/earth-optimization-day` MVP: countdown/RSVP + existing widgets.
-- [ ] President/leader reminder tooling batch: rename consideration, dashboard
-      link, copyable reminder language, managed-data-only.
-- [ ] Add `DEFENSE_NET_PROFIT_MARGIN`, `PHARMA_NET_PROFIT_MARGIN`,
-      `PHARMA_VS_DEFENSE_NET_MARGIN_RATIO` to the external `dih_models/parameters.py`
-      generator source (not in this repo) so the next regeneration of
-      `parameters-calculations-citations.ts` doesn't drop them (PR #112 review).
-- [ ] Startup-bro filler-word copy sweep (off-ramp, enforcement stack, …).
-- [ ] Visual-review workflow batch: missing-screenshot banner, Neon
-      branch-per-preview investigation, `/dev/email` index, GH Actions
-      inline-JS extraction.
-
-Trigger-gated (act when the trigger fires):
-
-- [ ] Sitemap file splitting — trigger: any sitemap file approaches 500 rows.
-- [ ] Bulk org-task import script — trigger: 200+ researched orgs in managed
-      data.
-- [ ] Server-side sign-in rate limiter — trigger: observed abuse.
-- [ ] Poster follow-ups (style selector, OG variants, PDF export) — trigger:
-      demand signal.
-
-Needs Mike (one-line answers unblock):
-
-- [ ] CI review artifact: the side-by-side prod/preview iframe + copy-diff spec
-      never shipped despite `feature/ci-review-artifact` merging 5 PRs of other
-      work — dropped, or still wanted?
-- [ ] Shirt checkout: is `SHIRT_COMMERCE_ENABLED` live in prod? If yes, the
-      launch-gates block in the archive is closed; if no, it's the checklist.
-- [ ] Funding-sprint cost-benefit table (2026-05-19) archived as stale — its
-      "write docs/funding-sprint.md" action never happened and its `/fund`
-      defer verdict was overridden by shipped work. Re-derive if a
-      distribution-sprint packet is still wanted.
-
-## Recently Landed (since 2026-06-27)
-
-- Personal Execution Planner (PR #107, 2026-07-10) + execution-planner
-  hierarchy/MCP output fixes (PR #110, in flight).
-- Four EV/MCP instrument bugs fixed: gross-vs-weighted EV, sibling-probability
-  scaling, BigInt `ok()` crash, `listTasks(parentTaskId)` filter (PRs
-  #105/#106/#108, through 2026-07-11).
-- Task funding: assurance-contract escrow (PR #98); double-allocation race
-  fixed via `withTaskFundingLock`; donations + Stripe Connect payouts (PR #97).
-- EOS landing v2 "Government of Tomorrow" showroom (PR #99); registry sourcing
-  + de-prescribed vote copy (PR #100).
-- Preview/production deploy smoke tests live and hardened (`smoke-deploy.yml`).
-- `/join` action list expanded + math-first rewrite (PR #96).
-- Foundations share-letter calculator rewrite (2026-07-09).
-- Vendored economic-data snapshot (PR #95); joke-page parameter calculations
-  (PR #94).
-- Codex hook cleanup (`.codex/hooks*` removed).
-
-## Standing Policy
-
-- Read the relevant `AGENTS.md` before package edits.
-- Prisma schema or exported `@optimitron/db` type changes require explicit
-  human approval.
-- Library packages never import Prisma client or runtime DB code; `import type`
-  only.
-- `@optimitron/optimizer` stays domain-agnostic: predictor, outcome, variable,
-  measurement, effect size.
-- No second task model: personal, org-assigned, treaty-invite, and
-  agent-proposed work are all `Task` rows with scoped ownership/visibility.
-- Outreach stays on `Task` / `TaskCommunicationEndpoint` / `TaskCommunication` /
-  `TaskComment` / `ReferralInvitation` / `ShareAttempt` / `EmailLog` — no
-  special outreach models.
-- Managed data is the source for semi-permanent records; missing from a
-  manifest must not imply delete.
-- Never write tests that only assert mocks were called.
-- Never merge PRs; report ready for human review.
-- Funding split: retail donations fund campaign operations; chain treasuries
-  are a separate prize-pool track. Never divert charitable donations into the
-  prize contract.
-- Copy commits require Mike seeing verbatim before/after + approving via
-  AskUserQuestion first (binding convention; blocking hooks retired
-  2026-07-12 — all pre-commit checks are advisory now, new hooks only when
-  Mike asks).
-
-## Commit Contract
-
-Update this file in the same commit as the work it covers. Commit messages
-carry `todo-touched: <item>` or `todo-skipped: <reason>` (advisory hook checks
-commits touching `packages/web/src/`). Rule source: `CLAUDE.md`.
+- `docs/PRD.md`: target-state product contracts.
+- `docs/FEATURES.md`: current maturity and evidence.
+- `docs/ROADMAP.md`: strategic sequence and gates.
+- Production Task rows: operational work and status.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -282,7 +282,7 @@ verified against `feature/private-execution-system` (2026-07-17).
 - **Summary:** Structured accountability cases: parties, claims, harms, evidence, remedies, jury votes.
 - **Evidence:** `upsertCourtCase`, `addCourtCaseClaim`, `getCourtCase`, `openCourtCaseJuryVote` in packages/web/src/lib/mcp-server.ts; packages/web/src/app/court/page.tsx
 - **Acceptance:** A case built via MCP renders complete on /court with its parties, claims, and evidence.
-- **Roadmap:** now — campaign track (operational-surface rework queued in TODO.md)
+- **Roadmap:** now — campaign track (operational-surface rework is production task `optimitron:dev:court-operational-surface`)
 
 ### OPT-EARTH-05 — Leader/signer reminders
 
@@ -387,6 +387,44 @@ verified against `feature/private-execution-system` (2026-07-17).
 - **Evidence:** packages/db/prisma/schema.prisma (`Document`, `DocumentRevision`, `Collection*`, `ContentAccessGrant`, `ContentAttachment`); packages/web/src/lib/documents.server.ts; packages/web/src/lib/collections.server.ts; packages/web/src/components/collections/collection-records-grid.tsx; packages/web/src/lib/content-access.server.ts; packages/web/src/lib/content-search.server.ts; REST/OpenAPI/MCP tests
 - **Acceptance:** A user can create and share a document or collection, edit and query table records without conflicts or authorization leaks, and retrieve a private file only through an authorized short-lived URL.
 - **Roadmap:** shipped foundation — expand only for migrated workflows
+
+## Knowledge, verification, improvement, and sustainability
+
+### OPT-KNOW-01 — Reusable entity knowledge
+
+- **Layer:** personal / organization
+- **Status:** planned
+- **Summary:** Reusable questions are tasks; approved person and organization answers become versioned, provenance-bearing artifacts or assertions that many consuming tasks can use without copying ownership into an application or collection row.
+- **Evidence:** target contract in PRD §9.5; production task `optimitron:dev:entity-knowledge-profiles`; existing Task, SourceArtifact, DocumentRevision, execution-artifact, and verification foundations; no canonical knowledge contract ships yet
+- **Acceptance:** A longevity-fellowship application reuses an owner-approved answer, records the exact version and destination used, creates a small blocking human task for an unknown answer, and later reuses the same answer in another application without duplication.
+- **Roadmap:** next — pilot with existing task and artifact primitives before considering schema
+
+### OPT-EPI-01 — Authority-aware collective verification
+
+- **Layer:** cross-cutting
+- **Status:** planned
+- **Summary:** Comment reactions may rank helpfulness or attention, while operational truth and acceptance remain a separate authority-, provenance-, freshness-, conflict-, and evidence-aware verification decision.
+- **Evidence:** target contract in PRD §9.6; TaskComment and typed TaskVerification foundations; production task `optimitron:dev:product-constitution:approve-schema-work`; no public reputation or consensus weighting ships
+- **Acceptance:** A popular but unauthorized or stale comment cannot verify an answer or task; an authorized verifier can accept or supersede a sourced answer with an auditable reason.
+- **Roadmap:** next — private owner-authorized verification first; public consensus later
+
+### OPT-LOOP-01 — Auditable product self-improvement loop
+
+- **Layer:** cross-cutting
+- **Status:** planned
+- **Summary:** Telemetry produces a proposed improvement, a ranked task, execution evidence, a verified outcome, and recalibration through the ordinary task lifecycle instead of a campaign-specific parallel reasoning system.
+- **Evidence:** target contract in PRD §9.7; task, impact, attempt, artifact, and verification foundations; production task `optimitron:dev:remove-reasoning-subsystem`; the end-to-end recalibration loop does not ship
+- **Acceptance:** A measured workflow failure creates a sourced improvement task, the implementation records an artifact and outcome, and the verified result updates the relevant estimate without self-approval.
+- **Roadmap:** next — remove the unused reasoning subsystem, then close one measured loop
+
+### OPT-BIZ-01 — Financially sustainable verified-work pilots
+
+- **Layer:** organization
+- **Status:** planned
+- **Summary:** Bounded paid organization workflows fund EOS operations through measured verified-work gross margin without selling truth, public priority, or nonprofit campaign influence.
+- **Evidence:** target contract in PRD §9.8; existing task listings, compensation, applications, artifacts, and verification foundations; no qualifying paid pilot or operating-margin proof ships
+- **Acceptance:** A named customer pays for a bounded workflow whose costs, receipts, verified deliverable, and gross margin are recorded, with commercial funds kept separate from Accelerated Medicine Foundation campaign donations.
+- **Roadmap:** later — one design-partner workflow, then a small paid pilot
 
 ### OPT-INTG-02 — Google Calendar import
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -61,6 +61,10 @@ authorization boundary, or preserve the evidence needed to audit it.
 | GOVERNMENT-PLAN   | As a citizen or government, I want preferences, evidence, policies, and budgets converted into ranked programs so that public resources maximize welfare rather than political intuition.               | Wishocracy, OPG, or OBG outputs can become sourced task bundles that compete under the same EV rules as other programs.                                                                                                                                |
 | CAMPAIGN-ACT      | As a human or organization, I want to vote, recruit others, endorse, register a plaintiff, or remind a leader so that the current highest-EV campaign gains measurable support.                         | Each action has a direct completion path and its referral, endorsement, case, or reminder outcome is recorded.                                                                                                                                         |
 | OPERATOR-INGEST   | As a user leaving other productivity tools, I want existing tasks and calendar commitments deduplicated into Optimitron so that I can use one canonical ranked system.                                  | Explicitly selected imports use stable private source identities and atomic review/apply; every grounded action becomes active, duplicates gain source links, meetings constrain capacity, and raw private transcripts are not retained.                                                                               |
+| KNOWLEDGE-REUSE   | As a person or organization owner, I want verified information about us reused across forms and tasks so that we answer once without losing context, ownership, or control.                              | Reusable questions are tasks; approved answers are versioned artifacts or assertions with provenance, sensitivity, validity, approval, and supersession; every application pins the exact version it used.                                               |
+| COLLECTIVE-VERIFY | As a decision-maker, I want evidence evaluated by the right authorities so that popularity, confidence, and truth are not confused.                                                                       | Helpful comment votes affect discussion ordering only; operational acceptance depends on authorization, provenance, freshness, corroboration, conflicts, and task-specific verification.                                                                |
+| SYSTEM-IMPROVE    | As an operator, I want outcomes to generate ranked, testable improvements so that Optimitron becomes more useful rather than merely accumulating plans.                                                    | Telemetry produces a proposed improvement, a ranked task, execution evidence, a verified outcome, and recalibration under one auditable loop.                                                                                                           |
+| BUSINESS-SUSTAIN  | As an operator, I want bounded paid workflows to fund the optimization machine so that it can keep operating without compromising mission ranking or nonprofit funds.                                     | Verified-work pilots demonstrate gross margin sufficient to cover EOS operating costs, while commercial revenue and nonprofit campaign donations remain legally and operationally separate.                                                             |
 
 ---
 
@@ -345,6 +349,66 @@ parameter constants from
 `packages/data/src/parameters/parameters-calculations-citations.ts` via
 `<ParameterValue>`; docs cite constants by name. Numbers without provenance
 do not ship.
+
+### 9.5 Reusable person and organization knowledge (OPT-KNOW-01)
+
+Reusable knowledge belongs to a stable `Person`, `User`, or `Organization`,
+not to one application or program. The target contract is:
+
+- A question, missing-fact request, or requested review is a `Task`, so it can
+  block one or more application or execution tasks and receive comments,
+  assignment, deadlines, and verification.
+- An approved answer is a versioned artifact or normalized assertion linked
+  to its subject, source provenance, sensitivity, validity window, approving
+  authority, and any superseded version. The pilot should use existing task
+  and artifact primitives before adding a new knowledge model.
+- One answer may serve many tasks. Each use records the exact question,
+  answer version, application context, actor, approval, destination, and
+  resulting receipt or outcome; applications do not copy the answer into a
+  program-owned canonical row.
+- Collections may provide bounded import, review, and table views, but they
+  are not a parallel truth store. A `program` column is not ownership or
+  lineage; task and artifact relations carry reuse.
+- Agents retrieve only knowledge the current actor may access. Ambiguous,
+  stale, conflicting, or missing answers create small human tasks instead of
+  confident guesses.
+
+### 9.6 Authority-aware collective verification (OPT-EPI-01)
+
+Optimitron separates attention from truth. Likes or votes on a `TaskComment`
+may rank helpfulness, relevance, or review priority; they never make the
+comment true. Operational acceptance combines the subject owner's authority,
+the verifier's authority for the claim type, primary-source provenance,
+freshness, independent corroboration, disclosed conflicts, and the consuming
+task's acceptance criteria. Verification and supersession are append-only
+evidence. Private owner-authorized verification must work before public
+reputation or consensus weighting is designed.
+
+### 9.7 Auditable self-improvement loop (OPT-LOOP-01)
+
+The product improvement loop is:
+
+```text
+telemetry -> proposed improvement -> ranked task -> execution
+-> verified outcome -> recalibration
+```
+
+This is the general form of campaign, personal, organization, and platform
+learning. A proposal cannot approve its own external action or outcome. The
+unused campaign-specific reasoning subsystem should be removed rather than
+preserved as a second planning or truth system; future reasoning products
+must emit evidence and tasks into this loop.
+
+### 9.8 Financial sustainability (OPT-BIZ-01)
+
+Optimitron may sell bounded organization workflows and verified-work pilots
+whose measured gross margin can cover Earth Optimization Services operating
+costs. Customers may buy execution capacity and workflow outcomes, but not
+truth, verification results, public queue priority, or mission ranking.
+Commercial EOS revenue, contracts, expenses, and liabilities remain legally
+and operationally separate from Accelerated Medicine Foundation and its DBA
+campaign donations. A pilot advances only with a named payer, deliverable,
+cost, receipt, verification method, and margin calculation.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,8 @@ the same thing, the one listed here owns it — fix the other.
 | [PRD.md](./PRD.md) | Product spec: the target-state vision for the four-layer optimization machine and the Daily Companion Loop. Never asserts current status. |
 | [FEATURES.md](./FEATURES.md) | Feature registry: what exists today, with evidence and acceptance criteria. The ONLY doc allowed to assert maturity status. |
 | [ROADMAP.md](./ROADMAP.md) | Sequencing: Now/Next/Later/Parked/Won't + the code-cleanup backlog (Appendix A). |
-| [../TODO.md](../TODO.md) | Tactical working queue: in-flight, next-up, recently-landed, standing policy. |
+| [Production development queue](https://optimitron.com/tasks/cmrh79s7h000604jtqfckws4t) | Operational source of truth: runtime task status, dependencies, decisions, and linked implementation evidence. Query through the production MCP server. |
+| [../TODO.md](../TODO.md) | Stable pointer to the production development queue and its MCP lookup commands. Contains no checklist or status. |
 | [../AGENTS.md](../AGENTS.md) | Canonical agent rules for all harnesses, incl. the ONE campaign priority list. |
 | [../CLAUDE.md](../CLAUDE.md) | Imports AGENTS.md and adds only Claude-specific tools and workflow. |
 | [../README.md](../README.md) | Public front door (Wishonia voice): pitch, quick start, package table, papers. |
@@ -77,4 +78,7 @@ for id in $(grep -o "OPT-[A-Z]*-[0-9]*" docs/ROADMAP.md | sort -u); do grep -q "
 
 # single ownership of the campaign priority list (AGENTS.md only)
 grep -rln "Increase treaty vote [c]onversion" *.md docs/*.md | grep -v archive
+
+# retired Markdown queue conventions — zero hits outside docs/archive
+grep -rinE "todo-[t]ouched|todo-[s]kipped|TODO\.md.*tactical|tactical.*TODO\.md" --include="*.md" . --exclude-dir=node_modules | grep -v docs/archive
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,11 @@
 # Product Roadmap
 
 Sequencing only. What exists is [FEATURES.md](./FEATURES.md) (cited here by
-`OPT-*` ID); what we're building toward is [PRD.md](./PRD.md); the tactical
-queue is [../TODO.md](../TODO.md).
+`OPT-*` ID); what we're building toward is [PRD.md](./PRD.md). The operational
+development queue is the production [`optimitron:dev` task
+tree](https://optimitron.com/tasks/cmrh79s7h000604jtqfckws4t), queried and
+updated through the production MCP server. Pull requests, issues, plans, and
+documents are linked implementation evidence, not parallel queues.
 
 ## North Star
 
@@ -29,6 +32,9 @@ as a parallel Now track, dogfooded by the operator as user #1.
   leader reminders, discoverability/trust — or a Daily Companion Loop stage.
 - One task model. Personal, org, treaty-invite, and agent-proposed work are
   all `Task` rows with scoped ownership and visibility (OPT-TASK-01).
+- Production Task rows own operational development status, dependencies, and
+  human decisions. Managed synchronization owns only stable system roots and
+  fixtures; it must not overwrite ordinary development children.
 - Black-and-white treaty style stays the default on public campaign surfaces.
 - Roadmap lines cite feature IDs so status claims live in one place.
 
@@ -74,7 +80,30 @@ Build in this order:
    (OPT-HEALTH-02), interleave recurring health tasks (OPT-HEALTH-06,
    OPT-EV-04), then report change-from-baseline outcomes (OPT-HEALTH-07).
 
+### Product constitution and schema gate
+
+Complete and approve the bounded
+[`optimitron:dev:product-constitution`](https://optimitron.com/tasks/cmrshxxqj000204jm3efmvf4o)
+pass before new knowledge, verification, reasoning, or agent schema work.
+This pass defines OPT-KNOW-01, OPT-EPI-01, OPT-LOOP-01, and OPT-BIZ-01,
+migrates the tactical queue into production tasks, and changes no product
+runtime. It does not block unrelated treaty-conversion work.
+
 ## Next
+
+For reusable knowledge and self-improvement, let the production queue rank
+work while preserving this dependency order:
+
+1. Delete the unused campaign reasoning subsystem in an isolated PR and
+   migration (OPT-LOOP-01).
+2. Pilot reusable question tasks and verified answer artifacts with the
+   longevity-fellowship application (OPT-KNOW-01, OPT-EPI-01).
+3. Add generic artifact lineage only if the pilot demonstrates a need for
+   exact answer-version-to-submission relations (OPT-KNOW-01).
+4. Add MCP blocker surfacing and notifications after the underlying human
+   review workflow is reliable (OPT-TASK-02, OPT-KNOW-01).
+5. Design public reputation or consensus weighting only after private
+   owner-authorized verification works (OPT-EPI-01).
 
 - Automated parent-task matching and reviewed decomposition into child tasks
   (OPT-TASK-06, OPT-TASK-07) after the private bundle path proves the contract.
@@ -111,7 +140,10 @@ Build in this order:
   measurable momentum.
 - Design-partner access to one bounded workflow, then a small paid
   verified-work pilot using existing listings, compensation, and application
-  fields. No company-wide migration or open marketplace.
+  fields (OPT-BIZ-01). Record verified deliverables, receipts, costs, and gross
+  margin; keep EOS commercial activity legally and operationally separate
+  from nonprofit campaign donations. No company-wide migration or open
+  marketplace.
 
 ## Parked
 
@@ -131,7 +163,8 @@ Do not pick these up unless they directly unblock a Now track:
 - Board/kanban parody, timeline/Gantt views, burndown/sprint parody chrome,
   generic gamified civics surfaces. The joke isn't worth the surface area.
 - A second task model, a separate personal-tracking app, or a bespoke
-  outreach model — covered by standing policy in TODO.md.
+  outreach model. The canonical Task graph, artifacts, and verification
+  lifecycle cover those workflows.
 - A custom chat client, coding agent, connector suite, model gateway, terminal,
   general browser controller, ambient private-message scraper, or credential
   sharing/resale system.
@@ -140,7 +173,9 @@ Do not pick these up unless they directly unblock a Now track:
 
 Shipped capability claims live exclusively in [FEATURES.md](./FEATURES.md)
 (the former "Done / Landed Foundations" list is superseded by `implemented`
-entries there). GitHub issues/projects mirror Now/Next/Later.
+entries there). Production Task rows under `optimitron:dev` are the canonical
+operational queue; GitHub pull requests and issues link implementation and
+review evidence back to those tasks.
 
 ---
 

--- a/docs/SYSTEM_MAP.md
+++ b/docs/SYSTEM_MAP.md
@@ -12,6 +12,9 @@ Use this page to orient before loading package-level details. It describes owner
 
 For private execution work, also read `docs/plans/phased-approach-optimitron.md`, `docs/TASK_MODEL.md`, and `docs/MCP_SERVER.md`.
 
+For active development work, inspect the production `optimitron:dev` task
+tree through the production MCP server before creating or changing a task.
+
 ## Product Boundary
 
 Optimitron is durable optimization and execution state. It owns:
@@ -52,6 +55,24 @@ reviewed source -> ACTIVE task -> execution attempt -> artifact submission
 ```
 
 `DRAFT` is for public/governance proposals. Reviewed private actions become private `ACTIVE` tasks. Negative-EV actions remain stored but are not recommended unless they are genuine obligations or safety guardrails.
+
+## Planning Source Of Truth
+
+| Surface | Owns |
+|---|---|
+| `docs/PRD.md` | Target-state product contracts and acceptance stories. |
+| `docs/FEATURES.md` | Current capability maturity and implementation evidence. |
+| `docs/ROADMAP.md` | Strategic sequence, gates, and deliberately parked work. |
+| Production [`optimitron:dev`](https://optimitron.com/tasks/cmrh79s7h000604jtqfckws4t) Task rows | Operational work, status, assignees, estimates, dependencies, and human decisions. |
+| Task comments, documents, artifacts, commits, pull requests, and issues | Dated context, plans, execution evidence, review, and receipts linked to the owning task. |
+
+Managed synchronization retains stable system roots and fixtures that must be
+reproducible from code. Ordinary development children are runtime-created;
+their status, comments, estimates, and edges are database-owned and must not
+be reset by synchronization. Search by stable task key and title before
+creating work, merge duplicates into the best existing task, and represent
+dependencies with `TaskEdge`. Markdown files do not duplicate the tactical
+queue.
 
 ## Runtime Ownership
 
@@ -97,13 +118,15 @@ External actions use an immutable payload hash. Agents may propose and execute a
 
 Before changing behavior:
 
-1. Find the canonical model/service and relevant tests.
-2. Confirm feature maturity in `FEATURES.md`.
-3. Check authorization before query, count, pagination, and child lookup.
-4. Keep task and source provenance intact.
-5. Add tests at the real policy or state-machine boundary.
-6. Update `FEATURES.md` only after behavior ships; update the roadmap when sequencing changes.
-7. For UI changes, follow the screenshot review gate in `AGENTS.md`.
+1. Find or create the canonical production development task and search for duplicates.
+2. Find the canonical model/service and relevant tests.
+3. Confirm feature maturity in `FEATURES.md`.
+4. Check authorization before query, count, pagination, and child lookup.
+5. Keep task and source provenance intact.
+6. Add tests at the real policy or state-machine boundary.
+7. Link the implementation and evidence from the production task.
+8. Update `FEATURES.md` only after behavior ships; update the roadmap when sequencing changes.
+9. For UI changes, follow the screenshot review gate in `AGENTS.md`.
 
 ## Canonical Documents
 
@@ -112,6 +135,7 @@ Before changing behavior:
 | What is the product? | `docs/PRD.md` |
 | What ships? | `docs/FEATURES.md` |
 | What happens next? | `docs/ROADMAP.md` |
+| What operational work is active now? | Production `optimitron:dev` task tree through the MCP server |
 | How is private execution being built? | `docs/plans/phased-approach-optimitron.md` |
 | What is the task lifecycle? | `docs/TASK_MODEL.md` |
 | How do agents use the task server? | `docs/MCP_SERVER.md` |


### PR DESCRIPTION
## Summary

This clean PR supersedes #130 after a concurrent visual-review commit landed
on that branch. The concurrent work remains untouched on its original branch.

- extend the existing PRD with target contracts for reusable entity knowledge, authority-aware verification, the auditable self-improvement loop, and financially sustainable verified-work pilots
- make production `Task` rows under `optimitron:dev` the operational development queue while keeping PRD, FEATURES, and ROADMAP ownership distinct
- replace `TODO.md` with a production-queue pointer and remove the obsolete TODO commit-marker hook and agent instructions
- auto-approve the repository production MCP entry so project agents can use the user-authorized server without repeated write prompts

The production MCP migration crosswalked 36 still-actionable TODO entries after duplicate search: 33 canonical tasks were created, 2 existing tasks were reused, and 1 historical in-flight item was intentionally not recreated. Trigger-gated work remains inactive and human decisions are represented as small blocking tasks.

## Scope

This pass changes planning documents and agent/tooling guidance only. It does not change Prisma, application runtime behavior, UI, or public campaign copy. The production approval task blocks reasoning deletion and verified-knowledge implementation until a human approves this architecture.

## Verification

- `git diff --check`
- changed Markdown local-link resolution
- FEATURES status and ROADMAP feature-ID integrity check: 46 valid feature entries, 30 cited roadmap IDs, 0 missing
- campaign-priority ownership check: one canonical list in `AGENTS.md`
- `node --check .claude/hooks/verify-ui-changes.mjs`
- production parent/child and blocker-edge inspection through the Optimitron MCP
