### PR TITLE
Fix tracking recurrence and refresh parameter metadata

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,16 +7,6 @@ sandbox_mode = "workspace-write"
 [features]
 goals = true
 
-[mcp_servers.optimitron-production]
-url = "https://optimitron.com/api/mcp"
-auth = "oauth"
-scopes = ["tasks:personal"]
-enabled = true
-required = false
-default_tools_approval_mode = "approve"
-startup_timeout_sec = 20
-tool_timeout_sec = 120
-
 # MCP server entries removed 2026-05-14: when the local dev server on 3001 or
 # the spawned pnpm MCP subprocess is unreachable / wedged, Codex hangs on the
 # handshake at startup ("thinking forever" in the VS Code extension). Re-add

--- a/packages/data/src/parameters/parameters-calculations-citations.ts
+++ b/packages/data/src/parameters/parameters-calculations-citations.ts
@@ -113,6 +113,38 @@ export const ADAPTABLE_TRIAL_TOTAL_COST: Parameter = {
   manualPageTitle: "The 1% Treaty: An Incentive-Compatible Approach to Ending War and Disease",
 };
 
+export const AGRICULTURE_FRESHWATER_WITHDRAWAL_PCT: Parameter = {
+  value: 0.7,
+  parameterName: "AGRICULTURE_FRESHWATER_WITHDRAWAL_PCT",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-agriculture_freshwater_withdrawal_pct",
+  unit: "percent",
+  displayName: "Agriculture Share of Freshwater Withdrawals",
+  description: "Agriculture's share of global freshwater withdrawals, ~70% (Our World in Data, FAO AQUASTAT / World Bank). This is the standard consensus figure but is a soft estimate; recent work argues the true irrigation share could plausibly range ~45-90%. Reported as the widely-cited ~70% with that uncertainty acknowledged.",
+  sourceType: "external",
+  sourceRef: "owid-water-use-stress",
+  sourceUrl: "https://ourworldindata.org/water-use-stress",
+  confidence: "medium",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
+};
+
+export const AMR_DEATHS_ATTRIBUTABLE_2019: Parameter = {
+  value: 1270000.0,
+  parameterName: "AMR_DEATHS_ATTRIBUTABLE_2019",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-amr_deaths_attributable_2019",
+  unit: "deaths",
+  displayName: "Deaths Directly Attributable to AMR (2019)",
+  description: "Deaths directly attributable to bacterial antimicrobial resistance in 2019, ~1.27 million (95% UI 0.91-1.71 million); ~4.95 million deaths were associated with it (Murray et al., The Lancet 2022). Attributable and associated are not additive. Animal agriculture consumes a large majority of medically important antibiotics, driving resistance.",
+  sourceType: "external",
+  sourceRef: "murray-2022-amr",
+  sourceUrl: "https://pubmed.ncbi.nlm.nih.gov/35065702/",
+  confidence: "high",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
+};
+
 export const ANNUAL_TERRORISM_DEATH_RISK_DENOMINATOR: Parameter = {
   value: 30000000.0,
   parameterName: "ANNUAL_TERRORISM_DEATH_RISK_DENOMINATOR",
@@ -142,6 +174,22 @@ export const ANTIDEPRESSANT_TRIAL_EXCLUSION_RATE: Parameter = {
   confidence: "high",
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html",
   manualPageTitle: "The 1% Treaty: An Incentive-Compatible Approach to Ending War and Disease",
+};
+
+export const AQUATIC_ANIMALS_KILLED_ANNUAL: Parameter = {
+  value: 1100000000000.0,
+  parameterName: "AQUATIC_ANIMALS_KILLED_ANNUAL",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-aquatic_animals_killed_annual",
+  unit: "animals",
+  displayName: "Wild Aquatic Animals Killed for Food per Year (low estimate)",
+  description: "Wild-caught fish killed globally per year, estimated at 1.1-2.2 trillion (average 2000-2019, fishcount.org.uk, derived from FAO capture tonnage and mean body weights). Value shown is the conservative low end; the range is wide because these animals are counted by weight, not headcount. Farmed finfish add ~120 billion more. Aquatic deaths exceed land-animal deaths by roughly an order of magnitude.",
+  sourceType: "external",
+  sourceRef: "fishcount-wild-fish",
+  sourceUrl: "https://fishcount.org.uk/fish-count-estimates-2",
+  confidence: "medium",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
 };
 
 export const AVERAGE_MARKET_RETURN_PCT: Parameter = {
@@ -193,6 +241,22 @@ export const BED_NETS_COST_PER_DALY: Parameter = {
   distribution: "normal",
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html",
   manualPageTitle: "The 1% Treaty: An Incentive-Compatible Approach to Ending War and Disease",
+};
+
+export const BEEF_FEED_CALORIE_EFFICIENCY_PCT: Parameter = {
+  value: 0.03,
+  parameterName: "BEEF_FEED_CALORIE_EFFICIENCY_PCT",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-beef_feed_calorie_efficiency_pct",
+  unit: "percent",
+  displayName: "Beef Caloric Conversion Efficiency",
+  description: "Caloric conversion efficiency of beef, ~3%: only about 3 of every 100 feed calories become beef calories (Cassidy et al. 2013, Environmental Research Letters). The often-quoted '~33 feed calories per beef calorie' is the arithmetic reciprocal of this figure, not a separate measurement. System-wide, 36% of crop calories go to animal feed and only 12% return as human food.",
+  sourceType: "external",
+  sourceRef: "cassidy-2013-nourished",
+  sourceUrl: "https://iopscience.iop.org/article/10.1088/1748-9326/8/3/034015",
+  confidence: "high",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
 };
 
 export const BULLETS_FIRED_PER_KILL_IRAQ_AFGHANISTAN: Parameter = {
@@ -697,6 +761,22 @@ export const DFDA_PRAGMATIC_TRIAL_COST_PER_PATIENT: Parameter = {
   manualPageTitle: "The 1% Treaty: An Incentive-Compatible Approach to Ending War and Disease",
 };
 
+export const DIETARY_RISK_DEATHS_ANNUAL: Parameter = {
+  value: 11000000.0,
+  parameterName: "DIETARY_RISK_DEATHS_ANNUAL",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-dietary_risk_deaths_annual",
+  unit: "deaths",
+  displayName: "Deaths per Year from Dietary Risks",
+  description: "Deaths per year attributable to dietary risk factors, ~11 million (95% UI 10-12 million; 255 million DALYs), from the Global Burden of Disease Study 2017 (Afshin et al., The Lancet 2019). Diet-driven chronic disease is one of the human-health costs the current food system externalizes.",
+  sourceType: "external",
+  sourceRef: "gbd-2017-diet",
+  sourceUrl: "https://pubmed.ncbi.nlm.nih.gov/30954305/",
+  confidence: "high",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
+};
+
 export const DISEASE_BURDEN_GDP_DRAG_PCT: Parameter = {
   value: 0.13,
   parameterName: "DISEASE_BURDEN_GDP_DRAG_PCT",
@@ -898,6 +978,54 @@ export const EXPERT_DECISION_ACCURACY: Parameter = {
   manualPageTitle: "Wishocracy",
 };
 
+export const FACTORY_FARM_SHARE_US: Parameter = {
+  value: 0.99,
+  parameterName: "FACTORY_FARM_SHARE_US",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-factory_farm_share_us",
+  unit: "percent",
+  displayName: "Share of US Farmed Animals on Factory Farms",
+  description: "Share of US farmed animals living on factory farms, ~99% (Sentience Institute, using EPA CAFO definitions and USDA farm-size census; widely cited incl. by Our World in Data). Per-species: ~75% of cows, ~99% of pigs, >99.9% of meat chickens. Global share is lower for land vertebrates (~74%) and higher once fish are included (>90%).",
+  sourceType: "external",
+  sourceRef: "sentience-us-factory-farming",
+  sourceUrl: "https://www.sentienceinstitute.org/us-factory-farming-estimates",
+  confidence: "high",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
+};
+
+export const FARMED_LAND_ANIMALS_SLAUGHTERED_ANNUAL: Parameter = {
+  value: 83000000000.0,
+  parameterName: "FARMED_LAND_ANIMALS_SLAUGHTERED_ANNUAL",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-farmed_land_animals_slaughtered_annual",
+  unit: "animals",
+  displayName: "Land Animals Slaughtered for Food per Year",
+  description: "Land animals slaughtered for meat globally per year, ~83 billion in 2022 (UN FAO via Our World in Data). Chickens are the immense majority. Excludes culled male chicks and animals without data, so it undercounts total farmed deaths. Dwarfed in turn by aquatic-animal deaths (see AQUATIC_ANIMALS_KILLED_ANNUAL).",
+  sourceType: "external",
+  sourceRef: "owid-land-animals-slaughtered",
+  sourceUrl: "https://ourworldindata.org/data-insights/billions-of-chickens-ducks-and-pigs-are-slaughtered-for-meat-every-year",
+  confidence: "high",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
+};
+
+export const FARMLAND_REDUCTION_POTENTIAL_PCT: Parameter = {
+  value: 0.75,
+  parameterName: "FARMLAND_REDUCTION_POTENTIAL_PCT",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-farmland_reduction_potential_pct",
+  unit: "percent",
+  displayName: "Farmland Freed Under a Shift Off Animal Products",
+  description: "Reduction in global farmland if the world shifted off meat and dairy while still feeding everyone, more than 75% (~4.1 billion down to ~1 billion hectares; University of Oxford LEAP, reporting Poore & Nemecek 2018, Science). Oxford's illustrative equivalent: an area the size of the US, China, EU, and Australia combined. A hypothetical full-shift model, not a forecast.",
+  sourceType: "external",
+  sourceRef: "oxford-leap-food-impacts",
+  sourceUrl: "https://www.leap.ox.ac.uk/article/reducing-foods-environmental-impacts",
+  confidence: "high",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
+};
+
 export const FDA_APPROVED_PRODUCTS_COUNT: Parameter = {
   value: 20000.0,
   parameterName: "FDA_APPROVED_PRODUCTS_COUNT",
@@ -963,6 +1091,38 @@ export const FDA_PHASE_1_TO_APPROVAL_YEARS: Parameter = {
   distribution: "gamma",
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/appendix/invisible-graveyard.html",
   manualPageTitle: "The Invisible Graveyard: Quantifying the Mortality Cost of FDA Efficacy Lag",
+};
+
+export const FOOD_PRODUCTION_GHG_PCT: Parameter = {
+  value: 0.26,
+  parameterName: "FOOD_PRODUCTION_GHG_PCT",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-food_production_ghg_pct",
+  unit: "percent",
+  displayName: "Food Production Share of Global GHG Emissions",
+  description: "Food production's share of global greenhouse-gas emissions, ~26% (~13.7 Gt CO2eq; Our World in Data, based on Poore & Nemecek 2018). Uses the 'food production' boundary. A wider whole-food-system boundary including retail, transport, packaging, and waste (Crippa et al. 2021, Nature Food) reaches ~34%. Present as boundary choices, not a contradiction.",
+  sourceType: "external",
+  sourceRef: "owid-environmental-impacts-food",
+  sourceUrl: "https://ourworldindata.org/environmental-impacts-of-food",
+  confidence: "high",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
+};
+
+export const FOOD_SYSTEM_HIDDEN_COST_ANNUAL: Parameter = {
+  value: 12000000000000.0,
+  parameterName: "FOOD_SYSTEM_HIDDEN_COST_ANNUAL",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-food_system_hidden_cost_annual",
+  unit: "USD",
+  displayName: "Global Food System Hidden Costs per Year",
+  description: "Hidden (external) costs of the global food and land-use system, ~$12 trillion/year, against a market value of ~$10 trillion (FOLU 'Growing Better' 2019; modeled by an advocacy coalition, widely cited). Comprises environmental, public-health, and poverty costs; projected to rise to $16.1 trillion by 2050 under current trends. US-only true-cost accounting (Rockefeller 2021) finds ~$2.1 trillion/year in hidden costs on top of ~$1.1 trillion paid.",
+  sourceType: "external",
+  sourceRef: "folu-growing-better-2019",
+  sourceUrl: "https://www.foodandlandusecoalition.org/wp-content/uploads/2019/09/FOLU-GrowingBetter-GlobalReport-SummaryReport.pdf",
+  confidence: "medium",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
 };
 
 export const GALLUP_GLOBAL_MEDIAN_INCOME_PER_CAPITA: Parameter = {
@@ -2099,6 +2259,54 @@ export const LIFE_EXTENSION_YEARS: Parameter = {
   validationMax: 150,
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/strategy/earth-optimization-prize.html",
   manualPageTitle: "The Earth Optimization Prize",
+};
+
+export const LIVESTOCK_SHARE_OF_AGRICULTURAL_LAND: Parameter = {
+  value: 0.8,
+  parameterName: "LIVESTOCK_SHARE_OF_AGRICULTURAL_LAND",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-livestock_share_of_agricultural_land",
+  unit: "percent",
+  displayName: "Livestock Share of Agricultural Land",
+  description: "Livestock's share of global agricultural land, combining grazing land and cropland grown for animal feed, ~80% (Our World in Data, FAOSTAT). Poore & Nemecek (2018) report ~83% of farmland by a slightly different boundary. Defensible range ~77-83%. The striking point is the mismatch: this majority of farmland returns only ~18% of calories.",
+  sourceType: "external",
+  sourceRef: "owid-land-for-agriculture",
+  sourceUrl: "https://ourworldindata.org/global-land-for-agriculture",
+  confidence: "high",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
+};
+
+export const LIVESTOCK_SHARE_OF_CALORIES: Parameter = {
+  value: 0.18,
+  parameterName: "LIVESTOCK_SHARE_OF_CALORIES",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-livestock_share_of_calories",
+  unit: "percent",
+  displayName: "Livestock Share of Global Calories",
+  description: "Share of the world's calories provided by meat, aquaculture, eggs, and dairy, ~18% (Poore & Nemecek 2018, Science, meta-analysis of ~38,700 farms across 119 countries). Our World in Data reports ~17% by FAOSTAT. Pair with LIVESTOCK_SHARE_OF_AGRICULTURAL_LAND: the majority of farmland for a small share of the calories.",
+  sourceType: "external",
+  sourceRef: "poore-nemecek-2018",
+  sourceUrl: "https://ora.ox.ac.uk/objects/uuid:b0b53649-5e93-4415-bf07-6b0b1227172f",
+  confidence: "high",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
+};
+
+export const LIVESTOCK_SHARE_OF_PROTEIN: Parameter = {
+  value: 0.37,
+  parameterName: "LIVESTOCK_SHARE_OF_PROTEIN",
+  calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-livestock_share_of_protein",
+  unit: "percent",
+  displayName: "Livestock Share of Global Protein",
+  description: "Share of the world's protein provided by meat, aquaculture, eggs, and dairy, ~37% (Poore & Nemecek 2018, Science). Our World in Data reports ~38% by FAOSTAT. Delivered using ~83% of farmland and producing the majority of food's emissions.",
+  sourceType: "external",
+  sourceRef: "poore-nemecek-2018",
+  sourceUrl: "https://ora.ox.ac.uk/objects/uuid:b0b53649-5e93-4415-bf07-6b0b1227172f",
+  confidence: "high",
+  distribution: "fixed",
+  manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
+  manualPageTitle: "The Slaughterhouse Was a Workaround",
 };
 
 export const LOBBYIST_SALARY_MAX: Parameter = {
@@ -14859,11 +15067,15 @@ export const _US_BASE_POLITICAL_SPENDING: Parameter = {
 export const parameters = {
   ADAPTABLE_TRIAL_COST_PER_PATIENT,
   ADAPTABLE_TRIAL_TOTAL_COST,
+  AGRICULTURE_FRESHWATER_WITHDRAWAL_PCT,
+  AMR_DEATHS_ATTRIBUTABLE_2019,
   ANNUAL_TERRORISM_DEATH_RISK_DENOMINATOR,
   ANTIDEPRESSANT_TRIAL_EXCLUSION_RATE,
+  AQUATIC_ANIMALS_KILLED_ANNUAL,
   AVERAGE_MARKET_RETURN_PCT,
   BASELINE_LIVES_SAVED_ANNUAL,
   BED_NETS_COST_PER_DALY,
+  BEEF_FEED_CALORIE_EFFICIENCY_PCT,
   BULLETS_FIRED_PER_KILL_IRAQ_AFGHANISTAN,
   BULLET_COST_556_NATO,
   CAREGIVER_ANNUAL_VALUE_TOTAL,
@@ -14895,6 +15107,7 @@ export const parameters = {
   DEMOCIDE_TOTAL_20TH_CENTURY,
   DEWORMING_COST_PER_DALY,
   DFDA_PRAGMATIC_TRIAL_COST_PER_PATIENT,
+  DIETARY_RISK_DEATHS_ANNUAL,
   DISEASE_BURDEN_GDP_DRAG_PCT,
   DOT_VALUE_OF_STATISTICAL_LIFE,
   DRUG_DEVELOPMENT_COST_1980S,
@@ -14907,10 +15120,15 @@ export const parameters = {
   EFFICACY_LAG_YEARS,
   EOS_SOCIAL_VALUE_CAPTURE_PCT,
   EXPERT_DECISION_ACCURACY,
+  FACTORY_FARM_SHARE_US,
+  FARMED_LAND_ANIMALS_SLAUGHTERED_ANNUAL,
+  FARMLAND_REDUCTION_POTENTIAL_PCT,
   FDA_APPROVED_PRODUCTS_COUNT,
   FDA_APPROVED_UNIQUE_ACTIVE_INGREDIENTS,
   FDA_GRAS_SUBSTANCES_COUNT,
   FDA_PHASE_1_TO_APPROVAL_YEARS,
+  FOOD_PRODUCTION_GHG_PCT,
+  FOOD_SYSTEM_HIDDEN_COST_ANNUAL,
   GALLUP_GLOBAL_MEDIAN_INCOME_PER_CAPITA,
   GIVEWELL_COST_PER_LIFE_AVG,
   GIVEWELL_COST_PER_LIFE_MAX,
@@ -14979,6 +15197,9 @@ export const parameters = {
   IRS_ANNUAL_OPERATING_BUDGET,
   LEADED_GASOLINE_US_AVG_IQ_LOSS_POINTS,
   LIFE_EXTENSION_YEARS,
+  LIVESTOCK_SHARE_OF_AGRICULTURAL_LAND,
+  LIVESTOCK_SHARE_OF_CALORIES,
+  LIVESTOCK_SHARE_OF_PROTEIN,
   LOBBYIST_SALARY_MAX,
   LOBBYIST_SALARY_MIN_K,
   MEASLES_VACCINATION_ROI,
@@ -15891,6 +16112,21 @@ export const citations: Record<string, Citation> = {
         issued: { 'date-parts': [[2023]] },
         URL: "https://costsofwar.watson.brown.edu/costs/environmental",
   },
+  "cassidy-2013-nourished": {
+        id: "cassidy-2013-nourished",
+        type: "article-journal",
+        title: "Redefining agricultural yields: from tonnes to people nourished per hectare",
+        author: [
+          {
+            family: "Cassidy",
+            given: "Emily S. and West, Paul C. and Gerber, James S. and Foley, Jonathan A."
+          },
+        ],
+        issued: { 'date-parts': [[2013]] },
+        'container-title': "Environmental Research Letters",
+        URL: "https://iopscience.iop.org/article/10.1088/1748-9326/8/3/034015",
+        note: "Quote: \"36% of the calories produced by the world's crops are being used for animal feed, and only 12% of those feed calories ultimately contribute to the human diet (as meat and other animal products).\" Beef caloric conversion efficiency 3% (Table 1).",
+  },
   "cbo-immigration-surge-2024": {
         id: "cbo-immigration-surge-2024",
         type: "report",
@@ -16498,6 +16734,33 @@ export const citations: Record<string, Citation> = {
         URL: "https://www.fec.gov/updates/statistical-summary-of-24-month-campaign-activity-of-the-2023-2024-election-cycle/",
         note: "Federal Election Commission, Statistical Summary of 24-Month Campaign Activity",
   },
+  "fishcount-wild-fish": {
+        id: "fishcount-wild-fish",
+        type: "webpage",
+        title: "Fish count estimates",
+        author: [
+          {
+            literal: "fishcount.org.uk"
+          },
+        ],
+        issued: { 'date-parts': [[2019]] },
+        URL: "https://fishcount.org.uk/fish-count-estimates-2",
+        note: "Derived from FAO capture tonnage and estimated mean body weights. Quote: \"1.1-2.2 trillion wild fishes were caught annually, on average, during 2000-2019.\" Advocacy-aligned project, standard methodology for these counts.",
+  },
+  "folu-growing-better-2019": {
+        id: "folu-growing-better-2019",
+        type: "report",
+        title: "Growing Better: Ten Critical Transitions to Transform Food and Land Use",
+        author: [
+          {
+            literal: "Food and Land Use Coalition"
+          },
+        ],
+        issued: { 'date-parts': [[2019]] },
+        publisher: "The Food and Land Use Coalition (FOLU)",
+        URL: "https://www.foodandlandusecoalition.org/wp-content/uploads/2019/09/FOLU-GrowingBetter-GlobalReport-SummaryReport.pdf",
+        note: "Advocacy coalition; modeled figures, widely cited. Quote: \"The hidden costs of global food and land use systems sum to \\$12 trillion, compared to a market value of the global food system of \\$10 trillion.\" Rises to \\$16.1 trillion by 2050 under current trends.",
+  },
   "forbes-billionaires-2024": {
         id: "forbes-billionaires-2024",
         type: "webpage",
@@ -16523,6 +16786,20 @@ export const citations: Record<string, Citation> = {
         issued: { 'date-parts': [[2013]] },
         URL: "https://news.gallup.com/poll/166211/worldwide-median-household-income-000.aspx",
         note: "Gallup World Poll, 131 countries, 2006--2012, PPP international dollars. Global median household income \\$9,733/year; median per-capita household income \\$2,920/year. The most recent comprehensive survey-based global median income estimate.",
+  },
+  "gbd-2017-diet": {
+        id: "gbd-2017-diet",
+        type: "article-journal",
+        title: "Health effects of dietary risks in 195 countries, 1990-2017: a systematic analysis for the Global Burden of Disease Study 2017",
+        author: [
+          {
+            literal: "GBD 2017 Diet Collaborators"
+          },
+        ],
+        issued: { 'date-parts': [[2019]] },
+        'container-title': "The Lancet",
+        URL: "https://pubmed.ncbi.nlm.nih.gov/30954305/",
+        note: "Lead author Ashkan Afshin. Quote: \"In 2017, 11 million (95% uncertainty interval [UI] 10-12) deaths and 255 million (234-274) DALYs were attributable to dietary risk factors.\"",
   },
   "gbd-disability-weights": {
         id: "gbd-disability-weights",
@@ -17139,6 +17416,20 @@ export const citations: Record<string, Citation> = {
         URL: "https://link.springer.com/article/10.1007/s11109-016-9373-5",
         note: "Field experiment using Twitter bot replies; effects depended on the perceived identity and follower status of the correcting account.",
   },
+  "murray-2022-amr": {
+        id: "murray-2022-amr",
+        type: "article-journal",
+        title: "Global burden of bacterial antimicrobial resistance in 2019: a systematic analysis",
+        author: [
+          {
+            literal: "Antimicrobial Resistance Collaborators"
+          },
+        ],
+        issued: { 'date-parts': [[2022]] },
+        'container-title': "The Lancet",
+        URL: "https://pubmed.ncbi.nlm.nih.gov/35065702/",
+        note: "Lead author Christopher J. L. Murray. Quote: \"1.27 million (95% UI 0.911-1.71) deaths attributable to bacterial AMR ... 4.95 million (3.62-6.57) deaths associated with bacterial AMR in 2019.\" Attributable and associated are not additive.",
+  },
   "nato-556-ammo-cost": {
         id: "nato-556-ammo-cost",
         type: "webpage",
@@ -17354,6 +17645,76 @@ export const citations: Record<string, Citation> = {
         URL: "https://www.gao.gov/assets/gao-21-207.pdf",
         note: "GAO reported Operation Warp Speed vaccine candidate awards with obligations of at least \\$10 billion and total potential estimated value of at least \\$18 billion.",
   },
+  "owid-environmental-impacts-food": {
+        id: "owid-environmental-impacts-food",
+        type: "webpage",
+        title: "Environmental Impacts of Food Production",
+        author: [
+          {
+            family: "Ritchie",
+            given: "Hannah and Rosado, Pablo and Roser, Max"
+          },
+        ],
+        issued: { 'date-parts': [[2022]] },
+        URL: "https://ourworldindata.org/environmental-impacts-of-food",
+        note: "Based on Poore and Nemecek 2018. Quote: \"Food production accounts for over a quarter (26%) of global greenhouse gas emissions.\" A wider whole-food-system boundary (Crippa et al. 2021) reaches ~34%.",
+  },
+  "owid-land-animals-slaughtered": {
+        id: "owid-land-animals-slaughtered",
+        type: "webpage",
+        title: "More than 80 billion land animals are slaughtered for meat every year",
+        author: [
+          {
+            family: "Rosado",
+            given: "Pablo"
+          },
+        ],
+        issued: { 'date-parts': [[2024]] },
+        URL: "https://ourworldindata.org/data-insights/billions-of-chickens-ducks-and-pigs-are-slaughtered-for-meat-every-year",
+        note: "Data from UN FAO / FAOSTAT. Quote: \"In 2022, the reported total reached 83 billion worldwide.\" Excludes culled male chicks, so undercounts total farmed deaths.",
+  },
+  "owid-land-for-agriculture": {
+        id: "owid-land-for-agriculture",
+        type: "webpage",
+        title: "Half of the world's habitable land is used for agriculture",
+        author: [
+          {
+            family: "Ritchie",
+            given: "Hannah and Roser, Max"
+          },
+        ],
+        issued: { 'date-parts': [[2019]] },
+        URL: "https://ourworldindata.org/global-land-for-agriculture",
+        note: "Data from UN FAO / FAOSTAT. Quote: \"livestock accounts for 80% of agricultural land use\"; \"Meat, dairy, and farmed fish provide just 17% of the world's calories and 38% of its protein.\"",
+  },
+  "owid-water-use-stress": {
+        id: "owid-water-use-stress",
+        type: "webpage",
+        title: "Water Use and Stress",
+        author: [
+          {
+            family: "Ritchie",
+            given: "Hannah and Roser, Max"
+          },
+        ],
+        issued: { 'date-parts': [[2018]] },
+        URL: "https://ourworldindata.org/water-use-stress",
+        note: "Data from FAO AQUASTAT / World Bank. Quote: \"Globally, we use approximately 70 percent of freshwater withdrawals for agriculture.\" Standard consensus figure; some recent work argues the true irrigation share is uncertain (~45-90%).",
+  },
+  "oxford-leap-food-impacts": {
+        id: "oxford-leap-food-impacts",
+        type: "webpage",
+        title: "Reducing food's environmental impacts",
+        author: [
+          {
+            family: "University of Oxford",
+            given: "LEAP"
+          },
+        ],
+        issued: { 'date-parts': [[2018]] },
+        URL: "https://www.leap.ox.ac.uk/article/reducing-foods-environmental-impacts",
+        note: "Reporting Poore and Nemecek 2018 (Science). Quote (lead author Joseph Poore): \"without meat and dairy consumption, global farmland use could be reduced by more than 75% - an area equivalent to the US, China, European Union and Australia combined - and still feed the world.\" Hypothetical full-shift model, not a forecast.",
+  },
   "papanicolas2018": {
         id: "papanicolas2018",
         type: "article-journal",
@@ -17492,6 +17853,21 @@ export const citations: Record<string, Citation> = {
         publisher: "Institute for Accelerated Medicine",
         URL: "https://manual.warondisease.org/knowledge/appendix/political-dysfunction-tax.html",
         note: "Working Draft",
+  },
+  "poore-nemecek-2018": {
+        id: "poore-nemecek-2018",
+        type: "article-journal",
+        title: "Reducing food's environmental impacts through producers and consumers",
+        author: [
+          {
+            family: "Poore",
+            given: "Joseph and Nemecek, Thomas"
+          },
+        ],
+        issued: { 'date-parts': [[2018]] },
+        'container-title': "Science",
+        URL: "https://ora.ox.ac.uk/objects/uuid:b0b53649-5e93-4415-bf07-6b0b1227172f",
+        note: "Meta-analysis of ~38,700 farms across 119 countries and 40 products. Quote (paper body): \"meat, aquaculture, eggs, and dairy use ~83% of the world's farmland and contribute 56-58% of food's different emissions, despite providing only 37% of our protein and 18% of our calories.\"",
   },
   "post-1962-drug-approval-drop": {
         id: "post-1962-drug-approval-drop",
@@ -17703,6 +18079,20 @@ export const citations: Record<string, Citation> = {
         issued: { 'date-parts': [[1994]] },
         publisher: "Transaction Publishers",
         URL: "https://www.hawaii.edu/powerkills/NOTE1.HTM",
+  },
+  "sentience-us-factory-farming": {
+        id: "sentience-us-factory-farming",
+        type: "webpage",
+        title: "US Factory Farming Estimates",
+        author: [
+          {
+            family: "Anthis",
+            given: "Jacy Reese"
+          },
+        ],
+        issued: { 'date-parts': [[2024]] },
+        URL: "https://www.sentienceinstitute.org/us-factory-farming-estimates",
+        note: "Uses EPA CAFO definitions and USDA farm-size census; cited by Our World in Data. Quote: \"We estimate that 99% of US farmed animals are living in factory farms at present.\" Advocacy think tank, transparent method.",
   },
   "september-11-memorial": {
         id: "september-11-memorial",
@@ -18279,11 +18669,11 @@ export const citations: Record<string, Citation> = {
 
 /** Summary statistics */
 export const PARAMETER_STATS = {
-  total: 874,
-  external: 241,
+  total: 887,
+  external: 254,
   calculated: 447,
   definitions: 186,
-  citations: 184,
+  citations: 196,
 } as const;
 
 // ============================================================================

--- a/packages/data/src/parameters/parameters-calculations-citations.ts
+++ b/packages/data/src/parameters/parameters-calculations-citations.ts
@@ -135,12 +135,13 @@ export const AMR_DEATHS_ATTRIBUTABLE_2019: Parameter = {
   calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-amr_deaths_attributable_2019",
   unit: "deaths",
   displayName: "Deaths Directly Attributable to AMR (2019)",
-  description: "Deaths directly attributable to bacterial antimicrobial resistance in 2019, ~1.27 million (95% UI 0.91-1.71 million); ~4.95 million deaths were associated with it (Murray et al., The Lancet 2022). Attributable and associated are not additive. Animal agriculture consumes a large majority of medically important antibiotics, driving resistance.",
+  description: "Deaths directly attributable to bacterial antimicrobial resistance in 2019, ~1.27 million (95% UI 0.91-1.71 million); ~4.95 million deaths were associated with it (Murray et al., The Lancet 2022). Attributable and associated are not additive.",
   sourceType: "external",
   sourceRef: "murray-2022-amr",
   sourceUrl: "https://pubmed.ncbi.nlm.nih.gov/35065702/",
   confidence: "high",
-  distribution: "fixed",
+  confidenceInterval: [911000.0, 1710000.0],
+  distribution: "lognormal",
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
   manualPageTitle: "The Slaughterhouse Was a Workaround",
 };
@@ -182,7 +183,7 @@ export const AQUATIC_ANIMALS_KILLED_ANNUAL: Parameter = {
   calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-aquatic_animals_killed_annual",
   unit: "animals",
   displayName: "Wild Aquatic Animals Killed for Food per Year (low estimate)",
-  description: "Wild-caught fish killed globally per year, estimated at 1.1-2.2 trillion (average 2000-2019, fishcount.org.uk, derived from FAO capture tonnage and mean body weights). Value shown is the conservative low end; the range is wide because these animals are counted by weight, not headcount. Farmed finfish add ~120 billion more. Aquatic deaths exceed land-animal deaths by roughly an order of magnitude.",
+  description: "Wild-caught fish killed globally per year, estimated at 1.1-2.2 trillion (average 2000-2019, fishcount.org.uk, derived from FAO capture tonnage and mean body weights). Value shown is the conservative low end; the range is wide because these animals are counted by weight, not headcount.",
   sourceType: "external",
   sourceRef: "fishcount-wild-fish",
   sourceUrl: "https://fishcount.org.uk/fish-count-estimates-2",
@@ -772,7 +773,8 @@ export const DIETARY_RISK_DEATHS_ANNUAL: Parameter = {
   sourceRef: "gbd-2017-diet",
   sourceUrl: "https://pubmed.ncbi.nlm.nih.gov/30954305/",
   confidence: "high",
-  distribution: "fixed",
+  confidenceInterval: [10000000.0, 12000000.0],
+  distribution: "normal",
   manualPageUrl: "https://manual.WarOnDisease.org/knowledge/solution/optimized-food-system.html",
   manualPageTitle: "The Slaughterhouse Was a Workaround",
 };
@@ -1115,7 +1117,7 @@ export const FOOD_SYSTEM_HIDDEN_COST_ANNUAL: Parameter = {
   calculationsUrl: "https://manual.WarOnDisease.org/calculations.html#sec-food_system_hidden_cost_annual",
   unit: "USD",
   displayName: "Global Food System Hidden Costs per Year",
-  description: "Hidden (external) costs of the global food and land-use system, ~$12 trillion/year, against a market value of ~$10 trillion (FOLU 'Growing Better' 2019; modeled by an advocacy coalition, widely cited). Comprises environmental, public-health, and poverty costs; projected to rise to $16.1 trillion by 2050 under current trends. US-only true-cost accounting (Rockefeller 2021) finds ~$2.1 trillion/year in hidden costs on top of ~$1.1 trillion paid.",
+  description: "Hidden (external) costs of the global food and land-use system, ~$12 trillion/year, against a market value of ~$10 trillion (FOLU 'Growing Better' 2019; modeled by an advocacy coalition, widely cited). Comprises environmental, public-health, and poverty costs; projected to rise to $16.1 trillion by 2050 under current trends.",
   sourceType: "external",
   sourceRef: "folu-growing-better-2019",
   sourceUrl: "https://www.foodandlandusecoalition.org/wp-content/uploads/2019/09/FOLU-GrowingBetter-GlobalReport-SummaryReport.pdf",
@@ -16105,8 +16107,7 @@ export const citations: Record<string, Citation> = {
         title: "Environmental Costs of War",
         author: [
           {
-            family: "Watson Institute",
-            given: "Brown University"
+            literal: "Watson Institute, Brown University"
           },
         ],
         issued: { 'date-parts': [[2023]] },
@@ -16119,7 +16120,19 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Cassidy",
-            given: "Emily S. and West, Paul C. and Gerber, James S. and Foley, Jonathan A."
+            given: "Emily S."
+          },
+          {
+            family: "West",
+            given: "Paul C."
+          },
+          {
+            family: "Gerber",
+            given: "James S."
+          },
+          {
+            family: "Foley",
+            given: "Jonathan A."
           },
         ],
         issued: { 'date-parts': [[2013]] },
@@ -16257,7 +16270,19 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Williams",
-            given: "Rebecca J and Tse, Tony and DiPiazza, Katelyn and Zarin, Deborah A"
+            given: "Rebecca J"
+          },
+          {
+            family: "Tse",
+            given: "Tony"
+          },
+          {
+            family: "DiPiazza",
+            given: "Katelyn"
+          },
+          {
+            family: "Zarin",
+            given: "Deborah A"
           },
         ],
         issued: { 'date-parts': [[2015]] },
@@ -16338,7 +16363,11 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Barrios",
-            given: "Dagoberto and Sanz-Gracia, Fernando"
+            given: "Dagoberto"
+          },
+          {
+            family: "Sanz-Gracia",
+            given: "Fernando"
           },
         ],
         issued: { 'date-parts': [[2024]] },
@@ -16476,7 +16505,23 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Cook",
-            given: "Christopher and Cole, Graham and Asaria, Perviz and Jabbour, Richard and Francis, Darrel P."
+            given: "Christopher"
+          },
+          {
+            family: "Cole",
+            given: "Graham"
+          },
+          {
+            family: "Asaria",
+            given: "Perviz"
+          },
+          {
+            family: "Jabbour",
+            given: "Richard"
+          },
+          {
+            family: "Francis",
+            given: "Darrel P."
           },
         ],
         issued: { 'date-parts': [[2014]] },
@@ -16660,8 +16705,7 @@ export const citations: Record<string, Citation> = {
         title: "Environmental cost of war (\\$100B annually)",
         author: [
           {
-            family: "Costs of War Project",
-            given: "Brown University Watson Institute"
+            literal: "Costs of War Project, Brown University Watson Institute"
           },
         ],
         'container-title': "Brown Watson Costs of War: Environmental Cost",
@@ -16873,8 +16917,7 @@ export const citations: Record<string, Citation> = {
         title: "World Population Prospects 2024: Summary of Results",
         author: [
           {
-            family: "United Nations Department of Economic and Social Affairs",
-            given: "Population Division"
+            literal: "United Nations Department of Economic and Social Affairs, Population Division"
           },
         ],
         issued: { 'date-parts': [[2024]] },
@@ -17025,7 +17068,11 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Hsieh",
-            given: "Chang-Tai and Moretti, Enrico"
+            given: "Chang-Tai"
+          },
+          {
+            family: "Moretti",
+            given: "Enrico"
           },
         ],
         issued: { 'date-parts': [[2019]] },
@@ -17188,7 +17235,11 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Jones",
-            given: "Garett and Schneider, W. Joel"
+            given: "Garett"
+          },
+          {
+            family: "Schneider",
+            given: "W. Joel"
           },
         ],
         issued: { 'date-parts': [[2006]] },
@@ -17326,7 +17377,11 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Bolt",
-            given: "Jutta and van Zanden, Jan Luiten"
+            given: "Jutta"
+          },
+          {
+            family: "van Zanden",
+            given: "Jan Luiten"
           },
         ],
         issued: { 'date-parts': [[2020]] },
@@ -17339,7 +17394,15 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "McFarland",
-            given: "Michael J. and Hauer, Matt E. and Reuben, Aaron"
+            given: "Michael J."
+          },
+          {
+            family: "Hauer",
+            given: "Matt E."
+          },
+          {
+            family: "Reuben",
+            given: "Aaron"
           },
         ],
         issued: { 'date-parts': [[2022]] },
@@ -17543,8 +17606,7 @@ export const citations: Record<string, Citation> = {
         title: "Nuclear Winter Famine",
         author: [
           {
-            family: "Xia et al.",
-            given: "Nature Food"
+            literal: "Xia et al., Nature Food"
           },
         ],
         issued: { 'date-parts': [[2022]] },
@@ -17652,7 +17714,15 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Ritchie",
-            given: "Hannah and Rosado, Pablo and Roser, Max"
+            given: "Hannah"
+          },
+          {
+            family: "Rosado",
+            given: "Pablo"
+          },
+          {
+            family: "Roser",
+            given: "Max"
           },
         ],
         issued: { 'date-parts': [[2022]] },
@@ -17680,7 +17750,11 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Ritchie",
-            given: "Hannah and Roser, Max"
+            given: "Hannah"
+          },
+          {
+            family: "Roser",
+            given: "Max"
           },
         ],
         issued: { 'date-parts': [[2019]] },
@@ -17694,7 +17768,11 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Ritchie",
-            given: "Hannah and Roser, Max"
+            given: "Hannah"
+          },
+          {
+            family: "Roser",
+            given: "Max"
           },
         ],
         issued: { 'date-parts': [[2018]] },
@@ -17707,8 +17785,7 @@ export const citations: Record<string, Citation> = {
         title: "Reducing food's environmental impacts",
         author: [
           {
-            family: "University of Oxford",
-            given: "LEAP"
+            literal: "University of Oxford, LEAP"
           },
         ],
         issued: { 'date-parts': [[2018]] },
@@ -17721,8 +17798,7 @@ export const citations: Record<string, Citation> = {
         title: "Health Care Spending in the United States and Other High-Income Countries",
         author: [
           {
-            family: "Papanicolas",
-            given: "Irene et al."
+            literal: "Papanicolas, Irene et al."
           },
         ],
         issued: { 'date-parts': [[2018]] },
@@ -17817,7 +17893,11 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Ramsberg",
-            given: "J. and Platt, R."
+            given: "J."
+          },
+          {
+            family: "Platt",
+            given: "R."
           },
         ],
         issued: { 'date-parts': [[2018]] },
@@ -17861,7 +17941,11 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Poore",
-            given: "Joseph and Nemecek, Thomas"
+            given: "Joseph"
+          },
+          {
+            family: "Nemecek",
+            given: "Thomas"
           },
         ],
         issued: { 'date-parts': [[2018]] },
@@ -17876,7 +17960,11 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Kinch",
-            given: "Michael S. and Griesenauer, Robert H."
+            given: "Michael S."
+          },
+          {
+            family: "Griesenauer",
+            given: "Robert H."
           },
         ],
         issued: { 'date-parts': [[2019]] },
