### PR TITLE
Stop three permanently-red checks that were all false alarms

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,17 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The action refuses bot-initiated runs by default, to stop a random
+          # bot from burning API credit on a privileged review. But our own
+          # `Update PR branches` workflow rebases every open PR whenever main
+          # moves, and that push fires `synchronize` with the pusher as actor.
+          # Unlisted, that turns this check red on every open PR after every
+          # merge -- pure noise that teaches us to ignore red checks.
+          #
+          # Allow only our two updater identities, never `*`:
+          #   github-actions        -- the GITHUB_TOKEN fallback path
+          #   optimitron-pr-updater -- the GitHub App, once it is installed
+          allowed_bots: "github-actions,optimitron-pr-updater"
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"

--- a/.github/workflows/smoke-deploy.yml
+++ b/.github/workflows/smoke-deploy.yml
@@ -32,12 +32,11 @@ jobs:
         github.event.deployment_status.environment == 'Production' ||
         github.event.deployment_status.environment == 'production' ||
         contains(github.event.deployment_status.environment_url, 'warondisease.org') ||
-        contains(github.event.deployment_status.environment_url, 'optimitron.com') ||
-        contains(github.event.deployment_status.environment_url, 'onepercenttreaty.org'))
+        contains(github.event.deployment_status.environment_url, 'optimitron.com'))
     runs-on: ubuntu-latest
     timeout-minutes: 90
     environment:
-      name: ${{ (github.event.deployment.environment == 'Production' || github.event.deployment.environment == 'production' || github.event.deployment_status.environment == 'Production' || github.event.deployment_status.environment == 'production' || contains(github.event.deployment_status.environment_url, 'warondisease.org') || contains(github.event.deployment_status.environment_url, 'optimitron.com') || contains(github.event.deployment_status.environment_url, 'onepercenttreaty.org')) && 'Production' || 'Preview' }}
+      name: ${{ (github.event.deployment.environment == 'Production' || github.event.deployment.environment == 'production' || github.event.deployment_status.environment == 'Production' || github.event.deployment_status.environment == 'production' || contains(github.event.deployment_status.environment_url, 'warondisease.org') || contains(github.event.deployment_status.environment_url, 'optimitron.com')) && 'Production' || 'Preview' }}
       deployment: false
 
     steps:
@@ -90,7 +89,6 @@ jobs:
                 return [
                   "warondisease.org",
                   "optimitron.com",
-                  "onepercenttreaty.org",
                 ].some(
                   (domain) => hostname === domain || hostname.endsWith(`.${domain}`),
                 );
@@ -276,12 +274,14 @@ jobs:
           RESOLVED_DEPLOYMENT_ENVIRONMENT: ${{ steps.deployment_status.outputs.environment }}
           RESOLVED_DEPLOYMENT_URL: ${{ steps.deployment_status.outputs.environment_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          # onepercenttreaty.org is deliberately absent: the domain's Cloudflare
-          # nameservers serve no A/AAAA record, so all nine of its routes have
-          # always returned "no response" and made production smoke permanently
-          # red. Point the domain at the Vercel project, then add it back by
-          # setting the PUBLIC_PRODUCTION_SMOKE_URLS repo variable -- no code
-          # change needed.
+          # onepercenttreaty.org used to be listed here and is gone on purpose:
+          # we do not own it. It was registered by someone else on 2026-04-30,
+          # points at Cloudflare nameservers with an empty zone, and has never
+          # resolved -- so all nine of its routes returned "no response" and
+          # kept production smoke permanently red. Do not add it back. If we
+          # ever acquire it, the redirect (not the app) is what should be
+          # asserted, since smoke follows redirects and would otherwise just
+          # re-test warondisease.org.
           PUBLIC_PRODUCTION_SMOKE_URLS: ${{ vars.PUBLIC_PRODUCTION_SMOKE_URLS || 'https://warondisease.org,https://optimitron.com' }}
         run: |
           node <<'NODE'
@@ -311,8 +311,6 @@ jobs:
             "www.warondisease.org",
             "optimitron.com",
             "www.optimitron.com",
-            "onepercenttreaty.org",
-            "www.onepercenttreaty.org",
           ]);
           const isProduction =
             /^production$/i.test(environmentName) ||

