### PR TITLE
Fix one-off task completion

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -63,6 +63,7 @@ Use these fields when creating personal tasks:
 - `available_at`: earliest ISO time the task should appear in active queues.
 - `due_at`: due date or expiry date.
 - `deadline_policy`: `NONE`, `SOFT`, `EXPIRES`, or `REQUIRED`.
+- `claimPolicy`: assigned tasks use `ASSIGNED_ONLY`; unassigned tasks default to `OPEN_SINGLE`. Set `OPEN_MANY` explicitly only when accepting one contribution should leave the task open for others. `updateTask` can correct this field on existing tasks.
 
 Deadline policy rules:
 

--- a/docs/TASK_MODEL.md
+++ b/docs/TASK_MODEL.md
@@ -71,6 +71,8 @@ Claims coordinate public or multi-claimant work. `TaskExecutionAttempt` is the c
 
 Acceptance verifies the task and releases dependents. Rejection preserves the attempt, artifacts, criteria snapshot, and verdict, then requeues the task for a new attempt. `ABANDONED` and `REJECTED` claim states remain useful for claim coordination without deleting history.
 
+For `OPEN_SINGLE`, accepting the completed claim also verifies the task in the same transaction and releases its dependents. `OPEN_MANY` represents independent contributions, so accepting one claim does not close the shared task. `maxClaims` limits simultaneous claims; it is not a completion target. Use `ASSIGNED_ONLY` for work addressed to a named person or organization, `OPEN_SINGLE` for ordinary one-off claimable work, and `OPEN_MANY` only when more accepted contributions should remain possible.
+
 ## Provenance
 
 - `TaskSourceArtifact` describes where the task came from.

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -4782,6 +4782,52 @@ describe("MCP server tool dispatch", () => {
       );
     });
 
