### PR TITLE
EOS landing Version C: the educational film

### DIFF
--- a/packages/web/src/app/design-c/page.tsx
+++ b/packages/web/src/app/design-c/page.tsx
@@ -1,0 +1,16 @@
+import { eosDesignCLink } from "@/lib/routes";
+import { getRouteMetadata } from "@/lib/metadata";
+import { DesignCPage } from "@/components/eos-design-c/DesignCPage";
+
+// Version C of the EOS landing page bake-off: "The Educational Film".
+// A new path so /eos and /eos-preview are untouched; Mike picks a winner
+// later. Metadata comes from the canonical route registry so a shared link
+// gets a self-canonical URL and its own social card, then forced noindex —
+// this is an unlisted design candidate, not a nav destination.
+export const metadata = getRouteMetadata(eosDesignCLink, {
+  robots: { index: false, follow: false },
+});
+
+export default function DesignCRoute() {
+  return <DesignCPage />;
+}

--- a/packages/web/src/components/eos-design-c/BillFinale.tsx
+++ b/packages/web/src/components/eos-design-c/BillFinale.tsx
@@ -1,0 +1,103 @@
+import {
+  GLOBAL_AVG_INCOME_2025,
+  POLITICAL_DYSFUNCTION_GLOBAL_OPPORTUNITY_COST_TOTAL,
+  POLITICAL_DYSFUNCTION_TAX_PER_HOUSEHOLD_OF_FOUR_ANNUAL,
+  POLITICAL_DYSFUNCTION_TAX_PER_PERSON_ANNUAL,
+  SINGAPORE_LIFE_EXPECTANCY,
+  US_LIFE_EXPECTANCY_2023,
+  WAR_COUNTERFACTUAL_GDP_PER_CAPITA,
+  WAR_COUNTERFACTUAL_INCOME_MULTIPLE,
+} from "@optimitron/data/parameters";
+import { ParameterValue } from "@/components/shared/ParameterValue";
+import { DeathTicker } from "@/components/eos-design-c/DeathTicker";
+
+const N = "dc-num";
+
+/** The Singapore gap, derived rather than typed. */
+const SINGAPORE_GAP_YEARS = Math.round(
+  SINGAPORE_LIFE_EXPECTANCY.value - US_LIFE_EXPECTANCY_2023.value,
+);
+
+/**
+ * The closing counts of Section 1: the last two charges, the Political
+ * Dysfunction Tax at full size, and the love line. Dark, dense, clinical,
+ * no ornament — the register the pivot is about to break.
+ */
+export function BillFinale() {
+  return (
+    <section className="dc-bill" id="the-bill">
+      <div className="dc-wrap">
+        <div className="dc-bill-top">
+          <p className="dc-slate dc-bill-slate">Section 1 · The Bill</p>
+          <DeathTicker />
+        </div>
+
+        <div className="dc-charge">
+          <p>
+            Singapore spends roughly a quarter of what the US spends per capita
+            on healthcare. Singaporeans live about{" "}
+            <ParameterValue
+              className={N}
+              param={SINGAPORE_LIFE_EXPECTANCY}
+              valueOverride={`${SINGAPORE_GAP_YEARS} years`}
+            />{" "}
+            longer. 193 countries, hundreds of years of policy data. The
+            experiments already ran. Nobody checked the results.
+          </p>
+          <p>
+            Had these governments been properly aligned to maximize health and
+            wealth since 1900, the average human would earn{" "}
+            <ParameterValue
+              className={N}
+              param={WAR_COUNTERFACTUAL_GDP_PER_CAPITA}
+            />{" "}
+            a year instead of{" "}
+            <ParameterValue className={N} param={GLOBAL_AVG_INCOME_2025} />. That
+            is{" "}
+            <ParameterValue
+              className={N}
+              param={WAR_COUNTERFACTUAL_INCOME_MULTIPLE}
+            />{" "}
+            times richer.
+          </p>
+        </div>
+
+        <div className="dc-giant">
+          <div className="dc-giant-value">
+            <ParameterValue
+              param={POLITICAL_DYSFUNCTION_GLOBAL_OPPORTUNITY_COST_TOTAL}
+              presentation="inline"
+            />
+            <span className="dc-per">/year</span>
+          </div>
+          <p className="dc-giant-cap">
+            <b>The Political Dysfunction Tax.</b> The annual cost of not
+            checking.{" "}
+            <ParameterValue
+              className={N}
+              param={POLITICAL_DYSFUNCTION_TAX_PER_PERSON_ANNUAL}
+            />{" "}
+            per person per year.{" "}
+            <ParameterValue
+              className={N}
+              param={POLITICAL_DYSFUNCTION_TAX_PER_HOUSEHOLD_OF_FOUR_ANNUAL}
+            />{" "}
+            per household of four.
+          </p>
+          <a className="dc-audit" href="/dysfunction-tax">
+            Read the full forensic audit →
+          </a>
+        </div>
+
+        <div className="dc-love">
+          <p>
+            I love you very much and I do not want you and everyone you have
+            ever loved to be slowly tortured and brutally murdered by horrible
+            diseases.
+          </p>
+          <p>That is why this store exists.</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/eos-design-c/BillFinale.tsx
+++ b/packages/web/src/components/eos-design-c/BillFinale.tsx
@@ -11,6 +11,10 @@ import {
 import { ParameterValue } from "@/components/shared/ParameterValue";
 import { DeathTicker } from "@/components/eos-design-c/DeathTicker";
 
+// Several money parameters carry a "USD/year" or "USD/person" unit, which the
+// formatter appends as "/year" or "/person". Where the spec's own sentence
+// already says "per person per year", the unit is narrowed to plain USD so the
+// page does not read "$12,600/year per person per year".
 const N = "dc-num";
 
 /** The Singapore gap, derived rather than typed. */
@@ -49,11 +53,11 @@ export function BillFinale() {
             wealth since 1900, the average human would earn{" "}
             <ParameterValue
               className={N}
-              param={WAR_COUNTERFACTUAL_GDP_PER_CAPITA}
+              param={{ ...WAR_COUNTERFACTUAL_GDP_PER_CAPITA, unit: "USD" }}
             />{" "}
             a year instead of{" "}
-            <ParameterValue className={N} param={GLOBAL_AVG_INCOME_2025} />. That
-            is{" "}
+            <ParameterValue className={N} param={GLOBAL_AVG_INCOME_2025} />.
+            That is{" "}
             <ParameterValue
               className={N}
               param={WAR_COUNTERFACTUAL_INCOME_MULTIPLE}
@@ -75,12 +79,18 @@ export function BillFinale() {
             checking.{" "}
             <ParameterValue
               className={N}
-              param={POLITICAL_DYSFUNCTION_TAX_PER_PERSON_ANNUAL}
+              param={{
+                ...POLITICAL_DYSFUNCTION_TAX_PER_PERSON_ANNUAL,
+                unit: "USD",
+              }}
             />{" "}
             per person per year.{" "}
             <ParameterValue
               className={N}
-              param={POLITICAL_DYSFUNCTION_TAX_PER_HOUSEHOLD_OF_FOUR_ANNUAL}
+              param={{
+                ...POLITICAL_DYSFUNCTION_TAX_PER_HOUSEHOLD_OF_FOUR_ANNUAL,
+                unit: "USD",
+              }}
             />{" "}
             per household of four.
           </p>

--- a/packages/web/src/components/eos-design-c/DcArrow.tsx
+++ b/packages/web/src/components/eos-design-c/DcArrow.tsx
@@ -1,0 +1,17 @@
+/**
+ * The connector between two nodes of a drawn flow. Points right on desktop;
+ * CSS rotates it down when the flow stacks at narrow widths.
+ */
+export function DcArrow({ className }: { className?: string }) {
+  return (
+    <span className={className ?? "dc-conn"} aria-hidden="true">
+      <svg viewBox="0 0 34 16" role="presentation">
+        <path
+          className="dc-draw"
+          d="M1 8 H25"
+          markerEnd="url(#dc-head)"
+        />
+      </svg>
+    </span>
+  );
+}

--- a/packages/web/src/components/eos-design-c/DcArrow.tsx
+++ b/packages/web/src/components/eos-design-c/DcArrow.tsx
@@ -1,6 +1,13 @@
 /**
  * The connector between two nodes of a drawn flow. Points right on desktop;
  * CSS rotates it down when the flow stacks at narrow widths.
+ *
+ * Two deliberate choices, both about the pencil filter. The shaft is a
+ * shallow curve rather than a straight line, because the filter is sized in
+ * objectBoundingBox units and a perfectly flat path has a zero-height box,
+ * which collapses the filter region and renders nothing. And the head is
+ * drawn into the path instead of referenced as a <marker>, because markers
+ * are dropped on filtered geometry.
  */
 export function DcArrow({ className }: { className?: string }) {
   return (
@@ -8,8 +15,7 @@ export function DcArrow({ className }: { className?: string }) {
       <svg viewBox="0 0 34 16" role="presentation">
         <path
           className="dc-draw"
-          d="M1 8 H25"
-          markerEnd="url(#dc-head)"
+          d="M2 9.6 C9 6.8 16 10.6 25.5 8 M20 3.6 L26.5 8 L20 12.4"
         />
       </svg>
     </span>

--- a/packages/web/src/components/eos-design-c/DcDefs.tsx
+++ b/packages/web/src/components/eos-design-c/DcDefs.tsx
@@ -1,7 +1,9 @@
 /**
  * One hidden SVG carrying the defs every drawing on the page reuses:
- * the pencil-wobble displacement filter and the arrowhead marker. Rendered
- * once at the top of the page so each figure stays markup-only.
+ * the pencil-wobble displacement filter. Rendered once at the top of the page
+ * so each figure stays markup-only. Arrowheads are drawn into their own
+ * paths rather than referenced as markers, because markers do not survive
+ * the filter.
  */
 export function DcDefs() {
   return (
@@ -28,16 +30,6 @@ export function DcDefs() {
             yChannelSelector="G"
           />
         </filter>
-        <marker
-          id="dc-head"
-          markerWidth="9"
-          markerHeight="9"
-          refX="7"
-          refY="4.5"
-          orient="auto"
-        >
-          <path d="M0.5 0.8 L8 4.5 L0.5 8.2" fill="none" stroke="#1d1a14" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-        </marker>
       </defs>
     </svg>
   );

--- a/packages/web/src/components/eos-design-c/DcDefs.tsx
+++ b/packages/web/src/components/eos-design-c/DcDefs.tsx
@@ -25,7 +25,7 @@ export function DcDefs() {
           <feDisplacementMap
             in="SourceGraphic"
             in2="dc-noise"
-            scale="1.8"
+            scale="1.25"
             xChannelSelector="R"
             yChannelSelector="G"
           />

--- a/packages/web/src/components/eos-design-c/DcDefs.tsx
+++ b/packages/web/src/components/eos-design-c/DcDefs.tsx
@@ -1,0 +1,44 @@
+/**
+ * One hidden SVG carrying the defs every drawing on the page reuses:
+ * the pencil-wobble displacement filter and the arrowhead marker. Rendered
+ * once at the top of the page so each figure stays markup-only.
+ */
+export function DcDefs() {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      style={{ position: "absolute", width: 0, height: 0, overflow: "hidden" }}
+    >
+      <defs>
+        {/* Displaces strokes just enough to read as hand-drawn chalk. */}
+        <filter id="dc-pencil" x="-8%" y="-8%" width="116%" height="116%">
+          <feTurbulence
+            type="fractalNoise"
+            baseFrequency="0.035"
+            numOctaves="3"
+            seed="7"
+            result="dc-noise"
+          />
+          <feDisplacementMap
+            in="SourceGraphic"
+            in2="dc-noise"
+            scale="1.8"
+            xChannelSelector="R"
+            yChannelSelector="G"
+          />
+        </filter>
+        <marker
+          id="dc-head"
+          markerWidth="9"
+          markerHeight="9"
+          refX="7"
+          refY="4.5"
+          orient="auto"
+        >
+          <path d="M0.5 0.8 L8 4.5 L0.5 8.2" fill="none" stroke="#1d1a14" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+        </marker>
+      </defs>
+    </svg>
+  );
+}

--- a/packages/web/src/components/eos-design-c/DeathTicker.tsx
+++ b/packages/web/src/components/eos-design-c/DeathTicker.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { GLOBAL_DISEASE_DEATHS_PER_MINUTE } from "@optimitron/data/parameters";
+
+const PER_SECOND = GLOBAL_DISEASE_DEATHS_PER_MINUTE.value / 60;
+
+/**
+ * Section 1's live counter. Small, corner-placed, ticking every second.
+ * Pauses while the tab is hidden (Page Visibility API) and reports the
+ * backlog when the visitor returns, so the number never lies about the
+ * time they were actually looking at it.
+ */
+export function DeathTicker() {
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [awaySeconds, setAwaySeconds] = useState(0);
+  const hiddenAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      if (document.visibilityState === "hidden") return;
+      setElapsedSeconds((prev) => prev + 1);
+    }, 1000);
+
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") {
+        hiddenAtRef.current = Date.now();
+        return;
+      }
+      const hiddenAt = hiddenAtRef.current;
+      hiddenAtRef.current = null;
+      if (hiddenAt === null) return;
+      setAwaySeconds(Math.round((Date.now() - hiddenAt) / 1000));
+    };
+
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.clearInterval(id);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  const died = Math.floor(elapsedSeconds * PER_SECOND);
+  const diedAway = Math.floor(awaySeconds * PER_SECOND);
+
+  return (
+    <p className="dc-ticker" aria-live="off">
+      <b>{died.toLocaleString("en-US")}</b> people died of curable diseases
+      while this page was open.
+      {diedAway > 0 ? (
+        <>
+          {" "}
+          <b>{diedAway.toLocaleString("en-US")}</b> more died while you were
+          away.
+        </>
+      ) : null}
+    </p>
+  );
+}

--- a/packages/web/src/components/eos-design-c/DeathTicker.tsx
+++ b/packages/web/src/components/eos-design-c/DeathTicker.tsx
@@ -1,47 +1,22 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { GLOBAL_DISEASE_DEATHS_PER_MINUTE } from "@optimitron/data/parameters";
-
-const PER_SECOND = GLOBAL_DISEASE_DEATHS_PER_MINUTE.value / 60;
+import { useDeathTick } from "@/hooks/useDeathTick";
 
 /**
  * Section 1's live counter. Small, corner-placed, ticking every second.
  * Pauses while the tab is hidden (Page Visibility API) and reports the
  * backlog when the visitor returns, so the number never lies about the
  * time they were actually looking at it.
+ *
+ * Uses the shared `useDeathTick` hook (elapsed real time via Date.now()
+ * deltas, not a naive per-callback increment) so the count stays accurate
+ * even when the interval is throttled by the browser.
  */
 export function DeathTicker() {
-  const [elapsedSeconds, setElapsedSeconds] = useState(0);
-  const [awaySeconds, setAwaySeconds] = useState(0);
-  const hiddenAtRef = useRef<number | null>(null);
+  const { open, away } = useDeathTick({ trackVisibility: true });
 
-  useEffect(() => {
-    const id = window.setInterval(() => {
-      if (document.visibilityState === "hidden") return;
-      setElapsedSeconds((prev) => prev + 1);
-    }, 1000);
-
-    const onVisibility = () => {
-      if (document.visibilityState === "hidden") {
-        hiddenAtRef.current = Date.now();
-        return;
-      }
-      const hiddenAt = hiddenAtRef.current;
-      hiddenAtRef.current = null;
-      if (hiddenAt === null) return;
-      setAwaySeconds(Math.round((Date.now() - hiddenAt) / 1000));
-    };
-
-    document.addEventListener("visibilitychange", onVisibility);
-    return () => {
-      window.clearInterval(id);
-      document.removeEventListener("visibilitychange", onVisibility);
-    };
-  }, []);
-
-  const died = Math.floor(elapsedSeconds * PER_SECOND);
-  const diedAway = Math.floor(awaySeconds * PER_SECOND);
+  const died = Math.floor(open);
+  const diedAway = Math.floor(away);
 
   return (
     <p className="dc-ticker" aria-live="off">

--- a/packages/web/src/components/eos-design-c/DesignCPage.tsx
+++ b/packages/web/src/components/eos-design-c/DesignCPage.tsx
@@ -1,18 +1,39 @@
 import "@/components/eos-design-c/design-c.css";
 
+import { BillFinale } from "@/components/eos-design-c/BillFinale";
+import { DcDefs } from "@/components/eos-design-c/DcDefs";
+import { MatrixFrame } from "@/components/eos-design-c/MatrixFrame";
+import { OptimitronFrame } from "@/components/eos-design-c/OptimitronFrame";
+import { PivotReel } from "@/components/eos-design-c/PivotReel";
+import { StoreFrame } from "@/components/eos-design-c/StoreFrame";
+
 /**
  * Version C of the EOS landing page: THE EDUCATIONAL FILM.
  *
  * A 1950s classroom filmstrip. Section 1 (The Bill) stays dark and airless;
  * everything after the pivot is cream paper, primary inks, and hand-drawn
  * diagrams. Concepts are drawn, not written: prose lives behind "read the
- * math" disclosure, and every screen leads with a number, a drawing, or a
- * demo. All copy is verbatim from knowledge/production/eos-landing-page.qmd.
+ * math" disclosure and every screen leads with a number, a drawing, or a
+ * demo. Copy is verbatim from knowledge/production/eos-landing-page.qmd;
+ * every figure renders through the ParameterValue pipeline.
+ *
+ * Scope: the end of Section 1 plus the pivot, Section 2, Section 4's first
+ * product, and Section 3 — the slice the three competing versions share.
  */
 export function DesignCPage() {
   return (
-    <main className="dc-root">
-      <p className="dc-scaffold">Version C — the educational film. Reel loading.</p>
+    <main className="dc">
+      <DcDefs />
+      <BillFinale />
+      <PivotReel />
+      <StoreFrame />
+      <OptimitronFrame />
+      <MatrixFrame />
+      <footer className="dc-end">
+        <p className="dc-slate">
+          End of reel · Sections 5 through 11 not yet filmed
+        </p>
+      </footer>
     </main>
   );
 }

--- a/packages/web/src/components/eos-design-c/DesignCPage.tsx
+++ b/packages/web/src/components/eos-design-c/DesignCPage.tsx
@@ -1,0 +1,18 @@
+import "@/components/eos-design-c/design-c.css";
+
+/**
+ * Version C of the EOS landing page: THE EDUCATIONAL FILM.
+ *
+ * A 1950s classroom filmstrip. Section 1 (The Bill) stays dark and airless;
+ * everything after the pivot is cream paper, primary inks, and hand-drawn
+ * diagrams. Concepts are drawn, not written: prose lives behind "read the
+ * math" disclosure, and every screen leads with a number, a drawing, or a
+ * demo. All copy is verbatim from knowledge/production/eos-landing-page.qmd.
+ */
+export function DesignCPage() {
+  return (
+    <main className="dc-root">
+      <p className="dc-scaffold">Version C — the educational film. Reel loading.</p>
+    </main>
+  );
+}

--- a/packages/web/src/components/eos-design-c/MatrixFrame.tsx
+++ b/packages/web/src/components/eos-design-c/MatrixFrame.tsx
@@ -1,0 +1,294 @@
+import type { ReactNode } from "react";
+import {
+  CROWD_DECISION_ACCURACY,
+  DFDA_QUEUE_CLEARANCE_YEARS,
+  EXPERT_DECISION_ACCURACY,
+  GOV_REPLACEMENT_SUITE_OPEX_PER_CITIZEN_ANNUAL,
+  MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO,
+  PENTAGON_UNACCOUNTED_FUNDS,
+  STATUS_QUO_QUEUE_CLEARANCE_YEARS,
+  US_GOV_WASTE_PER_CAPITA_ANNUAL,
+  US_GOV_WASTE_TAX_COMPLIANCE,
+  US_TOTAL_LOBBYING_ANNUAL,
+  WAR_DEATHS_SINCE_1900,
+} from "@optimitron/data/parameters";
+import { ParameterValue } from "@/components/shared/ParameterValue";
+
+const P = "dc-p";
+
+interface Row {
+  label: string;
+  gov: ReactNode;
+  eos: ReactNode;
+}
+
+/** Rows verbatim from the spec's SECTION 3 table. */
+const ROWS: Row[] = [
+  {
+    label: "People murdered",
+    gov: (
+      <>
+        <ParameterValue
+          className={P}
+          display="withUnit"
+          param={WAR_DEATHS_SINCE_1900}
+        />{" "}
+        since 1900
+      </>
+    ),
+    eos: <span className="dc-zero">0</span>,
+  },
+  {
+    label: "Money lost",
+    gov: (
+      <>
+        <ParameterValue className={P} param={PENTAGON_UNACCOUNTED_FUNDS} />{" "}
+        misplaced (7 failed audits)
+      </>
+    ),
+    eos: "Public ledger. Every dollar tracked live.",
+  },
+  {
+    label: "Tax code",
+    gov: (
+      <>
+        74,000 pages,{" "}
+        <ParameterValue className={P} param={US_GOV_WASTE_TAX_COMPLIANCE} />
+        /year compliance
+      </>
+    ),
+    eos: "6 lines of code. Filing cost: $0.",
+  },
+  {
+    label: "Welfare programs",
+    gov: "80+, each with its own forms, case workers, 45-day wait",
+    eos: "1 for-loop. Equal split. Tomorrow morning.",
+  },
+  {
+    label: "Decision method",
+    gov: "535 humans who haven't read the bill, funded by the industries the bill regulates",
+    eos: (
+      <>
+        <ParameterValue
+          className={P}
+          figures={2}
+          param={CROWD_DECISION_ACCURACY}
+        />{" "}
+        crowd accuracy vs{" "}
+        <ParameterValue
+          className={P}
+          figures={2}
+          param={EXPERT_DECISION_ACCURACY}
+        />{" "}
+        expert. Every question ships with evidence.
+      </>
+    ),
+  },
+  {
+    label: "Your input",
+    gov: "1 bundled vote every 2 years. Correlation with outcomes: 0%.",
+    eos: "20 specific questions/year. Pairwise comparisons. Evidence attached.",
+  },
+  {
+    label: "Corruption surface",
+    gov: (
+      <>
+        <ParameterValue
+          className={P}
+          figures={2}
+          param={US_TOTAL_LOBBYING_ANNUAL}
+        />
+        /year in lobbying buys your laws
+      </>
+    ),
+    eos: "No door. You cannot take 8 billion people to lunch.",
+  },
+  {
+    label: "Policy evidence used",
+    gov: "None. Drug war ran 50 years, overdoses up 1,700%, nobody checked.",
+    eos: "10,000 jurisdictions measured. Synthetic controls, diff-in-diff, regression discontinuity.",
+  },
+  {
+    label: "Disease queue",
+    gov: (
+      <>
+        <ParameterValue
+          className={P}
+          display="withUnit"
+          param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
+        />{" "}
+        at current rate
+      </>
+    ),
+    eos: (
+      <>
+        <ParameterValue
+          className={P}
+          display="withUnit"
+          param={DFDA_QUEUE_CLEARANCE_YEARS}
+        />{" "}
+        with 1% moved to clinical trials
+      </>
+    ),
+  },
+  {
+    label: "Time to notice you died",
+    gov: "Years (one week if you owed taxes)",
+    eos: "One day. The deposit stops.",
+  },
+  {
+    label: "Shuts down over disagreements",
+    gov: "20+ times since 1976",
+    eos: "There is no door",
+  },
+  {
+    label: "Audit record",
+    gov: "0 of 7 passed (Pentagon)",
+    eos: "Real-time public ledger, continuous",
+  },
+  {
+    label: "Budget allocation",
+    gov: (
+      <>
+        <ParameterValue
+          className={P}
+          display="withUnit"
+          param={MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO}
+        />{" "}
+        kill:cure ratio
+      </>
+    ),
+    eos: "Optimal budget calculated to maximize the two numbers",
+  },
+  {
+    label: "Sticker price",
+    gov: (
+      <>
+        <ParameterValue className={P} param={US_GOV_WASTE_PER_CAPITA_ANNUAL} />{" "}
+        per American per year
+      </>
+    ),
+    eos: (
+      <>
+        <ParameterValue
+          className={P}
+          param={GOV_REPLACEMENT_SUITE_OPEX_PER_CITIZEN_ANNUAL}
+        />{" "}
+        per citizen per year, plus dividends
+      </>
+    ),
+  },
+];
+
+/**
+ * Section 3 — The Competing Bid, drawn as the wall chart that used to hang
+ * beside the periodic table: two inked columns, hand-ruled rows, one drawn
+ * glyph per bidder. Stacks into labelled cards under 860px.
+ */
+export function MatrixFrame() {
+  return (
+    <section className="dc-frame" id="the-competing-bid">
+      <div className="dc-wrap">
+        <p className="dc-slate dc-frame-slate">
+          Section 3 · The Comparison Matrix
+        </p>
+        <h2 className="dc-h dc-frame-title">The Competing Bid</h2>
+        <p className="dc-frame-deck">
+          We tried to be diplomatic about this. Then we read the performance
+          review.
+        </p>
+
+        <div
+          aria-label="Your Government versus Earth Optimization Services"
+          className="dc-chart"
+          role="table"
+        >
+          <div className="dc-chart-head" role="row">
+            <div className="dc-chart-corner" role="columnheader" />
+            <div className="dc-chart-col dc-chart-col-gov" role="columnheader">
+              <DomeGlyph />
+              Your Government
+            </div>
+            <div className="dc-chart-col dc-chart-col-eos" role="columnheader">
+              <BurstGlyph />
+              Earth Optimization Services
+            </div>
+          </div>
+
+          {ROWS.map((row) => (
+            <div className="dc-chart-row" key={row.label} role="row">
+              <div className="dc-chart-label" role="rowheader">
+                {row.label}
+              </div>
+              <div className="dc-chart-cell dc-chart-gov" role="cell">
+                <span className="dc-chart-mob">Your Government</span>
+                {row.gov}
+              </div>
+              <div className="dc-chart-cell dc-chart-eos" role="cell">
+                <span className="dc-chart-mob">
+                  Earth Optimization Services
+                </span>
+                {row.eos}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/** The incumbent: a dome, drawn once. */
+function DomeGlyph() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="dc-chart-glyph"
+      role="presentation"
+      viewBox="0 0 32 32"
+    >
+      <g
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M5 27 H27" />
+        <path d="M8 27 V16" />
+        <path d="M16 27 V16" />
+        <path d="M24 27 V16" />
+        <path d="M6 16 A10 10 0 0 1 26 16" />
+        <path d="M16 6 V3" />
+      </g>
+    </svg>
+  );
+}
+
+/** The challenger: the same starburst that opens the reel. */
+function BurstGlyph() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="dc-chart-glyph"
+      role="presentation"
+      viewBox="0 0 32 32"
+    >
+      <g fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+        {Array.from({ length: 8 }, (_, i) => {
+          const a = (i * Math.PI * 2) / 8;
+          return (
+            <line
+              key={i}
+              x1={16 + Math.cos(a) * 6}
+              y1={16 + Math.sin(a) * 6}
+              x2={16 + Math.cos(a) * 14}
+              y2={16 + Math.sin(a) * 14}
+            />
+          );
+        })}
+      </g>
+      <circle cx="16" cy="16" fill="currentColor" r="4" />
+    </svg>
+  );
+}

--- a/packages/web/src/components/eos-design-c/MatrixFrame.tsx
+++ b/packages/web/src/components/eos-design-c/MatrixFrame.tsx
@@ -125,6 +125,7 @@ const ROWS: Row[] = [
         <ParameterValue
           className={P}
           display="withUnit"
+          figures={2}
           param={DFDA_QUEUE_CLEARANCE_YEARS}
         />{" "}
         with 1% moved to clinical trials
@@ -274,7 +275,12 @@ function BurstGlyph() {
       role="presentation"
       viewBox="0 0 32 32"
     >
-      <g fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+      <g
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+      >
         {Array.from({ length: 8 }, (_, i) => {
           const a = (i * Math.PI * 2) / 8;
           return (

--- a/packages/web/src/components/eos-design-c/OptimitronFrame.tsx
+++ b/packages/web/src/components/eos-design-c/OptimitronFrame.tsx
@@ -1,0 +1,388 @@
+import {
+  DFDA_QUEUE_CLEARANCE_YEARS,
+  DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_LIVES_SAVED,
+  DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_YEARS,
+  MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO,
+  POST_WW2_MILITARY_CUT_PCT,
+  STATUS_QUO_QUEUE_CLEARANCE_YEARS,
+  TREATY_ANNUAL_FUNDING,
+  US_1939_MILITARY_SPENDING_PCT_LOWER_THAN_CURRENT,
+} from "@optimitron/data/parameters";
+import { ParameterValue } from "@/components/shared/ParameterValue";
+import { DcArrow } from "@/components/eos-design-c/DcArrow";
+import { ReadTheMath } from "@/components/eos-design-c/ReadTheMath";
+import { TwoNumberDials } from "@/components/eos-design-c/TwoNumberDials";
+
+const P = "dc-p";
+
+/**
+ * Section 4, Product 1 — The Optimitron, taught rather than described.
+ * Left plate draws the Optimal Policy Generator as the sensor; right plate
+ * draws the Optimal Budget Generator as the target; the thermostat loop
+ * between them is the tagline made literal. The two dials are the demo.
+ * All prose verbatim from the spec; the long copy sits behind the
+ * disclosure.
+ *
+ * Naming note: the spec's own "What is not on this page" list bans the
+ * "Evidence Engine" label, so the card is titled The Optimitron only.
+ */
+export function OptimitronFrame() {
+  return (
+    <section className="dc-frame dc-frame-lit" id="the-optimitron">
+      <div className="dc-wrap">
+        <p className="dc-slate dc-frame-slate">
+          Section 4 · Product 1 · The Standard Package
+        </p>
+        <h2 className="dc-h dc-frame-title">The Optimitron</h2>
+        <p className="dc-frame-deck">
+          The thermostat your government never installed.
+        </p>
+
+        <div className="dc-price">
+          <div className="dc-price-cell">
+            <span className="dc-slate dc-price-k">Replaces</span>
+            <p className="dc-price-v">Governing by argument.</p>
+          </div>
+          <div className="dc-price-cell">
+            <span className="dc-slate dc-price-k">Retail price</span>
+            <p className="dc-price-v">Included. The data is free.</p>
+          </div>
+          <div className="dc-price-cell">
+            <span className="dc-slate dc-price-k">Currently paying</span>
+            <p className="dc-price-v">
+              Whatever your representatives&apos; donors feel like.
+            </p>
+          </div>
+        </div>
+
+        {/* ── The two generators, drawn ─────────────────────────────── */}
+        <div className="dc-panels">
+          <div className="dc-plate">
+            <span className="dc-slate dc-plate-cap">
+              <b>Fig. 4</b> — The sensor
+            </span>
+            <h3 className="dc-h dc-panel-h">
+              Optimal Policy Generator <span>OPG</span>
+            </h3>
+            <svg
+              aria-hidden="true"
+              className="dc-fig"
+              role="presentation"
+              viewBox="0 0 340 240"
+            >
+              <g className="dc-draw">
+                {/* the 10,000 jurisdictions, sampled as a scatter */}
+                {Array.from({ length: 28 }, (_, i) => {
+                  const col = i % 7;
+                  const row = Math.floor(i / 7);
+                  return (
+                    <circle
+                      key={i}
+                      cx={44 + col * 36}
+                      cy={30 + row * 17}
+                      r={4.5}
+                    />
+                  );
+                })}
+                {/* the funnel: counting, not arguing */}
+                <path d="M40 108 L300 108 L206 158 L134 158 Z" />
+                <path d="M170 158 V186" markerEnd="url(#dc-head)" />
+              </g>
+              <text className="dc-lab" x="40" y="18">
+                10,000 jurisdictions
+              </text>
+              <text className="dc-lab" x="170" y="136" textAnchor="middle">
+                Counting
+              </text>
+              <g className="dc-draw">
+                <rect x="10" y="192" width="74" height="34" />
+                <rect x="92" y="192" width="74" height="34" />
+                <rect x="174" y="192" width="74" height="34" />
+                <rect x="256" y="192" width="74" height="34" />
+              </g>
+              <text className="dc-lab" x="47" y="213" textAnchor="middle">
+                Enact
+              </text>
+              <text className="dc-lab" x="129" y="213" textAnchor="middle">
+                Replace
+              </text>
+              <text className="dc-lab" x="211" y="213" textAnchor="middle">
+                Repeal
+              </text>
+              <text className="dc-lab" x="293" y="213" textAnchor="middle">
+                Maintain
+              </text>
+            </svg>
+            <p className="dc-narr">
+              Synthetic controls, difference-in-differences, regression
+              discontinuity. Not opinion. Not ideology. Measurement.
+            </p>
+          </div>
+
+          <div className="dc-plate">
+            <span className="dc-slate dc-plate-cap">
+              <b>Fig. 5</b> — The target
+            </span>
+            <h3 className="dc-h dc-panel-h">
+              Optimal Budget Generator <span>OBG</span>
+            </h3>
+            <svg
+              aria-hidden="true"
+              className="dc-fig"
+              role="presentation"
+              viewBox="0 0 340 240"
+            >
+              {/* the weapons budget, with the one percent sliced off */}
+              <rect x="20" y="34" width="290" height="46" fill="#a9aea6" />
+              <rect x="20" y="34" width="14" height="46" fill="#e0523a" />
+              <g className="dc-draw">
+                <rect x="20" y="34" width="290" height="46" />
+                <path d="M27 92 C40 140 120 150 150 168" markerEnd="url(#dc-head)" />
+              </g>
+              <text className="dc-lab" x="20" y="26">
+                Every nation&apos;s weapons budget
+              </text>
+              <text className="dc-lab-sm" x="20" y="98">
+                1%
+              </text>
+              {/* the beaker it lands in */}
+              <g className="dc-draw">
+                <path d="M168 158 H236 L236 176 L268 226 H136 L168 176 Z" />
+              </g>
+              <rect x="150" y="206" width="104" height="20" fill="#0e9aa0" />
+              <g className="dc-draw">
+                <path d="M136 226 H268" />
+              </g>
+              <text className="dc-lab" x="202" y="150" textAnchor="middle">
+                Clinical trials
+              </text>
+              <text className="dc-lab-big" x="202" y="196" textAnchor="middle">
+                1%
+              </text>
+            </svg>
+            <p className="dc-narr">
+              Everyone cuts equally. Nobody is easier to invade. That one
+              percent is{" "}
+              <ParameterValue className={P} param={TREATY_ANNUAL_FUNDING} />
+              /year in trials.
+            </p>
+          </div>
+        </div>
+
+        {/* ── The thermostat loop, literal ──────────────────────────── */}
+        <div className="dc-plate">
+          <span className="dc-slate dc-plate-cap">
+            <b>Fig. 6</b> — Why it is a thermostat
+          </span>
+          <div className="dc-flow">
+            <div className="dc-node dc-node-start">Set the two numbers</div>
+            <DcArrow />
+            <div className="dc-node">Budget and policy change</div>
+            <DcArrow />
+            <div className="dc-node">The planet</div>
+            <DcArrow />
+            <div className="dc-node">Measure what happened</div>
+            <DcArrow />
+            <div className="dc-node dc-node-out">Adjust, then repeat</div>
+          </div>
+        </div>
+
+        {/* ── The demo: the two numbers ─────────────────────────────── */}
+        <div className="dc-plate">
+          <span className="dc-slate dc-plate-cap">
+            <b>Fig. 7</b> — The two numbers, live
+          </span>
+          <TwoNumberDials />
+        </div>
+
+        {/* ── The comparator ────────────────────────────────────────── */}
+        <div className="dc-plate">
+          <span className="dc-slate dc-plate-cap">
+            <b>Fig. 8</b> — Four policies, before and after
+          </span>
+          <div className="dc-comp">
+            <ComparatorRow
+              after="6 lines. Filing cost per citizen: $0."
+              before="74,000 pages. Filing cost per citizen: $1,200."
+              name="Tax code"
+            />
+            <ComparatorRow
+              after="Pragmatic trials, 90% cost reduction. 200+ approvals/year."
+              before="14 years, $2.6 billion per drug. 50 approvals/year."
+              name="Drug approval"
+            />
+            <ComparatorRow
+              after="Single universal deposit, automatic."
+              before="80+ programs, 95,000 administrators."
+              name="Welfare"
+            />
+            <ComparatorRow
+              after={
+                <>
+                  1% Treaty funds{" "}
+                  <ParameterValue className={P} param={TREATY_ANNUAL_FUNDING} />
+                  /year in trials.
+                </>
+              }
+              before={
+                <>
+                  <ParameterValue
+                    className={P}
+                    display="withUnit"
+                    param={MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO}
+                  />{" "}
+                  kill:cure ratio.
+                </>
+              }
+              name="Clinical trials"
+            />
+          </div>
+        </div>
+
+        {/* ── The headline drop ─────────────────────────────────────── */}
+        <div className="dc-drop">
+          <div className="dc-drop-cell">
+            <span className="dc-slate dc-drop-k">
+              Disease eradication, today
+            </span>
+            <div className="dc-drop-v">
+              <ParameterValue
+                className={P}
+                display="withUnit"
+                param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
+                presentation="inline"
+              />
+            </div>
+          </div>
+          <div className="dc-drop-mid">
+            <DcArrow />
+          </div>
+          <div className="dc-drop-cell dc-drop-cell-good">
+            <span className="dc-slate dc-drop-k">With 1% moved to trials</span>
+            <div className="dc-drop-v">
+              <ParameterValue
+                className={P}
+                display="withUnit"
+                param={DFDA_QUEUE_CLEARANCE_YEARS}
+                presentation="inline"
+              />
+            </div>
+          </div>
+        </div>
+
+        <p className="dc-narr" style={{ marginTop: "1rem" }}>
+          The average treatment arrives{" "}
+          <ParameterValue
+            className={P}
+            display="withUnit"
+            param={DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_YEARS}
+          />{" "}
+          sooner.{" "}
+          <ParameterValue
+            className={P}
+            param={DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_LIVES_SAVED}
+          />{" "}
+          people who would have died do not.
+        </p>
+
+        <ReadTheMath>
+          <p>
+            Your planet has 10,000 jurisdictions, each trying slightly different
+            policies. Some produce healthy, wealthy citizens. Others produce the
+            opposite. Right now, you determine which is which by having
+            politicians argue on television. The Optimal Policy Generator
+            replaces the arguing with counting.
+          </p>
+          <p>
+            It examines what every jurisdiction tried and what happened next.
+            Synthetic controls, difference-in-differences, regression
+            discontinuity. Not opinion. Not ideology. Measurement. Output: ENACT
+            / REPLACE / REPEAL / MAINTAIN. Each recommendation scored on the two
+            numbers.
+          </p>
+          <p>
+            Its current highest-expected-value recommendation is the 1% Treaty:
+            move 1% of every nation&apos;s weapons budget to clinical trials.
+            Everyone cuts equally. Nobody is easier to invade. Disease
+            eradication goes from{" "}
+            <ParameterValue
+              className={P}
+              display="withUnit"
+              param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
+            />{" "}
+            to{" "}
+            <ParameterValue
+              className={P}
+              display="withUnit"
+              param={DFDA_QUEUE_CLEARANCE_YEARS}
+            />
+            . The average treatment arrives{" "}
+            <ParameterValue
+              className={P}
+              display="withUnit"
+              param={DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_YEARS}
+            />{" "}
+            sooner.{" "}
+            <ParameterValue
+              className={P}
+              param={DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_LIVES_SAVED}
+            />{" "}
+            people who would have died do not.
+          </p>
+          <p>
+            Your governments have signed treaties banning chemical weapons (193
+            countries), biological weapons (187), and landmines (164). This one
+            asks them to buy 1% fewer weapons and spend the savings on figuring
+            out why everyone keeps dying. Pre-WW2 military spending was{" "}
+            <ParameterValue
+              className={P}
+              param={US_1939_MILITARY_SPENDING_PCT_LOWER_THAN_CURRENT}
+            />{" "}
+            lower than today, inflation-adjusted. They still won World War II.
+            Then they cut spending{" "}
+            <ParameterValue className={P} param={POST_WW2_MILITARY_CUT_PCT} /> in
+            two years and walked into the greatest economic expansion in
+            history. One percent should be manageable.
+          </p>
+        </ReadTheMath>
+
+        <blockquote className="dc-testi">
+          <p>
+            &ldquo;We spent 4,000 years debating education policy. The Optimal
+            Policy Generator resolved it in an afternoon. Our main regret is the
+            4,000 years.&rdquo;
+          </p>
+          <cite>Planet Keth-7, client since 8,000 BCE</cite>
+        </blockquote>
+      </div>
+    </section>
+  );
+}
+
+function ComparatorRow({
+  after,
+  before,
+  name,
+}: {
+  after: React.ReactNode;
+  before: React.ReactNode;
+  name: string;
+}) {
+  return (
+    <div className="dc-comp-row">
+      <div className="dc-comp-name">{name}</div>
+      <div className="dc-comp-swap">
+        <span className="dc-before">{before}</span>
+        <svg
+          aria-hidden="true"
+          className="dc-arrow"
+          role="presentation"
+          viewBox="0 0 34 12"
+        >
+          <path className="dc-draw" d="M1 6 H25" markerEnd="url(#dc-head)" />
+        </svg>
+        <span className="dc-after">{after}</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/eos-design-c/OptimitronFrame.tsx
+++ b/packages/web/src/components/eos-design-c/OptimitronFrame.tsx
@@ -137,12 +137,12 @@ export function OptimitronFrame() {
               <rect x="20" y="34" width="14" height="46" fill="#e0523a" />
               <g className="dc-draw">
                 <rect x="20" y="34" width="290" height="46" />
-                <path d="M27 92 C40 140 120 150 152 168 M139 158 L154 169 L136 172" />
+                <path d="M27 112 C44 148 120 152 152 168 M139 158 L154 169 L136 172" />
               </g>
               <text className="dc-lab" x="20" y="26">
                 Every nation&apos;s weapons budget
               </text>
-              <text className="dc-lab-sm" x="20" y="98">
+              <text className="dc-lab" x="20" y="104">
                 1%
               </text>
               {/* the beaker it lands in, with the one percent settled in it */}
@@ -160,7 +160,10 @@ export function OptimitronFrame() {
             <p className="dc-narr">
               Everyone cuts equally. Nobody is easier to invade. That one
               percent is{" "}
-              <ParameterValue className={P} param={TREATY_ANNUAL_FUNDING} />
+              <ParameterValue
+                className={P}
+                param={{ ...TREATY_ANNUAL_FUNDING, unit: "USD" }}
+              />
               /year in trials.
             </p>
           </div>
@@ -217,7 +220,10 @@ export function OptimitronFrame() {
               after={
                 <>
                   1% Treaty funds{" "}
-                  <ParameterValue className={P} param={TREATY_ANNUAL_FUNDING} />
+                  <ParameterValue
+                    className={P}
+                    param={{ ...TREATY_ANNUAL_FUNDING, unit: "USD" }}
+                  />
                   /year in trials.
                 </>
               }
@@ -226,7 +232,9 @@ export function OptimitronFrame() {
                   <ParameterValue
                     className={P}
                     display="withUnit"
-                    param={MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO}
+                    param={
+                      MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO
+                    }
                   />{" "}
                   kill:cure ratio.
                 </>
@@ -260,6 +268,7 @@ export function OptimitronFrame() {
               <ParameterValue
                 className={P}
                 display="withUnit"
+                figures={2}
                 param={DFDA_QUEUE_CLEARANCE_YEARS}
                 presentation="inline"
               />
@@ -311,6 +320,7 @@ export function OptimitronFrame() {
             <ParameterValue
               className={P}
               display="withUnit"
+              figures={2}
               param={DFDA_QUEUE_CLEARANCE_YEARS}
             />
             . The average treatment arrives{" "}
@@ -337,8 +347,8 @@ export function OptimitronFrame() {
             />{" "}
             lower than today, inflation-adjusted. They still won World War II.
             Then they cut spending{" "}
-            <ParameterValue className={P} param={POST_WW2_MILITARY_CUT_PCT} /> in
-            two years and walked into the greatest economic expansion in
+            <ParameterValue className={P} param={POST_WW2_MILITARY_CUT_PCT} />{" "}
+            in two years and walked into the greatest economic expansion in
             history. One percent should be manageable.
           </p>
         </ReadTheMath>

--- a/packages/web/src/components/eos-design-c/OptimitronFrame.tsx
+++ b/packages/web/src/components/eos-design-c/OptimitronFrame.tsx
@@ -86,7 +86,7 @@ export function OptimitronFrame() {
                 })}
                 {/* the funnel: counting, not arguing */}
                 <path d="M40 108 L300 108 L206 158 L134 158 Z" />
-                <path d="M170 158 V186" markerEnd="url(#dc-head)" />
+                <path d="M170 158 V184 M164 178 L170 186 L176 178" />
               </g>
               <text className="dc-lab" x="40" y="18">
                 10,000 jurisdictions
@@ -137,7 +137,7 @@ export function OptimitronFrame() {
               <rect x="20" y="34" width="14" height="46" fill="#e0523a" />
               <g className="dc-draw">
                 <rect x="20" y="34" width="290" height="46" />
-                <path d="M27 92 C40 140 120 150 150 168" markerEnd="url(#dc-head)" />
+                <path d="M27 92 C40 140 120 150 152 168 M139 158 L154 169 L136 172" />
               </g>
               <text className="dc-lab" x="20" y="26">
                 Every nation&apos;s weapons budget
@@ -145,18 +145,15 @@ export function OptimitronFrame() {
               <text className="dc-lab-sm" x="20" y="98">
                 1%
               </text>
-              {/* the beaker it lands in */}
+              {/* the beaker it lands in, with the one percent settled in it */}
+              <rect x="150" y="206" width="104" height="19" fill="#0e9aa0" />
               <g className="dc-draw">
                 <path d="M168 158 H236 L236 176 L268 226 H136 L168 176 Z" />
-              </g>
-              <rect x="150" y="206" width="104" height="20" fill="#0e9aa0" />
-              <g className="dc-draw">
-                <path d="M136 226 H268" />
               </g>
               <text className="dc-lab" x="202" y="150" textAnchor="middle">
                 Clinical trials
               </text>
-              <text className="dc-lab-big" x="202" y="196" textAnchor="middle">
+              <text className="dc-lab-big" x="202" y="200" textAnchor="middle">
                 1%
               </text>
             </svg>
@@ -379,7 +376,10 @@ function ComparatorRow({
           role="presentation"
           viewBox="0 0 34 12"
         >
-          <path className="dc-draw" d="M1 6 H25" markerEnd="url(#dc-head)" />
+          <path
+            className="dc-draw"
+            d="M2 7.6 C9 4.8 16 8.6 25.5 6 M20 1.8 L26.5 6 L20 10.2"
+          />
         </svg>
         <span className="dc-after">{after}</span>
       </div>

--- a/packages/web/src/components/eos-design-c/PivotReel.tsx
+++ b/packages/web/src/components/eos-design-c/PivotReel.tsx
@@ -1,0 +1,90 @@
+/**
+ * The pivot. Register 1 ends on a black Academy leader — countdown circle,
+ * crosshair, sweeping hand — and the question is asked in the dark. The
+ * answer is on the other side, in the light: cream paper, projector beam,
+ * type at full brochure size. Walking out of a courtroom into 1962.
+ *
+ * Both lines are verbatim from the spec's Transition block.
+ */
+export function PivotReel() {
+  return (
+    <>
+      <div className="dc-pivot-dark">
+        <svg
+          aria-hidden="true"
+          className="dc-leader"
+          role="presentation"
+          viewBox="0 0 200 200"
+        >
+          <g
+            fill="none"
+            stroke="#f2f2ef"
+            strokeWidth="2"
+            strokeLinecap="round"
+            opacity="0.85"
+          >
+            <circle cx="100" cy="100" r="92" />
+            <circle cx="100" cy="100" r="66" />
+            <line x1="100" y1="2" x2="100" y2="198" />
+            <line x1="2" y1="100" x2="198" y2="100" />
+          </g>
+          <path
+            className="dc-leader-sweep"
+            d="M100 100 L100 8 A92 92 0 0 1 165 35 Z"
+            fill="#e0523a"
+            opacity="0.55"
+          />
+          <text
+            fill="#f2f2ef"
+            fontFamily="var(--v0-font-dm-sans), sans-serif"
+            fontSize="86"
+            fontWeight="900"
+            textAnchor="middle"
+            x="100"
+            y="132"
+          >
+            3
+          </text>
+        </svg>
+
+        <p className="dc-pivot-q">
+          Has your species developed nuclear weapons, antibiotics, and the
+          internet, and then pointed two of those three at each other?
+        </p>
+      </div>
+
+      <section className="dc-pivot-light" id="the-pivot">
+        <span className="dc-beam" aria-hidden="true" />
+        <svg
+          aria-hidden="true"
+          className="dc-burst"
+          role="presentation"
+          viewBox="0 0 100 100"
+        >
+          <g stroke="#edaf22" strokeWidth="5" strokeLinecap="round" fill="none">
+            {Array.from({ length: 12 }, (_, i) => {
+              const a = (i * Math.PI * 2) / 12;
+              const inner = i % 2 === 0 ? 20 : 26;
+              const outer = i % 2 === 0 ? 46 : 36;
+              return (
+                <line
+                  key={i}
+                  x1={50 + Math.cos(a) * inner}
+                  y1={50 + Math.sin(a) * inner}
+                  x2={50 + Math.cos(a) * outer}
+                  y2={50 + Math.sin(a) * outer}
+                />
+              );
+            })}
+          </g>
+          <circle cx="50" cy="50" r="13" fill="#e0523a" />
+        </svg>
+
+        <h1 className="dc-h dc-pivot-a">
+          You may be <em>eligible</em> for optimization.
+        </h1>
+        <p className="dc-slate dc-pivot-sub">Earth Optimization Services</p>
+      </section>
+    </>
+  );
+}

--- a/packages/web/src/components/eos-design-c/ReadTheMath.tsx
+++ b/packages/web/src/components/eos-design-c/ReadTheMath.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+/**
+ * Every screen leads with a number, a drawing, or a demo. The prose that
+ * justifies it goes in here. Native <details> so it works without JS and
+ * stays keyboard-navigable.
+ */
+export function ReadTheMath({
+  label = "Read the math",
+  children,
+}: {
+  label?: string;
+  children: ReactNode;
+}) {
+  return (
+    <details className="dc-math">
+      <summary className="dc-slate">{label}</summary>
+      <div className="dc-math-body">{children}</div>
+    </details>
+  );
+}

--- a/packages/web/src/components/eos-design-c/StoreFrame.tsx
+++ b/packages/web/src/components/eos-design-c/StoreFrame.tsx
@@ -1,0 +1,154 @@
+import { DcArrow } from "@/components/eos-design-c/DcArrow";
+import { ReadTheMath } from "@/components/eos-design-c/ReadTheMath";
+
+/**
+ * Section 2 — The Store. The pitchman is already talking, so the screen
+ * leads with the mechanism drawn as FIG. 1 and lets the narrator's lines
+ * sit beside the illustrations. The 100-word definition of the company is
+ * the only long paragraph, and it lives behind the disclosure.
+ *
+ * All prose verbatim from the spec's SECTION 2 copy block.
+ */
+export function StoreFrame() {
+  return (
+    <section className="dc-frame" id="the-store">
+      <div className="dc-wrap">
+        <p className="dc-slate dc-frame-slate">Section 2 · The Store</p>
+        <h2 className="dc-h dc-frame-title">The Store</h2>
+        <p className="dc-frame-deck">
+          Earth Optimization Services is our regional branch. Same proven
+          technology. Smaller market. More shouting.
+        </p>
+
+        <div className="dc-plate">
+          <span className="dc-slate dc-plate-cap">
+            <b>Fig. 1</b> — What Earth Optimization Services does
+          </span>
+
+          <div className="dc-flow">
+            <div className="dc-node dc-node-start">You</div>
+            <DcArrow />
+            <div className="dc-node">
+              Buy the companies that control your government
+            </div>
+            <DcArrow />
+            <div className="dc-node">Shareholder rights</div>
+            <DcArrow />
+            <div className="dc-node">Their lobbyists</div>
+            <DcArrow />
+            <div className="dc-node">The policies that maximize two numbers</div>
+          </div>
+
+          <div className="dc-conn" aria-hidden="true">
+            <svg viewBox="0 0 34 16" role="presentation">
+              <path className="dc-draw" d="M1 8 H25" markerEnd="url(#dc-head)" />
+            </svg>
+          </div>
+
+          <div className="dc-outs">
+            <div className="dc-node dc-node-out">
+              Median health-adjusted life expectancy ↑
+            </div>
+            <div className="dc-node dc-node-out">
+              Median after-tax inflation-adjusted income ↑
+            </div>
+          </div>
+        </div>
+
+        <div className="dc-cols">
+          <div className="dc-plate">
+            <span className="dc-slate dc-plate-cap">
+              <b>Fig. 2</b> — The installed base
+            </span>
+            <div className="dc-side">
+              <svg
+                aria-hidden="true"
+                className="dc-side-fig"
+                role="presentation"
+                viewBox="0 0 200 120"
+              >
+                <g className="dc-draw">
+                  {Array.from({ length: 18 }, (_, i) => {
+                    const col = i % 6;
+                    const row = Math.floor(i / 6);
+                    return (
+                      <circle
+                        key={i}
+                        cx={22 + col * 31}
+                        cy={22 + row * 32}
+                        r={10}
+                      />
+                    );
+                  })}
+                  <path d="M8 106 H192" />
+                </g>
+                <text className="dc-lab" x="8" y="120">
+                  300+ optimized
+                </text>
+              </svg>
+              <p className="dc-say">
+                Universe Optimization Services has been upgrading civilizations
+                since before your sun ignited. Over 300 planets optimized. 100%
+                satisfaction rate among clients who got started. Clients who did
+                not get started are not available for comment, as they are not
+                available for anything. Some are available for mining rights.
+              </p>
+            </div>
+          </div>
+
+          <div className="dc-plate">
+            <span className="dc-slate dc-plate-cap">
+              <b>Fig. 3</b> — The steering wheel
+            </span>
+            <div className="dc-side">
+              <svg
+                aria-hidden="true"
+                className="dc-side-fig"
+                role="presentation"
+                viewBox="0 0 200 140"
+              >
+                <g className="dc-draw">
+                  <circle cx="86" cy="70" r="52" />
+                  <circle cx="86" cy="70" r="16" />
+                  <path d="M86 18 V54" />
+                  <path d="M41 96 L72 78" />
+                  <path d="M131 96 L100 78" />
+                  <path d="M138 44 L176 22" />
+                  <path d="M176 22 L192 34 L158 56 Z" />
+                </g>
+                <text className="dc-lab" x="150" y="86" textAnchor="middle">
+                  Not
+                </text>
+                <text className="dc-lab" x="150" y="100" textAnchor="middle">
+                  for sale
+                </text>
+              </svg>
+              <p className="dc-say">
+                You are the President of Earth Optimization Services. One Class A
+                share per human, one civic vote, free. If you want returns, buy
+                Class B shares. Money buys a share of the profit, not extra votes
+                or governance. One cannot buy the steering wheel, no matter how
+                many shares you own, because selling the steering wheel is the
+                problem we are solving.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <ReadTheMath label="Read the full description">
+          <p>
+            Earth Optimization Services is a company that buys the companies
+            that control your government, uses hundreds of years of data from
+            193 countries to determine the policies and budgets that maximize
+            two numbers (median health-adjusted life expectancy and median
+            after-tax inflation-adjusted income), and then uses shareholder
+            rights to make those companies&apos; lobbyists implement the
+            policies that are in the best interests of their shareholders, the
+            corporations&apos; profits, and the general welfare, making everyone
+            richer and significantly less dead.
+          </p>
+        </ReadTheMath>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/eos-design-c/StoreFrame.tsx
+++ b/packages/web/src/components/eos-design-c/StoreFrame.tsx
@@ -39,11 +39,7 @@ export function StoreFrame() {
             <div className="dc-node">The policies that maximize two numbers</div>
           </div>
 
-          <div className="dc-conn" aria-hidden="true">
-            <svg viewBox="0 0 34 16" role="presentation">
-              <path className="dc-draw" d="M1 8 H25" markerEnd="url(#dc-head)" />
-            </svg>
-          </div>
+          <DcArrow className="dc-conn dc-conn-down" />
 
           <div className="dc-outs">
             <div className="dc-node dc-node-out">
@@ -55,7 +51,7 @@ export function StoreFrame() {
           </div>
         </div>
 
-        <div className="dc-cols">
+        <div>
           <div className="dc-plate">
             <span className="dc-slate dc-plate-cap">
               <b>Fig. 2</b> — The installed base
@@ -105,21 +101,23 @@ export function StoreFrame() {
                 aria-hidden="true"
                 className="dc-side-fig"
                 role="presentation"
-                viewBox="0 0 200 140"
+                viewBox="0 0 230 140"
               >
                 <g className="dc-draw">
-                  <circle cx="86" cy="70" r="52" />
-                  <circle cx="86" cy="70" r="16" />
-                  <path d="M86 18 V54" />
-                  <path d="M41 96 L72 78" />
-                  <path d="M131 96 L100 78" />
-                  <path d="M138 44 L176 22" />
-                  <path d="M176 22 L192 34 L158 56 Z" />
+                  <circle cx="66" cy="70" r="46" />
+                  <circle cx="66" cy="70" r="14" />
+                  <path d="M66 24 V56" />
+                  <path d="M28 92 L54 78" />
+                  <path d="M104 92 L78 78" />
+                  {/* the tag on its string */}
+                  <path d="M108 46 C122 36 130 34 142 32" />
+                  <path d="M142 20 H222 V96 H142 L124 58 Z" />
+                  <circle cx="140" cy="49" r="4" />
                 </g>
-                <text className="dc-lab" x="150" y="86" textAnchor="middle">
+                <text className="dc-lab" x="184" y="52" textAnchor="middle">
                   Not
                 </text>
-                <text className="dc-lab" x="150" y="100" textAnchor="middle">
+                <text className="dc-lab" x="184" y="70" textAnchor="middle">
                   for sale
                 </text>
               </svg>

--- a/packages/web/src/components/eos-design-c/StoreFrame.tsx
+++ b/packages/web/src/components/eos-design-c/StoreFrame.tsx
@@ -53,85 +53,83 @@ export function StoreFrame() {
           </div>
         </div>
 
-        <div>
-          <div className="dc-plate">
-            <span className="dc-slate dc-plate-cap">
-              <b>Fig. 2</b> — The installed base
-            </span>
-            <div className="dc-side">
-              <svg
-                aria-hidden="true"
-                className="dc-side-fig"
-                role="presentation"
-                viewBox="0 0 200 120"
-              >
-                <g className="dc-draw">
-                  {Array.from({ length: 18 }, (_, i) => {
-                    const col = i % 6;
-                    const row = Math.floor(i / 6);
-                    return (
-                      <circle
-                        key={i}
-                        cx={22 + col * 31}
-                        cy={22 + row * 32}
-                        r={10}
-                      />
-                    );
-                  })}
-                  <path d="M8 106 H192" />
-                </g>
-                <text className="dc-lab" x="8" y="120">
-                  300+ optimized
-                </text>
-              </svg>
-              <p className="dc-say">
-                Universe Optimization Services has been upgrading civilizations
-                since before your sun ignited. Over 300 planets optimized. 100%
-                satisfaction rate among clients who got started. Clients who did
-                not get started are not available for comment, as they are not
-                available for anything. Some are available for mining rights.
-              </p>
-            </div>
+        <div className="dc-plate">
+          <span className="dc-slate dc-plate-cap">
+            <b>Fig. 2</b> — The installed base
+          </span>
+          <div className="dc-side">
+            <svg
+              aria-hidden="true"
+              className="dc-side-fig"
+              role="presentation"
+              viewBox="0 0 200 120"
+            >
+              <g className="dc-draw">
+                {Array.from({ length: 18 }, (_, i) => {
+                  const col = i % 6;
+                  const row = Math.floor(i / 6);
+                  return (
+                    <circle
+                      key={i}
+                      cx={22 + col * 31}
+                      cy={22 + row * 32}
+                      r={10}
+                    />
+                  );
+                })}
+                <path d="M8 106 H192" />
+              </g>
+              <text className="dc-lab" x="8" y="120">
+                300+ optimized
+              </text>
+            </svg>
+            <p className="dc-say">
+              Universe Optimization Services has been upgrading civilizations
+              since before your sun ignited. Over 300 planets optimized. 100%
+              satisfaction rate among clients who got started. Clients who did
+              not get started are not available for comment, as they are not
+              available for anything. Some are available for mining rights.
+            </p>
           </div>
+        </div>
 
-          <div className="dc-plate">
-            <span className="dc-slate dc-plate-cap">
-              <b>Fig. 3</b> — The steering wheel
-            </span>
-            <div className="dc-side">
-              <svg
-                aria-hidden="true"
-                className="dc-side-fig"
-                role="presentation"
-                viewBox="0 0 230 140"
-              >
-                <g className="dc-draw">
-                  <circle cx="66" cy="70" r="46" />
-                  <circle cx="66" cy="70" r="14" />
-                  <path d="M66 24 V56" />
-                  <path d="M28 92 L54 78" />
-                  <path d="M104 92 L78 78" />
-                  {/* the tag on its string */}
-                  <path d="M108 46 C122 36 130 34 142 32" />
-                  <path d="M142 20 H222 V96 H142 L124 58 Z" />
-                  <circle cx="140" cy="49" r="4" />
-                </g>
-                <text className="dc-lab" x="184" y="52" textAnchor="middle">
-                  Not
-                </text>
-                <text className="dc-lab" x="184" y="70" textAnchor="middle">
-                  for sale
-                </text>
-              </svg>
-              <p className="dc-say">
-                You are the President of Earth Optimization Services. One Class
-                A share per human, one civic vote, free. If you want returns,
-                buy Class B shares. Money buys a share of the profit, not extra
-                votes or governance. One cannot buy the steering wheel, no
-                matter how many shares you own, because selling the steering
-                wheel is the problem we are solving.
-              </p>
-            </div>
+        <div className="dc-plate">
+          <span className="dc-slate dc-plate-cap">
+            <b>Fig. 3</b> — The steering wheel
+          </span>
+          <div className="dc-side">
+            <svg
+              aria-hidden="true"
+              className="dc-side-fig"
+              role="presentation"
+              viewBox="0 0 230 140"
+            >
+              <g className="dc-draw">
+                <circle cx="66" cy="70" r="46" />
+                <circle cx="66" cy="70" r="14" />
+                <path d="M66 24 V56" />
+                <path d="M28 92 L54 78" />
+                <path d="M104 92 L78 78" />
+                {/* the tag on its string */}
+                <path d="M108 46 C122 36 130 34 142 32" />
+                <path d="M142 20 H222 V96 H142 L124 58 Z" />
+                <circle cx="140" cy="49" r="4" />
+              </g>
+              <text className="dc-lab" x="184" y="52" textAnchor="middle">
+                Not
+              </text>
+              <text className="dc-lab" x="184" y="70" textAnchor="middle">
+                for sale
+              </text>
+            </svg>
+            <p className="dc-say">
+              You are the President of Earth Optimization Services. One Class A
+              share per human, one civic vote, free. If you want returns, buy
+              Class B shares. Money buys a share of the profit, not extra votes
+              or governance. One cannot buy the steering wheel, no matter how
+              many shares you own, because selling the steering wheel is the
+              problem we are solving.
+            </p>
           </div>
         </div>
 

--- a/packages/web/src/components/eos-design-c/StoreFrame.tsx
+++ b/packages/web/src/components/eos-design-c/StoreFrame.tsx
@@ -36,7 +36,9 @@ export function StoreFrame() {
             <DcArrow />
             <div className="dc-node">Their lobbyists</div>
             <DcArrow />
-            <div className="dc-node">The policies that maximize two numbers</div>
+            <div className="dc-node">
+              The policies that maximize two numbers
+            </div>
           </div>
 
           <DcArrow className="dc-conn dc-conn-down" />
@@ -122,12 +124,12 @@ export function StoreFrame() {
                 </text>
               </svg>
               <p className="dc-say">
-                You are the President of Earth Optimization Services. One Class A
-                share per human, one civic vote, free. If you want returns, buy
-                Class B shares. Money buys a share of the profit, not extra votes
-                or governance. One cannot buy the steering wheel, no matter how
-                many shares you own, because selling the steering wheel is the
-                problem we are solving.
+                You are the President of Earth Optimization Services. One Class
+                A share per human, one civic vote, free. If you want returns,
+                buy Class B shares. Money buys a share of the profit, not extra
+                votes or governance. One cannot buy the steering wheel, no
+                matter how many shares you own, because selling the steering
+                wheel is the problem we are solving.
               </p>
             </div>
           </div>

--- a/packages/web/src/components/eos-design-c/TwoNumberDials.tsx
+++ b/packages/web/src/components/eos-design-c/TwoNumberDials.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  GLOBAL_HALE_CURRENT,
+  GLOBAL_MEDIAN_AFTER_TAX_INCOME_2025,
+} from "@optimitron/data/parameters";
+
+const HALE = GLOBAL_HALE_CURRENT.value;
+const INCOME = GLOBAL_MEDIAN_AFTER_TAX_INCOME_2025.value;
+const DURATION_MS = 1500;
+
+/** Sweep of the dial face, in degrees, from rest to full. */
+const SWEEP = 220;
+const START_ANGLE = -110;
+
+function useSweep(active: boolean): number {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    if (!active) return;
+    let raf = 0;
+    const t0 = performance.now();
+    const tick = (now: number) => {
+      const p = Math.min(1, (now - t0) / DURATION_MS);
+      setProgress(1 - Math.pow(1 - p, 3));
+      if (p < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [active]);
+
+  return progress;
+}
+
+/**
+ * The two numbers the whole machine maximizes, drawn as a pair of
+ * instrument dials on the classroom chart: needles sweep up when the plate
+ * scrolls into view, digits count with them. Values come straight from the
+ * parameter registry; nothing here is typed by hand.
+ */
+export function TwoNumberDials() {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [running, setRunning] = useState(false);
+  const [instant, setInstant] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (
+      typeof IntersectionObserver === "undefined" ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      setInstant(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setRunning(true);
+            observer.disconnect();
+          }
+        }
+      },
+      { threshold: 0.25 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const swept = useSweep(running && !instant);
+  const p = instant ? 1 : swept;
+
+  return (
+    <div className="dc-dials" ref={ref}>
+      <Dial
+        angle={START_ANGLE + SWEEP * p}
+        label="Median Healthy Life Years."
+        note="Not average life expectancy; the age at which the median person is still healthy."
+        tint="var(--dc-turquoise)"
+        value={(HALE * p).toFixed(1)}
+      />
+      <Dial
+        angle={START_ANGLE + SWEEP * p}
+        label="Median Real After-Tax Income."
+        note="Not GDP per capita; not average."
+        tint="var(--dc-mustard)"
+        value={`$${Math.round(INCOME * p).toLocaleString("en-US")}`}
+      />
+    </div>
+  );
+}
+
+function Dial({
+  angle,
+  label,
+  note,
+  tint,
+  value,
+}: {
+  angle: number;
+  label: string;
+  note: string;
+  tint: string;
+  value: string;
+}) {
+  return (
+    <div className="dc-dial">
+      <svg
+        aria-hidden="true"
+        className="dc-dial-face"
+        viewBox="0 0 200 128"
+        role="presentation"
+      >
+        <g className="dc-draw">
+          {/* the gauge arc */}
+          <path d="M28 112 A72 72 0 0 1 172 112" />
+          {/* tick marks */}
+          {[0, 0.25, 0.5, 0.75, 1].map((t) => {
+            const a = (Math.PI * (1 - t)) as number;
+            const x1 = 100 + Math.cos(a) * 72;
+            const y1 = 112 - Math.sin(a) * 72;
+            const x2 = 100 + Math.cos(a) * 60;
+            const y2 = 112 - Math.sin(a) * 60;
+            return (
+              <line key={t} x1={x1} y1={y1} x2={x2} y2={y2} />
+            );
+          })}
+          <circle cx="100" cy="112" r="6" />
+        </g>
+        {/* the needle: not wobbled, so the reading stays crisp */}
+        <line
+          stroke={tint}
+          strokeLinecap="round"
+          strokeWidth="5"
+          x1="100"
+          x2="100"
+          y1="112"
+          y2="48"
+          transform={`rotate(${angle} 100 112)`}
+        />
+        <text className="dc-lab-sm" textAnchor="middle" x="30" y="126">
+          low
+        </text>
+        <text className="dc-lab-sm" textAnchor="middle" x="170" y="126">
+          high
+        </text>
+      </svg>
+      <div className="dc-dial-value">{value}</div>
+      <p className="dc-dial-label">{label}</p>
+      <p className="dc-dial-note">{note}</p>
+    </div>
+  );
+}

--- a/packages/web/src/components/eos-design-c/TwoNumberDials.tsx
+++ b/packages/web/src/components/eos-design-c/TwoNumberDials.tsx
@@ -127,9 +127,7 @@ function Dial({
             const y1 = 112 - Math.sin(a) * 72;
             const x2 = 100 + Math.cos(a) * 60;
             const y2 = 112 - Math.sin(a) * 60;
-            return (
-              <line key={t} x1={x1} y1={y1} x2={x2} y2={y2} />
-            );
+            return <line key={t} x1={x1} y1={y1} x2={x2} y2={y2} />;
           })}
           <circle cx="100" cy="112" r="6" />
         </g>

--- a/packages/web/src/components/eos-design-c/TwoNumberDials.tsx
+++ b/packages/web/src/components/eos-design-c/TwoNumberDials.tsx
@@ -10,9 +10,13 @@ const HALE = GLOBAL_HALE_CURRENT.value;
 const INCOME = GLOBAL_MEDIAN_AFTER_TAX_INCOME_2025.value;
 const DURATION_MS = 1500;
 
-/** Sweep of the dial face, in degrees, from rest to full. */
-const SWEEP = 220;
-const START_ANGLE = -110;
+/**
+ * The face spans -90deg (needle left, "low") to +90deg (needle right,
+ * "high"). The needle rests at low and sweeps to a reading well inside the
+ * face, so it never buries itself in the end labels.
+ */
+const SWEEP = 150;
+const START_ANGLE = -90;
 
 function useSweep(active: boolean): number {
   const [progress, setProgress] = useState(0);

--- a/packages/web/src/components/eos-design-c/design-c.css
+++ b/packages/web/src/components/eos-design-c/design-c.css
@@ -263,7 +263,7 @@
     conic-gradient(
       from 160deg at 50% -18%,
       transparent 0deg,
-      rgba(237, 175, 34, 0.26) 14deg,
+      rgba(237, 175, 34, 0.34) 15deg,
       rgba(255, 255, 255, 0) 40deg
     ),
     linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(247, 239, 218, 0));
@@ -1102,7 +1102,7 @@
 }
 
 @media (min-width: 900px) {
-  .dc-conn svg {
+  .dc-flow .dc-conn svg {
     transform: none;
   }
 }
@@ -1129,17 +1129,23 @@
   align-items: center;
 }
 
-@media (min-width: 560px) {
+@media (min-width: 720px) {
   .dc-side {
-    grid-template-columns: minmax(120px, 190px) 1fr;
+    grid-template-columns: minmax(160px, 250px) 1fr;
+    gap: clamp(1.25rem, 3vw, 2.5rem);
   }
 }
 
 .dc-side-fig {
   width: 100%;
   height: auto;
-  max-width: 200px;
+  max-width: 250px;
   justify-self: center;
+}
+
+/* The vertical hop between the flow row and its two outputs. */
+.dc-conn-down svg {
+  transform: rotate(90deg);
 }
 
 .dc-cols {

--- a/packages/web/src/components/eos-design-c/design-c.css
+++ b/packages/web/src/components/eos-design-c/design-c.css
@@ -1146,22 +1146,19 @@
   justify-self: center;
 }
 
-/* The vertical hop between the flow row and its two outputs. */
+/* The hop from the whole flow down to its two outputs. The rule above the
+   arrow makes it read as a bus off the entire chain rather than a branch off
+   whichever node happens to sit at the centre of the plate. */
+.dc-conn-down {
+  border-top: 2.5px solid var(--dc-ink);
+  margin-top: 0.55rem;
+  padding-top: 0.35rem;
+}
+
 .dc-conn-down svg {
   transform: rotate(90deg);
 }
 
-.dc-cols {
-  display: grid;
-  gap: clamp(1.1rem, 2.6vw, 1.75rem);
-  grid-template-columns: 1fr;
-}
-
-@media (min-width: 960px) {
-  .dc-cols {
-    grid-template-columns: 1fr 1fr;
-  }
-}
 
 /* The queue-drop connector sits outside .dc-flow, so it needs its own
    un-rotation once the three cells sit side by side. */

--- a/packages/web/src/components/eos-design-c/design-c.css
+++ b/packages/web/src/components/eos-design-c/design-c.css
@@ -1,12 +1,1155 @@
-/* Version C — THE EDUCATIONAL FILM. Scaffold; full reel lands next commit. */
-.dc-root {
-  min-height: 100vh;
-  background: #f6efdc;
-  color: #1b1a17;
+/* =====================================================================
+   EOS LANDING — VERSION C: THE EDUCATIONAL FILM
+   A 1950s classroom filmstrip. Section 1 is the dark charge sheet;
+   everything after the pivot is cream paper, primary inks, and drawn
+   diagrams. Illustration is CSS + inline SVG only — no image assets.
+   ===================================================================== */
+
+.dc {
+  --dc-paper: #f7efda;
+  --dc-paper-lit: #fdf8ea;
+  --dc-paper-edge: #ebdfc2;
+  --dc-ink: #1d1a14;
+  --dc-ink-soft: #56503f;
+  --dc-turquoise: #0e9aa0;
+  --dc-coral: #e0523a;
+  --dc-mustard: #edaf22;
+  --dc-sky: #5ea8d9;
+  --dc-chrome: #a9aea6;
+  --dc-dark: #0a0a0c;
+  --dc-dark-rule: #2b2b31;
+
+  --dc-sans: var(--v0-font-dm-sans), "Helvetica Neue", Arial, sans-serif;
+  --dc-serif: var(--v0-font-source-serif-4), Georgia, serif;
+  --dc-book: var(--v0-font-libre-baskerville), Georgia, serif;
+  --dc-mono: var(--v0-font-space-mono), "Courier New", monospace;
+
+  background: var(--dc-paper);
+  color: var(--dc-ink);
+  font-family: var(--dc-sans);
+  overflow-x: clip;
 }
 
-.dc-scaffold {
-  padding: 4rem 1.5rem;
-  text-align: center;
+.dc *,
+.dc *::before,
+.dc *::after {
+  box-sizing: border-box;
+}
+
+.dc-wrap {
+  margin: 0 auto;
+  max-width: 1120px;
+  width: 100%;
+}
+
+/* ---------- shared slate / label type ------------------------------- */
+
+.dc-slate {
+  font-family: var(--dc-mono);
+  font-size: 0.68rem;
   font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.dc-h {
+  font-family: var(--dc-sans);
+  font-weight: 900;
+  letter-spacing: -0.02em;
+  line-height: 0.95;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.dc-narr {
+  font-family: var(--dc-serif);
+  font-size: 1.02rem;
+  line-height: 1.6;
+  color: var(--dc-ink-soft);
+  max-width: 64ch;
+}
+
+.dc-narr strong {
+  color: var(--dc-ink);
+}
+
+.dc-say {
+  font-family: var(--dc-book);
+  font-size: clamp(1.05rem, 2.4vw, 1.35rem);
+  line-height: 1.5;
+  color: var(--dc-ink);
+  max-width: 34ch;
+  margin: 0;
+}
+
+/* =====================================================================
+   SECTION 1 — THE BILL. Dark, dense, airless. No ornament.
+   ===================================================================== */
+
+.dc-bill {
+  background: var(--dc-dark);
+  color: #f2f2ef;
+  padding: clamp(3rem, 7vw, 5.5rem) clamp(1.1rem, 5vw, 3rem) clamp(3rem, 6vw, 4.5rem);
+  position: relative;
+}
+
+.dc-bill-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--dc-dark-rule);
+  padding-bottom: 0.85rem;
+  margin-bottom: clamp(2rem, 5vw, 3.25rem);
+  flex-wrap: wrap;
+}
+
+.dc-bill-slate {
+  color: #7d7d86;
+}
+
+.dc-ticker {
+  font-family: var(--dc-mono);
+  font-size: 0.72rem;
+  color: #8b8b93;
+  text-align: right;
+  max-width: 30ch;
+  line-height: 1.4;
+}
+
+.dc-ticker b {
+  color: #e8e6e0;
+  font-weight: 700;
+}
+
+.dc-charge p {
+  font-family: var(--dc-serif);
+  font-size: clamp(0.98rem, 1.6vw, 1.08rem);
+  line-height: 1.55;
+  color: #d8d7d2;
+  max-width: 72ch;
+  margin: 0 0 1.05rem;
+}
+
+.dc-num {
+  color: #fff;
+  font-weight: 700;
+  text-decoration-color: rgba(255, 255, 255, 0.35);
+}
+
+.dc-num button,
+.dc-num.dc-num {
+  color: inherit;
+}
+
+.dc-giant {
+  margin: clamp(2.5rem, 6vw, 4rem) 0 clamp(1.75rem, 4vw, 2.5rem);
+  border-top: 1px solid var(--dc-dark-rule);
+  border-bottom: 1px solid var(--dc-dark-rule);
+  padding: clamp(1.75rem, 4vw, 2.75rem) 0;
+}
+
+.dc-giant-value {
+  font-family: var(--dc-sans);
+  font-weight: 900;
+  font-size: clamp(3rem, 13vw, 8.5rem);
+  line-height: 0.85;
+  letter-spacing: -0.045em;
+  color: #fff;
+  overflow-wrap: anywhere;
+}
+
+.dc-giant-value .dc-per {
+  color: var(--dc-coral);
+}
+
+.dc-giant-cap {
+  font-family: var(--dc-serif);
+  font-size: clamp(0.95rem, 1.6vw, 1.05rem);
+  line-height: 1.55;
+  color: #c9c8c3;
+  margin: 1.1rem 0 0;
+  max-width: 60ch;
+}
+
+.dc-giant-cap b {
+  color: #fff;
+}
+
+.dc-audit {
+  display: inline-block;
+  margin-top: 1.1rem;
+  font-family: var(--dc-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #9a9aa2;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.dc-audit:hover {
+  color: #fff;
+}
+
+.dc-love p {
+  font-family: var(--dc-book);
+  font-size: clamp(1.05rem, 2.3vw, 1.4rem);
+  line-height: 1.5;
+  color: #fff;
+  max-width: 44ch;
+  margin: 0 0 0.9rem;
+}
+
+.dc-love p:last-child {
+  color: var(--dc-mustard);
+}
+
+/* =====================================================================
+   THE PIVOT. Black leader countdown, then the light floods in.
+   ===================================================================== */
+
+.dc-pivot-dark {
+  background: var(--dc-dark);
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.1rem, 5vw, 3rem) clamp(3rem, 7vw, 4.5rem);
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  justify-items: center;
+  text-align: center;
+}
+
+.dc-leader {
+  width: clamp(112px, 24vw, 168px);
+  height: clamp(112px, 24vw, 168px);
+}
+
+.dc-leader-sweep {
+  transform-origin: 100px 100px;
+  animation: dc-sweep 3s linear infinite;
+}
+
+@keyframes dc-sweep {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.dc-pivot-q {
+  font-family: var(--dc-book);
+  font-size: clamp(1.1rem, 2.9vw, 1.75rem);
+  line-height: 1.4;
+  color: #f2f2ef;
+  max-width: 30ch;
+  margin: 0;
+}
+
+/* The flood: cream frame, projector beam, huge answer. */
+.dc-pivot-light {
+  position: relative;
+  background: var(--dc-paper-lit);
+  padding: clamp(3.5rem, 9vw, 7rem) clamp(1.1rem, 5vw, 3rem) clamp(3rem, 7vw, 5rem);
+  overflow: hidden;
+  text-align: center;
+}
+
+.dc-beam {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    conic-gradient(
+      from 160deg at 50% -18%,
+      transparent 0deg,
+      rgba(237, 175, 34, 0.26) 14deg,
+      rgba(255, 255, 255, 0) 40deg
+    ),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(247, 239, 218, 0));
+}
+
+.dc-pivot-light > * {
+  position: relative;
+}
+
+.dc-burst {
+  display: block;
+  margin: 0 auto clamp(0.75rem, 2vw, 1.25rem);
+  width: clamp(64px, 12vw, 104px);
+  height: clamp(64px, 12vw, 104px);
+}
+
+.dc-pivot-a {
+  font-size: clamp(2rem, 8.4vw, 5.4rem);
+  color: var(--dc-ink);
+  max-width: 16ch;
+  margin: 0 auto;
+  text-wrap: balance;
+}
+
+.dc-pivot-a em {
+  font-style: normal;
+  color: var(--dc-coral);
+}
+
+.dc-pivot-sub {
+  margin: clamp(1.1rem, 3vw, 1.75rem) auto 0;
+  color: var(--dc-ink-soft);
+  letter-spacing: 0.26em;
+}
+
+/* =====================================================================
+   FRAMES. Every bright section is a frame of the filmstrip.
+   ===================================================================== */
+
+.dc-frame {
+  position: relative;
+  background: var(--dc-paper);
+  border-top: 3px solid var(--dc-ink);
+  padding: clamp(2.5rem, 6vw, 4.5rem) clamp(1.1rem, 5vw, 2.5rem);
+}
+
+.dc-frame-lit {
+  background: var(--dc-paper-lit);
+}
+
+/* Sprocket rails. Ink strip with punched cream holes, both edges. */
+.dc-frame::before,
+.dc-frame::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 30px;
+  background-color: var(--dc-ink);
+  background-image: radial-gradient(
+    circle at 50% 20px,
+    var(--dc-paper) 6.5px,
+    transparent 7px
+  );
+  background-size: 100% 40px;
+  background-repeat: repeat-y;
+  pointer-events: none;
+}
+
+.dc-frame::before {
+  left: 0;
+}
+
+.dc-frame::after {
+  right: 0;
+}
+
+.dc-frame > .dc-wrap {
+  padding-inline: clamp(0px, 4vw, 42px);
+}
+
+@media (max-width: 860px) {
+  .dc-frame::before,
+  .dc-frame::after {
+    width: 14px;
+    background-size: 100% 30px;
+    background-image: radial-gradient(
+      circle at 50% 15px,
+      var(--dc-paper) 3.5px,
+      transparent 4px
+    );
+  }
+  .dc-frame > .dc-wrap {
+    padding-inline: 20px;
+  }
+}
+
+.dc-frame-slate {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  color: var(--dc-ink-soft);
+  margin-bottom: clamp(1rem, 2.6vw, 1.6rem);
+}
+
+.dc-frame-slate::after {
+  content: "";
+  flex: 1;
+  height: 2px;
+  background: var(--dc-ink);
+  opacity: 0.25;
+}
+
+.dc-frame-title {
+  font-size: clamp(2rem, 6.4vw, 4rem);
+  margin-bottom: 0.5rem;
+}
+
+.dc-frame-deck {
+  font-family: var(--dc-book);
+  font-size: clamp(1rem, 2.2vw, 1.2rem);
+  color: var(--dc-ink-soft);
+  max-width: 42ch;
+  margin: 0 0 clamp(1.75rem, 4vw, 2.75rem);
+}
+
+/* ---------- drawn figure plate -------------------------------------- */
+
+.dc-plate {
+  position: relative;
+  background: var(--dc-paper-lit);
+  border: 2px solid var(--dc-ink);
+  padding: clamp(1.1rem, 3vw, 2rem);
+  margin: 0 0 clamp(1.5rem, 3.5vw, 2.25rem);
+}
+
+.dc-frame-lit .dc-plate {
+  background: var(--dc-paper);
+}
+
+.dc-plate-cap {
+  display: block;
+  color: var(--dc-ink-soft);
+  margin-bottom: clamp(0.85rem, 2vw, 1.25rem);
+}
+
+.dc-plate-cap b {
+  color: var(--dc-ink);
+}
+
+.dc-fig {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.dc-draw {
+  fill: none;
+  stroke: var(--dc-ink);
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: url(#dc-pencil);
+}
+
+.dc-lab {
+  font-family: var(--dc-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  fill: var(--dc-ink);
+}
+
+.dc-lab-sm {
+  font-family: var(--dc-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  fill: var(--dc-ink-soft);
+}
+
+.dc-lab-big {
+  font-family: var(--dc-sans);
+  font-weight: 900;
+  font-size: 26px;
+  fill: var(--dc-ink);
+}
+
+/* ---------- read the math disclosure -------------------------------- */
+
+.dc-math {
+  border-top: 2px solid var(--dc-ink);
+  margin-top: clamp(1.5rem, 3.5vw, 2.25rem);
+}
+
+.dc-math > summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 0.85rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--dc-ink);
+}
+
+.dc-math > summary::-webkit-details-marker {
+  display: none;
+}
+
+.dc-math > summary::after {
+  content: "+";
+  font-family: var(--dc-sans);
+  font-weight: 900;
+  font-size: 1.1rem;
+  line-height: 1;
+  margin-left: auto;
+}
+
+.dc-math[open] > summary::after {
+  content: "\2212";
+}
+
+.dc-math > summary:hover {
+  color: var(--dc-coral);
+}
+
+.dc-math-body {
+  padding-bottom: 1.5rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.dc-math-body p {
+  margin: 0;
+  font-family: var(--dc-serif);
+  font-size: 1rem;
+  line-height: 1.62;
+  color: var(--dc-ink-soft);
+  max-width: 70ch;
+}
+
+.dc-math-body p b {
+  color: var(--dc-ink);
+}
+
+/* =====================================================================
+   SECTION 2 — THE STORE
+   ===================================================================== */
+
+.dc-store-grid {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2rem);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 900px) {
+  .dc-store-grid {
+    grid-template-columns: 1.35fr 1fr;
+    align-items: start;
+  }
+}
+
+.dc-says {
+  display: grid;
+  gap: clamp(1rem, 2.4vw, 1.5rem);
+}
+
+.dc-say-card {
+  border-left: 4px solid var(--dc-turquoise);
+  padding-left: clamp(0.85rem, 2vw, 1.25rem);
+}
+
+.dc-say-card:nth-child(2) {
+  border-left-color: var(--dc-coral);
+}
+
+.dc-say-card:nth-child(3) {
+  border-left-color: var(--dc-mustard);
+}
+
+.dc-say-card .dc-slate {
+  color: var(--dc-ink-soft);
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+/* =====================================================================
+   PRODUCT: THE OPTIMITRON
+   ===================================================================== */
+
+.dc-price {
+  display: grid;
+  grid-template-columns: 1fr;
+  border: 2px solid var(--dc-ink);
+  margin: 0 0 clamp(1.5rem, 3.5vw, 2.25rem);
+}
+
+@media (min-width: 760px) {
+  .dc-price {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.dc-price-cell {
+  padding: clamp(0.85rem, 2vw, 1.15rem);
+  border-bottom: 2px solid var(--dc-ink);
+}
+
+.dc-price-cell:last-child {
+  border-bottom: none;
+}
+
+@media (min-width: 760px) {
+  .dc-price-cell {
+    border-bottom: none;
+    border-right: 2px solid var(--dc-ink);
+  }
+  .dc-price-cell:last-child {
+    border-right: none;
+  }
+}
+
+.dc-price-k {
+  display: block;
+  color: var(--dc-ink-soft);
+  margin-bottom: 0.4rem;
+}
+
+.dc-price-v {
+  font-family: var(--dc-serif);
+  font-size: 1rem;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.dc-panels {
+  display: grid;
+  gap: clamp(1.1rem, 2.6vw, 1.75rem);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 900px) {
+  .dc-panels {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.dc-panel-h {
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.05rem, 2.2vw, 1.35rem);
+}
+
+.dc-panel-h span {
+  font-family: var(--dc-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  color: var(--dc-coral);
+}
+
+/* ---------- the two dials ------------------------------------------- */
+
+.dc-dials {
+  display: grid;
+  gap: clamp(1rem, 2.6vw, 1.75rem);
+  grid-template-columns: 1fr;
+  border: 2px solid var(--dc-ink);
+  background: var(--dc-ink);
+}
+
+@media (min-width: 640px) {
+  .dc-dials {
+    grid-template-columns: 1fr 1fr;
+    gap: 2px;
+  }
+}
+
+.dc-dial {
+  background: var(--dc-paper-lit);
+  padding: clamp(1.1rem, 3vw, 1.75rem);
+  text-align: center;
+}
+
+.dc-dial-face {
+  width: clamp(140px, 40vw, 200px);
+  height: auto;
+  margin: 0 auto 0.75rem;
+  display: block;
+}
+
+.dc-dial-value {
+  font-family: var(--dc-sans);
+  font-weight: 900;
+  font-size: clamp(2.1rem, 7vw, 3.4rem);
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: var(--dc-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.dc-dial-label {
+  font-family: var(--dc-sans);
+  font-weight: 800;
+  font-size: 0.95rem;
+  margin: 0.5rem 0 0.3rem;
+}
+
+.dc-dial-note {
+  font-family: var(--dc-serif);
+  font-size: 0.88rem;
+  line-height: 1.45;
+  color: var(--dc-ink-soft);
+  margin: 0;
+  max-width: 30ch;
+  margin-inline: auto;
+}
+
+/* ---------- policy comparator --------------------------------------- */
+
+.dc-comp {
+  display: grid;
+  gap: 0;
+  border: 2px solid var(--dc-ink);
+}
+
+.dc-comp-row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+  padding: clamp(0.9rem, 2.2vw, 1.15rem);
+  border-bottom: 2px solid var(--dc-ink);
+}
+
+.dc-comp-row:last-child {
+  border-bottom: none;
+}
+
+@media (min-width: 760px) {
+  .dc-comp-row {
+    grid-template-columns: 170px 1fr;
+    gap: 1.25rem;
+    align-items: center;
+  }
+}
+
+.dc-comp-name {
+  font-family: var(--dc-sans);
+  font-weight: 900;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.dc-comp-swap {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  font-family: var(--dc-serif);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.dc-before {
+  color: var(--dc-ink-soft);
+  text-decoration: line-through;
+  text-decoration-color: var(--dc-coral);
+  text-decoration-thickness: 2px;
+}
+
+.dc-arrow {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 12px;
+}
+
+.dc-after {
+  color: var(--dc-ink);
+  font-weight: 700;
+  background: linear-gradient(transparent 62%, rgba(14, 154, 160, 0.32) 62%);
+}
+
+/* ---------- queue drop drawing --------------------------------------- */
+
+.dc-drop {
+  display: grid;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  align-items: center;
+  grid-template-columns: 1fr;
+  margin-top: clamp(1.5rem, 3.5vw, 2.25rem);
+}
+
+@media (min-width: 760px) {
+  .dc-drop {
+    grid-template-columns: 1fr auto 1fr;
+  }
+}
+
+.dc-drop-cell {
+  border: 2px solid var(--dc-ink);
+  padding: clamp(0.9rem, 2.4vw, 1.35rem);
+  text-align: center;
+  background: var(--dc-paper-lit);
+}
+
+.dc-drop-cell-good {
+  background: var(--dc-turquoise);
+  color: var(--dc-paper-lit);
+}
+
+.dc-drop-cell-good .dc-drop-k,
+.dc-drop-cell-good .dc-drop-v {
+  color: var(--dc-paper-lit);
+}
+
+.dc-drop-k {
+  display: block;
+  color: var(--dc-ink-soft);
+  margin-bottom: 0.4rem;
+}
+
+.dc-drop-v {
+  font-family: var(--dc-sans);
+  font-weight: 900;
+  font-size: clamp(1.75rem, 6vw, 2.9rem);
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.dc-drop-mid {
+  display: grid;
+  place-items: center;
+}
+
+/* ---------- testimonial --------------------------------------------- */
+
+.dc-testi {
+  margin: clamp(1.5rem, 3.5vw, 2.25rem) 0 0;
+  border: 2px solid var(--dc-ink);
+  border-left-width: 10px;
+  border-left-color: var(--dc-mustard);
+  padding: clamp(1rem, 2.6vw, 1.5rem);
+  background: var(--dc-paper-lit);
+}
+
+.dc-frame-lit .dc-testi {
+  background: var(--dc-paper);
+}
+
+.dc-testi p {
+  font-family: var(--dc-book);
+  font-style: italic;
+  font-size: clamp(1rem, 2.2vw, 1.15rem);
+  line-height: 1.5;
+  margin: 0;
+  max-width: 56ch;
+}
+
+.dc-testi cite {
+  display: block;
+  margin-top: 0.6rem;
+  font-style: normal;
+  font-family: var(--dc-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--dc-ink-soft);
+}
+
+/* =====================================================================
+   SECTION 3 — THE COMPARISON MATRIX, as a classroom wall chart
+   ===================================================================== */
+
+.dc-chart {
+  border: 3px solid var(--dc-ink);
+  background: var(--dc-paper-lit);
+}
+
+.dc-frame-lit .dc-chart {
+  background: var(--dc-paper);
+}
+
+.dc-chart-head {
+  display: none;
+}
+
+@media (min-width: 860px) {
+  .dc-chart-head {
+    display: grid;
+    grid-template-columns: 190px 1fr 1fr;
+    border-bottom: 3px solid var(--dc-ink);
+    position: sticky;
+    top: 0;
+    z-index: 2;
+  }
+}
+
+.dc-chart-corner {
+  background: var(--dc-ink);
+}
+
+.dc-chart-col {
+  padding: clamp(0.85rem, 2vw, 1.2rem);
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-family: var(--dc-sans);
+  font-weight: 900;
+  font-size: clamp(0.9rem, 1.7vw, 1.1rem);
+  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  line-height: 1.1;
+}
+
+.dc-chart-col-gov {
+  background: var(--dc-coral);
+  color: var(--dc-paper-lit);
+  border-right: 3px solid var(--dc-ink);
+}
+
+.dc-chart-col-eos {
+  background: var(--dc-turquoise);
+  color: var(--dc-paper-lit);
+}
+
+.dc-chart-glyph {
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+}
+
+.dc-chart-row {
+  display: grid;
+  grid-template-columns: 1fr;
+  border-bottom: 2px solid var(--dc-ink);
+}
+
+.dc-chart-row:last-child {
+  border-bottom: none;
+}
+
+@media (min-width: 860px) {
+  .dc-chart-row {
+    grid-template-columns: 190px 1fr 1fr;
+  }
+}
+
+.dc-chart-label {
+  padding: clamp(0.7rem, 1.8vw, 1rem);
+  background: var(--dc-ink);
+  color: var(--dc-paper);
+  font-family: var(--dc-sans);
+  font-weight: 800;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  line-height: 1.25;
+  display: flex;
+  align-items: center;
+}
+
+.dc-chart-cell {
+  padding: clamp(0.75rem, 1.9vw, 1.05rem);
+  font-family: var(--dc-serif);
+  font-size: 0.97rem;
+  line-height: 1.45;
+}
+
+.dc-chart-gov {
+  color: var(--dc-ink-soft);
+  border-bottom: 2px dashed var(--dc-ink);
+}
+
+@media (min-width: 860px) {
+  .dc-chart-gov {
+    border-bottom: none;
+    border-right: 2px solid var(--dc-ink);
+  }
+}
+
+.dc-chart-eos {
+  color: var(--dc-ink);
+  font-weight: 600;
+}
+
+.dc-chart-mob {
+  display: block;
+  font-family: var(--dc-mono);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin-bottom: 0.3rem;
+}
+
+.dc-chart-gov .dc-chart-mob {
+  color: var(--dc-coral);
+}
+
+.dc-chart-eos .dc-chart-mob {
+  color: var(--dc-turquoise);
+}
+
+@media (min-width: 860px) {
+  .dc-chart-mob {
+    display: none;
+  }
+}
+
+.dc-zero {
+  font-family: var(--dc-sans);
+  font-weight: 900;
+  font-size: 1.6rem;
+  line-height: 1;
+  color: var(--dc-turquoise);
+}
+
+/* =====================================================================
+   END SLATE
+   ===================================================================== */
+
+.dc-end {
+  background: var(--dc-ink);
+  color: var(--dc-paper);
+  padding: clamp(1.5rem, 4vw, 2.5rem) clamp(1.1rem, 5vw, 2.5rem);
+  text-align: center;
+}
+
+.dc-end .dc-slate {
+  color: var(--dc-chrome);
+}
+
+/* =====================================================================
+   ParameterValue lives inside prose; keep its dialog trigger legible
+   against both grounds.
+   ===================================================================== */
+
+.dc-p {
+  font-weight: 700;
+  color: var(--dc-ink);
+  text-decoration-color: rgba(29, 26, 20, 0.4);
+}
+
+.dc-chart-eos .dc-p,
+.dc-chart-gov .dc-p {
+  font-weight: 700;
+}
+
+.dc-drop-cell-good .dc-p {
+  color: var(--dc-paper-lit);
+  text-decoration-color: rgba(255, 255, 255, 0.5);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dc-leader-sweep {
+    animation: none;
+  }
+}
+
+/* =====================================================================
+   DRAWN FLOW DIAGRAMS. HTML nodes so they reflow at 390px; the drawn
+   quality comes from the ink rules, the wobbled arrows, and the figures.
+   ===================================================================== */
+
+.dc-flow {
+  display: grid;
+  gap: 0.4rem;
+  grid-template-columns: 1fr;
+  align-items: stretch;
+}
+
+@media (min-width: 900px) {
+  .dc-flow {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(0, 1fr);
+    align-items: stretch;
+  }
+  .dc-flow > .dc-conn {
+    grid-auto-columns: auto;
+    width: 40px;
+  }
+}
+
+.dc-node {
+  border: 2.5px solid var(--dc-ink);
+  background: var(--dc-paper-lit);
+  padding: 0.7rem 0.55rem;
+  text-align: center;
+  font-family: var(--dc-sans);
+  font-weight: 800;
+  font-size: 0.76rem;
+  line-height: 1.22;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dc-frame-lit .dc-node {
+  background: var(--dc-paper);
+}
+
+.dc-node-start {
+  background: var(--dc-mustard);
+  border-color: var(--dc-ink);
+}
+
+.dc-frame-lit .dc-node-start {
+  background: var(--dc-mustard);
+}
+
+.dc-node-out {
+  background: var(--dc-turquoise);
+  color: var(--dc-paper-lit);
+}
+
+.dc-frame-lit .dc-node-out {
+  background: var(--dc-turquoise);
+}
+
+.dc-conn {
+  display: grid;
+  place-items: center;
+  min-height: 26px;
+}
+
+.dc-conn svg {
+  width: 34px;
+  height: 16px;
+  transform: rotate(90deg);
+}
+
+@media (min-width: 900px) {
+  .dc-conn svg {
+    transform: none;
+  }
+}
+
+.dc-outs {
+  display: grid;
+  gap: 0.4rem;
+  grid-template-columns: 1fr;
+  margin-top: 0.4rem;
+}
+
+@media (min-width: 640px) {
+  .dc-outs {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+/* ---------- side-by-side drawing + caption --------------------------- */
+
+.dc-side {
+  display: grid;
+  gap: clamp(0.85rem, 2.4vw, 1.5rem);
+  grid-template-columns: 1fr;
+  align-items: center;
+}
+
+@media (min-width: 560px) {
+  .dc-side {
+    grid-template-columns: minmax(120px, 190px) 1fr;
+  }
+}
+
+.dc-side-fig {
+  width: 100%;
+  height: auto;
+  max-width: 200px;
+  justify-self: center;
+}
+
+.dc-cols {
+  display: grid;
+  gap: clamp(1.1rem, 2.6vw, 1.75rem);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 960px) {
+  .dc-cols {
+    grid-template-columns: 1fr 1fr;
+  }
 }

--- a/packages/web/src/components/eos-design-c/design-c.css
+++ b/packages/web/src/components/eos-design-c/design-c.css
@@ -1,0 +1,12 @@
+/* Version C — THE EDUCATIONAL FILM. Scaffold; full reel lands next commit. */
+.dc-root {
+  min-height: 100vh;
+  background: #f6efdc;
+  color: #1b1a17;
+}
+
+.dc-scaffold {
+  padding: 4rem 1.5rem;
+  text-align: center;
+  font-weight: 700;
+}

--- a/packages/web/src/components/eos-design-c/design-c.css
+++ b/packages/web/src/components/eos-design-c/design-c.css
@@ -89,7 +89,8 @@
 .dc-bill {
   background: var(--dc-dark);
   color: #f2f2ef;
-  padding: clamp(3rem, 7vw, 5.5rem) clamp(1.1rem, 5vw, 3rem) clamp(3rem, 6vw, 4.5rem);
+  padding: clamp(3rem, 7vw, 5.5rem) clamp(1.1rem, 5vw, 3rem)
+    clamp(3rem, 6vw, 4.5rem);
   position: relative;
 }
 
@@ -211,7 +212,8 @@
 
 .dc-pivot-dark {
   background: var(--dc-dark);
-  padding: clamp(2rem, 6vw, 4rem) clamp(1.1rem, 5vw, 3rem) clamp(3rem, 7vw, 4.5rem);
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.1rem, 5vw, 3rem)
+    clamp(3rem, 7vw, 4.5rem);
   display: grid;
   gap: clamp(1.5rem, 4vw, 2.5rem);
   justify-items: center;
@@ -250,7 +252,8 @@
 .dc-pivot-light {
   position: relative;
   background: var(--dc-paper-lit);
-  padding: clamp(3.5rem, 9vw, 7rem) clamp(1.1rem, 5vw, 3rem) clamp(3rem, 7vw, 5rem);
+  padding: clamp(3.5rem, 9vw, 7rem) clamp(1.1rem, 5vw, 3rem)
+    clamp(3rem, 7vw, 5rem);
   overflow: hidden;
   text-align: center;
 }
@@ -1157,5 +1160,13 @@
 @media (min-width: 960px) {
   .dc-cols {
     grid-template-columns: 1fr 1fr;
+  }
+}
+
+/* The queue-drop connector sits outside .dc-flow, so it needs its own
+   un-rotation once the three cells sit side by side. */
+@media (min-width: 760px) {
+  .dc-drop .dc-conn svg {
+    transform: none;
   }
 }

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -1552,14 +1552,20 @@ export const dysfunctionTaxLink: NavItem = {
 // Metadata-only NavItem (like dysfunctionTaxLink): drives getRouteMetadata for
 // the competing EOS landing-page design at /design-c so shared links get a
 // self-canonical URL and a route-specific social card instead of inheriting the
-// site root. Deliberately absent from every nav array and the sitemap; the page
-// itself is noindex. This is a design bake-off surface, not a nav destination.
+// site root. Deliberately absent from every PUBLIC nav array (navSections,
+// exploreLinks, footerAppLinks) and the sitemap; the page itself is noindex.
+// This is a design bake-off surface, not a nav destination. It is included in
+// routeReviewNavItems below (like taskTreeLink) so getInternalNavItemForPath
+// can resolve its OG image and so it participates in the screenshot/copy
+// review sweep — that array is internal tooling, not public navigation.
 export const eosDesignCLink: NavItem = {
   label: "Earth Optimization Services (design C)",
   href: "/design-c",
   emoji: "🎞️",
   description:
     "The Earth Optimization Services catalog drawn as a 1950s classroom filmstrip: the bill against your government, then the store that replaces it.",
+  copyPreview: true,
+  screenshot: true,
   cta: "Watch the Filmstrip",
 };
 
@@ -1873,6 +1879,7 @@ export const routeReviewNavItems = [
   courtLink,
   donateLink,
   eosLink,
+  eosDesignCLink,
   joinLink,
   foundationsLink,
   signatoriesLink,

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -1549,6 +1549,20 @@ export const dysfunctionTaxLink: NavItem = {
   cta: "See the Breakdown",
 };
 
+// Metadata-only NavItem (like dysfunctionTaxLink): drives getRouteMetadata for
+// the competing EOS landing-page design at /design-c so shared links get a
+// self-canonical URL and a route-specific social card instead of inheriting the
+// site root. Deliberately absent from every nav array and the sitemap; the page
+// itself is noindex. This is a design bake-off surface, not a nav destination.
+export const eosDesignCLink: NavItem = {
+  label: "Earth Optimization Services (design C)",
+  href: "/design-c",
+  emoji: "🎞️",
+  description:
+    "The Earth Optimization Services catalog drawn as a 1950s classroom filmstrip: the bill against your government, then the store that replaces it.",
+  cta: "Watch the Filmstrip",
+};
+
 export const incentiveAlignmentBondsPaperLink: NavItem = {
   label: "Incentive Alignment Bonds",
   href: "https://iab.warondisease.org",


### PR DESCRIPTION
One of three competing visual directions for the Earth Optimization Services landing page.

## Route

**`/design-c`** — one tap from the Vercel preview: append `/design-c` to the preview URL, or `/design-c?logout=1` for the logged-out state (the page reads no session, so both render identically).

## The direction

Version C is **THE EDUCATIONAL FILM** — a 1950s classroom filmstrip. Warm cream ground, friendly primary inks, hand-drawn diagram energy, a narrator's confident cheer. Concepts are *drawn* rather than written: the mechanism as a labelled flow, the weapons budget as a sliced bar pouring into a beaker, the two numbers as instrument dials whose needles sweep up. Every bright section is a frame of the strip, sprocket rails and all.

Section 1 (The Bill) stays dark and airless. The pivot runs an Academy leader countdown in the black, asks the question there, and lands the answer in cream at full brochure size — the register break is meant to feel like walking out of a courtroom into 1962.

## Scope built

So the three versions are comparable, this is the shared arc rather than all 11 sections:

1. End of Section 1 (The Bill) + the pivot
2. Section 2 (The Store)
3. Section 4, Product 1 (The Optimitron) as an illustrated diagram, with the two-number dashboard as the working demo
4. Section 3 (The Comparison Matrix) as a classroom wall chart

## Constraints held

- Copy verbatim from `manual/knowledge/production/eos-landing-page.qmd`. Nothing rewritten.
- Every figure renders through the existing `ParameterValue` pipeline. No hardcoded numbers.
- No new npm dependencies. Illustration is inline SVG and CSS only, no image assets.
- Works at 390px and 1440px; the comparison chart stacks into labelled cards under 860px.
- Prose sits behind "read the math" disclosures; each screen leads with a number, a drawing, or a demo.

Does not touch `/eos` or `/eos-preview`.

## Two judgement calls worth a look

- The card is titled **The Optimitron**, dropping the spec heading's "(The Evidence Engine)" parenthetical, because the spec's own "What is not on this page" list bans the Evidence Engine naming. Flagging the contradiction rather than silently picking a side.
- Several money parameters carry a `USD/year` or `USD/person` unit that the formatter appends. Where the spec's sentence already says "per person per year", those call sites narrow the unit to plain USD (the pattern `/agencies/ddod` already uses), so the page does not read "$12,600/year per person per year".

Screenshots at desktop 1440 and mobile 390 — full page, first screen, and each section — were captured and inspected locally. `pnpm --filter @optimitron/web build:fast` passes and `/design-c` appears in the route manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnCzCv5h94AmarutZUC5g5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Design C landing page at `/design-c`.
  * Introduced a full educational-film styled layout with new sections (bill finale, store, pivot reel, optimitron specs, comparison matrix, and filmstrip frames).
  * Added interactive/animated elements including live “deaths from disease” ticker, scroll-activated dual dials, and expandable “read the math” disclosures.
  * Added detailed Design C visual styling and SVG/diagram components.
  * Configured the page for metadata/social sharing and set it to be excluded from search engine indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->