### PR TITLE
Fix the EOS landing defects that made adjacent lines read as broken

### DIFF
--- a/packages/web/src/components/site/EarthOptimizationServicesLandingPage.tsx
+++ b/packages/web/src/components/site/EarthOptimizationServicesLandingPage.tsx
@@ -74,7 +74,11 @@ const thermostatPanels = [
     feedback: "no sensor, no adjust",
     flow: ['"War on Drugs"', "$1 trillion", "policy", "???"],
     kicker: "it doesn't check anything",
-    stats: ["Overdose deaths 6,000 -> 107,000", "Budget change: none", "53 years"],
+    stats: [
+      "Overdose deaths: 6,000 → 107,000",
+      "Budget change: none",
+      "Years running: 53",
+    ],
     title: "Your government",
   },
   {
@@ -421,14 +425,19 @@ function ThermostatPanel({
                 aria-hidden="true"
                 className="text-center text-lg font-black"
               >
-                -&gt;
+                {"→"}
               </div>
             ) : null}
           </div>
         ))}
       </div>
+      {/* The return path. Without the arrows this reads as a fifth box under
+          the row instead of the loop closing — and the loop closing is the
+          entire argument of the section. */}
       <div className="mt-4 border-2 border-foreground p-3 text-center text-sm font-black uppercase">
+        {"← "}
         {panel.feedback}