+    it("keeps relation-shaped assigned tasks assigned during claim-policy updates", async () => {
+      mocks.getTaskDetailData
+        .mockResolvedValueOnce({
+          task: makeCreatedTask({
+            id: "assigned-task",
+            assigneePerson: { id: "person-1" },
+            assigneePersonId: undefined,
+            claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
+            createdByUserId: "user-1",
+            isPublic: false,
+          }),
+        })
+        .mockResolvedValueOnce({
+          task: makeCreatedTask({
+            id: "assigned-task",
+            assigneePerson: { id: "person-1" },
+            assigneePersonId: undefined,
+            claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
+            createdByUserId: "user-1",
+            isPublic: false,
+          }),
+        });
+      mocks.computeTaskPriority.mockReturnValue(makePriority());
+
+      const client = await setup("user-1", [McpScope.TASKS_PERSONAL]);
+      const result = await client.callTool({
+        name: "updateTask",
+        arguments: {
+          taskId: "assigned-task",
+          claimPolicy: "OPEN_MANY",
+          maxClaims: 4,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.taskUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
+            maxClaims: null,
+          }),
+          where: { id: "assigned-task" },
+        }),
+      );
+    });
+
     it("does not let platform admins update another user's private task", async () => {
       mocks.getTaskDetailData.mockResolvedValue(null);
       mocks.taskFindFirst.mockResolvedValue(null);

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -4828,6 +4828,52 @@ describe("MCP server tool dispatch", () => {
       );
     });
 
+    it("makes a task claimable when its assignee is cleared", async () => {
+      mocks.getTaskDetailData
+        .mockResolvedValueOnce({
+          task: makeCreatedTask({
+            id: "assigned-task",
+            assigneePerson: { id: "person-1" },
+            assigneePersonId: "person-1",
+            claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
+            createdByUserId: "user-1",
+            isPublic: false,
+          }),
+        })
+        .mockResolvedValueOnce({
+          task: makeCreatedTask({
+            id: "assigned-task",
+            assigneePerson: null,
+            assigneePersonId: null,
+            claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
+            createdByUserId: "user-1",
+            isPublic: false,
+          }),
+        });
+      mocks.computeTaskPriority.mockReturnValue(makePriority());
+
+      const client = await setup("user-1", [McpScope.TASKS_PERSONAL]);
+      const result = await client.callTool({
+        name: "updateTask",
+        arguments: {
+          taskId: "assigned-task",
+          assigneePersonId: "",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.taskUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            assigneePersonId: null,
+            claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
+            maxClaims: null,
+          }),
+          where: { id: "assigned-task" },
+        }),
+      );
+    });
+
     it("does not let platform admins update another user's private task", async () => {
       mocks.getTaskDetailData.mockResolvedValue(null);
       mocks.taskFindFirst.mockResolvedValue(null);

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -4782,6 +4782,33 @@ describe("MCP server tool dispatch", () => {
       );
     });
 
+    it("rejects invalid maxClaims during a claim-policy update", async () => {
+      mocks.getTaskDetailData.mockResolvedValueOnce({
+        task: makeCreatedTask({
+          id: "one-off-task",
+          claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
+          createdByUserId: "user-1",
+          isPublic: false,
+        }),
+      });
+
+      const client = await setup("user-1", [McpScope.TASKS_PERSONAL]);
+      const result = await client.callTool({
+        name: "updateTask",
+        arguments: {
+          taskId: "one-off-task",
+          claimPolicy: "OPEN_MANY",
+          maxClaims: 0,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).error).toBe(
+        "maxClaims must be at least 1 for OPEN_MANY tasks.",
+      );
+      expect(mocks.taskUpdate).not.toHaveBeenCalled();
+    });
+
     it("keeps relation-shaped assigned tasks assigned during claim-policy updates", async () => {
       mocks.getTaskDetailData
         .mockResolvedValueOnce({

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -3616,17 +3616,29 @@ describe("MCP server tool dispatch", () => {
       expect(mocks.taskUpdate).not.toHaveBeenCalled();
     });
 
-    it("createTask schema exposes an explicit visibility override", async () => {
+    it("task write schemas expose visibility and claim-policy controls", async () => {
       const client = await setup("admin-1", ALL_SCOPES, { isAdmin: true });
       const result = await client.listTools();
       const createTask = result.tools.find(
         (tool) => tool.name === "createTask",
+      );
+      const updateTask = result.tools.find(
+        (tool) => tool.name === "updateTask",
       );
 
       expect(createTask?.inputSchema.properties).toMatchObject({
         visibility: {
           type: "string",
           enum: ["PUBLIC", "PRIVATE"],
+        },
+      });
+      expect(updateTask?.inputSchema.properties).toMatchObject({
+        claimPolicy: {
+          type: "string",
+          enum: ["ASSIGNED_ONLY", "OPEN_SINGLE", "OPEN_MANY"],
+        },
+        maxClaims: {
+          type: ["integer", "null"],
         },
       });
     });
@@ -4551,6 +4563,8 @@ describe("MCP server tool dispatch", () => {
         mocks.taskCreate.mock.calls[0]![0] as { data: Record<string, unknown> }
       ).data;
       expect(data.parentTaskId).toBe("personal-project");
+      expect(data.claimPolicy).toBe(TaskClaimPolicy.OPEN_SINGLE);
+      expect(data.maxClaims).toBeNull();
       expect(data).not.toHaveProperty("assigneePersonId");
       expect(data).not.toHaveProperty("assigneeOrganizationId");
       expect(data).not.toHaveProperty("sourceUrl");
@@ -4558,6 +4572,47 @@ describe("MCP server tool dispatch", () => {
       expect(data.contextJson).toMatchObject({
         sourceUrls: expect.arrayContaining(["https://example.com/source"]),
       });
+    });
+
+    it("keeps OPEN_MANY only when a multi-contributor task requests it explicitly", async () => {
+      mocks.getTaskDetailData.mockResolvedValue({
+        task: makeCreatedTask({
+          id: "created-task",
+          claimPolicy: TaskClaimPolicy.OPEN_MANY,
+          contextJson: {
+            executor_type: "Self",
+            value: 100,
+            p_success: 0.5,
+            cash_cost: 0,
+          },
+        }),
+      });
+      mocks.computeTaskPriority.mockReturnValue(makePriority());
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "createTask",
+        arguments: {
+          parentTaskId: "personal-project",
+          title: "Translate campaign pages",
+          description: "Accept independent translations from several people.",
+          category: "COMMUNICATION",
+          acceptanceCriteria: ["Each accepted claim contains one translation"],
+          impactStatement: "More translations expand campaign reach.",
+          hours: 1,
+          value: 100,
+          p_success: 0.5,
+          claimPolicy: "OPEN_MANY",
+          maxClaims: 3,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const data = (
+        mocks.taskCreate.mock.calls[0]![0] as { data: Record<string, unknown> }
+      ).data;
+      expect(data.claimPolicy).toBe(TaskClaimPolicy.OPEN_MANY);
+      expect(data.maxClaims).toBe(3);
     });
 
     it("createTask passes parentTaskId / assigneePersonId when supplied (the spread is conditional, not always-omit)", async () => {
@@ -4620,6 +4675,8 @@ describe("MCP server tool dispatch", () => {
       ).data;
       expect(data.parentTaskId).toBe("parent-1");
       expect(data.assigneePersonId).toBe("person-1");
+      expect(data.claimPolicy).toBe(TaskClaimPolicy.ASSIGNED_ONLY);
+      expect(data.maxClaims).toBeNull();
     });
 
     it("rejects updateTask when a non-admin user targets a public task", async () => {
@@ -4678,6 +4735,49 @@ describe("MCP server tool dispatch", () => {
         expect.objectContaining({
           data: expect.objectContaining({ title: "Updated private task" }),
           where: { id: "own-private-task" },
+        }),
+      );
+    });
+
+    it("lets an owner repair a one-off task that was incorrectly left OPEN_MANY", async () => {
+      mocks.getTaskDetailData
+        .mockResolvedValueOnce({
+          task: makeCreatedTask({
+            id: "stuck-task",
+            claimPolicy: TaskClaimPolicy.OPEN_MANY,
+            maxClaims: 4,
+            createdByUserId: "user-1",
+            isPublic: false,
+          }),
+        })
+        .mockResolvedValueOnce({
+          task: makeCreatedTask({
+            id: "stuck-task",
+            claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
+            maxClaims: null,
+            createdByUserId: "user-1",
+            isPublic: false,
+          }),
+        });
+      mocks.computeTaskPriority.mockReturnValue(makePriority());
+
+      const client = await setup("user-1", [McpScope.TASKS_PERSONAL]);
+      const result = await client.callTool({
+        name: "updateTask",
+        arguments: {
+          taskId: "stuck-task",
+          claimPolicy: "OPEN_SINGLE",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.taskUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
+            maxClaims: null,
+          }),
+          where: { id: "stuck-task" },
         }),
       );
     });

--- a/packages/web/src/lib/__tests__/tasks.server.test.ts
+++ b/packages/web/src/lib/__tests__/tasks.server.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   ensureExecutionPlanningBranch: vi.fn(),
   grantWishes: vi.fn(),
   notifyTaskAssigneeOfAssignment: vi.fn(),
+  queueTaskPayoutForVerifiedClaim: vi.fn(),
   prisma: {
     taskCreate: vi.fn(),
     taskFindFirst: vi.fn(),
@@ -68,6 +69,11 @@ vi.mock("@/lib/tasks/task-assignment-notifications.server", () => ({
   notifyTaskAssigneeOfAssignment: mocks.notifyTaskAssigneeOfAssignment,
 }));
 
+vi.mock("@/lib/task-payouts.server", () => ({
+  assertUserCanClaimPaidTask: vi.fn(),
+  queueTaskPayoutForVerifiedClaim: mocks.queueTaskPayoutForVerifiedClaim,
+}));
+
 vi.mock("@/lib/tasks/task-communications.server", () => ({
   countTaskCommunications: mocks.countTaskCommunications,
 }));
@@ -110,6 +116,7 @@ function resetAllMocks() {
   mocks.ensureExecutionPlanningBranch.mockReset();
   mocks.grantWishes.mockReset();
   mocks.notifyTaskAssigneeOfAssignment.mockReset();
+  mocks.queueTaskPayoutForVerifiedClaim.mockReset();
 
   for (const group of [mocks.prisma, mocks.tx]) {
     for (const mockFn of Object.values(group)) {
@@ -252,6 +259,72 @@ describe("tasks server", () => {
     expect(mocks.tx.taskClaimUpdate).not.toHaveBeenCalled();
     expect(mocks.tx.taskUpdate).not.toHaveBeenCalled();
     expect(mocks.grantWishes).not.toHaveBeenCalled();
+  });
+
+  it("closes one-off claimable tasks when their completed claim is verified", async () => {
+    mocks.tx.taskFindFirst.mockResolvedValue({
+      claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
+      id: "task_1",
+      status: TaskStatus.ACTIVE,
+    });
+    mocks.tx.taskClaimFindUniqueOrThrow.mockResolvedValue({
+      completionEvidence: "Merged pull request 132",
+      id: "claim_1",
+      status: TaskClaimStatus.COMPLETED,
+      taskId: "task_1",
+      userId: "user_1",
+    });
+    mocks.tx.taskClaimUpdate.mockResolvedValue({
+      id: "claim_1",
+      status: TaskClaimStatus.VERIFIED,
+    });
+    mocks.tx.taskUpdate.mockResolvedValue({
+      id: "task_1",
+      status: TaskStatus.VERIFIED,
+    });
+
+    await verifyTask("task_1", "admin_1", { claimId: "claim_1" });
+
+    expect(mocks.tx.taskClaimUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: TaskClaimStatus.VERIFIED }),
+        where: { id: "claim_1" },
+      }),
+    );
+    expect(mocks.tx.taskUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: TaskStatus.VERIFIED }),
+        where: { id: "task_1" },
+      }),
+    );
+  });
+
+  it("keeps multi-contributor tasks open after one claim is verified", async () => {
+    mocks.tx.taskFindFirst.mockResolvedValue({
+      claimPolicy: TaskClaimPolicy.OPEN_MANY,
+      id: "task_1",
+      status: TaskStatus.ACTIVE,
+    });
+    mocks.tx.taskClaimFindUniqueOrThrow.mockResolvedValue({
+      completionEvidence: "Translated one page",
+      id: "claim_1",
+      status: TaskClaimStatus.COMPLETED,
+      taskId: "task_1",
+      userId: "user_1",
+    });
+    mocks.tx.taskClaimUpdate.mockResolvedValue({
+      id: "claim_1",
+      status: TaskClaimStatus.VERIFIED,
+    });
+
+    await verifyTask("task_1", "admin_1", { claimId: "claim_1" });
+
+    expect(mocks.tx.taskClaimUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: TaskClaimStatus.VERIFIED }),
+      }),
+    );
+    expect(mocks.tx.taskUpdate).not.toHaveBeenCalled();
   });
 
   it("listTasks defaults to public-only visibility", async () => {

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -116,6 +116,7 @@ import {
   isTaskWithinClientAccessBoundary,
   type TaskClientAccessBoundary,
 } from "./tasks/task-visibility.server";
+import { resolveTaskClaimSettings } from "./tasks/task-claim-policy";
 import type { PlanningCommitment } from "./tasks/execution-planner";
 import {
   auditExecutionGraph,
@@ -6108,7 +6109,8 @@ const TASK_TOOL_DEFINITIONS = [
         claimPolicy: {
           type: "string",
           enum: ["ASSIGNED_ONLY", "OPEN_SINGLE", "OPEN_MANY"],
-          description: "Who can claim this task",
+          description:
+            "How work is claimed. Assigned tasks always use ASSIGNED_ONLY. Unassigned tasks default to OPEN_SINGLE; use OPEN_MANY only for ongoing independent contributions.",
         },
         assigneePersonId: {
           type: "string",
@@ -6602,6 +6604,12 @@ const TASK_TOOL_DEFINITIONS = [
         status: {
           type: "string",
           enum: ["DRAFT", "ACTIVE", "STALE"],
+        },
+        claimPolicy: {
+          type: "string",
+          enum: ["ASSIGNED_ONLY", "OPEN_SINGLE", "OPEN_MANY"],
+          description:
+            "How work is claimed. Use ASSIGNED_ONLY for a named person or organization, OPEN_SINGLE for one claim that completes the task, and OPEN_MANY only for ongoing independent contributions.",
         },
         title: { type: "string" },
         description: { type: "string" },
@@ -10432,8 +10440,22 @@ export function createMcpServer(
                 ? parseTaskDate(a.due_at ?? a.dueAt)
                 : null;
             let routingData: Record<string, unknown>;
+            let claimSettings: ReturnType<typeof resolveTaskClaimSettings>;
             try {
               routingData = buildTaskRoutingData(a);
+              claimSettings = resolveTaskClaimSettings({
+                assigneeOrganizationId,
+                assigneePersonId,
+                requestedClaimPolicy: parseEnumInput(
+                  TaskClaimPolicy,
+                  a.claimPolicy,
+                  "claimPolicy",
+                ),
+                requestedMaxClaims: routingData.maxClaims as
+                  | number
+                  | null
+                  | undefined,
+              });
             } catch (error) {
               return err(
                 error instanceof Error
@@ -10461,9 +10483,8 @@ export function createMcpServer(
               availableAt,
               dueAt,
               deadlinePolicy: resolveDeadlinePolicyInput(a, dueAt),
-              claimPolicy: a.claimPolicy
-                ? TaskClaimPolicy[a.claimPolicy as keyof typeof TaskClaimPolicy]
-                : TaskClaimPolicy.OPEN_MANY,
+              claimPolicy: claimSettings.claimPolicy,
+              maxClaims: claimSettings.maxClaims,
               ...(assigneePersonId ? { assigneePersonId } : {}),
               ...(assigneeOrganizationId ? { assigneeOrganizationId } : {}),
               ...(ownerOrganizationId ? { ownerOrganizationId } : {}),
@@ -12194,6 +12215,9 @@ export function createMcpServer(
                   isPublic: true,
                 },
                 select: {
+                  assigneeOrganizationId: true,
+                  assigneePersonId: true,
+                  claimPolicy: true,
                   contextJson: true,
                   createdByUserId: true,
                   currentImpactEstimateSet: {
@@ -12216,6 +12240,7 @@ export function createMcpServer(
                   estimatedEffortHours: true,
                   id: true,
                   isPublic: true,
+                  maxClaims: true,
                   ownerOrganizationId: true,
                 },
               });
@@ -12367,8 +12392,49 @@ export function createMcpServer(
             }
             const economicsPatch = hasEconomicsPatch(a);
             const economics = resolveTaskEconomics(a, existingTask);
+            let routingData: Record<string, unknown>;
             try {
-              Object.assign(updates, buildTaskRoutingData(a));
+              routingData = buildTaskRoutingData(a);
+              Object.assign(updates, routingData);
+
+              const shouldUpdateClaimSettings =
+                a.claimPolicy !== undefined ||
+                a.maxClaims !== undefined ||
+                a.assigneePersonId !== undefined ||
+                a.assigneeOrganizationId !== undefined;
+              if (shouldUpdateClaimSettings) {
+                const currentClaimPolicy = parseEnumInput(
+                  TaskClaimPolicy,
+                  existingTask.claimPolicy,
+                  "existing claimPolicy",
+                );
+                const claimSettings = resolveTaskClaimSettings({
+                  assigneeOrganizationId:
+                    a.assigneeOrganizationId !== undefined
+                      ? (a.assigneeOrganizationId as string) || null
+                      : existingTask.assigneeOrganizationId,
+                  assigneePersonId:
+                    a.assigneePersonId !== undefined
+                      ? (a.assigneePersonId as string) || null
+                      : existingTask.assigneePersonId,
+                  currentClaimPolicy,
+                  currentMaxClaims: existingTask.maxClaims as
+                    | number
+                    | null
+                    | undefined,
+                  requestedClaimPolicy: parseEnumInput(
+                    TaskClaimPolicy,
+                    a.claimPolicy,
+                    "claimPolicy",
+                  ),
+                  requestedMaxClaims:
+                    a.maxClaims !== undefined
+                      ? (routingData.maxClaims as number | null)
+                      : undefined,
+                });
+                updates.claimPolicy = claimSettings.claimPolicy;
+                updates.maxClaims = claimSettings.maxClaims;
+              }
             } catch (error) {
               return err(
                 error instanceof Error

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -12412,11 +12412,25 @@ export function createMcpServer(
                   assigneeOrganizationId:
                     a.assigneeOrganizationId !== undefined
                       ? (a.assigneeOrganizationId as string) || null
-                      : existingTask.assigneeOrganizationId,
+                      : (existingTask.assigneeOrganizationId ??
+                        (
+                          existingTask.assigneeOrganization as
+                            | { id?: string }
+                            | null
+                            | undefined
+                        )?.id ??
+                        null),
                   assigneePersonId:
                     a.assigneePersonId !== undefined
                       ? (a.assigneePersonId as string) || null
-                      : existingTask.assigneePersonId,
+                      : (existingTask.assigneePersonId ??
+                        (
+                          existingTask.assigneePerson as
+                            | { id?: string }
+                            | null
+                            | undefined
+                        )?.id ??
+                        null),
                   currentClaimPolicy,
                   currentMaxClaims: existingTask.maxClaims as
                     | number

--- a/packages/web/src/lib/tasks.server.ts
+++ b/packages/web/src/lib/tasks.server.ts
@@ -28,6 +28,10 @@ import {
   ensureExecutionPlanningBranch,
   OrganizationPlanningAccessError,
 } from "@/lib/tasks/planning-branch.server";
+import {
+  resolveTaskClaimSettings,
+  verifiedClaimClosesTask,
+} from "@/lib/tasks/task-claim-policy";
 import { getSourceArtifactVisibilityWhere } from "@/lib/source-artifact-visibility.server";
 import {
   assertUserCanClaimPaidTask,
@@ -1936,13 +1940,16 @@ export async function createTask(
   const assigneeOrganizationId = input.assigneeOrganizationId?.trim() || null;
   const assigneePersonId = input.assigneePersonId?.trim() || null;
   const isAssignedTask = Boolean(assigneeOrganizationId || assigneePersonId);
-  const defaultClaimPolicy =
-    input.isPublic === false
-      ? TaskClaimPolicy.ASSIGNED_ONLY
-      : TaskClaimPolicy.OPEN_SINGLE;
-  const resolvedClaimPolicy = isAssignedTask
-    ? TaskClaimPolicy.ASSIGNED_ONLY
-    : (input.claimPolicy ?? defaultClaimPolicy);
+  const claimSettings = resolveTaskClaimSettings({
+    assigneeOrganizationId,
+    assigneePersonId,
+    requestedClaimPolicy:
+      input.isPublic === false && input.claimPolicy == null
+        ? TaskClaimPolicy.ASSIGNED_ONLY
+        : input.claimPolicy,
+    requestedMaxClaims: input.maxClaims,
+  });
+  const resolvedClaimPolicy = claimSettings.claimPolicy;
   const requestedIsPublic =
     input.isPublic ??
     (resolvedClaimPolicy !== TaskClaimPolicy.ASSIGNED_ONLY || isAssignedTask);
@@ -1959,14 +1966,6 @@ export async function createTask(
   }
   if (input.status === TaskStatus.VERIFIED) {
     throw new Error("Task verification must use the verification flow.");
-  }
-
-  if (
-    resolvedClaimPolicy === TaskClaimPolicy.OPEN_MANY &&
-    input.maxClaims != null &&
-    input.maxClaims < 1
-  ) {
-    throw new Error("maxClaims must be at least 1 for OPEN_MANY tasks.");
   }
 
   // Parent resolution (OPT-TASK-06): an explicit parent wins. A private
@@ -2005,10 +2004,7 @@ export async function createTask(
       estimatedEffortHours: input.estimatedEffortHours ?? null,
       interestTags: input.interestTags?.filter(Boolean) ?? [],
       isPublic,
-      maxClaims:
-        resolvedClaimPolicy === TaskClaimPolicy.OPEN_MANY
-          ? (input.maxClaims ?? null)
-          : null,
+      maxClaims: claimSettings.maxClaims,
       parentTaskId,
       createdByUserId: creatorUserId,
       roleTitle: input.roleTitle?.trim() || null,
@@ -2082,9 +2078,12 @@ export async function updateTaskCreatedByUser(
       ],
     },
     select: {
+      assigneeOrganizationId: true,
+      assigneePersonId: true,
       claimPolicy: true,
       id: true,
       isPublic: true,
+      maxClaims: true,
     },
   });
 
@@ -2096,14 +2095,16 @@ export async function updateTaskCreatedByUser(
     throw new Error("Public tasks can't be unpublished. Ask an admin.");
   }
 
-  const nextClaimPolicy = input.claimPolicy ?? existingTask.claimPolicy;
-  if (
-    nextClaimPolicy === TaskClaimPolicy.OPEN_MANY &&
-    input.maxClaims != null &&
-    input.maxClaims < 1
-  ) {
-    throw new Error("maxClaims must be at least 1 for OPEN_MANY tasks.");
-  }
+  const shouldUpdateClaimSettings =
+    input.claimPolicy !== undefined || input.maxClaims !== undefined;
+  const claimSettings = resolveTaskClaimSettings({
+    assigneeOrganizationId: existingTask.assigneeOrganizationId,
+    assigneePersonId: existingTask.assigneePersonId,
+    currentClaimPolicy: existingTask.claimPolicy,
+    currentMaxClaims: existingTask.maxClaims,
+    requestedClaimPolicy: input.claimPolicy,
+    requestedMaxClaims: input.maxClaims,
+  });
 
   const title = input.title == null ? undefined : input.title.trim();
   if (title !== undefined && !title) {
@@ -2117,19 +2118,18 @@ export async function updateTaskCreatedByUser(
       where: { id: taskId },
       data: {
         category: input.category ?? undefined,
-        claimPolicy: input.claimPolicy ?? undefined,
+        claimPolicy: shouldUpdateClaimSettings
+          ? claimSettings.claimPolicy
+          : undefined,
         description:
           input.description == null ? undefined : input.description.trim(),
         dueAt: input.dueAt ?? undefined,
         estimatedEffortHours: input.estimatedEffortHours ?? undefined,
         interestTags: input.interestTags?.filter(Boolean) ?? undefined,
         isPublic: input.isPublic ?? undefined,
-        maxClaims:
-          nextClaimPolicy === TaskClaimPolicy.OPEN_MANY
-            ? (input.maxClaims ?? undefined)
-            : input.claimPolicy
-              ? null
-              : undefined,
+        maxClaims: shouldUpdateClaimSettings
+          ? claimSettings.maxClaims
+          : undefined,
         roleTitle:
           input.roleTitle == null ? undefined : input.roleTitle.trim() || null,
         skillTags: input.skillTags?.filter(Boolean) ?? undefined,
@@ -2444,7 +2444,7 @@ export async function verifyTask(
         },
       });
 
-      if (task.claimPolicy !== TaskClaimPolicy.OPEN_MANY) {
+      if (verifiedClaimClosesTask(task.claimPolicy)) {
         await tx.task.update({
           where: { id: task.id },
           data: {

--- a/packages/web/src/lib/tasks/task-claim-policy.ts
+++ b/packages/web/src/lib/tasks/task-claim-policy.ts
@@ -18,10 +18,14 @@ export function resolveTaskClaimSettings({
   requestedMaxClaims,
 }: ResolveTaskClaimSettingsInput) {
   const isAssigned = Boolean(assigneeOrganizationId || assigneePersonId);
+  const unassignedCurrentPolicy =
+    currentClaimPolicy === TaskClaimPolicy.ASSIGNED_ONLY
+      ? null
+      : currentClaimPolicy;
   const claimPolicy = isAssigned
     ? TaskClaimPolicy.ASSIGNED_ONLY
     : (requestedClaimPolicy ??
-      currentClaimPolicy ??
+      unassignedCurrentPolicy ??
       TaskClaimPolicy.OPEN_SINGLE);
   const maxClaims =
     claimPolicy === TaskClaimPolicy.OPEN_MANY

--- a/packages/web/src/lib/tasks/task-claim-policy.ts
+++ b/packages/web/src/lib/tasks/task-claim-policy.ts
@@ -1,0 +1,44 @@
+import { TaskClaimPolicy } from "@optimitron/db";
+
+type ResolveTaskClaimSettingsInput = {
+  assigneeOrganizationId?: string | null;
+  assigneePersonId?: string | null;
+  currentClaimPolicy?: TaskClaimPolicy | null;
+  currentMaxClaims?: number | null;
+  requestedClaimPolicy?: TaskClaimPolicy | null;
+  requestedMaxClaims?: number | null;
+};
+
+export function resolveTaskClaimSettings({
+  assigneeOrganizationId,
+  assigneePersonId,
+  currentClaimPolicy,
+  currentMaxClaims,
+  requestedClaimPolicy,
+  requestedMaxClaims,
+}: ResolveTaskClaimSettingsInput) {
+  const isAssigned = Boolean(assigneeOrganizationId || assigneePersonId);
+  const claimPolicy = isAssigned
+    ? TaskClaimPolicy.ASSIGNED_ONLY
+    : (requestedClaimPolicy ??
+      currentClaimPolicy ??
+      TaskClaimPolicy.OPEN_SINGLE);
+  const maxClaims =
+    claimPolicy === TaskClaimPolicy.OPEN_MANY
+      ? requestedMaxClaims !== undefined
+        ? requestedMaxClaims
+        : currentClaimPolicy === TaskClaimPolicy.OPEN_MANY
+          ? (currentMaxClaims ?? null)
+          : null
+      : null;
+
+  if (maxClaims != null && (!Number.isInteger(maxClaims) || maxClaims < 1)) {
+    throw new Error("maxClaims must be at least 1 for OPEN_MANY tasks.");
+  }
+
+  return { claimPolicy, maxClaims };
+}
+
+export function verifiedClaimClosesTask(claimPolicy: TaskClaimPolicy) {
+  return claimPolicy !== TaskClaimPolicy.OPEN_MANY;
+}


### PR DESCRIPTION
## Summary
- default unassigned MCP-created tasks to `OPEN_SINGLE`, so accepting their one completed claim verifies the task and releases dependents
- force tasks assigned to a person or organization to `ASSIGNED_ONLY`
- reserve `OPEN_MANY` for explicitly ongoing, independent contributions
- expose `claimPolicy` on `updateTask` so incorrectly configured existing tasks can be repaired, clearing obsolete `maxClaims`
- document the task-closing behavior and add focused regressions

No schema, UI, or public-copy changes.

## Verification
- `vitest run src/lib/__tests__/tasks.server.test.ts` (25 passed)
- focused `mcp-server.test.ts` regressions (7 passed)
- application TypeScript check passed
- test TypeScript check passed
- full `mcp-server.test.ts`: 178 passed; 5 unrelated existing cases attempted the placeholder `test` database and failed authentication or timed out

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added clearer `claimPolicy` and `maxClaims` handling for task creation and updates, including normalization based on task assignment context.
  * Task verification now closes one-off tasks transactionally, while multi-contributor tasks remain open.
  * Added support for routing and enforcing claim limits on multi-contributor tasks.

* **Documentation**
  * Documented `claimPolicy` defaults and lifecycle semantics, including how existing tasks can be corrected.

* **Tests**
  * Expanded coverage for MCP tool schemas and claim-policy validation/repair behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

