### PR TITLE
Fix PR auto-update to catch behind PRs with pending checks

### DIFF
--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -35,13 +35,25 @@ jobs:
           # UNSTABLE/BLOCKED, which masks the behind-ness. Keying off the compare
           # API's behind_by catches every behind PR regardless of check/review
           # state — which is exactly the case a human ends up clicking by hand.
-          for row in $(gh pr list --repo "$REPO" --state open --base main \
-              --json number,headRefName,isDraft \
-              --jq '.[] | select(.isDraft | not) | "\(.number):\(.headRefName)"'); do
-            num="${row%%:*}"; head="${row#*:}"
-            behind=$(gh api "repos/$REPO/compare/main...$head" --jq '.behind_by' 2>/dev/null || echo "")
+          repo_owner="${REPO%%/*}"
+          if ! rows=$(gh pr list --repo "$REPO" --state open --base main \
+              --json number,headRefName,isDraft,headRepositoryOwner \
+              --jq '.[] | select(.isDraft | not) | "\(.number):\(.headRepositoryOwner.login):\(.headRefName)"'); then
+            echo "::error::gh pr list failed; aborting instead of silently treating a discovery outage as \"no PRs to update\""
+            exit 1
+          fi
+          for row in $rows; do
+            num="${row%%:*}"; rest="${row#*:}"; owner="${rest%%:*}"; head="${rest#*:}"
+            # Fork PR heads must be owner-qualified for the compare API; same-repo
+            # heads compare fine as bare branch names.
+            if [ "$owner" = "$repo_owner" ]; then
+              compare_head="$head"
+            else
+              compare_head="$owner:$head"
+            fi
+            behind=$(gh api "repos/$REPO/compare/main...$compare_head" --jq '.behind_by' 2>/dev/null || echo "")
             if [ -z "$behind" ]; then
-              echo "::warning::PR #$num compare failed (head $head)"; failed="$failed #$num"; continue
+              echo "::warning::PR #$num compare failed (head $compare_head)"; failed="$failed #$num"; continue
             fi
             if [ "$behind" -gt 0 ]; then
               if out=$(gh pr update-branch "$num" --repo "$REPO" 2>&1); then

--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -29,9 +29,21 @@ jobs:
         run: |
           set -u
           updated=""; skipped=""; failed=""
-          for num in $(gh pr list --repo "$REPO" --state open --base main --json number --jq '.[].number'); do
-            state=$(gh pr view "$num" --repo "$REPO" --json mergeStateStatus --jq .mergeStateStatus)
-            if [ "$state" = "BEHIND" ]; then
+          # Compute behind-ness directly instead of trusting mergeStateStatus.
+          # GitHub only reports mergeStateStatus=BEHIND when a PR is behind AND
+          # otherwise mergeable; a behind PR with pending checks reports as
+          # UNSTABLE/BLOCKED, which masks the behind-ness. Keying off the compare
+          # API's behind_by catches every behind PR regardless of check/review
+          # state — which is exactly the case a human ends up clicking by hand.
+          for row in $(gh pr list --repo "$REPO" --state open --base main \
+              --json number,headRefName,isDraft \
+              --jq '.[] | select(.isDraft | not) | "\(.number):\(.headRefName)"'); do
+            num="${row%%:*}"; head="${row#*:}"
+            behind=$(gh api "repos/$REPO/compare/main...$head" --jq '.behind_by' 2>/dev/null || echo "")
+            if [ -z "$behind" ]; then
+              echo "::warning::PR #$num compare failed (head $head)"; failed="$failed #$num"; continue
+            fi
+            if [ "$behind" -gt 0 ]; then
               if out=$(gh pr update-branch "$num" --repo "$REPO" 2>&1); then
                 updated="$updated #$num"
               else
@@ -40,7 +52,7 @@ jobs:
                 failed="$failed #$num"
               fi
             else
-              skipped="$skipped #$num($state)"
+              skipped="$skipped #$num(up-to-date)"
             fi
           done
           {


### PR DESCRIPTION
## Problem
`update-pr-branches.yml` is supposed to keep every open PR up to date with main so no one clicks "Update branch" by hand. But it only acted on PRs whose `mergeStateStatus == BEHIND`.

GitHub reports `BEHIND` **only** when a PR is behind main *and otherwise mergeable* (checks green, reviews satisfied, no conflicts). A behind PR with pending CI or unsatisfied reviews reports as `UNSTABLE`/`BLOCKED`, which masks the behind-ness. With ~20-minute CI plus bot reviewers, behind PRs are almost always non-clean right after a merge lands — so the workflow skipped exactly the PRs that a human then updates manually once checks settle.

## Fix
Compute behind-ness directly from the compare API (`behind_by > 0`) instead of trusting the composite status. Now any behind, non-draft, conflict-free PR is auto-updated regardless of its check/review state. Conflicted PRs still fail cleanly and are listed as "needs human" in the job summary.

## Notes
- Draft PRs are now explicitly skipped (they shouldn't be force-updated).
- Trigger unchanged (runs on every push to main). Takes effect once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of pull requests that are behind the main branch.
  * Prevented branch updates when comparison checks fail or branches are already up to date.
  * Enhanced job summaries to clearly record updated, skipped, and failed branch-update attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->