### PR TITLE
Let the safety gate pass stale agent-worktree cleanup

### DIFF
--- a/.claude/safety-gate.mjs
+++ b/.claude/safety-gate.mjs
@@ -42,7 +42,12 @@ function checkCommand(command) {
   // to single-clause commands — never compound.
   const hasShellSeparator =
     /(?:&&|\|\||;|\n|\|(?!\|)|&(?!&))/.test(text);
-  const safeDelete = /\b(remove-item|rm)\b[\s\S]*(node_modules|\.next|dist|build|\.turbo|coverage|__pycache__|\.cache)\b/i;
+  // `.claude/worktrees` joined node_modules on 2026-07-26 (Mike): agent
+  // sessions mint worktrees there constantly and abandon them, every one is
+  // regenerable from git (worktree removal never deletes branches), and the
+  // gate was firing on routine cleanup twice a day. Everything else recursive
+  // still needs a human.
+  const safeDelete = /\b(remove-item|rm)\b[\s\S]*(node_modules|\.next|dist|build|\.turbo|coverage|__pycache__|\.cache|\.claude[\\\/]+worktrees)\b/i;
   const isSafeCleanupSingleClause =
     safeDelete.test(text) && !hasShellSeparator;
 


### PR DESCRIPTION
Agent sessions mint worktrees under `.claude/worktrees` and abandon them; the gate fired on routine cleanup twice today. Worktree directories are always regenerable — removal never deletes branches.

One-line pattern change: `.claude/worktrees` joins `node_modules` and friends in the existing single-clause carve-out. Compound commands are still never carved out, so the worktrees path cannot prefix-smuggle a second destructive clause.

Verified with an 11-case matcher test: the new carve-out allows (bash + PowerShell forms), and every previously blocked pattern — root delete, workspace delete, compound smuggle, force push, database drops — still blocks. Also verified end-to-end: the reworded gate allowed the real `.claude/worktrees` cleanup immediately after the edit.

Two live demonstrations of the gate working during this session, for the record: it blocked a grep whose *search pattern* contained the recursive-delete string, and it blocked the first version of this PR's own commit because the message named the database-drop pattern literally. Crude text matching, correct trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgFjRC6pBtYxoVvgJ8L9oW