+        {" ←"}
       </div>
       {"stats" in panel ? (
         <dl className="mt-4 grid gap-2 text-sm font-black uppercase sm:grid-cols-3">
@@ -495,12 +504,6 @@ export function EarthOptimizationServicesLandingPage() {
                 {mastheadStatus}
               </p>
             </div>
-            <nav aria-label="Primary actions" className="flex flex-wrap gap-3">
-              <ActionButton href="#departments" primary>
-                {tourLabel}
-              </ActionButton>
-              <ActionButton href="#service-counter">{shopLabel}</ActionButton>
-            </nav>
           </header>
 
           <section className="py-12 sm:py-16">

--- a/packages/web/src/components/site/EarthOptimizationServicesLandingPage.tsx
+++ b/packages/web/src/components/site/EarthOptimizationServicesLandingPage.tsx
@@ -435,19 +435,18 @@ function ThermostatPanel({
           the row instead of the loop closing — and the loop closing is the
           entire argument of the section. */}
       <div className="mt-4 border-2 border-foreground p-3 text-center text-sm font-black uppercase">
-        {"← "}
+        <span aria-hidden="true">{"← "}</span>
         {panel.feedback}
-        {" ←"}
+        <span aria-hidden="true">{" ←"}</span>
       </div>
       {"stats" in panel ? (
-        <dl className="mt-4 grid gap-2 text-sm font-black uppercase sm:grid-cols-3">
+        <div className="mt-4 grid gap-2 text-sm font-black uppercase sm:grid-cols-3">
           {panel.stats.map((stat) => (
             <div className="border-2 border-foreground p-3" key={stat}>
-              <dt className="sr-only">{stat}</dt>
-              <dd>{stat}</dd>
+              {stat}
             </div>
           ))}
-        </dl>
+        </div>
       ) : null}
       <p className="mt-4 text-base font-bold leading-7">{panel.caption}</p>
     </article>

--- a/packages/web/src/components/site/EarthOptimizationServicesLandingPage.tsx
+++ b/packages/web/src/components/site/EarthOptimizationServicesLandingPage.tsx
@@ -66,6 +66,7 @@ const thermostatPanels = [
     feedback: "Thermometer feedback",
     flow: ["Set 350F", "Heat", "Oven", "Food"],
     kicker: "it checks, then adjusts",
+    loopClosed: true,
     title: "Your oven",
   },
   {
@@ -74,6 +75,8 @@ const thermostatPanels = [
     feedback: "no sensor, no adjust",
     flow: ['"War on Drugs"', "$1 trillion", "policy", "???"],
     kicker: "it doesn't check anything",
+    // The whole point of this panel is that the return path DOES NOT exist.
+    loopClosed: false,
     stats: [
       "Overdose deaths: 6,000 → 107,000",
       "Budget change: none",
@@ -87,6 +90,7 @@ const thermostatPanels = [
     feedback: "health and income feedback",
     flow: ["Measure", "Compare", "Adjust", "Repeat"],
     kicker: "installs the thermostat",
+    loopClosed: true,
     title: "Earth Optimization Services",
   },
 ] as const;
@@ -431,13 +435,28 @@ function ThermostatPanel({
           </div>
         ))}
       </div>
-      {/* The return path. Without the arrows this reads as a fifth box under
-          the row instead of the loop closing — and the loop closing is the
-          entire argument of the section. */}
-      <div className="mt-4 border-2 border-foreground p-3 text-center text-sm font-black uppercase">
-        <span aria-hidden="true">{"← "}</span>
-        {panel.feedback}
-        <span aria-hidden="true">{" ←"}</span>
+      {/* The return path — but only where one exists. The oven and EOS panels
+          close the loop, so their bars carry return arrows (aria-hidden:
+          decorative). The government panel's entire argument is that no
+          return path exists (Codex review on PR #157 caught arrows here
+          reversing the panel's point), so its bar renders dashed with no
+          arrows: a visibly missing wire. */}
+      <div
+        className={
+          panel.loopClosed
+            ? "mt-4 border-2 border-foreground p-3 text-center text-sm font-black uppercase"
+            : "mt-4 border-2 border-dashed border-foreground p-3 text-center text-sm font-black uppercase text-muted-foreground"
+        }
+      >
+        {panel.loopClosed ? (
+          <>
+            <span aria-hidden="true">{"← "}</span>
+            {panel.feedback}
+            <span aria-hidden="true">{" ←"}</span>
+          </>
+        ) : (
+          panel.feedback
+        )}
       </div>
       {"stats" in panel ? (
         <div className="mt-4 grid gap-2 text-sm font-black uppercase sm:grid-cols-3">

--- a/packages/web/src/lib/task-funding/format.ts
+++ b/packages/web/src/lib/task-funding/format.ts
@@ -30,7 +30,9 @@ export function formatUsd(value: number) {
 
 export function formatRatio(value: number) {
   if (!Number.isFinite(value) || value <= 0) return "Unranked";
-  return `${formatUsd(value)} expected per $1`;
+  // Bare value: the card's label already says "Return per $1", so a suffix
+  // here produced "RETURN PER $1 / $848K expected per $1" — per-$1 twice.
+  return formatUsd(value);
 }
 
 export function formatPercent(percent: number) {


### PR DESCRIPTION
Five defects on the optimitron.com landing page. Copy changes were reviewed verbatim and approved from screenshots before commit.

| Before | After |
|---|---|
| ASCII `->` as diagram arrows (9 places) | real `→` glyph |
| Feedback bar floating as a disconnected fifth box | `← thermometer feedback ←` — the loop visually closes, which is the section's whole argument |
| Same two CTAs twice within 470px (masthead + hero) | hero pair only |
| `Overdose deaths 6,000 -> 107,000` / `Budget change: none` / `53 years` (mixed grammar) | parallel `label: value` fragments |
| `RETURN PER $1` → `$848K expected per $1` (per-$1 twice) | `RETURN PER $1` → `$848K` |

Notes:
- `formatRatio`'s only consumer is `FundingTaskCard`, whose label carries the unit. No other surface changes.
- The "five identical empty progress bars" complaint from review turned out to be data, not code: production has zero commitments. With any funding the bars show `$X committed – N%` (verified locally).
- No test or snapshot references the old strings.
- Screenshots captured locally at `/?site=optimitron`, inspected, and approved by the owner before commit. The CI visual review page for this PR is the shareable version.

Review pages (once CI publishes): the **Visual review** check on this PR links to the gh-pages review for this exact commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgFjRC6pBtYxoVvgJ8L9oW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated thermostat panels with revised copy and clearer statistics presentation.
  * Improved visual flow guidance using arrow glyphs to better show progression and return paths.
  * Simplified the landing page masthead by removing primary action buttons (kept only in the hero).
* **Bug Fixes**
  * Corrected funding ratio formatting to show only the formatted USD value, removing redundant explanatory text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->