### PR TITLE
Stop each visual review from deleting every other PR's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,9 +422,18 @@ jobs:
     # their own directory, and the second push would drop the first. Serialise
     # publishes repo-wide and queue rather than cancel, so no PR loses its
     # review page to a concurrent run.
+    #
+    # `queue: max` is load-bearing, not decoration. The default `queue: single`
+    # allows exactly one pending member and cancels it when a newer one
+    # arrives, so a burst of three PRs would cancel the middle one outright —
+    # worse than the bug this job is fixing, because the canceled run never
+    # publishes at all and leaves a canceled check on the PR. `max` holds up
+    # to 100 waiters in FIFO order. It may not be combined with
+    # `cancel-in-progress: true`; `false` is what we want anyway.
     concurrency:
       group: visual-review-gh-pages
       cancel-in-progress: false
+      queue: max
     permissions:
       actions: read
       contents: write
@@ -742,16 +751,40 @@ jobs:
         #
         # Fail-open on the API check: if the PR-state lookup errors, carry the
         # directory anyway. Keeping a stale page beats deleting a live one.
+        #
+        # The `|| true` on each cp is required, not sloppiness. Since coreutils
+        # 9.2 `cp -n` exits non-zero whenever it skips a file, and 9.5 also
+        # prints a diagnostic per skip. ubuntu-latest ships 9.4. Skipping is
+        # the normal case here — this PR's own directory already exists in
+        # gh-pages from its previous run — so under `set -e` a bare cp would
+        # fail the step on every re-push and block the publish entirely.
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           publish_root="${{ steps.prepare_pages.outputs.publish_dir }}"
-          if ! git fetch --depth=1 origin gh-pages 2>/dev/null; then
+          # "gh-pages does not exist yet" and "the lookup failed" both make
+          # git exit non-zero, but only the first is safe to continue from.
+          # Treating a transient network or GitHub error as an absent branch
+          # would let the force_orphan publish below run with nothing carried
+          # forward, deleting every other PR's page — the exact bug this step
+          # exists to prevent. `ls-remote --exit-code` separates the two: 2
+          # means no matching ref, anything else non-zero is a real failure.
+          ls_remote_status=0
+          git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1 \
+            || ls_remote_status=$?
+          if [ "$ls_remote_status" -eq 2 ]; then
             echo "No gh-pages branch yet; publishing this PR's review only."
             exit 0
           fi
+          if [ "$ls_remote_status" -ne 0 ]; then
+            echo "::error::Could not determine whether gh-pages exists (git ls-remote exit $ls_remote_status). Failing before the force_orphan publish rather than wiping other PRs' review pages."
+            exit 1
+          fi
+          # Bare, so set -e fails the step on a fetch error. A failed step
+          # skips the publish and leaves gh-pages untouched.
+          git fetch --depth=1 origin gh-pages
           staging="$(mktemp -d)"
           git archive FETCH_HEAD | tar -x -C "$staging"
           carried=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -723,7 +723,7 @@ jobs:
               target_url: process.env.VISUAL_REVIEW_URL,
             });
 
-      - name: Carry forward other PRs' review pages
+      - name: Carry forward open PRs' review pages, prune closed ones
         # force_orphan below replaces the whole branch with one commit, which
         # keeps screenshot binaries out of git history but also deletes every
         # other PR's review directory. Before 2026-07-26 that left exactly one
@@ -731,11 +731,20 @@ jobs:
         # review" check still said SUCCESS, because each publish had genuinely
         # succeeded and was then overwritten minutes later by the next one.
         #
-        # Re-materialise the existing pr-* directories into the publish dir so
-        # the orphan commit contains them too. cp -n means anything this run
-        # just generated wins, so the current PR's fresh `latest` is kept while
-        # its older per-sha directories survive.
+        # Re-materialise existing pr-* directories into the publish dir so the
+        # orphan commit contains them too — but only for PRs that are still
+        # OPEN. Because every publish rebuilds the branch from scratch,
+        # pruning is simply declining to carry a directory forward: merged and
+        # closed PRs' pages drop off on the next publish with no separate
+        # cleanup job. cp -n means anything this run just generated wins, so
+        # the current PR's fresh `latest` is kept while its older per-sha
+        # directories survive.
+        #
+        # Fail-open on the API check: if the PR-state lookup errors, carry the
+        # directory anyway. Keeping a stale page beats deleting a live one.
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           publish_root="${{ steps.prepare_pages.outputs.publish_dir }}"
@@ -746,13 +755,29 @@ jobs:
           staging="$(mktemp -d)"
           git archive FETCH_HEAD | tar -x -C "$staging"
           carried=0
+          pruned=0
           for existing in "$staging"/pr-*; do
             [ -d "$existing" ] || continue