@@ -18015,8 +18103,7 @@ export const citations: Record<string, Citation> = {
         title: "RECOVERY Trial Cost per Patient",
         author: [
           {
-            family: "Oren Cass",
-            given: "Manhattan Institute"
+            literal: "Oren Cass, Manhattan Institute"
           },
         ],
         issued: { 'date-parts': [[2023]] },
@@ -18058,7 +18145,23 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Roozenbeek",
-            given: "Jon and van der Linden, Sander and Goldberg, Beth and Rathje, Steve and Lewandowsky, Stephan"
+            given: "Jon"
+          },
+          {
+            family: "van der Linden",
+            given: "Sander"
+          },
+          {
+            family: "Goldberg",
+            given: "Beth"
+          },
+          {
+            family: "Rathje",
+            given: "Steve"
+          },
+          {
+            family: "Lewandowsky",
+            given: "Stephan"
           },
         ],
         issued: { 'date-parts': [[2022]] },
@@ -18550,7 +18653,11 @@ export const citations: Record<string, Citation> = {
         author: [
           {
             family: "Wood",
-            given: "Thomas and Porter, Ethan"
+            given: "Thomas"
+          },
+          {
+            family: "Porter",
+            given: "Ethan"
           },
         ],
         issued: { 'date-parts': [[2019]] },
@@ -18630,8 +18737,7 @@ export const citations: Record<string, Citation> = {
         title: "US GDP 2024 (\\$28.78 trillion)",
         author: [
           {
-            family: "World Bank",
-            given: "Bureau of Economic Analysis"
+            literal: "World Bank, Bureau of Economic Analysis"
           },
         ],
         issued: { 'date-parts': [[2024]] },

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -6668,6 +6668,23 @@ describe("MCP server tool dispatch", () => {
           stopTrackingDate: null,
           userId: "user-1",
         },
+        {
+          active: true,
+          createdAt: new Date("2026-07-20T09:30:00.000Z"),
+          defaultValue: 1,
+          deletedAt: null,
+          globalVariable: TRACKING_VARIABLE,
+          globalVariableId: "gv-vitd",
+          id: "malformed-reminder",
+          instructions: "Invalid legacy interval",
+          nOf1Variable: NOF1_VARIABLE,
+          reminderEndTime: null,
+          reminderFrequency: -1,
+          reminderStartTime: "09:30",
+          startTrackingDate: new Date("2026-07-20T09:30:00.000Z"),
+          stopTrackingDate: null,
+          userId: "user-1",
+        },
       ]);
       mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
 

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -6649,6 +6649,82 @@ describe("MCP server tool dispatch", () => {
       expect(mocks.trackingReminderUpsert).not.toHaveBeenCalled();
     });
 
+    it("listDueTrackingReminders honors a 28-day reminder frequency", async () => {
+      mocks.trackingReminderFindMany.mockResolvedValue([
+        {
+          active: true,
+          createdAt: new Date("2026-07-20T09:30:00.000Z"),
+          defaultValue: 1,
+          deletedAt: null,
+          globalVariable: TRACKING_VARIABLE,
+          globalVariableId: "gv-vitd",
+          id: "reminder-1",
+          instructions: "Every four weeks",
+          nOf1Variable: NOF1_VARIABLE,
+          reminderEndTime: null,
+          reminderFrequency: 28 * 24 * 60 * 60,
+          reminderStartTime: "09:30",
+          startTrackingDate: new Date("2026-07-20T09:30:00.000Z"),
+          stopTrackingDate: null,
+          userId: "user-1",
+        },
+      ]);
+      mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const offDayResult = await client.callTool({
+        name: "listDueTrackingReminders",
+        arguments: { dateKey: "2026-08-16" },
+      });
+      const dueDayResult = await client.callTool({
+        name: "listDueTrackingReminders",
+        arguments: { dateKey: "2026-08-17" },
+      });
+
+      expect(offDayResult.isError).toBeFalsy();
+      expect(dueDayResult.isError).toBeFalsy();
+      expect(
+        (parseToolBody(offDayResult) as { reminders: unknown[] }).reminders,
+      ).toEqual([]);
+      expect(
+        (parseToolBody(dueDayResult) as { reminders: unknown[] }).reminders,
+      ).toHaveLength(1);
+    });
+
+    it("listDueTrackingReminders keeps daily reminders due", async () => {
+      mocks.trackingReminderFindMany.mockResolvedValue([
+        {
+          active: true,
+          createdAt: new Date("2026-07-20T09:00:00.000Z"),
+          defaultValue: 1,
+          deletedAt: null,
+          globalVariable: TRACKING_VARIABLE,
+          globalVariableId: "gv-vitd",
+          id: "reminder-1",
+          instructions: "Daily",
+          nOf1Variable: NOF1_VARIABLE,
+          reminderEndTime: null,
+          reminderFrequency: 24 * 60 * 60,
+          reminderStartTime: "09:00",
+          startTrackingDate: null,
+          stopTrackingDate: null,
+          userId: "user-1",
+        },
+      ]);
+      mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listDueTrackingReminders",
+        arguments: { dateKey: "2026-08-17" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(
+        (parseToolBody(result) as { reminders: unknown[] }).reminders,
+      ).toHaveLength(1);
+    });
+
     it("respondToTrackingReminder TRACKED records the notification and a Measurement via the same write path", async () => {
       mocks.trackingReminderFindFirst.mockResolvedValue({
         defaultValue: 3,

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -6708,6 +6708,45 @@ describe("MCP server tool dispatch", () => {
       ).toHaveLength(1);
     });
 
+    it("listDueTrackingReminders keeps local reminder time across DST", async () => {
+      mocks.userFindUnique.mockResolvedValue({
+        timeZone: "America/Chicago",
+      });
+      mocks.trackingReminderFindMany.mockResolvedValue([
+        {
+          active: true,
+          createdAt: new Date("2026-10-20T14:30:00.000Z"),
+          defaultValue: 1,
+          deletedAt: null,
+          globalVariable: TRACKING_VARIABLE,
+          globalVariableId: "gv-vitd",
+          id: "reminder-1",
+          instructions: "Every four weeks",
+          nOf1Variable: NOF1_VARIABLE,
+          reminderEndTime: null,
+          reminderFrequency: 28 * 24 * 60 * 60,
+          reminderStartTime: "09:30",
+          startTrackingDate: new Date("2026-10-20T14:30:00.000Z"),
+          stopTrackingDate: null,
+          userId: "user-1",
+        },
+      ]);
+      mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listDueTrackingReminders",
+        arguments: { dateKey: "2026-11-17" },
+      });
+      const body = parseToolBody(result) as {
+        reminders: Array<{ notifyAt: string }>;
+      };
+
+      expect(result.isError).toBeFalsy();
+      expect(body.reminders).toHaveLength(1);
+      expect(body.reminders[0]?.notifyAt).toBe("2026-11-17T15:30:00.000Z");
+    });
+
     it("listDueTrackingReminders keeps daily reminders due", async () => {
       mocks.trackingReminderFindMany.mockResolvedValue([
         {

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -106,6 +106,13 @@ import { normalizeTaskTextLineBreaks } from "./task-text";
 import { slugify } from "./slugify";
 import { IMAGE_UPLOAD_KINDS, isImageUploadKind } from "./image-upload-types";
 import { ensureSubjectForUser } from "./subject.server";
+import {
+  getStartOfZonedDayUtc,
+  getZonedDateKey,
+  getZonedDateTimeUtc,
+  parseDateKey as parseZonedDateKey,
+  shiftDateKey,
+} from "./time-zone";
 import type { RankableTask } from "./tasks/rank-tasks";
 import { resolveTaskVisibilityParam } from "./tasks/task-visibility-param";
 import { MCP_SERVER_INSTRUCTIONS } from "./mcp-instructions";
@@ -2508,30 +2515,40 @@ function parseOptionalTimeOfDay(value: unknown, fieldName: string) {
   return parseTimeOfDay(value, fieldName);
 }
 
-function parseDateKey(value: unknown, fallback = dateKeyFromDate(new Date())) {
+function parseDateKey(
+  value: unknown,
+  fallback = getZonedDateKey(new Date(), "UTC"),
+) {
   if (value == null || value === "") return fallback;
-  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value.trim())) {
+  if (typeof value !== "string" || !parseZonedDateKey(value.trim())) {
     throw new Error("dateKey must use YYYY-MM-DD.");
   }
   return value.trim();
 }
 
-function dateKeyFromDate(date: Date) {
-  return date.toISOString().slice(0, 10);
-}
-
-function dayRange(dateKey: string) {
-  const [year, month, day] = dateKey.split("-").map(Number);
+function dayRange(dateKey: string, timeZone: string) {
+  const startParts = parseZonedDateKey(dateKey);
+  const nextDateKey = shiftDateKey(dateKey, 1);
+  const endParts = nextDateKey ? parseZonedDateKey(nextDateKey) : null;
+  if (!startParts || !endParts) throw new Error("Invalid tracking date.");
   return {
-    end: new Date(Date.UTC(year, month - 1, day + 1, 0, 0, 0, 0)),
-    start: new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0)),
+    end: getStartOfZonedDayUtc(endParts, timeZone),
+    start: getStartOfZonedDayUtc(startParts, timeZone),
   };
 }
 
-function reminderNotifyAt(dateKey: string, reminderStartTime: string) {
-  const [year, month, day] = dateKey.split("-").map(Number);
+function reminderNotifyAt(
+  dateKey: string,
+  reminderStartTime: string,
+  timeZone: string,
+) {
+  const dateParts = parseZonedDateKey(dateKey);
+  if (!dateParts) throw new Error("Invalid tracking date.");
   const [hours, minutes] = reminderStartTime.split(":").map(Number);
-  return new Date(Date.UTC(year, month - 1, day, hours, minutes, 0, 0));
+  return getZonedDateTimeUtc(
+    { ...dateParts, hour: hours, minute: minutes, second: 0 },
+    timeZone,
+  );
 }
 
 function reminderOccursWithinRange(
@@ -2541,15 +2558,30 @@ function reminderOccursWithinRange(
     reminderStartTime: string;
     startTrackingDate: Date | null;
   },
-  range: { end: Date; start: Date },
+  range: { dateKey: string; end: Date; start: Date; timeZone: string },
 ) {
   const anchorDate = reminder.startTrackingDate ?? reminder.createdAt;
+  const anchorDateKey = getZonedDateKey(anchorDate, range.timeZone);
+  if (reminder.reminderFrequency <= 0) return false;
+
+  const frequencyDays = reminder.reminderFrequency / 86_400;
+  if (Number.isInteger(frequencyDays)) {
+    const anchorParts = parseZonedDateKey(anchorDateKey);
+    const targetParts = parseZonedDateKey(range.dateKey);
+    if (!anchorParts || !targetParts) return false;
+    const daysSinceAnchor =
+      (Date.UTC(targetParts.year, targetParts.month - 1, targetParts.day) -
+        Date.UTC(anchorParts.year, anchorParts.month - 1, anchorParts.day)) /
+      86_400_000;
+    return daysSinceAnchor >= 0 && daysSinceAnchor % frequencyDays === 0;
+  }
+
   const anchor = reminderNotifyAt(
-    dateKeyFromDate(anchorDate),
+    anchorDateKey,
     reminder.reminderStartTime,
+    range.timeZone,
   );
   if (range.end <= anchor) return false;
-  if (reminder.reminderFrequency <= 0) return false;
 
   const frequencyMilliseconds = reminder.reminderFrequency * 1_000;
   const firstOccurrenceIndex = Math.max(
@@ -2939,9 +2971,17 @@ async function listDueTrackingRemindersForUser(
   input: Record<string, unknown>,
   userId: string,
 ) {
-  const dateKey = parseDateKey(input.dateKey);
-  const { end, start } = dayRange(dateKey);
   const prisma = await getPrisma();
+  const user = await prisma.user.findUnique({
+    select: { timeZone: true },
+    where: { id: userId },
+  });
+  const timeZone = user?.timeZone ?? "UTC";
+  const dateKey = parseDateKey(
+    input.dateKey,
+    getZonedDateKey(new Date(), timeZone),
+  );
+  const { end, start } = dayRange(dateKey, timeZone);
   const reminders = await prisma.trackingReminder.findMany({
     include: TRACKING_REMINDER_INCLUDE,
     orderBy: [{ reminderStartTime: "asc" }],
@@ -2966,7 +3006,7 @@ async function listDueTrackingRemindersForUser(
     },
   });
   const dueReminders = reminders.filter((reminder) =>
-    reminderOccursWithinRange(reminder, { end, start }),
+    reminderOccursWithinRange(reminder, { dateKey, end, start, timeZone }),
   );
   if (dueReminders.length === 0) return { dateKey, reminders: [] };
 
@@ -3001,7 +3041,7 @@ async function listDueTrackingRemindersForUser(
         notification,
         notifyAt:
           notification?.notifyAt ??
-          reminderNotifyAt(dateKey, reminder.reminderStartTime),
+          reminderNotifyAt(dateKey, reminder.reminderStartTime, timeZone),
         reminderEndTime: reminder.reminderEndTime,
         reminderFrequency: reminder.reminderFrequency,
         reminderId: reminder.id,
@@ -3075,11 +3115,16 @@ async function respondToTrackingReminderForUser(
   const trackingReminderId = optionalString(input.trackingReminderId);
   if (!trackingReminderId) throw new Error("trackingReminderId is required.");
   const trackedAt = parseOptionalDateValue(input.trackedAt, "trackedAt");
+  const prisma = await getPrisma();
+  const user = await prisma.user.findUnique({
+    select: { timeZone: true },
+    where: { id: userId },
+  });
+  const timeZone = user?.timeZone ?? "UTC";
   const dateKey = parseDateKey(
     input.dateKey,
-    dateKeyFromDate(trackedAt ?? new Date()),
+    getZonedDateKey(trackedAt ?? new Date(), timeZone),
   );
-  const prisma = await getPrisma();
   return prisma.$transaction(async (tx) => {
     const reminder = await tx.trackingReminder.findFirst({
       include: TRACKING_REMINDER_INCLUDE,
@@ -3102,7 +3147,11 @@ async function respondToTrackingReminderForUser(
         "Provide value or configure defaultValue before marking this reminder TRACKED.",
       );
     }
-    const notifyAt = reminderNotifyAt(dateKey, reminder.reminderStartTime);
+    const notifyAt = reminderNotifyAt(
+      dateKey,
+      reminder.reminderStartTime,
+      timeZone,
+    );
     const notification = await findOrCreateTrackingNotification(tx, {
       notifyAt,
       status,

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -2534,6 +2534,35 @@ function reminderNotifyAt(dateKey: string, reminderStartTime: string) {
   return new Date(Date.UTC(year, month - 1, day, hours, minutes, 0, 0));
 }
 
+function reminderOccursWithinRange(
+  reminder: {
+    createdAt: Date;
+    reminderFrequency: number;
+    reminderStartTime: string;
+    startTrackingDate: Date | null;
+  },
+  range: { end: Date; start: Date },
+) {
+  const anchorDate = reminder.startTrackingDate ?? reminder.createdAt;
+  const anchor = reminderNotifyAt(
+    dateKeyFromDate(anchorDate),
+    reminder.reminderStartTime,
+  );
+  if (range.end <= anchor) return false;
+
+  const frequencyMilliseconds = reminder.reminderFrequency * 1_000;
+  const firstOccurrenceIndex = Math.max(
+    0,
+    Math.ceil(
+      (range.start.getTime() - anchor.getTime()) / frequencyMilliseconds,
+    ),
+  );
+  const firstOccurrence = new Date(
+    anchor.getTime() + firstOccurrenceIndex * frequencyMilliseconds,
+  );
+  return firstOccurrence < range.end;
+}
+
 function cleanNumber(value: number | null | undefined) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
@@ -2935,14 +2964,19 @@ async function listDueTrackingRemindersForUser(
       ],
     },
   });
-  if (reminders.length === 0) return { dateKey, reminders: [] };
+  const dueReminders = reminders.filter((reminder) =>
+    reminderOccursWithinRange(reminder, { end, start }),
+  );
+  if (dueReminders.length === 0) return { dateKey, reminders: [] };
 
   const notifications = await prisma.trackingReminderNotification.findMany({
     orderBy: [{ notifyAt: "asc" }],
     where: {
       deletedAt: null,
       notifyAt: { gte: start, lt: end },
-      trackingReminderId: { in: reminders.map((reminder) => reminder.id) },
+      trackingReminderId: {
+        in: dueReminders.map((reminder) => reminder.id),
+      },
       userId,
     },
   });
@@ -2952,7 +2986,7 @@ async function listDueTrackingRemindersForUser(
       notification,
     ]),
   );
-  const remindersWithStatus = reminders
+  const remindersWithStatus = dueReminders
     .map((reminder) => {
       // null = no notification recorded yet for this dateKey (reminder still pending), not an error.
       const existingNotification = byReminderId.get(reminder.id);

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -2549,6 +2549,7 @@ function reminderOccursWithinRange(
     reminder.reminderStartTime,
   );
   if (range.end <= anchor) return false;
+  if (reminder.reminderFrequency <= 0) return false;
 
   const frequencyMilliseconds = reminder.reminderFrequency * 1_000;
   const firstOccurrenceIndex = Math.max(

--- a/packages/web/src/lib/parameters/generated-parameter-catalog.test.ts
+++ b/packages/web/src/lib/parameters/generated-parameter-catalog.test.ts
@@ -125,7 +125,7 @@ describe("compileGeneratedParameterCatalog", () => {
     expect(first.catalogContentHash).toBe(second.catalogContentHash);
   });
 
-  it("compiles the complete copied manual catalog", async () => {
+  it("compiles the complete copied manual catalog without dropping entries", async () => {
     const catalog = await compileGeneratedParameterCatalog(
       parameters,
       citations,
@@ -139,14 +139,12 @@ describe("compileGeneratedParameterCatalog", () => {
       .map((parameter) => parameter.key)
       .sort();
 
-    expect(catalog.counts).toEqual({
-      total: 874,
-      calculated: 447,
-      withCalculationCode: 438,
-      snapshotCalculated: 9,
-      withDistribution: 312,
-    });
-    expect(Object.keys(catalog.citations)).toHaveLength(184);
+    expect(catalog.parameters.map(({ key }) => key).sort()).toEqual(
+      Object.keys(parameters).sort(),
+    );
+    expect(Object.keys(catalog.citations).sort()).toEqual(
+      Object.keys(citations).sort(),
+    );
     expect(snapshots).toEqual([
       "CURRENT_TRAJECTORY_CUMULATIVE_LIFETIME_INCOME",
       "DESTRUCTIVE_ECONOMY_25PCT_YEAR",

--- a/packages/web/src/lib/tasks/execution-planner-audit.test.ts
+++ b/packages/web/src/lib/tasks/execution-planner-audit.test.ts
@@ -76,8 +76,8 @@ describe("auditExecutionGraph", () => {
       tasks: [
         graphTask(OPTIMIZE_EARTH_ROOT_TASK_ID, null),
         graphTask("planning-root", OPTIMIZE_EARTH_ROOT_TASK_ID, {
-          executionEligible: false,
           hasMarginalEstimate: false,
+          requiresMarginalEstimate: false,
         }),
       ],
     });

--- a/packages/web/src/lib/tasks/execution-planner-audit.test.ts
+++ b/packages/web/src/lib/tasks/execution-planner-audit.test.ts
@@ -70,6 +70,25 @@ describe("auditExecutionGraph", () => {
     );
   });
 
+  it("does not demand estimates for non-executable planning containers", () => {
+    const findings = auditExecutionGraph({
+      edges: [],
+      tasks: [
+        graphTask(OPTIMIZE_EARTH_ROOT_TASK_ID, null),
+        graphTask("planning-root", OPTIMIZE_EARTH_ROOT_TASK_ID, {
+          executionEligible: false,
+          hasMarginalEstimate: false,
+        }),
+      ],
+    });
+
+    expect(
+      findings.filter(
+        (finding) => finding.code === "MISSING_MARGINAL_ESTIMATE",
+      ),
+    ).toEqual([]);
+  });
+
   it("gives unannotated value edges no inherited value and reports them", () => {
     const findings = auditExecutionGraph({
       edges: [

--- a/packages/web/src/lib/tasks/execution-planner-audit.ts
+++ b/packages/web/src/lib/tasks/execution-planner-audit.ts
@@ -2,7 +2,6 @@ export const OPTIMIZE_EARTH_ROOT_TASK_ID = "optimize-earth";
 
 export interface ExecutionGraphTask {
   activeChildTaskCount: number;
-  executionEligible?: boolean;
   estimatePublicationEligible?: boolean;
   estimateInputsStale?: boolean;
   hasMarginalEstimate: boolean;
@@ -10,6 +9,7 @@ export interface ExecutionGraphTask {
   parentTaskId: string | null;
   priority?: number | null;
   queueEligible?: boolean;
+  requiresMarginalEstimate?: boolean;
 }
 
 export interface ExecutionGraphEdge {
@@ -163,7 +163,7 @@ export function auditExecutionGraph(input: {
       });
     }
     if (
-      task.executionEligible !== false &&
+      task.requiresMarginalEstimate !== false &&
       task.activeChildTaskCount === 0 &&
       !task.hasMarginalEstimate
     ) {
@@ -175,7 +175,7 @@ export function auditExecutionGraph(input: {
       });
     }
     if (
-      task.executionEligible !== false &&
+      task.requiresMarginalEstimate !== false &&
       task.activeChildTaskCount === 0 &&
       task.hasMarginalEstimate &&
       task.estimatePublicationEligible === false

--- a/packages/web/src/lib/tasks/execution-planner-audit.ts
+++ b/packages/web/src/lib/tasks/execution-planner-audit.ts
@@ -2,6 +2,7 @@ export const OPTIMIZE_EARTH_ROOT_TASK_ID = "optimize-earth";
 
 export interface ExecutionGraphTask {
   activeChildTaskCount: number;
+  executionEligible?: boolean;
   estimatePublicationEligible?: boolean;
   estimateInputsStale?: boolean;
   hasMarginalEstimate: boolean;
@@ -161,7 +162,11 @@ export function auditExecutionGraph(input: {
         taskId: task.id,
       });
     }
-    if (task.activeChildTaskCount === 0 && !task.hasMarginalEstimate) {
+    if (
+      task.executionEligible !== false &&
+      task.activeChildTaskCount === 0 &&
+      !task.hasMarginalEstimate
+    ) {
       findings.push({
         code: "MISSING_MARGINAL_ESTIMATE",
         message: `Atomic task ${task.id} has no direct or explicitly edge-derived marginal estimate.`,
@@ -170,6 +175,7 @@ export function auditExecutionGraph(input: {
       });
     }
     if (
+      task.executionEligible !== false &&
       task.activeChildTaskCount === 0 &&
       task.hasMarginalEstimate &&
       task.estimatePublicationEligible === false

--- a/packages/web/src/lib/tasks/personal-planning.server.ts
+++ b/packages/web/src/lib/tasks/personal-planning.server.ts
@@ -6,6 +6,7 @@ import {
   TaskImpactPublicationStatus,
   TaskStatus,
 } from "@optimitron/db/enums";
+import { isReservedPlanningRootTask } from "@optimitron/db/task-keys";
 import {
   assessTaskCapability,
   type TaskCapabilityAssessment,
@@ -739,10 +740,10 @@ export async function loadExecutionGraphContext(
     graphTaskById.set(task.id, {
       activeChildTaskCount:
         task.activeChildTaskCount ?? task.childTasks?.length ?? 0,
-      executionEligible: isExecutableWorkItem(task),
       hasMarginalEstimate: hasRecordedMarginalEstimate(task),
       id: task.id,
       parentTaskId: task.parentTaskId ?? null,
+      requiresMarginalEstimate: !isReservedPlanningRootTask(task),
     });
   }
 
@@ -770,10 +771,10 @@ export async function loadExecutionGraphContext(
     for (const parent of storedParents) {
       graphTaskById.set(parent.id, {
         activeChildTaskCount: 0,
-        executionEligible: false,
         hasMarginalEstimate: false,
         id: parent.id,
         parentTaskId: parent.parentTaskId ?? null,
+        requiresMarginalEstimate: false,
       });
     }
     pendingParentIds = Array.from(

--- a/packages/web/src/lib/tasks/personal-planning.server.ts
+++ b/packages/web/src/lib/tasks/personal-planning.server.ts
@@ -739,6 +739,7 @@ export async function loadExecutionGraphContext(
     graphTaskById.set(task.id, {
       activeChildTaskCount:
         task.activeChildTaskCount ?? task.childTasks?.length ?? 0,
+      executionEligible: isExecutableWorkItem(task),
       hasMarginalEstimate: hasRecordedMarginalEstimate(task),
       id: task.id,
       parentTaskId: task.parentTaskId ?? null,
@@ -769,6 +770,7 @@ export async function loadExecutionGraphContext(
     for (const parent of storedParents) {
       graphTaskById.set(parent.id, {
         activeChildTaskCount: 0,
+        executionEligible: false,
         hasMarginalEstimate: false,
         id: parent.id,
         parentTaskId: parent.parentTaskId ?? null,


### PR DESCRIPTION
## Summary
- filter recurring tracking reminders by their anchored interval and ignore invalid non-positive frequencies
- resolve reminder dates and wall-clock times in the user's configured timezone, including across DST
- keep daily, 28-day, and DST behavior covered by focused MCP tests
- keep non-executable planning roots out of missing-impact audit findings
- refresh the generated manual parameter catalog with structured uncertainty and valid CSL contributors
- replace brittle catalog-size assertions with source-derived no-drop checks
- remove the duplicate project-level production MCP entry

## Source of truth
The generated parameter corrections come from mikepsinn/disease-eradication-plan#34. Merge that source PR before this consumer snapshot so future generation cannot overwrite the fixes.

## Verification
- `pnpm --filter @optimitron/web exec vitest run src/lib/__tests__/mcp-server.test.ts src/lib/tasks/execution-planner-audit.test.ts` (196 passed)
- `pnpm --filter @optimitron/web exec vitest run src/lib/parameters/generated-parameter-catalog.test.ts` (8 passed)
- `pnpm --filter @optimitron/data run build`
- `pnpm --filter @optimitron/web run typecheck:fast`
- real local stdio MCP against `postgresql://localhost:5432/optimitron`: retired 22 stale calendar-pilot rows, confirmed `Refill Taltz prescription` as the deadline-guarded next action, recorded the reported July 20 Taltz injection, and verified its August 17 reminder resolves to 09:00 America/Chicago

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added food-system metrics covering environmental impacts, health risks, livestock, land use, and hidden costs.
  - Expanded the parameter catalog with supporting research citations and metadata.

- **Bug Fixes**
  - Tracking reminders now respect each user’s local timezone, including daylight-saving transitions.
  - Improved support for daily and multi-week reminder schedules.
  - Planning audits now correctly distinguish executable tasks from structural planning items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->