--- a/.github/workflows/smoke-deploy.yml
+++ b/.github/workflows/smoke-deploy.yml
@@ -276,7 +276,13 @@ jobs:
           RESOLVED_DEPLOYMENT_ENVIRONMENT: ${{ steps.deployment_status.outputs.environment }}
           RESOLVED_DEPLOYMENT_URL: ${{ steps.deployment_status.outputs.environment_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          PUBLIC_PRODUCTION_SMOKE_URLS: ${{ vars.PUBLIC_PRODUCTION_SMOKE_URLS || 'https://warondisease.org,https://optimitron.com,https://onepercenttreaty.org' }}
+          # onepercenttreaty.org is deliberately absent: the domain's Cloudflare
+          # nameservers serve no A/AAAA record, so all nine of its routes have
+          # always returned "no response" and made production smoke permanently
+          # red. Point the domain at the Vercel project, then add it back by
+          # setting the PUBLIC_PRODUCTION_SMOKE_URLS repo variable -- no code
+          # change needed.
+          PUBLIC_PRODUCTION_SMOKE_URLS: ${{ vars.PUBLIC_PRODUCTION_SMOKE_URLS || 'https://warondisease.org,https://optimitron.com' }}
         run: |
           node <<'NODE'
           const fs = require("node:fs");

--- a/packages/web/scripts/smoke-deploy.mjs
+++ b/packages/web/scripts/smoke-deploy.mjs
@@ -27,8 +27,13 @@ const ROUTES_TO_SMOKE = [
     path: "/",
     expectedH1: "PLEASE TAKE 30 SECONDS TO END WAR AND DISEASE",
     expectedH1ByHost: {
-      "optimitron.com": "Play the Earth Optimization Game!",
-      "www.optimitron.com": "Play the Earth Optimization Game!",
+      // Kept in sync with `heroHeading` in
+      // packages/web/src/components/site/EarthOptimizationServicesLandingPage.tsx.
+      // The EOS showroom landing (e055e1dd) replaced the old game heading here
+      // without updating this assertion, so production smoke failed on a
+      // healthy page for every merge after it.
+      "optimitron.com": "The Government of Tomorrow is in stock.",
+      "www.optimitron.com": "The Government of Tomorrow is in stock.",
     },
     source: "warondisease landing action heading",
   },


### PR DESCRIPTION
Every open PR and every merge to `main` has been showing red checks that had nothing to do with the code under review. Three unrelated causes, all noise, none a real defect in the app.

## 1. `Claude Code Review` — "Workflow initiated by non-human actor"

Our own `Update PR branches` workflow rebases every open PR whenever `main` moves. That push fires `synchronize` with `github-actions[bot]` as the actor, and `claude-code-action` rejects bot actors unless they're listed — so the review check went red on all six open PRs after every merge.

Fixed by listing only our two updater identities. Not `*`:

- `github-actions` — the `GITHUB_TOKEN` fallback path
- `optimitron-pr-updater` — the GitHub App (now created and installed; verified working in [run 30188254273](https://github.com/mikepsinn/optimitron/actions/runs/30188254273))

## 2. Production smoke failed `optimitron.com /` on a healthy page

The EOS showroom landing (`e055e1dd`) changed the hero h1 to **"The Government of Tomorrow is in stock."** but the smoke test's host override still expected **"Play the Earth Optimization Game!"**. The page was fine; the assertion was stale. Now sourced from `heroHeading` with a comment pointing at the component so the next copy change doesn't silently repeat this.

## 3. Production smoke failed all nine `onepercenttreaty.org` routes — we do not own that domain

Originally read as a DNS gap on our side. It isn't. RDAP shows the domain **registered by someone else on 2026-04-30** (expires 2027-04-30), pointed at Cloudflare nameservers over an empty zone. It has never resolved and never will for us.

So this wasn't config to fix, it was a domain to stop referencing. Removed all five live references in `smoke-deploy.yml`, every one of them dead code that could only match a deployment URL we cannot produce:

- the smoke job's `if:` guard
- the Production/Preview environment-name expression
- `isProductionUrl()` in the deployment-status script
- `productionHosts` in the resolve-target script
- the default `PUBLIC_PRODUCTION_SMOKE_URLS` list

The remaining mention is a comment explaining why it must not be added back.

## Verification

Ran `smoke-deploy.mjs` against **live production**, not a mock:

```
Deploy smoke passed for 18 route check(s) in 11706ms.
```

18/18 across `warondisease.org` and `optimitron.com`. Before this change the same run reported `failed for 10 of 27`.

No UI surface changed — this is workflow config plus one test assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgFjRC6pBtYxoVvgJ8L9oW
