### PR TITLE
EOS landing Version B: the press kit

### DIFF
--- a/packages/web/src/app/design-b/page.tsx
+++ b/packages/web/src/app/design-b/page.tsx
@@ -1,12 +1,10 @@
-import type { Metadata } from "next";
 import { EosDesignBPage } from "@/components/eos-design-b/EosDesignBPage";
+import { getRouteMetadata } from "@/lib/metadata";
+import { designBLink } from "@/lib/routes";
 
-export const metadata: Metadata = {
-  title: "EOS Landing — Version B (The Press Kit)",
-  description:
-    "Competing visual direction B for the Earth Optimization Services landing page: a 1962 NASA press kit.",
+export const metadata = getRouteMetadata(designBLink, {
   robots: { index: false, follow: false },
-};
+});
 
 export default function DesignBPage() {
   return <EosDesignBPage />;

--- a/packages/web/src/app/design-b/page.tsx
+++ b/packages/web/src/app/design-b/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import { EosDesignBPage } from "@/components/eos-design-b/EosDesignBPage";
+
+export const metadata: Metadata = {
+  title: "EOS Landing — Version B (The Press Kit)",
+  description:
+    "Competing visual direction B for the Earth Optimization Services landing page: a 1962 NASA press kit.",
+  robots: { index: false, follow: false },
+};
+
+export default function DesignBPage() {
+  return <EosDesignBPage />;
+}

--- a/packages/web/src/components/eos-design-b/BillTailAndPivot.tsx
+++ b/packages/web/src/components/eos-design-b/BillTailAndPivot.tsx
@@ -9,6 +9,7 @@ import {
   WAR_COUNTERFACTUAL_GDP_PER_CAPITA,
   WAR_COUNTERFACTUAL_INCOME_MULTIPLE,
 } from "@optimitron/data/parameters";
+import Link from "next/link";
 import { ParameterValue } from "@/components/shared/ParameterValue";
 
 const N = "pk-n";
@@ -105,9 +106,9 @@ export function BillTailAndPivot() {
               />{" "}
               per household of four.
             </p>
-            <a className="pkb-billlink" href={AUDIT_URL}>
+            <Link className="pkb-billlink" href={AUDIT_URL}>
               Read the full forensic audit →
-            </a>
+            </Link>
           </div>
 
           <div className="pkb-love">

--- a/packages/web/src/components/eos-design-b/BillTailAndPivot.tsx
+++ b/packages/web/src/components/eos-design-b/BillTailAndPivot.tsx
@@ -89,7 +89,7 @@ export function BillTailAndPivot() {
                 param={POLITICAL_DYSFUNCTION_GLOBAL_OPPORTUNITY_COST_TOTAL}
                 presentation="inline"
               />
-              <span className="pkb-huge-unit">/year</span>
+              <span className="pkb-huge-unit">per year</span>
             </span>
             <p className="pkb-legend">
               <strong>The Political Dysfunction Tax.</strong> The annual cost of

--- a/packages/web/src/components/eos-design-b/BillTailAndPivot.tsx
+++ b/packages/web/src/components/eos-design-b/BillTailAndPivot.tsx
@@ -68,7 +68,7 @@ export function BillTailAndPivot() {
               wealth since 1900, the average human would earn{" "}
               <ParameterValue
                 className={N}
-                param={WAR_COUNTERFACTUAL_GDP_PER_CAPITA}
+                param={{ ...WAR_COUNTERFACTUAL_GDP_PER_CAPITA, unit: "USD" }}
               />{" "}
               a year instead of{" "}
               <ParameterValue className={N} param={GLOBAL_AVG_INCOME_2025} />.
@@ -97,12 +97,18 @@ export function BillTailAndPivot() {
               not checking.{" "}
               <ParameterValue
                 className={N}
-                param={POLITICAL_DYSFUNCTION_TAX_PER_PERSON_ANNUAL}
+                param={{
+                  ...POLITICAL_DYSFUNCTION_TAX_PER_PERSON_ANNUAL,
+                  unit: "USD",
+                }}
               />{" "}
               per person per year.{" "}
               <ParameterValue
                 className={N}
-                param={POLITICAL_DYSFUNCTION_TAX_PER_HOUSEHOLD_OF_FOUR_ANNUAL}
+                param={{
+                  ...POLITICAL_DYSFUNCTION_TAX_PER_HOUSEHOLD_OF_FOUR_ANNUAL,
+                  unit: "USD",
+                }}
               />{" "}
               per household of four.
             </p>

--- a/packages/web/src/components/eos-design-b/BillTailAndPivot.tsx
+++ b/packages/web/src/components/eos-design-b/BillTailAndPivot.tsx
@@ -1,0 +1,184 @@
+import {
+  DISEASES_WITHOUT_EFFECTIVE_TREATMENT,
+  GLOBAL_AVG_INCOME_2025,
+  NIH_CLINICAL_TRIALS_SPENDING_PCT,
+  POLITICAL_DYSFUNCTION_GLOBAL_OPPORTUNITY_COST_TOTAL,
+  POLITICAL_DYSFUNCTION_TAX_PER_HOUSEHOLD_OF_FOUR_ANNUAL,
+  POLITICAL_DYSFUNCTION_TAX_PER_PERSON_ANNUAL,
+  STATUS_QUO_QUEUE_CLEARANCE_YEARS,
+  WAR_COUNTERFACTUAL_GDP_PER_CAPITA,
+  WAR_COUNTERFACTUAL_INCOME_MULTIPLE,
+} from "@optimitron/data/parameters";
+import { ParameterValue } from "@/components/shared/ParameterValue";
+
+const N = "pk-n";
+const AUDIT_URL = "/dysfunction-tax";
+
+/**
+ * The end of Section 1 (The Bill) and the pivot into the press kit.
+ *
+ * Section 1 keeps the spec's dark, dense, humourless register: the charge
+ * sheet runs to the end, the Political Dysfunction Tax lands as the screen's
+ * one enormous number, and the love line closes it. Then the chrome
+ * changeover strip and the release masthead: courtroom, door, 1962.
+ */
+export function BillTailAndPivot() {
+  return (
+    <>
+      <section className="pkb-bill" id="the-bill">
+        <div className="pkb-wrap">
+          <div className="pkb-billhead">
+            <p className="pkb-tag">Section 1 · The Bill</p>
+            <p className="pkb-tag">Continued · Counts 8 through 10</p>
+          </div>
+
+          <div className="pkb-charge">
+            <p>
+              They maintain 74,000 pages of tax code. They run 80+ overlapping
+              welfare programs. The NIH directs only{" "}
+              <ParameterValue
+                className={N}
+                figures={2}
+                param={NIH_CLINICAL_TRIALS_SPENDING_PCT}
+              />{" "}
+              of its budget to clinical trials; the rest studies disease without
+              testing cures.{" "}
+              <ParameterValue
+                className={N}
+                param={DISEASES_WITHOUT_EFFECTIVE_TREATMENT}
+              />{" "}
+              diseases have zero approved treatments. At the current discovery
+              rate, clearing the queue takes{" "}
+              <ParameterValue
+                className={N}
+                display="integer"
+                param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
+              />{" "}
+              years.
+            </p>
+            <p>
+              Singapore spends roughly a quarter of what the US spends per
+              capita on healthcare. Singaporeans live about seven years longer.
+              193 countries, hundreds of years of policy data. The experiments
+              already ran. Nobody checked the results.
+            </p>
+            <p>
+              Had these governments been properly aligned to maximize health and
+              wealth since 1900, the average human would earn{" "}
+              <ParameterValue
+                className={N}
+                param={WAR_COUNTERFACTUAL_GDP_PER_CAPITA}
+              />{" "}
+              a year instead of{" "}
+              <ParameterValue className={N} param={GLOBAL_AVG_INCOME_2025} />.
+              That is{" "}
+              <ParameterValue
+                className={N}
+                param={WAR_COUNTERFACTUAL_INCOME_MULTIPLE}
+              />{" "}
+              times richer.
+            </p>
+          </div>
+
+          <div className="pkb-billnum">
+            <p className="pkb-tag pkb-tag--hot">
+              Exhibit A · Annual cost of not checking
+            </p>
+            <span className="pkb-huge">
+              <ParameterValue
+                param={POLITICAL_DYSFUNCTION_GLOBAL_OPPORTUNITY_COST_TOTAL}
+                presentation="inline"
+              />
+              <span className="pkb-huge-unit">/year</span>
+            </span>
+            <p className="pkb-legend">
+              <strong>The Political Dysfunction Tax.</strong> The annual cost of
+              not checking.{" "}
+              <ParameterValue
+                className={N}
+                param={POLITICAL_DYSFUNCTION_TAX_PER_PERSON_ANNUAL}
+              />{" "}
+              per person per year.{" "}
+              <ParameterValue
+                className={N}
+                param={POLITICAL_DYSFUNCTION_TAX_PER_HOUSEHOLD_OF_FOUR_ANNUAL}
+              />{" "}
+              per household of four.
+            </p>
+            <a className="pkb-billlink" href={AUDIT_URL}>
+              Read the full forensic audit →
+            </a>
+          </div>
+
+          <div className="pkb-love">
+            <p>
+              I love you very much and I do not want you and everyone you have
+              ever loved to be slowly tortured and brutally murdered by horrible
+              diseases.
+            </p>
+            <p>That is why this store exists.</p>
+          </div>
+        </div>
+      </section>
+
+      {/* The changeover: dark, chrome, daylight. */}
+      <div className="pkb-changeover" aria-hidden="true" />
+
+      <section className="pkb-pivot pkb-grid" id="the-pivot">
+        <div className="pkb-wrap">
+          <div className="pkb-release">
+            <p className="pkb-tag pkb-tag--blue">
+              Universe Optimization Services · Earth Regional Branch
+            </p>
+            <p className="pkb-tag">Release No. EOS-B-001 · Sheet 1 of 4</p>
+          </div>
+
+          <div className="pkb-pivotgrid">
+            <div className="pkb-masthead">
+              <div className="pkb-roundel">
+                <span>
+                  U O S
+                  <br />
+                  EARTH
+                  <br />
+                  BRANCH
+                </span>
+              </div>
+              <p className="pkb-marque">Press Kit</p>
+              <div className="pkb-callouts">
+                <div className="pkb-callout">
+                  <span className="pkb-callout-k">Document class</span>
+                  <span className="pkb-callout-v">For immediate release</span>
+                </div>
+                <div className="pkb-callout">
+                  <span className="pkb-callout-k">Prepared for</span>
+                  <span className="pkb-callout-v">The President of EOS</span>
+                </div>
+                <div className="pkb-callout">
+                  <span className="pkb-callout-k">Prior clients</span>
+                  <span className="pkb-callout-v">300 planets</span>
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <p className="pkb-tag pkb-tag--blue">Eligibility screening</p>
+              <p className="pkb-pivot-q">
+                Has your species developed nuclear weapons, antibiotics, and the
+                internet, and then pointed two of those three at each other?
+              </p>
+              <p className="pkb-pivot-a">
+                You may be <em>eligible</em> for optimization.
+              </p>
+              <div className="pkb-dim">
+                <span className="pkb-tag">Section 1 ends</span>
+                <span className="pkb-dim-rule" />
+                <span className="pkb-tag pkb-tag--blue">Catalog begins</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/packages/web/src/components/eos-design-b/BillTailAndPivot.tsx
+++ b/packages/web/src/components/eos-design-b/BillTailAndPivot.tsx
@@ -123,6 +123,7 @@ export function BillTailAndPivot() {
 
       {/* The changeover: dark, chrome, daylight. */}
       <div className="pkb-changeover" aria-hidden="true" />
+      <div className="pkb-ruler" aria-hidden="true" />
 
       <section className="pkb-pivot pkb-grid" id="the-pivot">
         <div className="pkb-wrap">

--- a/packages/web/src/components/eos-design-b/ComparisonSheet.tsx
+++ b/packages/web/src/components/eos-design-b/ComparisonSheet.tsx
@@ -67,7 +67,14 @@ export function ComparisonSheet() {
           <p className="pkb-tag pkb-tag--blue pkb-scrollhint">
             Scroll the sheet sideways for the EOS column →
           </p>
-          <div className="pkb-matrixscroll">
+          {/* Focusable so keyboard users can reach the EOS column the scroll
+              hint points them at. */}
+          <div
+            className="pkb-matrixscroll"
+            role="region"
+            aria-label="Vendor comparison: your government versus Earth Optimization Services"
+            tabIndex={0}
+          >
             <table className="pkb-matrix">
               <caption className="sr-only">
                 Vendor comparison: your government versus Earth Optimization
@@ -266,7 +273,7 @@ export function ComparisonSheet() {
               Universe Optimization Services · Earth Regional Branch
             </p>
             <p className="pkb-tag pkb-tag--blue">
-              Every figure sourced. Select any number for its derivation.
+              Select any highlighted figure for its derivation.
             </p>
           </div>
         </div>

--- a/packages/web/src/components/eos-design-b/ComparisonSheet.tsx
+++ b/packages/web/src/components/eos-design-b/ComparisonSheet.tsx
@@ -37,34 +37,31 @@ export function ComparisonSheet() {
             review.
           </p>
 
-          <div className="pkb-verdict" style={{ marginTop: "2rem" }}>
-            <div className="pkb-verdict-col">
-              <p className="pkb-tag pkb-tag--hot">
-                Your government · sticker price
-              </p>
-              <span className="pkb-huge pkb-huge--hot">
-                <ParameterValue
-                  param={US_GOV_WASTE_PER_CAPITA_ANNUAL}
-                  presentation="inline"
-                />
-                <span className="pkb-huge-unit">per American / year</span>
-              </span>
+          <div className="pkb-verdict">
+            <p className="pkb-tag pkb-tag--hot">
+              Sticker price · your government
+            </p>
+            <span className="pkb-huge pkb-huge--hot">
+              <ParameterValue
+                param={US_GOV_WASTE_PER_CAPITA_ANNUAL}
+                presentation="inline"
+              />
+              <span className="pkb-huge-unit">per American / year</span>
+            </span>
+            <div className="pkb-dim">
+              <span className="pkb-tag pkb-tag--hot">Their bid</span>
+              <span className="pkb-dim-rule" />
+              <span className="pkb-tag pkb-tag--blue">Ours</span>
             </div>
-            <div className="pkb-verdict-col pkb-verdict-col--eos">
-              <p className="pkb-tag pkb-tag--blue">
-                Earth Optimization Services · sticker price
-              </p>
-              <span className="pkb-huge">
+            <p className="pkb-counterbid">
+              <span className="pkb-counterbid-v">
                 <ParameterValue
+                  className={N}
                   param={GOV_REPLACEMENT_SUITE_OPEX_PER_CITIZEN_ANNUAL}
-                  presentation="inline"
                 />
-                <span className="pkb-huge-unit">per citizen / year</span>
-              </span>
-              <p className="pkb-legend" style={{ marginTop: "0.9rem" }}>
-                Plus dividends.
-              </p>
-            </div>
+              </span>{" "}
+              per citizen per year, plus dividends.
+            </p>
           </div>
 
           <div className="pkb-matrixscroll">

--- a/packages/web/src/components/eos-design-b/ComparisonSheet.tsx
+++ b/packages/web/src/components/eos-design-b/ComparisonSheet.tsx
@@ -46,7 +46,7 @@ export function ComparisonSheet() {
                 param={US_GOV_WASTE_PER_CAPITA_ANNUAL}
                 presentation="inline"
               />
-              <span className="pkb-huge-unit">per American / year</span>
+              <span className="pkb-huge-unit">per American per year</span>
             </span>
             <div className="pkb-dim">
               <span className="pkb-tag pkb-tag--hot">Their bid</span>
@@ -64,6 +64,9 @@ export function ComparisonSheet() {
             </p>
           </div>
 
+          <p className="pkb-tag pkb-tag--blue pkb-scrollhint">
+            Scroll the sheet sideways for the EOS column →
+          </p>
           <div className="pkb-matrixscroll">
             <table className="pkb-matrix">
               <caption className="sr-only">

--- a/packages/web/src/components/eos-design-b/ComparisonSheet.tsx
+++ b/packages/web/src/components/eos-design-b/ComparisonSheet.tsx
@@ -1,0 +1,276 @@
+import {
+  CROWD_DECISION_ACCURACY,
+  DFDA_QUEUE_CLEARANCE_YEARS,
+  EXPERT_DECISION_ACCURACY,
+  GOV_REPLACEMENT_SUITE_OPEX_PER_CITIZEN_ANNUAL,
+  MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO,
+  PENTAGON_UNACCOUNTED_FUNDS,
+  STATUS_QUO_QUEUE_CLEARANCE_YEARS,
+  US_GOV_WASTE_PER_CAPITA_ANNUAL,
+  US_GOV_WASTE_TAX_COMPLIANCE,
+  US_TOTAL_LOBBYING_ANNUAL,
+  WAR_DEATHS_SINCE_1900,
+} from "@optimitron/data/parameters";
+import { ParameterValue } from "@/components/shared/ParameterValue";
+
+const N = "pk-n";
+
+/**
+ * Section 3 — The Comparison Matrix.
+ *
+ * The screen leads with the head-to-head sticker price (the one number a
+ * procurement officer reads first), then the full fourteen-row vendor
+ * comparison as a technical data sheet.
+ */
+export function ComparisonSheet() {
+  return (
+    <section className="pkb-sec pkb-grid" id="the-competing-bid">
+      <div className="pkb-wrap">
+        <div className="pkb-sheet">
+          <div className="pkb-sheethead">
+            <h2>Fig. 4 — The Competing Bid</h2>
+            <p className="pkb-tag">Release No. EOS-B-001 · Sheet 4 of 4</p>
+          </div>
+
+          <p className="pkb-lede" style={{ maxWidth: "44ch" }}>
+            We tried to be diplomatic about this. Then we read the performance
+            review.
+          </p>
+
+          <div className="pkb-verdict" style={{ marginTop: "2rem" }}>
+            <div className="pkb-verdict-col">
+              <p className="pkb-tag pkb-tag--hot">
+                Your government · sticker price
+              </p>
+              <span className="pkb-huge pkb-huge--hot">
+                <ParameterValue
+                  param={US_GOV_WASTE_PER_CAPITA_ANNUAL}
+                  presentation="inline"
+                />
+                <span className="pkb-huge-unit">per American / year</span>
+              </span>
+            </div>
+            <div className="pkb-verdict-col pkb-verdict-col--eos">
+              <p className="pkb-tag pkb-tag--blue">
+                Earth Optimization Services · sticker price
+              </p>
+              <span className="pkb-huge">
+                <ParameterValue
+                  param={GOV_REPLACEMENT_SUITE_OPEX_PER_CITIZEN_ANNUAL}
+                  presentation="inline"
+                />
+                <span className="pkb-huge-unit">per citizen / year</span>
+              </span>
+              <p className="pkb-legend" style={{ marginTop: "0.9rem" }}>
+                Plus dividends.
+              </p>
+            </div>
+          </div>
+
+          <div className="pkb-matrixscroll">
+            <table className="pkb-matrix">
+              <caption className="sr-only">
+                Vendor comparison: your government versus Earth Optimization
+                Services
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Line item</th>
+                  <th scope="col">Your Government</th>
+                  <th scope="col" className="pkb-col-eos">
+                    Earth Optimization Services
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row">People murdered</th>
+                  <td className="pkb-col-gov">
+                    <ParameterValue
+                      className={N}
+                      display="withUnit"
+                      param={WAR_DEATHS_SINCE_1900}
+                    />{" "}
+                    since 1900
+                  </td>
+                  <td className="pkb-col-eos">0</td>
+                </tr>
+                <tr>
+                  <th scope="row">Money lost</th>
+                  <td className="pkb-col-gov">
+                    <ParameterValue
+                      className={N}
+                      param={PENTAGON_UNACCOUNTED_FUNDS}
+                    />{" "}
+                    misplaced (7 failed audits)
+                  </td>
+                  <td className="pkb-col-eos">
+                    Public ledger. Every dollar tracked live.
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">Tax code</th>
+                  <td className="pkb-col-gov">
+                    74,000 pages,{" "}
+                    <ParameterValue
+                      className={N}
+                      param={US_GOV_WASTE_TAX_COMPLIANCE}
+                    />
+                    /year compliance
+                  </td>
+                  <td className="pkb-col-eos">
+                    6 lines of code. Filing cost: $0.
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">Welfare programs</th>
+                  <td className="pkb-col-gov">
+                    80+, each with its own forms, case workers, 45-day wait
+                  </td>
+                  <td className="pkb-col-eos">
+                    1 for-loop. Equal split. Tomorrow morning.
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">Decision method</th>
+                  <td className="pkb-col-gov">
+                    535 humans who haven&apos;t read the bill, funded by the
+                    industries the bill regulates
+                  </td>
+                  <td className="pkb-col-eos">
+                    <ParameterValue
+                      className={N}
+                      param={CROWD_DECISION_ACCURACY}
+                    />{" "}
+                    crowd accuracy vs{" "}
+                    <ParameterValue
+                      className={N}
+                      param={EXPERT_DECISION_ACCURACY}
+                    />{" "}
+                    expert. Every question ships with evidence.
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">Your input</th>
+                  <td className="pkb-col-gov">
+                    1 bundled vote every 2 years. Correlation with outcomes: 0%.
+                  </td>
+                  <td className="pkb-col-eos">
+                    20 specific questions/year. Pairwise comparisons. Evidence
+                    attached.
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">Corruption surface</th>
+                  <td className="pkb-col-gov">
+                    <ParameterValue
+                      className={N}
+                      param={US_TOTAL_LOBBYING_ANNUAL}
+                    />
+                    /year in lobbying buys your laws
+                  </td>
+                  <td className="pkb-col-eos">
+                    No door. You cannot take 8 billion people to lunch.
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">Policy evidence used</th>
+                  <td className="pkb-col-gov">
+                    None. Drug war ran 50 years, overdoses up 1,700%, nobody
+                    checked.
+                  </td>
+                  <td className="pkb-col-eos">
+                    10,000 jurisdictions measured. Synthetic controls,
+                    diff-in-diff, regression discontinuity.
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">Disease queue</th>
+                  <td className="pkb-col-gov">
+                    <ParameterValue
+                      className={N}
+                      display="withUnit"
+                      figures={3}
+                      param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
+                    />{" "}
+                    at current rate
+                  </td>
+                  <td className="pkb-col-eos">
+                    <ParameterValue
+                      className={N}
+                      display="withUnit"
+                      figures={3}
+                      param={DFDA_QUEUE_CLEARANCE_YEARS}
+                    />{" "}
+                    with 1% moved to clinical trials
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">Time to notice you died</th>
+                  <td className="pkb-col-gov">
+                    Years (one week if you owed taxes)
+                  </td>
+                  <td className="pkb-col-eos">One day. The deposit stops.</td>
+                </tr>
+                <tr>
+                  <th scope="row">Shuts down over disagreements</th>
+                  <td className="pkb-col-gov">20+ times since 1976</td>
+                  <td className="pkb-col-eos">There is no door</td>
+                </tr>
+                <tr>
+                  <th scope="row">Audit record</th>
+                  <td className="pkb-col-gov">0 of 7 passed (Pentagon)</td>
+                  <td className="pkb-col-eos">
+                    Real-time public ledger, continuous
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">Budget allocation</th>
+                  <td className="pkb-col-gov">
+                    <ParameterValue
+                      className={N}
+                      display="withUnit"
+                      param={
+                        MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO
+                      }
+                    />{" "}
+                    kill:cure ratio
+                  </td>
+                  <td className="pkb-col-eos">
+                    Optimal budget calculated to maximize the two numbers
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">Sticker price</th>
+                  <td className="pkb-col-gov">
+                    <ParameterValue
+                      className={N}
+                      param={US_GOV_WASTE_PER_CAPITA_ANNUAL}
+                    />{" "}
+                    per American per year
+                  </td>
+                  <td className="pkb-col-eos">
+                    <ParameterValue
+                      className={N}
+                      param={GOV_REPLACEMENT_SUITE_OPEX_PER_CITIZEN_ANNUAL}
+                    />{" "}
+                    per citizen per year, plus dividends
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div className="pkb-colophon">
+            <p className="pkb-tag">
+              Universe Optimization Services · Earth Regional Branch
+            </p>
+            <p className="pkb-tag pkb-tag--blue">
+              Every figure sourced. Select any number for its derivation.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/eos-design-b/EosDesignBPage.tsx
+++ b/packages/web/src/components/eos-design-b/EosDesignBPage.tsx
@@ -1,0 +1,13 @@
+import "./eos-design-b.css";
+
+export function EosDesignBPage() {
+  return (
+    <main className="dsb">
+      <section className="dsb-bill">
+        <div className="dsb-wrap">
+          <p className="dsb-eyebrow">Section 1 · The Bill</p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/packages/web/src/components/eos-design-b/EosDesignBPage.tsx
+++ b/packages/web/src/components/eos-design-b/EosDesignBPage.tsx
@@ -11,6 +11,11 @@ import { StoreSheet } from "@/components/eos-design-b/StoreSheet";
  * A competing visual direction, built as a comparison slice rather than the
  * full eleven-section page: the end of Section 1 and the pivot, Section 2,
  * one Section 4 product at full scale, and Section 3.
+ *
+ * Section order follows the build brief rather than the spec's numbering, so
+ * the matrix closes the slice: Bill tail, pivot, Store, Optimitron, matrix.
+ * Every figure the spec supplies as a variable renders through
+ * ParameterValue; the plain-text figures are verbatim spec prose.
  */
 export function EosDesignBPage() {
   return (

--- a/packages/web/src/components/eos-design-b/EosDesignBPage.tsx
+++ b/packages/web/src/components/eos-design-b/EosDesignBPage.tsx
@@ -1,13 +1,24 @@
 import "./eos-design-b.css";
 
+import { BillTailAndPivot } from "@/components/eos-design-b/BillTailAndPivot";
+import { ComparisonSheet } from "@/components/eos-design-b/ComparisonSheet";
+import { OptimitronSheet } from "@/components/eos-design-b/OptimitronSheet";
+import { StoreSheet } from "@/components/eos-design-b/StoreSheet";
+
+/**
+ * EOS landing — Version B, "The Press Kit".
+ *
+ * A competing visual direction, built as a comparison slice rather than the
+ * full eleven-section page: the end of Section 1 and the pivot, Section 2,
+ * one Section 4 product at full scale, and Section 3.
+ */
 export function EosDesignBPage() {
   return (
-    <main className="dsb">
-      <section className="dsb-bill">
-        <div className="dsb-wrap">
-          <p className="dsb-eyebrow">Section 1 · The Bill</p>
-        </div>
-      </section>
+    <main className="pkb">
+      <BillTailAndPivot />
+      <StoreSheet />
+      <OptimitronSheet />
+      <ComparisonSheet />
     </main>
   );
 }

--- a/packages/web/src/components/eos-design-b/OptimitronSheet.tsx
+++ b/packages/web/src/components/eos-design-b/OptimitronSheet.tsx
@@ -133,13 +133,13 @@ export function OptimitronSheet() {
                 invade. Disease eradication goes from{" "}
                 <ParameterValue
                   className={N}
-                  display="integer"
+                  display="withUnit"
                   param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
                 />{" "}
                 to{" "}
                 <ParameterValue
                   className={N}
-                  display="integer"
+                  display="withUnit"
                   param={DFDA_QUEUE_CLEARANCE_YEARS}
                 />
                 . The average treatment arrives{" "}

--- a/packages/web/src/components/eos-design-b/OptimitronSheet.tsx
+++ b/packages/web/src/components/eos-design-b/OptimitronSheet.tsx
@@ -1,0 +1,191 @@
+import {
+  DFDA_QUEUE_CLEARANCE_YEARS,
+  DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_LIVES_SAVED,
+  DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_YEARS,
+  POST_WW2_MILITARY_CUT_PCT,
+  STATUS_QUO_QUEUE_CLEARANCE_YEARS,
+  US_1939_MILITARY_SPENDING_PCT_LOWER_THAN_CURRENT,
+} from "@optimitron/data/parameters";
+import { ParameterValue } from "@/components/shared/ParameterValue";
+import { PolicyComparator } from "@/components/eos-design-b/PolicyComparator";
+import { TwoNumberDashboard } from "@/components/eos-design-b/TwoNumberDashboard";
+
+const N = "pk-n";
+
+/**
+ * Section 4, Product 1 — The Optimitron, at data-journalism scale.
+ *
+ * The two-number dashboard is the section: two enormous counters that run
+ * from today's measured value to the treaty-trajectory target. The policy
+ * comparator sits under it as the working demo. All four prose paragraphs
+ * from the spec live behind "read the math".
+ */
+export function OptimitronSheet() {
+  return (
+    <section className="pkb-sec" id="the-optimitron">
+      <div className="pkb-wrap">
+        <div className="pkb-sheet">
+          <div className="pkb-sheethead">
+            <h2>Fig. 3 — Product 1: The Optimitron</h2>
+            <p className="pkb-tag">Release No. EOS-B-001 · Sheet 3 of 4</p>
+          </div>
+
+          <div className="pkb-prodhead">
+            <p className="pkb-tag pkb-tag--blue">The Evidence Engine</p>
+            <p className="pkb-prodname">The Optimitron</p>
+            <p className="pkb-prodtag">
+              The thermostat your government never installed.
+            </p>
+            <table className="pkb-spec">
+              <tbody>
+                <tr>
+                  <th scope="row">Replaces</th>
+                  <td>Governing by argument.</td>
+                </tr>
+                <tr>
+                  <th scope="row">Retail price</th>
+                  <td>Included. The data is free.</td>
+                </tr>
+                <tr>
+                  <th scope="row">Currently paying</th>
+                  <td>
+                    Whatever your representatives&apos; donors feel like.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p className="pkb-tag pkb-tag--hot" style={{ marginBottom: "1rem" }}>
+            Center display · The two numbers everything is scored on
+          </p>
+          <TwoNumberDashboard />
+
+          <p
+            className="pkb-tag pkb-tag--blue"
+            style={{ marginTop: "clamp(2.5rem, 6vw, 4rem)" }}
+          >
+            Policy comparator · Select a line to open the measurement
+          </p>
+          <PolicyComparator />
+
+          <div className="pkb-callouts" style={{ marginTop: "2rem" }}>
+            <div className="pkb-callout">
+              <span className="pkb-callout-k">
+                Disease queue, current rate
+              </span>
+              <span className="pkb-callout-v">
+                <ParameterValue
+                  className={N}
+                  display="integer"
+                  param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
+                />{" "}
+                years
+              </span>
+            </div>
+            <div className="pkb-callout">
+              <span className="pkb-callout-k">
+                Disease queue, 1% Treaty rate
+              </span>
+              <span className="pkb-callout-v">
+                <ParameterValue
+                  className={N}
+                  display="integer"
+                  param={DFDA_QUEUE_CLEARANCE_YEARS}
+                />{" "}
+                years
+              </span>
+            </div>
+            <div className="pkb-callout">
+              <span className="pkb-callout-k">
+                People who would have died and do not
+              </span>
+              <span className="pkb-callout-v">
+                <ParameterValue
+                  className={N}
+                  param={DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_LIVES_SAVED}
+                />
+              </span>
+            </div>
+          </div>
+
+          <details className="pkb-math">
+            <summary>Read the math · how the recommendation is made</summary>
+            <div className="pkb-mathbody">
+              <p>
+                Your planet has 10,000 jurisdictions, each trying slightly
+                different policies. Some produce healthy, wealthy citizens.
+                Others produce the opposite. Right now, you determine which is
+                which by having politicians argue on television. The Optimal
+                Policy Generator replaces the arguing with counting.
+              </p>
+              <p>
+                It examines what every jurisdiction tried and what happened
+                next. Synthetic controls, difference-in-differences, regression
+                discontinuity. Not opinion. Not ideology. Measurement. Output:
+                ENACT / REPLACE / REPEAL / MAINTAIN. Each recommendation scored
+                on the two numbers.
+              </p>
+              <p>
+                Its current highest-expected-value recommendation is the 1%
+                Treaty: move 1% of every nation&apos;s weapons budget to
+                clinical trials. Everyone cuts equally. Nobody is easier to
+                invade. Disease eradication goes from{" "}
+                <ParameterValue
+                  className={N}
+                  display="integer"
+                  param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
+                />{" "}
+                to{" "}
+                <ParameterValue
+                  className={N}
+                  display="integer"
+                  param={DFDA_QUEUE_CLEARANCE_YEARS}
+                />
+                . The average treatment arrives{" "}
+                <ParameterValue
+                  className={N}
+                  param={DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_YEARS}
+                />{" "}
+                sooner.{" "}
+                <ParameterValue
+                  className={N}
+                  param={DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_LIVES_SAVED}
+                />{" "}
+                people who would have died do not.
+              </p>
+              <p>
+                Your governments have signed treaties banning chemical weapons
+                (193 countries), biological weapons (187), and landmines (164).
+                This one asks them to buy 1% fewer weapons and spend the savings
+                on figuring out why everyone keeps dying. Pre-WW2 military
+                spending was{" "}
+                <ParameterValue
+                  className={N}
+                  param={US_1939_MILITARY_SPENDING_PCT_LOWER_THAN_CURRENT}
+                />{" "}
+                lower than today, inflation-adjusted. They still won World War
+                II. Then they cut spending{" "}
+                <ParameterValue
+                  className={N}
+                  param={POST_WW2_MILITARY_CUT_PCT}
+                />{" "}
+                in two years and walked into the greatest economic expansion in
+                history. One percent should be manageable.
+              </p>
+            </div>
+          </details>
+
+          <div className="pkb-quote">
+            <p>
+              &ldquo;We spent 4,000 years debating education policy. The Optimal
+              Policy Generator resolved it in an afternoon. Our main regret is
+              the 4,000 years.&rdquo;
+            </p>
+            <cite>Planet Keth-7, client since 8,000 BCE</cite>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/eos-design-b/OptimitronSheet.tsx
+++ b/packages/web/src/components/eos-design-b/OptimitronSheet.tsx
@@ -145,6 +145,7 @@ export function OptimitronSheet() {
                 . The average treatment arrives{" "}
                 <ParameterValue
                   className={N}
+                  display="withUnit"
                   param={DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_YEARS}
                 />{" "}
                 sooner.{" "}

--- a/packages/web/src/components/eos-design-b/PolicyComparator.tsx
+++ b/packages/web/src/components/eos-design-b/PolicyComparator.tsx
@@ -62,7 +62,10 @@ const ROWS: Row[] = [
     after: (
       <>
         1% Treaty funds{" "}
-        <ParameterValue className={N} param={TREATY_ANNUAL_FUNDING} />
+        <ParameterValue
+          className={N}
+          param={{ ...TREATY_ANNUAL_FUNDING, unit: "USD" }}
+        />
         /year in trials
       </>
     ),

--- a/packages/web/src/components/eos-design-b/PolicyComparator.tsx
+++ b/packages/web/src/components/eos-design-b/PolicyComparator.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import {
+  MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO,
+  TREATY_ANNUAL_FUNDING,
+} from "@optimitron/data/parameters";
+import { ParameterValue } from "@/components/shared/ParameterValue";
+
+const N = "pk-n";
+
+interface Row {
+  name: string;
+  before: ReactNode;
+  after: ReactNode;
+}
+
+const ROWS: Row[] = [
+  {
+    name: "Tax code",
+    before: "74,000 pages. Filing cost per citizen: $1,200.",
+    after: "6 lines. Filing cost per citizen: $0.",
+  },
+  {
+    name: "Drug approval",
+    before: "14 years, $2.6 billion per drug. 50 approvals/year.",
+    after: "Pragmatic trials, 90% cost reduction. 200+ approvals/year.",
+  },
+  {
+    name: "Welfare",
+    before: "80+ programs, 95,000 administrators.",
+    after: "Single universal deposit, automatic.",
+  },
+  {
+    name: "Clinical trials",
+    before: (
+      <>
+        <ParameterValue
+          className={N}
+          display="integer"
+          param={MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO}
+        />{" "}
+        kill:cure ratio
+      </>
+    ),
+    after: (
+      <>
+        1% Treaty funds{" "}
+        <ParameterValue className={N} param={TREATY_ANNUAL_FUNDING} />
+        /year in trials
+      </>
+    ),
+  },
+];
+
+/**
+ * The Optimal Policy Generator's comparator: four policies, each with the
+ * measured before and the recommended after. Click a row to open it.
+ */
+export function PolicyComparator() {
+  const [open, setOpen] = useState<number | null>(0);
+
+  return (
+    <div className="pkb-policygrid">
+      {ROWS.map((row, index) => {
+        const isOpen = open === index;
+        const panelId = `pkb-policy-${index}`;
+        return (
+          <div className="pkb-policy" key={row.name}>
+            <button
+              type="button"
+              aria-expanded={isOpen}
+              aria-controls={panelId}
+              onClick={() => setOpen(isOpen ? null : index)}
+            >
+              <span className="pkb-policy-no">
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <span className="pkb-policy-name">{row.name}</span>
+              <span className="pkb-policy-sign" aria-hidden="true">
+                {isOpen ? "−" : "+"}
+              </span>
+            </button>
+            {isOpen && (
+              <div className="pkb-policy-body" id={panelId}>
+                <div className="pkb-ba">
+                  <span className="pkb-ba-k">Currently paying</span>
+                  <span className="pkb-ba-v">{row.before}</span>
+                </div>
+                <span className="pkb-arrow" aria-hidden="true">
+                  →
+                </span>
+                <div className="pkb-ba pkb-ba--after">
+                  <span className="pkb-ba-k">Recommendation</span>
+                  <span className="pkb-ba-v">{row.after}</span>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/components/eos-design-b/PolicyComparator.tsx
+++ b/packages/web/src/components/eos-design-b/PolicyComparator.tsx
@@ -2,7 +2,10 @@
 
 import { useState, type ReactNode } from "react";
 import {
+  CURRENT_DRUG_APPROVALS_PER_YEAR,
+  DRUG_DISCOVERY_TO_APPROVAL_YEARS,
   MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO,
+  PHARMA_DRUG_DEVELOPMENT_COST_CURRENT,
   TREATY_ANNUAL_FUNDING,
 } from "@optimitron/data/parameters";
 import { ParameterValue } from "@/components/shared/ParameterValue";
@@ -23,7 +26,20 @@ const ROWS: Row[] = [
   },
   {
     name: "Drug approval",
-    before: "14 years, $2.6 billion per drug. 50 approvals/year.",
+    before: (
+      <>
+        <ParameterValue className={N} param={DRUG_DISCOVERY_TO_APPROVAL_YEARS} />{" "}
+        years,{" "}
+        <ParameterValue
+          className={N}
+          display="withUnit"
+          param={PHARMA_DRUG_DEVELOPMENT_COST_CURRENT}
+        />{" "}
+        per drug.{" "}
+        <ParameterValue className={N} param={CURRENT_DRUG_APPROVALS_PER_YEAR} />{" "}
+        approvals/year.
+      </>
+    ),
     after: "Pragmatic trials, 90% cost reduction. 200+ approvals/year.",
   },
   {

--- a/packages/web/src/components/eos-design-b/StoreSheet.tsx
+++ b/packages/web/src/components/eos-design-b/StoreSheet.tsx
@@ -1,0 +1,108 @@
+import { GLOBAL_POPULATION_2024 } from "@optimitron/data/parameters";
+import { ParameterValue } from "@/components/shared/ParameterValue";
+
+/**
+ * Section 2 — The Store.
+ *
+ * Press-kit treatment: the screen leads with the share register (one Class A
+ * share per human, so the enormous number is the human population), the short
+ * verbatim paragraphs run as figure legend and provenance note, and the long
+ * definition paragraph sits behind "read the math".
+ */
+export function StoreSheet() {
+  return (
+    <section className="pkb-sec pkb-grid" id="the-store">
+      <div className="pkb-wrap">
+        <div className="pkb-sheet">
+          <div className="pkb-sheethead">
+            <h2>Fig. 2 — The Store</h2>
+            <p className="pkb-tag">Release No. EOS-B-001 · Sheet 2 of 4</p>
+          </div>
+
+          <div className="pkb-storegrid">
+            <div>
+              <p className="pkb-tag pkb-tag--blue">
+                Class A shares outstanding
+              </p>
+              <span className="pkb-huge">
+                <ParameterValue
+                  param={GLOBAL_POPULATION_2024}
+                  presentation="inline"
+                />
+                <span className="pkb-huge-unit">humans</span>
+              </span>
+              <div className="pkb-dim">
+                <span className="pkb-tag">1 human</span>
+                <span className="pkb-dim-rule" />
+                <span className="pkb-tag pkb-tag--blue">1 share · 1 vote</span>
+              </div>
+              <p className="pkb-legend" style={{ marginTop: "1.4rem" }}>
+                You are the President of Earth Optimization Services. One Class
+                A share per human, one civic vote, free. If you want returns,
+                buy Class B shares. Money buys a share of the profit, not extra
+                votes or governance. One cannot buy the steering wheel, no
+                matter how many shares you own, because selling the steering
+                wheel is the problem we are solving.
+              </p>
+            </div>
+
+            <div>
+              <p className="pkb-lede">
+                Universe Optimization Services has been upgrading civilizations
+                since before your sun ignited. Over 300 planets optimized. 100%
+                satisfaction rate among clients who got started.
+              </p>
+              <p
+                className="pkb-legend"
+                style={{ marginTop: "1.1rem", maxWidth: "40ch" }}
+              >
+                Clients who did not get started are not available for comment,
+                as they are not available for anything. Some are available for
+                mining rights.
+              </p>
+              <div className="pkb-callouts" style={{ marginTop: "1.75rem" }}>
+                <div className="pkb-callout">
+                  <span className="pkb-callout-k">Regional branch</span>
+                  <span className="pkb-callout-v">
+                    Earth Optimization Services
+                  </span>
+                </div>
+                <div className="pkb-callout">
+                  <span className="pkb-callout-k">Technology</span>
+                  <span className="pkb-callout-v">Same proven technology</span>
+                </div>
+                <div className="pkb-callout">
+                  <span className="pkb-callout-k">Market</span>
+                  <span className="pkb-callout-v">
+                    Smaller market. More shouting.
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <details className="pkb-math">
+            <summary>Read the math · what the company actually does</summary>
+            <div className="pkb-mathbody">
+              <p>
+                Earth Optimization Services is a company that buys the companies
+                that control your government, uses hundreds of years of data
+                from 193 countries to determine the policies and budgets that
+                maximize two numbers (median health-adjusted life expectancy and
+                median after-tax inflation-adjusted income), and then uses
+                shareholder rights to make those companies&apos; lobbyists
+                implement the policies that are in the best interests of their
+                shareholders, the corporations&apos; profits, and the general
+                welfare, making everyone richer and significantly less dead.
+              </p>
+              <p>
+                Earth Optimization Services is our regional branch. Same proven
+                technology. Smaller market. More shouting.
+              </p>
+            </div>
+          </details>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/eos-design-b/TwoNumberDashboard.tsx
+++ b/packages/web/src/components/eos-design-b/TwoNumberDashboard.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  fmtParamValueOnly,
+  GLOBAL_HALE_CURRENT,
+  GLOBAL_MEDIAN_AFTER_TAX_INCOME_2025,
+  PRIZE_TARGET_HALE_YEAR_15,
+  PRIZE_TARGET_MEDIAN_INCOME_YEAR_15,
+  type Parameter,
+} from "@optimitron/data/parameters";
+import { ParameterValue } from "@/components/shared/ParameterValue";
+
+const N = "pk-n";
+const DURATION_MS = 1500;
+
+function easeOutCubic(t: number) {
+  return 1 - (1 - t) ** 3;
+}
+
+/**
+ * Counts a parameter up from its baseline to its target when the gauge
+ * scrolls into view. The rendered string always comes back through the
+ * parameter formatter, so nothing here is a hardcoded figure.
+ */
+function useCountUp(from: Parameter, to: Parameter) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [value, setValue] = useState(from.value);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const reduced =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+    if (reduced) {
+      setValue(to.value);
+      return;
+    }
+
+    let frame = 0;
+    let start = 0;
+
+    const step = (now: number) => {
+      if (!start) start = now;
+      const t = Math.min(1, (now - start) / DURATION_MS);
+      setValue(from.value + (to.value - from.value) * easeOutCubic(t));
+      if (t < 1) frame = requestAnimationFrame(step);
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          observer.disconnect();
+          frame = requestAnimationFrame(step);
+        }
+      },
+      { threshold: 0.35 },
+    );
+
+    observer.observe(node);
+    return () => {
+      observer.disconnect();
+      if (frame) cancelAnimationFrame(frame);
+    };
+  }, [from, to]);
+
+  return { ref, value };
+}
+
+function Gauge({
+  baseline,
+  target,
+  unitLabel,
+  title,
+  legend,
+}: {
+  baseline: Parameter;
+  target: Parameter;
+  unitLabel: string;
+  title: string;
+  legend: string;
+}) {
+  const { ref, value } = useCountUp(baseline, target);
+  const scaleMax = target.value * 1.15;
+  const fillPct = Math.max(0, Math.min(100, (value / scaleMax) * 100));
+  const targetPct = Math.max(0, Math.min(100, (target.value / scaleMax) * 100));
+
+  return (
+    <div className="pkb-gauge" ref={ref}>
+      <div className="pkb-gauge-head">
+        <p className="pkb-tag pkb-tag--blue">{title}</p>
+        <p className="pkb-tag">Year 15</p>
+      </div>
+      <span className="pkb-huge">
+        {fmtParamValueOnly({ ...target, value })}
+        <span className="pkb-huge-unit">{unitLabel}</span>
+      </span>
+      <div className="pkb-track" aria-hidden="true">
+        <span className="pkb-track-base" />
+        <span className="pkb-track-fill" style={{ width: `${fillPct}%` }} />
+        <span className="pkb-track-tick" style={{ left: `${targetPct}%` }} />
+      </div>
+      <p className="pkb-gauge-sub">
+        Today <ParameterValue className={N} param={baseline} /> → treaty
+        trajectory <b>
+          <ParameterValue className={N} param={target} />
+        </b>
+      </p>
+      <p className="pkb-legend" style={{ marginTop: "0.6rem" }}>
+        {legend}
+      </p>
+    </div>
+  );
+}
+
+export function TwoNumberDashboard() {
+  return (
+    <div className="pkb-dash">
+      <Gauge
+        baseline={GLOBAL_HALE_CURRENT}
+        target={PRIZE_TARGET_HALE_YEAR_15}
+        unitLabel="years"
+        title="Median Healthy Life Years"
+        legend="Not average life expectancy; the age at which the median person is still healthy."
+      />
+      <Gauge
+        baseline={GLOBAL_MEDIAN_AFTER_TAX_INCOME_2025}
+        target={PRIZE_TARGET_MEDIAN_INCOME_YEAR_15}
+        unitLabel="per year"
+        title="Median Real After-Tax Income"
+        legend="Not GDP per capita; not average."
+      />
+    </div>
+  );
+}

--- a/packages/web/src/components/eos-design-b/eos-design-b.css
+++ b/packages/web/src/components/eos-design-b/eos-design-b.css
@@ -150,16 +150,24 @@
   color: var(--pk-blue);
   display: block;
   overflow-wrap: anywhere;
+  /* line-height below 1 pulls the box up into the eyebrow above it */
+  margin-top: 0.12em;
 }
 .pkb-huge--hot {
   color: var(--pk-hot);
 }
+/* The unit sits on its own line beneath the number, the way a drawing
+   annotates a dimension. Superscripting it wrecks the line box at this
+   type size. */
 .pkb-huge .pkb-huge-unit {
+  display: block;
+  margin-top: 0.7rem;
   font-family: var(--pk-mono);
   font-weight: 400;
-  font-size: clamp(0.75rem, 1.8vw, 1.1rem);
-  letter-spacing: 0.2em;
-  vertical-align: super;
+  font-size: clamp(0.62rem, 1.4vw, 0.78rem);
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  line-height: 1.4;
   color: var(--pk-ink-faint);
 }
 
@@ -580,6 +588,7 @@
 /* Spec table: the "retail price / currently paying" ledger. */
 .pkb-spec {
   width: 100%;
+  max-width: 46rem;
   border-collapse: collapse;
   font-size: clamp(0.82rem, 1.7vw, 0.95rem);
 }
@@ -597,7 +606,7 @@
   text-transform: uppercase;
   color: var(--pk-ink-faint);
   font-weight: 400;
-  width: 40%;
+  width: 30%;
 }
 .pkb-spec td {
   font-weight: 600;
@@ -654,7 +663,7 @@
   margin-bottom: 0.75rem;
 }
 .pkb-gauge .pkb-huge {
-  font-size: clamp(3.2rem, 12vw, 9.5rem);
+  font-size: clamp(3rem, 10.5vw, 8.25rem);
 }
 .pkb-gauge-sub {
   font-family: var(--pk-mono);
@@ -816,6 +825,18 @@
 }
 .pkb-counterbid-v .pk-n {
   color: var(--pk-blue);
+}
+
+/* The matrix is wider than a phone. Say so rather than letting the EOS
+   column hide off-screen. */
+.pkb-scrollhint {
+  display: none;
+  margin-bottom: 0.5rem;
+}
+@media (max-width: 780px) {
+  .pkb-scrollhint {
+    display: block;
+  }
 }
 
 .pkb-matrixscroll {

--- a/packages/web/src/components/eos-design-b/eos-design-b.css
+++ b/packages/web/src/components/eos-design-b/eos-design-b.css
@@ -1,22 +1,884 @@
-/* Version B — "The Press Kit". Scaffold; full design system lands next commit. */
-.dsb {
-  background: #ffffff;
-  color: #12161d;
+/*
+ * EOS landing — VERSION B, "THE PRESS KIT" (/design-b).
+ *
+ * A 1962 NASA press kit: white and pale-sky grounds, engineering-drawing
+ * hairlines, figure numbers, technical callouts, NASA blue with one hot
+ * accent. Data-journalism scale: one enormous number per screen, the demo
+ * IS the section, prose demoted to captions and "read the math" disclosure.
+ *
+ * SANCTIONED DARK EXCEPTION, same basis as eos-retro.css (Mike 2026-07-11):
+ * Section 1 (The Bill) is the only dark register on this page, per the
+ * landing spec. Everything from the pivot onward is bright and must stay
+ * bright. Every rule is scoped under .pkb and must not leak onto treaty
+ * pages.
+ */
+
+.pkb {
+  /* ---- grounds ---- */
+  --pk-paper: #ffffff;
+  --pk-sky: #dce8f4;
+  --pk-sky-deep: #c2d6e9;
+  --pk-chrome: #e6ebf0;
+
+  /* ---- ink ---- */
+  --pk-ink: #0d141c;
+  --pk-ink-soft: #4a5765;
+  --pk-ink-faint: #7d8b99;
+
+  /* ---- linework ---- */
+  --pk-line: #9db0c2;
+  --pk-line-soft: #c8d5e1;
+  --pk-line-hard: #0d141c;
+
+  /* ---- signal ---- */
+  --pk-blue: #0b3d91;
+  --pk-blue-mid: #2f6fbd;
+  --pk-hot: #e0301b;
+
+  /* ---- the bill (dark register, section 1 only) ---- */
+  --pk-bill-bg: #05070a;
+  --pk-bill-ink: #f2f1ec;
+  --pk-bill-ink-soft: #8d8b85;
+  --pk-bill-hot: #ff5c50;
+
+  --pk-display: var(--v0-font-dm-sans), ui-sans-serif, system-ui, sans-serif;
+  --pk-mono: var(--v0-font-space-mono), ui-monospace, "Consolas", monospace;
+
+  background: var(--pk-paper);
+  color: var(--pk-ink);
+  font-family: var(--pk-display);
+  -webkit-font-smoothing: antialiased;
+  overflow-x: clip;
 }
-.dsb-wrap {
+
+/* ==========================================================================
+   PRIMITIVES
+   ========================================================================== */
+
+.pkb-wrap {
   width: 100%;
-  max-width: 1180px;
+  max-width: 1240px;
   margin: 0 auto;
-  padding: 0 clamp(1.25rem, 4vw, 3rem);
+  padding: 0 clamp(1rem, 4vw, 3.5rem);
 }
-.dsb-bill {
-  background: #05070a;
-  color: #f4f2ed;
-  padding: 4rem 0;
+
+.pkb-sec {
+  padding: clamp(3.5rem, 8vw, 7rem) 0;
+  position: relative;
 }
-.dsb-eyebrow {
-  font-family: var(--v0-font-space-mono), ui-monospace, monospace;
-  font-size: 0.72rem;
-  letter-spacing: 0.28em;
+
+/* Blueprint hairline grid, used on pale-sky grounds only. */
+.pkb-grid {
+  background-color: var(--pk-sky);
+  background-image:
+    linear-gradient(to right, rgba(11, 61, 145, 0.07) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(11, 61, 145, 0.07) 1px, transparent 1px);
+  background-size: 28px 28px;
+}
+
+/* Mono technical label. The press kit's connective tissue. */
+.pkb-tag {
+  font-family: var(--pk-mono);
+  font-size: clamp(0.6rem, 1.4vw, 0.7rem);
+  letter-spacing: 0.24em;
   text-transform: uppercase;
+  color: var(--pk-ink-faint);
+  line-height: 1.6;
+}
+.pkb-tag--blue {
+  color: var(--pk-blue);
+}
+.pkb-tag--hot {
+  color: var(--pk-hot);
+}
+
+/* Sheet: the white document card with registration ticks at the corners. */
+.pkb-sheet {
+  position: relative;
+  background: var(--pk-paper);
+  border: 1px solid var(--pk-line);
+  padding: clamp(1.25rem, 3.5vw, 2.75rem);
+}
+.pkb-sheet::before,
+.pkb-sheet::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  pointer-events: none;
+}
+.pkb-sheet::before {
+  top: 7px;
+  left: 7px;
+  border-top: 1px solid var(--pk-line-hard);
+  border-left: 1px solid var(--pk-line-hard);
+}
+.pkb-sheet::after {
+  bottom: 7px;
+  right: 7px;
+  border-bottom: 1px solid var(--pk-line-hard);
+  border-right: 1px solid var(--pk-line-hard);
+}
+
+/* Sheet header rule: FIG. number left, sheet id right. */
+.pkb-sheethead {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1.5rem;
+  border-bottom: 1px solid var(--pk-line-hard);
+  padding-bottom: 0.6rem;
+  margin-bottom: clamp(1.5rem, 4vw, 2.75rem);
+}
+.pkb-sheethead h2 {
+  font-size: clamp(1.05rem, 2.6vw, 1.6rem);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  line-height: 1.1;
+}
+
+/* The enormous number. One per screen. */
+.pkb-huge {
+  font-family: var(--pk-display);
+  font-weight: 900;
+  font-size: clamp(3.4rem, 15vw, 13.5rem);
+  line-height: 0.82;
+  letter-spacing: -0.045em;
+  font-variant-numeric: tabular-nums;
+  color: var(--pk-blue);
+  display: block;
+  overflow-wrap: anywhere;
+}
+.pkb-huge--hot {
+  color: var(--pk-hot);
+}
+.pkb-huge .pkb-huge-unit {
+  font-family: var(--pk-mono);
+  font-weight: 400;
+  font-size: clamp(0.75rem, 1.8vw, 1.1rem);
+  letter-spacing: 0.2em;
+  vertical-align: super;
+  color: var(--pk-ink-faint);
+}
+
+/* Figure legend: the caption doing the work prose used to do. */
+.pkb-legend {
+  font-size: clamp(0.9rem, 1.7vw, 1.02rem);
+  line-height: 1.55;
+  color: var(--pk-ink-soft);
+  max-width: 62ch;
+}
+.pkb-legend strong {
+  color: var(--pk-ink);
+  font-weight: 700;
+}
+
+/* Dimension line, engineering-drawing style: |<----- label ----->| */
+.pkb-dim {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin: 1.1rem 0 0;
+}
+.pkb-dim-rule {
+  flex: 1 1 auto;
+  height: 1px;
+  background: var(--pk-line);
+  position: relative;
+  min-width: 1.5rem;
+}
+.pkb-dim-rule::before,
+.pkb-dim-rule::after {
+  content: "";
+  position: absolute;
+  top: -3px;
+  width: 1px;
+  height: 7px;
+  background: var(--pk-line-hard);
+}
+.pkb-dim-rule::before {
+  left: 0;
+}
+.pkb-dim-rule::after {
+  right: 0;
+}
+.pkb-dim .pkb-tag {
+  flex: 0 0 auto;
+}
+
+/* Callout stack: mono annotations hung off a hairline, like a drawing key. */
+.pkb-callouts {
+  border-left: 1px solid var(--pk-line);
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.85rem;
+}
+.pkb-callout {
+  position: relative;
+}
+.pkb-callout::before {
+  content: "";
+  position: absolute;
+  left: -1rem;
+  top: 0.5rem;
+  width: 0.6rem;
+  height: 1px;
+  background: var(--pk-line-hard);
+}
+.pkb-callout-k {
+  font-family: var(--pk-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--pk-ink-faint);
+  display: block;
+}
+.pkb-callout-v {
+  font-size: clamp(1rem, 2.2vw, 1.25rem);
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  color: var(--pk-ink);
+  letter-spacing: -0.01em;
+}
+
+/* Numbers inside prose: blue, tabular, no dotted-underline chrome. */
+.pkb :where(.pk-n) {
+  color: var(--pk-blue);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  text-decoration: none;
+  cursor: pointer;
+}
+.pkb :where(.pk-n):hover {
+  color: var(--pk-hot);
+}
+
+/* "Read the math" disclosure: prose lives behind this, never in front. */
+.pkb-math {
+  border-top: 1px solid var(--pk-line-soft);
+  margin-top: clamp(1.5rem, 4vw, 2.5rem);
+}
+.pkb-math > summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 0.85rem 0;
+  font-family: var(--pk-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--pk-blue);
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+.pkb-math > summary::-webkit-details-marker {
+  display: none;
+}
+.pkb-math > summary::before {
+  content: "+";
+  font-size: 0.95rem;
+  line-height: 1;
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 1px solid currentColor;
+  display: grid;
+  place-items: center;
+}
+.pkb-math[open] > summary::before {
+  content: "\2212";
+}
+.pkb-math > summary:hover {
+  color: var(--pk-hot);
+}
+.pkb-mathbody {
+  columns: 2;
+  column-gap: 2.5rem;
+  padding-bottom: 1.25rem;
+}
+.pkb-mathbody p {
+  font-size: 0.88rem;
+  line-height: 1.62;
+  color: var(--pk-ink-soft);
+  margin: 0 0 0.9rem;
+  break-inside: avoid;
+}
+@media (max-width: 780px) {
+  .pkb-mathbody {
+    columns: 1;
+  }
+}
+
+/* Press quote / testimonial */
+.pkb-quote {
+  border-top: 2px solid var(--pk-line-hard);
+  border-bottom: 1px solid var(--pk-line);
+  padding: 1.1rem 0;
+  margin-top: clamp(1.75rem, 4vw, 2.75rem);
+  display: grid;
+  gap: 0.5rem;
+}
+.pkb-quote p {
+  font-size: clamp(1rem, 2.1vw, 1.22rem);
+  line-height: 1.45;
+  font-style: italic;
+  max-width: 68ch;
+}
+.pkb-quote cite {
+  font-family: var(--pk-mono);
+  font-style: normal;
+  font-size: 0.65rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--pk-ink-faint);
+}
+
+/* ==========================================================================
+   SECTION 1 — THE BILL (dark; the only dark register on this page)
+   ========================================================================== */
+
+.pkb-bill {
+  background: var(--pk-bill-bg);
+  color: var(--pk-bill-ink);
+  padding: clamp(3rem, 7vw, 5.5rem) 0 clamp(3.5rem, 8vw, 6rem);
+}
+.pkb-bill .pkb-tag {
+  color: var(--pk-bill-ink-soft);
+}
+.pkb-bill :where(.pk-n) {
+  color: var(--pk-bill-hot);
+}
+.pkb-bill :where(.pk-n):hover {
+  color: #fff;
+}
+.pkb-billhead {
+  border-bottom: 1px solid rgba(242, 241, 236, 0.16);
+  padding-bottom: 1rem;
+  margin-bottom: clamp(1.75rem, 4vw, 2.5rem);
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.pkb-charge {
+  max-width: 68ch;
+  display: grid;
+  gap: 1.1rem;
+}
+.pkb-charge p {
+  font-size: clamp(0.95rem, 1.9vw, 1.05rem);
+  line-height: 1.55;
+  color: rgba(242, 241, 236, 0.86);
+}
+.pkb-billnum {
+  margin: clamp(2.5rem, 6vw, 4.5rem) 0 0;
+  border-top: 1px solid rgba(242, 241, 236, 0.16);
+  padding-top: clamp(1.5rem, 4vw, 2.5rem);
+}
+.pkb-billnum .pkb-huge {
+  color: var(--pk-bill-hot);
+}
+.pkb-billnum .pkb-legend {
+  color: rgba(242, 241, 236, 0.72);
+  margin-top: 1.25rem;
+}
+.pkb-billnum .pkb-legend strong {
+  color: var(--pk-bill-ink);
+}
+.pkb-billlink {
+  display: inline-block;
+  margin-top: 1.1rem;
+  font-family: var(--pk-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--pk-bill-ink-soft);
+  border-bottom: 1px solid rgba(242, 241, 236, 0.3);
+  padding-bottom: 2px;
+}
+.pkb-billlink:hover {
+  color: var(--pk-bill-ink);
+}
+.pkb-love {
+  margin: clamp(2.5rem, 6vw, 4rem) 0 0;
+  max-width: 46ch;
+  display: grid;
+  gap: 0.8rem;
+}
+.pkb-love p {
+  font-size: clamp(1.05rem, 2.4vw, 1.45rem);
+  line-height: 1.35;
+  color: var(--pk-bill-ink);
+}
+
+/* ==========================================================================
+   THE PIVOT — courtroom to 1962
+   ========================================================================== */
+
+/* Chrome changeover strip: the dark ends, metal, then daylight. */
+.pkb-changeover {
+  height: clamp(10px, 2vw, 16px);
+  background: linear-gradient(
+    to bottom,
+    #05070a 0%,
+    #3d444c 18%,
+    #cfd6dc 42%,
+    #ffffff 58%,
+    #9fb0c0 74%,
+    var(--pk-sky) 100%
+  );
+}
+
+.pkb-pivot {
+  position: relative;
+  padding: clamp(3rem, 8vw, 6.5rem) 0 clamp(3.5rem, 8vw, 6rem);
+}
+/* Sunburst: light flooding in, kept to a single soft radial. */
+.pkb-pivot::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    120% 90% at 50% -10%,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(255, 255, 255, 0.55) 34%,
+    rgba(255, 255, 255, 0) 68%
+  );
+  pointer-events: none;
+}
+.pkb-pivot > * {
+  position: relative;
+}
+.pkb-release {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1.5rem;
+  border-top: 2px solid var(--pk-line-hard);
+  border-bottom: 1px solid var(--pk-line-hard);
+  padding: 0.55rem 0;
+  margin-bottom: clamp(1.75rem, 4vw, 3rem);
+}
+.pkb-masthead {
+  display: grid;
+  gap: clamp(1rem, 2.5vw, 1.5rem);
+  max-width: 22ch;
+}
+.pkb-marque {
+  font-size: clamp(1.6rem, 5.2vw, 3.4rem);
+  font-weight: 900;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  text-transform: uppercase;
+  color: var(--pk-blue);
+  max-width: 16ch;
+}
+.pkb-pivotgrid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  grid-template-columns: 1fr;
+  align-items: start;
+}
+@media (min-width: 900px) {
+  .pkb-pivotgrid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.15fr);
+    gap: clamp(2rem, 5vw, 4.5rem);
+  }
+}
+.pkb-pivot-q {
+  font-size: clamp(1.15rem, 2.6vw, 1.6rem);
+  line-height: 1.3;
+  font-weight: 500;
+  color: var(--pk-ink);
+  max-width: 30ch;
+}
+.pkb-pivot-a {
+  margin-top: clamp(1.25rem, 3vw, 2rem);
+  font-size: clamp(2.1rem, 7.4vw, 5.6rem);
+  font-weight: 900;
+  line-height: 0.92;
+  letter-spacing: -0.038em;
+  text-transform: uppercase;
+  color: var(--pk-ink);
+}
+.pkb-pivot-a em {
+  font-style: normal;
+  color: var(--pk-hot);
+}
+
+/* Roundel: the technical badge in place of a logo. */
+.pkb-roundel {
+  width: clamp(84px, 13vw, 132px);
+  height: clamp(84px, 13vw, 132px);
+  border-radius: 50%;
+  border: 1px solid var(--pk-line-hard);
+  display: grid;
+  place-items: center;
+  text-align: center;
+  background:
+    radial-gradient(circle at 50% 50%, transparent 0 38%, rgba(11, 61, 145, 0.08) 38% 39%, transparent 39%),
+    var(--pk-paper);
+  flex: 0 0 auto;
+}
+.pkb-roundel span {
+  font-family: var(--pk-mono);
+  font-size: clamp(0.5rem, 1.1vw, 0.6rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  line-height: 1.5;
+  color: var(--pk-blue);
+}
+
+/* ==========================================================================
+   SECTION 2 — THE STORE
+   ========================================================================== */
+
+.pkb-storegrid {
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 3rem);
+  grid-template-columns: 1fr;
+  align-items: start;
+}
+@media (min-width: 980px) {
+  .pkb-storegrid {
+    grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+    gap: clamp(2rem, 5vw, 4rem);
+  }
+}
+.pkb-lede {
+  font-size: clamp(1.05rem, 2.3vw, 1.35rem);
+  line-height: 1.4;
+  font-weight: 500;
+  color: var(--pk-ink);
+  max-width: 34ch;
+}
+
+/* Spec table: the "retail price / currently paying" ledger. */
+.pkb-spec {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: clamp(0.82rem, 1.7vw, 0.95rem);
+}
+.pkb-spec th,
+.pkb-spec td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.6rem 0.75rem 0.6rem 0;
+  border-bottom: 1px solid var(--pk-line-soft);
+}
+.pkb-spec th {
+  font-family: var(--pk-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--pk-ink-faint);
+  font-weight: 400;
+  width: 40%;
+}
+.pkb-spec td {
+  font-weight: 600;
+  color: var(--pk-ink);
+}
+
+/* ==========================================================================
+   PRODUCT SHEET — THE OPTIMITRON
+   ========================================================================== */
+
+.pkb-prodhead {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
+}
+.pkb-prodname {
+  font-size: clamp(1.9rem, 6vw, 4rem);
+  font-weight: 900;
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+  text-transform: uppercase;
+}
+.pkb-prodtag {
+  font-size: clamp(1rem, 2.2vw, 1.3rem);
+  color: var(--pk-blue);
+  font-weight: 500;
+  max-width: 40ch;
+}
+
+/* Two-number dashboard: the section's enormous pair. */
+.pkb-dash {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  grid-template-columns: 1fr;
+}
+@media (min-width: 860px) {
+  .pkb-dash {
+    grid-template-columns: 1fr 1fr;
+    gap: clamp(2rem, 4vw, 3.5rem);
+  }
+}
+.pkb-gauge {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
+}
+.pkb-gauge-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--pk-line-hard);
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+.pkb-gauge .pkb-huge {
+  font-size: clamp(3.2rem, 12vw, 9.5rem);
+}
+.pkb-gauge-sub {
+  font-family: var(--pk-mono);
+  font-size: clamp(0.65rem, 1.5vw, 0.76rem);
+  letter-spacing: 0.06em;
+  color: var(--pk-ink-soft);
+  line-height: 1.6;
+}
+.pkb-gauge-sub b {
+  color: var(--pk-blue);
+}
+
+/* Track: current -> target, drawn as an engineering scale. */
+.pkb-track {
+  margin-top: 0.9rem;
+  height: 26px;
+  position: relative;
+  border-left: 1px solid var(--pk-line-hard);
+  border-right: 1px solid var(--pk-line-hard);
+}
+.pkb-track-base {
+  position: absolute;
+  top: 12px;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--pk-line);
+}
+.pkb-track-fill {
+  position: absolute;
+  top: 10px;
+  left: 0;
+  height: 5px;
+  background: var(--pk-blue);
+  transition: width 900ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.pkb-track-tick {
+  position: absolute;
+  top: 4px;
+  width: 1px;
+  height: 17px;
+  background: var(--pk-hot);
+}
+
+.pkb-policygrid {
+  display: grid;
+  gap: 0;
+  border-top: 1px solid var(--pk-line-hard);
+  margin-top: clamp(2rem, 5vw, 3.5rem);
+}
+.pkb-policy {
+  border-bottom: 1px solid var(--pk-line-soft);
+}
+.pkb-policy > button {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem 1rem;
+  padding: 1rem 0;
+  background: none;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+}
+.pkb-policy > button:hover .pkb-policy-name {
+  color: var(--pk-hot);
+}
+.pkb-policy-no {
+  font-family: var(--pk-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.16em;
+  color: var(--pk-ink-faint);
+}
+.pkb-policy-name {
+  font-size: clamp(1rem, 2.2vw, 1.28rem);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+.pkb-policy-sign {
+  font-family: var(--pk-mono);
+  font-size: 1rem;
+  color: var(--pk-blue);
+  width: 1.4rem;
+  height: 1.4rem;
+  border: 1px solid var(--pk-line);
+  display: grid;
+  place-items: center;
+}
+.pkb-policy-body {
+  padding: 0 0 1.4rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 760px) {
+  .pkb-policy-body {
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 1.5rem;
+  }
+}
+.pkb-ba {
+  border-top: 1px solid var(--pk-line);
+  padding-top: 0.6rem;
+  min-width: 0;
+}
+.pkb-ba--after {
+  border-top-color: var(--pk-blue);
+}
+.pkb-ba-k {
+  font-family: var(--pk-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--pk-ink-faint);
+  display: block;
+  margin-bottom: 0.3rem;
+}
+.pkb-ba-v {
+  font-size: clamp(1rem, 2.1vw, 1.2rem);
+  font-weight: 700;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+.pkb-ba--after .pkb-ba-v {
+  color: var(--pk-blue);
+}
+.pkb-arrow {
+  font-family: var(--pk-mono);
+  color: var(--pk-hot);
+  font-size: 1.1rem;
+  justify-self: center;
+}
+
+/* ==========================================================================
+   SECTION 3 — THE COMPARISON MATRIX
+   ========================================================================== */
+
+.pkb-verdict {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2rem);
+  grid-template-columns: 1fr;
+  margin-bottom: clamp(2rem, 5vw, 3.5rem);
+}
+@media (min-width: 780px) {
+  .pkb-verdict {
+    grid-template-columns: 1fr 1fr;
+    gap: clamp(1.5rem, 4vw, 3rem);
+  }
+}
+.pkb-verdict-col {
+  border-top: 2px solid var(--pk-line-hard);
+  padding-top: 0.85rem;
+  min-width: 0;
+}
+.pkb-verdict-col--eos {
+  border-top-color: var(--pk-blue);
+}
+
+.pkb-matrixscroll {
+  overflow-x: auto;
+  border-top: 2px solid var(--pk-line-hard);
+  border-bottom: 2px solid var(--pk-line-hard);
+}
+.pkb-matrix {
+  width: 100%;
+  min-width: 620px;
+  border-collapse: collapse;
+  font-size: clamp(0.8rem, 1.6vw, 0.94rem);
+}
+.pkb-matrix thead th {
+  position: sticky;
+  top: 0;
+  background: var(--pk-paper);
+  text-align: left;
+  padding: 0.85rem 1rem 0.85rem 0;
+  border-bottom: 1px solid var(--pk-line-hard);
+  font-family: var(--pk-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-weight: 400;
+  color: var(--pk-ink-faint);
+  z-index: 1;
+}
+.pkb-matrix thead th.pkb-col-eos {
+  color: var(--pk-blue);
+}
+.pkb-matrix tbody th {
+  text-align: left;
+  font-family: var(--pk-mono);
+  font-weight: 400;
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--pk-ink-faint);
+  padding: 0.85rem 1.25rem 0.85rem 0;
+  vertical-align: top;
+  width: 22%;
+  border-bottom: 1px solid var(--pk-line-soft);
+}
+.pkb-matrix td {
+  padding: 0.85rem 1.25rem 0.85rem 0;
+  vertical-align: top;
+  line-height: 1.4;
+  border-bottom: 1px solid var(--pk-line-soft);
+  width: 39%;
+}
+.pkb-matrix td:last-child {
+  padding-right: 0;
+}
+.pkb-matrix tbody tr:hover td,
+.pkb-matrix tbody tr:hover th {
+  background: rgba(11, 61, 145, 0.04);
+}
+.pkb-col-gov {
+  color: var(--pk-ink-soft);
+}
+.pkb-col-eos {
+  color: var(--pk-ink);
+  font-weight: 600;
+  box-shadow: inset 1px 0 0 var(--pk-line-soft);
+  padding-left: 1.25rem !important;
+}
+.pkb-matrix .pkb-col-eos .pk-n {
+  color: var(--pk-blue);
+}
+.pkb-matrix .pkb-col-gov .pk-n {
+  color: var(--pk-hot);
+}
+
+/* Footer note strip */
+.pkb-colophon {
+  border-top: 1px solid var(--pk-line-hard);
+  margin-top: clamp(2rem, 5vw, 3.5rem);
+  padding-top: 0.85rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.5rem;
+  justify-content: space-between;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pkb-track-fill {
+    transition: none;
+  }
 }

--- a/packages/web/src/components/eos-design-b/eos-design-b.css
+++ b/packages/web/src/components/eos-design-b/eos-design-b.css
@@ -844,6 +844,10 @@
   border-top: 2px solid var(--pk-line-hard);
   border-bottom: 2px solid var(--pk-line-hard);
 }
+.pkb-matrixscroll:focus-visible {
+  outline: 2px solid var(--pk-blue);
+  outline-offset: 3px;
+}
 .pkb-matrix {
   width: 100%;
   min-width: 620px;

--- a/packages/web/src/components/eos-design-b/eos-design-b.css
+++ b/packages/web/src/components/eos-design-b/eos-design-b.css
@@ -1,0 +1,22 @@
+/* Version B — "The Press Kit". Scaffold; full design system lands next commit. */
+.dsb {
+  background: #ffffff;
+  color: #12161d;
+}
+.dsb-wrap {
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 clamp(1.25rem, 4vw, 3rem);
+}
+.dsb-bill {
+  background: #05070a;
+  color: #f4f2ed;
+  padding: 4rem 0;
+}
+.dsb-eyebrow {
+  font-family: var(--v0-font-space-mono), ui-monospace, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+}

--- a/packages/web/src/components/eos-design-b/eos-design-b.css
+++ b/packages/web/src/components/eos-design-b/eos-design-b.css
@@ -430,6 +430,22 @@
   );
 }
 
+/* Measured ruler, drawn straight under the changeover: the first thing the
+   bright register does is start counting. */
+.pkb-ruler {
+  height: 14px;
+  background-color: var(--pk-sky);
+  background-image: repeating-linear-gradient(
+    to right,
+    var(--pk-line-hard) 0 1px,
+    transparent 1px 16px
+  );
+  background-position: bottom;
+  background-size: 100% 7px;
+  background-repeat: repeat-x;
+  border-bottom: 1px solid var(--pk-line);
+}
+
 .pkb-pivot {
   position: relative;
   padding: clamp(3rem, 8vw, 6.5rem) 0 clamp(3.5rem, 8vw, 6rem);
@@ -547,6 +563,12 @@
     gap: clamp(2rem, 5vw, 4rem);
   }
 }
+/* The share register number carries a word suffix ("billion"), so it runs a
+   size down from the full-bleed enormous numbers and is allowed to wrap. */
+.pkb-storegrid .pkb-huge {
+  font-size: clamp(2.8rem, 9vw, 7.5rem);
+}
+
 .pkb-lede {
   font-size: clamp(1.05rem, 2.3vw, 1.35rem);
   line-height: 1.4;
@@ -773,25 +795,27 @@
    SECTION 3 — THE COMPARISON MATRIX
    ========================================================================== */
 
+/* The head-to-head: one enormous price, one very small one. The size
+   difference is the argument. */
 .pkb-verdict {
-  display: grid;
-  gap: clamp(1.25rem, 3vw, 2rem);
-  grid-template-columns: 1fr;
-  margin-bottom: clamp(2rem, 5vw, 3.5rem);
-}
-@media (min-width: 780px) {
-  .pkb-verdict {
-    grid-template-columns: 1fr 1fr;
-    gap: clamp(1.5rem, 4vw, 3rem);
-  }
-}
-.pkb-verdict-col {
+  margin: clamp(1.75rem, 4vw, 2.75rem) 0 clamp(2rem, 5vw, 3.5rem);
   border-top: 2px solid var(--pk-line-hard);
   padding-top: 0.85rem;
-  min-width: 0;
 }
-.pkb-verdict-col--eos {
-  border-top-color: var(--pk-blue);
+.pkb-counterbid {
+  margin-top: 0.9rem;
+  font-size: clamp(1rem, 2.2vw, 1.3rem);
+  color: var(--pk-ink-soft);
+  max-width: 46ch;
+}
+.pkb-counterbid-v {
+  font-size: clamp(1.5rem, 3.4vw, 2.2rem);
+  font-weight: 900;
+  letter-spacing: -0.02em;
+  color: var(--pk-blue);
+}
+.pkb-counterbid-v .pk-n {
+  color: var(--pk-blue);
 }
 
 .pkb-matrixscroll {
@@ -806,8 +830,6 @@
   font-size: clamp(0.8rem, 1.6vw, 0.94rem);
 }
 .pkb-matrix thead th {
-  position: sticky;
-  top: 0;
   background: var(--pk-paper);
   text-align: left;
   padding: 0.85rem 1rem 0.85rem 0;

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -1131,6 +1131,8 @@ export const designBLink: NavItem = {
   emoji: "🚀",
   description:
     "Competing visual direction B for the Earth Optimization Services landing page: a 1962 NASA press kit.",
+  copyPreview: true,
+  screenshot: true,
   cta: "View",
 };
 
@@ -1873,6 +1875,7 @@ export const routeReviewNavItems = [
   courtLink,
   donateLink,
   eosLink,
+  designBLink,
   joinLink,
   foundationsLink,
   signatoriesLink,

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -71,6 +71,7 @@ const warOnDiseaseDefaultSocialImage = {
 export const ROUTES = {
   home: "/",
   eos: "/eos",
+  designB: "/design-b",
   // Optimized Governance
   agencies: "/agencies",
   dfda: "/agencies/dfda",
@@ -1117,6 +1118,19 @@ export const eosLink: NavItem = {
   reviewName: "eos",
   screenshot: true,
   // TODO(copy): Mike copy gate. Source: Pivot 3 route requirement.
+  cta: "View",
+};
+
+/**
+ * Unlisted preview route for a bake-off visual direction. Not part of any
+ * nav section or STATIC_SITEMAP_ROUTES — metadata only, noindex.
+ */
+export const designBLink: NavItem = {
+  href: ROUTES.designB,
+  label: "EOS Landing — Version B (The Press Kit)",
+  emoji: "🚀",
+  description:
+    "Competing visual direction B for the Earth Optimization Services landing page: a 1962 NASA press kit.",
   cta: "View",
 };
 


### PR DESCRIPTION
One of three competing visual directions for the Earth Optimization Services landing page.

**Route: `/design-b`**

Preview it at `<preview-url>/design-b`.

## The direction

A 1962 NASA press kit. White and pale-sky grounds, engineering-drawing hairlines, figure numbers and sheet numbers, technical callouts, NASA blue with one hot red accent. Data-journalism scale: one enormous number per screen, the interactive demo *is* the section, prose demoted to captions, figure legends, and "read the math" disclosure.

## What is built (a comparison slice, not all 11 sections)

1. **End of Section 1 (The Bill) + the pivot.** Section 1 stays dark and dense per the spec; the Political Dysfunction Tax lands as that screen's enormous number. Then a chrome changeover strip, a measured ruler, and the release masthead: courtroom to 1962.
2. **Section 2 (The Store)** — leads with the share register (one Class A share per human).
3. **Section 4, Product 1 (The Optimitron)** at full data-journalism scale — the two-number dashboard is the section, with animated count-up gauges and a working policy comparator.
4. **Section 3 (The Comparison Matrix)** — head-to-head sticker price, then the full fourteen-row vendor data sheet.

## Constraints honoured

- Copy is verbatim from `manual/knowledge/production/eos-landing-page.qmd`. Nothing rewritten.
- Every spec `{{< var >}}` number goes through the existing `ParameterValue` pipeline, including the animated counters (they re-format through `fmtParamValueOnly` on every frame). No hardcoded figures.
- No new npm dependencies.
- Works at 390px and 1440px. The matrix scrolls inside its own container; the page body never scrolls sideways.

Screenshots captured and inspected locally at desktop 1440 and mobile 390, full page plus first-screen crops.

Do not merge. This is one of three directions to compare.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `/design-b` visual preview page featuring an “EOS Press Kit”-style layout.
  * Introduced new bill, store, recommendation (with collapsible math), and competing bid comparison matrix sections.
  * Added an animated two-metric dashboard with reduced-motion support.
  * Added noindex/no-follow routing plus a corresponding navigation preview entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->