+            dir_name="$(basename "$existing")"
+            pr_number="${dir_name#pr-}"
+            case "$pr_number" in
+              ''|*[!0-9]*)
+                # Not a pr-<number> directory; carry it untouched.
+                cp -Rn "$existing" "$publish_root/" 2>/dev/null || true
+                continue
+                ;;
+            esac
+            state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" --jq .state 2>/dev/null || echo unknown)"
+            if [ "$state" = "closed" ]; then
+              pruned=$((pruned + 1))
+              echo "Pruning $dir_name (PR is closed)."
+              continue
+            fi
             cp -Rn "$existing" "$publish_root/" 2>/dev/null || true
             carried=$((carried + 1))
           done
           rm -rf "$staging"
-          echo "Carried forward $carried existing PR review director(ies)."
+          echo "Carried forward $carried open PR page(s); pruned $pruned closed."
 
       - name: Publish visual review to gh-pages
         id: visual_review_pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,6 +417,14 @@ jobs:
       - web-e2e-validate
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    # Every run of this job force-pushes the gh-pages branch. Two PRs
+    # publishing at once would both read the same starting state, both add
+    # their own directory, and the second push would drop the first. Serialise
+    # publishes repo-wide and queue rather than cancel, so no PR loses its
+    # review page to a concurrent run.
+    concurrency:
+      group: visual-review-gh-pages
+      cancel-in-progress: false
     permissions:
       actions: read
       contents: write
@@ -714,6 +722,37 @@ jobs:
               description: 'Publishing screenshot review',
               target_url: process.env.VISUAL_REVIEW_URL,
             });
+
+      - name: Carry forward other PRs' review pages
+        # force_orphan below replaces the whole branch with one commit, which
+        # keeps screenshot binaries out of git history but also deletes every
+        # other PR's review directory. Before 2026-07-26 that left exactly one
+        # PR live at a time: three of four open PRs 404'd while their "Visual
+        # review" check still said SUCCESS, because each publish had genuinely
+        # succeeded and was then overwritten minutes later by the next one.
+        #
+        # Re-materialise the existing pr-* directories into the publish dir so
+        # the orphan commit contains them too. cp -n means anything this run
+        # just generated wins, so the current PR's fresh `latest` is kept while
+        # its older per-sha directories survive.
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish_root="${{ steps.prepare_pages.outputs.publish_dir }}"
+          if ! git fetch --depth=1 origin gh-pages 2>/dev/null; then
+            echo "No gh-pages branch yet; publishing this PR's review only."
+            exit 0
+          fi
+          staging="$(mktemp -d)"
+          git archive FETCH_HEAD | tar -x -C "$staging"
+          carried=0
+          for existing in "$staging"/pr-*; do
+            [ -d "$existing" ] || continue
+            cp -Rn "$existing" "$publish_root/" 2>/dev/null || true
+            carried=$((carried + 1))
+          done
+          rm -rf "$staging"
+          echo "Carried forward $carried existing PR review director(ies)."
 
       - name: Publish visual review to gh-pages
         id: visual_review_pages


### PR DESCRIPTION
## The bug

The visual-review publish step uses `force_orphan: true`, which replaces the entire `gh-pages` branch with a single commit containing only the PR that just ran. Every other PR's review directory is deleted.

Verified 2026-07-26 — `gh-pages` held **one directory and one commit**, while four open PRs all reported a green `Visual review` status:

| PR | Status | Page |
|---|---|---|
| #147 | SUCCESS | **404** |
| #148 | SUCCESS | **404** |
| #149 | SUCCESS | 200 |
| #152 | SUCCESS | **404** |

The status check isn't lying. Each publish genuinely succeeded and was overwritten minutes later by the next PR's run. #149 worked only because it published last. A review link stays valid until *any* other PR builds — which breaks exactly the case the feature exists for, comparing several PRs side by side.

## The fix

`force_orphan` is deliberate and stays: it keeps screenshot binaries out of git history, which would otherwise grow without bound. Rather than dropping it, the existing `pr-*` directories are re-materialised into the publish dir before the orphan push, so the single commit contains them too.

`cp -n` means anything the current run generated wins, so a PR's fresh `latest` is kept while its older per-sha directories survive. If `gh-pages` doesn't exist yet, the step no-ops.

Also serialises the job. Two PRs publishing at once would both read the same starting state and the second push would still drop the first, carry-forward or not. The concurrency group queues rather than cancels, so no PR loses its page to a concurrent run.

## Verification

- `ci.yml` parses (`yaml.safe_load`)
- Step ordering confirmed: `Carry forward other PRs' review pages` → `Publish visual review to gh-pages`
- `force_orphan: true` / `keep_files: false` intentionally unchanged
- Real proof is this PR's own visual-review run: after it merges, publishing a second PR should leave both pages live

## Known gap, not fixed here

Nothing prunes directories for merged or closed PRs, so the tree grows without bound. That's a slow leak in tree size rather than history, and worth a follow-up once the count is large enough to matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnCzCv5h94AmarutZUC5g5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual review publishing to prevent concurrent runs from overwriting each other.
  * Preserved review pages for multiple active pull requests when publishing new results.
  * Ensured in-progress visual review publications are completed instead of being canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->