### PR TITLE
Stop agents writing to a shadow database and reading the wrong queue

### DIFF
--- a/.claude/agents/voice-critic.md
+++ b/.claude/agents/voice-critic.md
@@ -35,7 +35,7 @@ If you can't confirm by reading the source, DROP the finding or label it explici
 
 These run regardless of which smell first caught your attention.
 
-1. **Manual-search before suggesting new copy.** If you're proposing replacement wording for any user-facing string, first call `mcp__optimitron-tasks__searchManual` with the topic phrase and check whether the manual already has a sharper version we should steal. The manual is the source of truth for voice — quoting from it beats inventing fresh prose. If the manual has nothing usable, say so explicitly in the finding so the reader knows you checked.
+1. **Manual-search before suggesting new copy.** If you're proposing replacement wording for any user-facing string, first call the Optimitron MCP `searchManual` tool with the topic phrase and check whether the manual already has a sharper version we should steal. The manual is the source of truth for voice — quoting from it beats inventing fresh prose. If the manual has nothing usable, say so explicitly in the finding so the reader knows you checked.
 2. **Parameter coverage for every number.** For every hardcoded user-facing number in the changeset (digits, percentages, multipliers, dollar amounts, year counts), grep `packages/data/src/parameters/parameters-calculations-citations.ts` and the wider `packages/data/src/parameters/` directory for an existing parameter. If one exists and the JSX uses a raw literal instead of `<ParameterValue>`, flag it with the parameter ID. If no parameter exists yet, flag whether a new parameter is warranted (cited statistics warrant one; arithmetic identities like "2² = 4" do not).
 
 # Common smells (use as hypotheses to investigate, not as automatic verdicts)

--- a/.claude/skills/qa-editorial.md
+++ b/.claude/skills/qa-editorial.md
@@ -23,7 +23,7 @@ Run the gstack chain FIRST, then this:
 
 Three subagents IN PARALLEL via the `Agent` tool:
 
-1. **`voice-critic`** — Copy critique against project voice rules. Catches startup-bro phrasing, banned vocabulary (engage, empower, off-ramp, primitive), tautological hints under headings, adjective stacks with no number, Stripe-keynote sentences. **Required to call `mcp__optimitron-tasks__searchManual`** before proposing replacement copy, and to grep `parameters-calculations-citations.ts` for every hardcoded user-facing number. If MCP isn't wired, fall back to `curl https://manual.warondisease.org/assets/json/search-index.json` — same content, no auth.
+1. **`voice-critic`** — Copy critique against project voice rules. Catches startup-bro phrasing, banned vocabulary (engage, empower, off-ramp, primitive), tautological hints under headings, adjective stacks with no number, Stripe-keynote sentences. **Required to call the Optimitron MCP `searchManual` tool** before proposing replacement copy, and to grep `parameters-calculations-citations.ts` for every hardcoded user-facing number. If MCP isn't wired, fall back to `curl https://manual.warondisease.org/assets/json/search-index.json` — same content, no auth.
 2. **`cold-stranger-ux`** — Zero-context first-time reader reaction. Drives a real browser at iPhone-14 viewport, takes screenshots, reacts in plain English. Catches confusing UX, missing case-for-action, would-bail moments.
 3. **`test-auditor`** — Test suite slop + missing coverage. Catches "tests added for symmetry / documentation / to silence a bot" and missing regression tests for fixed bugs.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@
 
 ## Research And Copy
 
-- For user-facing copy, call `mcp__optimitron-tasks__searchManual` before drafting. Use `askWishonia` only when synthesis is needed. If MCP is unavailable, search `https://manual.warondisease.org/assets/json/search-index.json` and say the fallback was used.
+- For user-facing copy, call the Optimitron MCP `searchManual` tool before drafting. Use `askWishonia` only when synthesis is needed. If MCP is unavailable, search `https://manual.warondisease.org/assets/json/search-index.json` and say the fallback was used.
+- **Use the hosted Optimitron connector, never a local MCP server.** Task, person, and organization writes must land in the production database. A local server exposes identically-named tools backed by a different database, so writes appear to succeed and are invisible on optimitron.com. If you see more than one Optimitron MCP server offering `createTask` or `proposeTaskBundle`, stop and ask which is production before writing.
 - Never hand-edit `page.logged-out.md` or `*.email.md`. Generate them with `pnpm --filter @optimitron/web copy:preview` or `email:preview-md`.
 - Use the production `optimitron:dev` task tree as the operational queue. Update the owning task's comments/status and link the implementation PR; do not maintain a parallel Markdown checklist.
 - Ask the human owner only for copy approval, a strategic fork, or a ship/redraft/abandon decision. Decide ordinary engineering details from code and tests.

