### PR TITLE
Stop auto-updated PRs from needing manual workflow approval

### DIFF
--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -22,9 +22,34 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      # Pushing the update as github-actions[bot] leaves every refreshed PR
+      # with its checks stuck on "This workflow requires approval from a
+      # maintainer". The bot is not a repository collaborator, so the
+      # resulting `synchronize` event is treated as coming from an untrusted
+      # actor and gated — even though the branches are the owner's own. On
+      # 2026-07-26 one merge left 12 runs across 6 PRs sitting unapproved.
+      #
+      # Minting a short-lived GitHub App installation token fixes it at the
+      # source: the push is attributed to an installed app with write access,
+      # so the gate does not fire. Preferred over a personal access token
+      # because it is scoped to this repo, expires in an hour, is revocable
+      # by uninstalling the app, and is auditable as the app rather than as a
+      # human who did not actually do it.
+      #
+      # Optional by design. Without PR_UPDATER_APP_ID set the step is skipped
+      # and the run falls back to GITHUB_TOKEN, i.e. exactly today's
+      # behaviour, so this file is safe to merge before the app exists.
+      - name: Mint GitHub App token
+        id: app_token
+        if: ${{ vars.PR_UPDATER_APP_ID != '' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.PR_UPDATER_APP_ID }}
+          private-key: ${{ secrets.PR_UPDATER_APP_PRIVATE_KEY }}
+
       - name: Update open PR branches that are behind main
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token || secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -u


### PR DESCRIPTION
## Symptom

After merging #153, six PRs showed **"2 workflows awaiting approval — This workflow requires approval from a maintainer."** Twelve runs sat unapproved across `feature/eos-landing-page`, `feature/eos-design-{a,b,c}-*`, `feature/fictional-test-orgs`, and `feature/outbound-safety-gate`.

None of them are forks. They are all the owner's own branches in this repo, which rules out the usual fork-approval explanation.

## Cause

`update-pr-branches.yml` runs `gh pr update-branch` with `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`, so the push is attributed to **`github-actions[bot]`**. The bot is not a repository collaborator, so the `synchronize` event it produces is treated as coming from an untrusted actor and hits the approval gate.

The effect is self-defeating: the workflow exists so nobody has to click "Update branch" by hand, and it replaced that click with a different manual click on every refreshed PR.

## Fix

Mint a short-lived GitHub App installation token and push with that. The push is then attributed to an installed app that genuinely has write access, so the gate does not fire.

**Why an App token rather than a PAT:** scoped to this repository, expires in an hour, revocable by uninstalling the app, and auditable as the app rather than as a human who did not perform the action. A PAT is a long-lived personal credential in a secret and attributes bot pushes to a person.

**Why not loosen the approval policy:** that would weaken review on genuine outside contributions in order to fix an internal annoyance. Wrong trade.

## Safe to merge before the app exists

The step is guarded by `if: vars.PR_UPDATER_APP_ID != ''`. Unset, it is skipped and `GH_TOKEN` falls back to `secrets.GITHUB_TOKEN` — today's behaviour exactly. Nothing breaks; the fix simply activates once the app is configured.

## To activate (owner, ~3 minutes)

1. Create a GitHub App on the account: **Settings → Developer settings → GitHub Apps → New**. Permissions: `Contents: Read and write`, `Pull requests: Read and write`. No webhook, no user permissions.
2. Install it on `mikepsinn/optimitron`.
3. Generate a private key.
4. Repo → Settings → Secrets and variables → Actions:
   - **Variable** `PR_UPDATER_APP_ID` = the app's numeric ID
   - **Secret** `PR_UPDATER_APP_PRIVATE_KEY` = the full `.pem` contents

Next merge to `main` refreshes every open PR with no approval prompt.

## Note

The twelve runs blocked by this were approved manually so tonight's rebuild wave could proceed; they are running now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnCzCv5h94AmarutZUC5g5