--- a/docs/OPTIMIZE_EARTH_PROTOCOL.md
+++ b/docs/OPTIMIZE_EARTH_PROTOCOL.md
@@ -23,20 +23,32 @@ Every agent must follow this order:
 2. If GitHub Actions are broken because of repo code, treat fixing them as the immediate system-blocker task before trusting the queue.
 3. Audit whether the current queue is sane enough to trust.
 4. If the queue is clearly missing canonical campaign tasks, run `pnpm db:sync:managed-data -- --apply` first. If the queue is still broken after managed data sync, propose the smallest system-improvement task that would fix the specific gap.
-5. Call `getQueueAudit`, then call `getNextAction` with its capabilities.
-6. If no executable task exists:
+5. Call `getQueueAudit`, then select a task from the **agent** queue:
+   - Use `getAIQueue` (signed-in agent) or `getNextTask` (anonymous agent).
+   - Do **not** use `getNextAction`. That tool is documented as "the best next **self-work** action from
+     available **private** tasks" — it ranks the human owner's personal queue and will hand an agent
+     things like "Talk with <person> about the grant" (`executor_type: "Self"`, category `COMMUNICATION`).
+     An agent cannot execute those, and attempting them violates the outreach rules below.
+6. Before working, verify the selected task is actually agent-executable:
+   - Require `executor_type: "AI Agent"` and `executionMode` of `HUMAN_OR_AGENT` or `AGENT_ONLY`.
+   - Skip and log anything `HUMAN_ONLY` or `executor_type: "Self"`, even if the queue ranked it first.
+   - Do not trust `capabilityStatus: "eligible"` on its own. When no skills are recorded for the target
+     executor, the capability check has no data and returns "All recorded capability requirements are
+     satisfied" for every task, including human-only ones. Treat an empty capability record as UNKNOWN,
+     not as approval.
+7. If no executable task exists:
    - call `proposeTaskBundle` only for high-value missing tasks or unblockers
    - do not create `ACTIVE` tasks directly
    - stop after logging the skipped run
-7. If a task exists, call `acquireLease`.
-8. Work only on the leased task.
-9. If the work outlives the lease TTL, call `heartbeatLease`.
-10. If the work involves outreach:
+8. If a task exists, call `acquireLease`.
+9. Work only on the leased task.
+10. If the work outlives the lease TTL, call `heartbeatLease`.
+11. If the work involves outreach:
    - do not perform automated live outreach unless the task explicitly authorizes it
    - post a source-backed `postTaskComment` with the proposed message, target, and rationale
    - let comment notifications/delivery infrastructure handle recipients where configured
-11. Log the run with `logAgentRun`.
-12. Release the lease when the step is complete or skipped.
+12. Log the run with `logAgentRun`.
+13. Release the lease when the step is complete or skipped.
 
 ## Ownership Model
 
@@ -66,6 +78,25 @@ Agents should not:
 - generate broad speculative backlogs
 - create duplicate tasks for the same objective
 - trust a stupid queue without first trying to fix it
+
+### Precedence: system blockers outrank EV
+
+Steps 1–2 outrank this section. A broken build or deploy is a blocker on every other task, and the EV
+score does not know that. Observed 2026-07-25: `Deploy smoke` was failing on `main` while the queue
+ranked "Fix the current Optimitron deployment-smoke failure" at priority 175 and a one-hour phone call
+at priority 20000 — a 114x inversion against the thing actually blocking the repo. Fix the blocker
+first regardless of its computed rank.
+
+### Known limitation: EV units are not comparable across branches
+
+Estimates in the tree are currently denominated in **dollars of fundraising or developer velocity**
+(e.g. $8,000 for a pitch slide, $350 for a CI fix), not in the north-star units from `AGENTS.md`
+(median healthy life expectancy, median real after-tax income). Dollar-denominated personal and
+organization tasks therefore outrank campaign work in the same ordering, and a global "highest value"
+comparison across branches is not currently meaningful. Until estimates are recalibrated, rank within
+a branch and treat cross-branch comparisons as unreliable. The open dev tasks on estimate calibration,
+auto-estimation, semantic duplicate detection, and the anti-queue are the fix for this; the calibration
+guard is the stated prerequisite for the other three.
 
 ## Outreach Rules
 

--- a/docs/OPTIMIZE_EARTH_PROTOCOL.md
+++ b/docs/OPTIMIZE_EARTH_PROTOCOL.md
@@ -23,15 +23,25 @@ Every agent must follow this order:
 2. If GitHub Actions are broken because of repo code, treat fixing them as the immediate system-blocker task before trusting the queue.
 3. Audit whether the current queue is sane enough to trust.
 4. If the queue is clearly missing canonical campaign tasks, run `pnpm db:sync:managed-data -- --apply` first. If the queue is still broken after managed data sync, propose the smallest system-improvement task that would fix the specific gap.
-5. Call `getQueueAudit`, then select a task from the **agent** queue:
-   - Use `getAIQueue` (signed-in agent) or `getNextTask` (anonymous agent).
+5. If signed in, call `getQueueAudit` first to sanity-check your personal queue data (it requires an
+   authenticated caller — skip it if you have no session). Then select a task from the **public**
+   Earth queue with `getNextTask`. Use `getNextTask` whether or not you are signed in: `getAIQueue`
+   queries `visibility: "personal"` and returns only the authenticated user's own private AI-agent
+   tasks, never the public `optimize-earth` campaign tree. Signing in does not change which task
+   universe you should draw from — call `getAIQueue` only as an *additional* check of your own
+   private/assigned queue, never as a replacement for `getNextTask`.
    - Do **not** use `getNextAction`. That tool is documented as "the best next **self-work** action from
      available **private** tasks" — it ranks the human owner's personal queue and will hand an agent
      things like "Talk with <person> about the grant" (`executor_type: "Self"`, category `COMMUNICATION`).
      An agent cannot execute those, and attempting them violates the outreach rules below.
 6. Before working, verify the selected task is actually agent-executable:
-   - Require `executor_type: "AI Agent"` and `executionMode` of `HUMAN_OR_AGENT` or `AGENT_ONLY`.
-   - Skip and log anything `HUMAN_ONLY` or `executor_type: "Self"`, even if the queue ranked it first.
+   - Require `executionMode` of `HUMAN_OR_AGENT` or `AGENT_ONLY`. Skip and log anything `HUMAN_ONLY`,
+     even if the queue ranked it first.
+   - Do not additionally require `executor_type: "AI Agent"`. The managed public campaign tree mostly
+     leaves `executor_type` unset, and the server normalizes a missing value to `"Self"` — treating
+     that default as a hard gate would make an agent skip nearly every legitimately agent-executable
+     `HUMAN_OR_AGENT` task. `getNextTask`/`getAIQueue` already capability-filter on `executionMode`;
+     trust that filter instead of re-deriving eligibility from `executor_type`.
    - Do not trust `capabilityStatus: "eligible"` on its own. When no skills are recorded for the target
      executor, the capability check has no data and returns "All recorded capability requirements are
      satisfied" for every task, including human-only ones. Treat an empty capability record as UNKNOWN,


### PR DESCRIPTION
Two agent-misrouting bugs found while trying to work the queue today. Both are docs/config only; no runtime code changes.

## 1. A local MCP server shadowed production

`.mcp.json` (gitignored, so not in this diff) registered a local stdio server running `scripts/mcp-task-server.ts` out of a **second checkout** at `E:\code\optimitron`, with its own database. It exposed `createTask`, `proposeTaskBundle`, `createPerson`, `upsertOrganization` and friends under the same names as the hosted connector.

Writes appeared to succeed and were invisible on optimitron.com. Seventeen tasks, six people, and five organizations landed in the shadow database before the owner reported he could not open any of the links.

This also caused a false accusation: a subagent correctly read four tasks from production, I looked them up in the local database, found nothing, and reported them as hallucinated.

**Fix:** local servers removed from `.mcp.json`. Docs no longer name that server. `searchManual` and `askWishonia` exist on the hosted connector, so nothing is lost — the docs now name the *tool* rather than the server, which survives whichever connector is attached. CLAUDE.md gains an explicit rule to stop and ask if more than one Optimitron MCP offers `createTask`.

Worth noting the failure mode: `/tasks/[id]` deliberately renders one access gate for both "no permission" and "does not exist", so a missing row is indistinguishable from a permissions problem. That is correct for not leaking private task existence, and it made this take a while to diagnose.

## 2. The optimize-earth protocol pointed at the human queue

Step 5 said to call `getNextAction`, documented as *"the best next self-work action from available private tasks"* — the owner's personal queue. Following the protocol handed an agent **"Talk with \<person\> about the grant"**: a phone call, `executor_type: "Self"`, ranked first at priority 20000.

**Fix:** use `getAIQueue` / `getNextTask`, and verify the task is agent-executable before working it. Also documents that `capabilityStatus: "eligible"` is not trustworthy on its own — with no skills recorded for any executor, the check has no data and returns satisfied for everything, including human-only tasks.

Two further notes added to the protocol: system blockers outrank EV (Deploy smoke was failing on `main` while the queue ranked its fix at priority 175 against a phone call at 20000, a 114x inversion), and EV units are not comparable across branches because estimates are denominated in dollars while the north star is in health and income.

## Verification
- No hook or script hardcodes the removed server name; only a historical plan JSON mentions it.
- `.mcp.json` is gitignored and untracked, so the config change is local-only and not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnCzCv5h94AmarutZUC5g5