### PR TITLE
Add MCP tool access diagnostics (`inspectToolAccess`)

### DIFF
--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -633,6 +633,7 @@ function makePriority(overrides: Record<string, unknown> = {}) {
 }
 
 beforeEach(() => {
+  vi.unstubAllEnvs();
   for (const fn of Object.values(mocks)) fn.mockReset();
   // Default: the caller can view the task. Visibility-denial cases override.
   mocks.canUserViewTask.mockResolvedValue(true);
@@ -6038,6 +6039,8 @@ describe("MCP server tool dispatch", () => {
     });
 
     it("inspectToolAccess explains scope, admin, unknown, and argument-dependent access", async () => {
+      vi.stubEnv("NEXTAUTH_URL", "https://mcp.example.test");
+      vi.stubEnv("VERCEL_ENV", "preview");
       const client = await setup("user-1", [
         McpScope.TASKS_ADMIN,
         McpScope.TASKS_ORGANIZATION,
@@ -6058,8 +6061,8 @@ describe("MCP server tool dispatch", () => {
         userId: "user-1",
       });
       expect(body.server).toMatchObject({
-        canonicalUrl: "http://localhost:3001/api/mcp",
-        environment: "development",
+        canonicalUrl: "https://mcp.example.test/api/mcp",
+        environment: "preview",
       });
       expect(body.server).toHaveProperty("catalogRevision");
       expect(body.tools).toEqual([
@@ -6069,11 +6072,15 @@ describe("MCP server tool dispatch", () => {
           name: "createPerson",
           reasonCodes: ["ADMIN_USER_REQUIRED"],
           requiredScopes: ["tasks:admin"],
+          scopeMatch: "ANY",
         }),
         expect.objectContaining({
           accessible: true,
+          missingScopes: [],
           name: "getMyQueue",
           reasonCodes: ["AVAILABLE", "ARGUMENT_DEPENDENT_ACCESS"],
+          requiredScopes: ["tasks:personal", "tasks:organization"],
+          scopeMatch: "ANY",
         }),
         expect.objectContaining({
           accessible: false,
@@ -6096,23 +6103,36 @@ describe("MCP server tool dispatch", () => {
           accessible: false,
           missingScopes: ["tasks:admin"],
           reasonCodes: ["MISSING_REQUIRED_SCOPE", "ADMIN_USER_REQUIRED"],
+          scopeMatch: "ANY",
         }),
       ]);
 
-      const adminClient = await setup("admin-1", [McpScope.TASKS_ADMIN], {
-        isAdmin: true,
-      });
+      const adminClient = await setup(
+        "admin-1",
+        [McpScope.TASKS_ADMIN, McpScope.EARTHDATA_ADMIN],
+        { isAdmin: true },
+      );
       const allowed = parseToolBody(
         await adminClient.callTool({
           name: "inspectToolAccess",
-          arguments: { toolNames: ["createPerson"] },
+          arguments: {
+            toolNames: ["createPerson", "mergeDuplicatePeople"],
+          },
         }),
       );
       expect(allowed.tools).toEqual([
         expect.objectContaining({
           accessible: true,
           missingScopes: [],
+          name: "createPerson",
           reasonCodes: ["AVAILABLE"],
+        }),
+        expect.objectContaining({
+          accessible: false,
+          enabled: false,
+          missingScopes: [],
+          name: "mergeDuplicatePeople",
+          reasonCodes: ["TOOL_DISABLED"],
         }),
       ]);
     });

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -6137,6 +6137,32 @@ describe("MCP server tool dispatch", () => {
       ]);
     });
 
+    it("inspectToolAccess rejects filters that exceed its response bounds", async () => {
+      const client = await setup("user-1", [McpScope.TASKS_PERSONAL]);
+
+      const oversized = await client.callTool({
+        name: "inspectToolAccess",
+        arguments: {
+          toolNames: Array.from({ length: 201 }, (_, index) => `tool-${index}`),
+        },
+      });
+      expect(oversized.isError).toBe(true);
+      expect(parseToolBody(oversized)).toMatchObject({
+        details: { field: "toolNames", maxItems: 200 },
+        errorCode: "INVALID_ARGUMENT",
+      });
+
+      const duplicated = await client.callTool({
+        name: "inspectToolAccess",
+        arguments: { toolNames: ["getMe", "getMe"] },
+      });
+      expect(duplicated.isError).toBe(true);
+      expect(parseToolBody(duplicated)).toMatchObject({
+        details: { field: "toolNames", uniqueItems: true },
+        errorCode: "INVALID_ARGUMENT",
+      });
+    });
+
     it("inspectToolAccess requires an authenticated connection", async () => {
       const client = await setup(undefined, ALL_SCOPES);
 

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -6037,6 +6037,101 @@ describe("MCP server tool dispatch", () => {
       expect(body.details).toMatchObject({ tool: "getMe" });
     });
 
+    it("inspectToolAccess explains scope, admin, unknown, and argument-dependent access", async () => {
+      const client = await setup("user-1", [
+        McpScope.TASKS_ADMIN,
+        McpScope.TASKS_ORGANIZATION,
+      ]);
+
+      const result = await client.callTool({
+        name: "inspectToolAccess",
+        arguments: {
+          toolNames: ["createPerson", "getMyQueue", "doesNotExist"],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const body = parseToolBody(result);
+      expect(body.principal).toMatchObject({
+        grantedScopes: ["tasks:admin", "tasks:organization"],
+        isAdmin: false,
+        userId: "user-1",
+      });
+      expect(body.server).toMatchObject({
+        canonicalUrl: "http://localhost:3001/api/mcp",
+        environment: "development",
+      });
+      expect(body.server).toHaveProperty("catalogRevision");
+      expect(body.tools).toEqual([
+        expect.objectContaining({
+          accessible: false,
+          missingScopes: [],
+          name: "createPerson",
+          reasonCodes: ["ADMIN_USER_REQUIRED"],
+          requiredScopes: ["tasks:admin"],
+        }),
+        expect.objectContaining({
+          accessible: true,
+          name: "getMyQueue",
+          reasonCodes: ["AVAILABLE", "ARGUMENT_DEPENDENT_ACCESS"],
+        }),
+        expect.objectContaining({
+          accessible: false,
+          name: "doesNotExist",
+          reasonCodes: ["TOOL_NOT_FOUND"],
+        }),
+      ]);
+    });
+
+    it("inspectToolAccess reports missing scopes and allows an authorized admin", async () => {
+      const personalClient = await setup("user-1", [McpScope.TASKS_PERSONAL]);
+      const denied = parseToolBody(
+        await personalClient.callTool({
+          name: "inspectToolAccess",
+          arguments: { toolNames: ["createPerson"] },
+        }),
+      );
+      expect(denied.tools).toEqual([
+        expect.objectContaining({
+          accessible: false,
+          missingScopes: ["tasks:admin"],
+          reasonCodes: ["MISSING_REQUIRED_SCOPE", "ADMIN_USER_REQUIRED"],
+        }),
+      ]);
+
+      const adminClient = await setup("admin-1", [McpScope.TASKS_ADMIN], {
+        isAdmin: true,
+      });
+      const allowed = parseToolBody(
+        await adminClient.callTool({
+          name: "inspectToolAccess",
+          arguments: { toolNames: ["createPerson"] },
+        }),
+      );
+      expect(allowed.tools).toEqual([
+        expect.objectContaining({
+          accessible: true,
+          missingScopes: [],
+          reasonCodes: ["AVAILABLE"],
+        }),
+      ]);
+    });
+
+    it("inspectToolAccess requires an authenticated connection", async () => {
+      const client = await setup(undefined, ALL_SCOPES);
+
+      const result = await client.callTool({
+        name: "inspectToolAccess",
+        arguments: {},
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result)).toMatchObject({
+        errorCode: "AUTHENTICATION_REQUIRED",
+        details: { tool: "inspectToolAccess" },
+      });
+    });
+
     it("updateMyProfile forwards only the supplied fields and returns the fresh profile", async () => {
       mocks.updateUserProfile.mockResolvedValue(profile);
       const client = await setup("user-1", [McpScope.TASKS_PERSONAL]);

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -405,6 +405,7 @@ function inspectToolAccess(
   name: string;
   reasonCodes: ToolAccessReasonCode[];
   requiredScopes: string[];
+  scopeMatch: "ANY" | "NONE_REQUIRED";
 } {
   const definition = TASK_TOOL_DEFINITIONS.find(
     (tool) => tool.name === toolName,
@@ -418,10 +419,12 @@ function inspectToolAccess(
       name: toolName,
       reasonCodes: ["TOOL_NOT_FOUND"],
       requiredScopes: [],
+      scopeMatch: "NONE_REQUIRED",
     };
   }
 
   const requiredScopes = TOOL_SCOPES[toolName] ?? [];
+  const scopeMatch = requiredScopes.length > 0 ? "ANY" : "NONE_REQUIRED";
   const scopeGranted = hasScope(grantedScopes, toolName);
   const missingScopes = scopeGranted ? [] : requiredScopes;
   const enabled = !DISABLED_TOOLS.has(toolName);
@@ -448,6 +451,7 @@ function inspectToolAccess(
     name: toolName,
     reasonCodes,
     requiredScopes: requiredScopes.map(scopeToWire),
+    scopeMatch,
   };
 }
 

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -317,6 +317,7 @@ const TOOL_SCOPES: Record<string, McpScope[]> = {
   listDueTrackingReminders: [McpScope.TASKS_PERSONAL],
   respondToTrackingReminder: [McpScope.TASKS_PERSONAL],
   getMe: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ORGANIZATION],
+  inspectToolAccess: [],
   updateMyProfile: [McpScope.TASKS_PERSONAL],
   searchRepo: [McpScope.GITHUB],
   getFileContent: [McpScope.GITHUB],
@@ -382,6 +383,72 @@ function hasScope(
   if (!required) return false;
   if (required.length === 0) return true;
   return required.some((s) => grantedScopes.includes(s));
+}
+
+type ToolAccessReasonCode =
+  | "ADMIN_USER_REQUIRED"
+  | "ARGUMENT_DEPENDENT_ACCESS"
+  | "AVAILABLE"
+  | "MISSING_REQUIRED_SCOPE"
+  | "TOOL_DISABLED"
+  | "TOOL_NOT_FOUND";
+
+function inspectToolAccess(
+  toolName: string,
+  grantedScopes: McpScope[] | undefined,
+  isAdmin: boolean,
+): {
+  accessible: boolean;
+  adminOnly: boolean;
+  enabled: boolean;
+  missingScopes: string[];
+  name: string;
+  reasonCodes: ToolAccessReasonCode[];
+  requiredScopes: string[];
+} {
+  const definition = TASK_TOOL_DEFINITIONS.find(
+    (tool) => tool.name === toolName,
+  );
+  if (!definition) {
+    return {
+      accessible: false,
+      adminOnly: false,
+      enabled: false,
+      missingScopes: [],
+      name: toolName,
+      reasonCodes: ["TOOL_NOT_FOUND"],
+      requiredScopes: [],
+    };
+  }
+
+  const requiredScopes = TOOL_SCOPES[toolName] ?? [];
+  const scopeGranted = hasScope(grantedScopes, toolName);
+  const missingScopes = scopeGranted ? [] : requiredScopes;
+  const enabled = !DISABLED_TOOLS.has(toolName);
+  const adminOnly = ADMIN_ONLY_TOOLS.has(toolName);
+  const accessible = enabled && scopeGranted && (!adminOnly || isAdmin);
+  const reasonCodes: ToolAccessReasonCode[] = [];
+  if (!enabled) reasonCodes.push("TOOL_DISABLED");
+  if (!scopeGranted) {
+    reasonCodes.push("MISSING_REQUIRED_SCOPE");
+  }
+  if (adminOnly && !isAdmin) reasonCodes.push("ADMIN_USER_REQUIRED");
+  if (accessible) {
+    reasonCodes.push("AVAILABLE");
+    if (requiredScopes.includes(McpScope.TASKS_ORGANIZATION)) {
+      reasonCodes.push("ARGUMENT_DEPENDENT_ACCESS");
+    }
+  }
+
+  return {
+    accessible,
+    adminOnly,
+    enabled,
+    missingScopes: missingScopes.map(scopeToWire),
+    name: toolName,
+    reasonCodes,
+    requiredScopes: requiredScopes.map(scopeToWire),
+  };
 }
 
 function hasAdminTaskWriteAccess(
@@ -6064,6 +6131,24 @@ const TASK_TOOL_DEFINITIONS = [
     },
   },
   {
+    name: "inspectToolAccess",
+    description:
+      "Explain which MCP tools this connection can use and why. Optionally filter by tool name. Returns effective scopes, server identity, and stable access reason codes without exposing token data.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        toolNames: {
+          type: "array",
+          description:
+            "Optional tool names to inspect. Omit to inspect the complete compact catalog.",
+          items: { type: "string" },
+          maxItems: 200,
+          uniqueItems: true,
+        },
+      },
+    },
+  },
+  {
     name: "updateMyProfile",
     description:
       'Update the authenticated user\'s profile. Person is canonical for the public-facing fields (displayName, handle, bio, headline, coverImage, website, isPublic); this tool writes Person directly. Only fields you supply are changed. Pass `handle: ""` (or null) to clear the handle. Returns the fresh profile.',
@@ -11658,6 +11743,54 @@ export function createMcpServer(
               setupGaps,
               userId,
               ...profile,
+            });
+          }
+
+          case "inspectToolAccess": {
+            if (!userId)
+              return authRequired(
+                name,
+                "This tool explains access for the authenticated connection.",
+              );
+            const requestedNames = Array.isArray(a.toolNames)
+              ? a.toolNames.filter(
+                  (value): value is string => typeof value === "string",
+                )
+              : null;
+            const toolNames =
+              requestedNames ??
+              TASK_TOOL_DEFINITIONS.map((definition) => definition.name);
+            const catalogRevision = createHash("sha256")
+              .update(
+                JSON.stringify(
+                  TASK_TOOL_DEFINITIONS.map((definition) => ({
+                    adminOnly: ADMIN_ONLY_TOOLS.has(definition.name),
+                    enabled: !DISABLED_TOOLS.has(definition.name),
+                    definition,
+                    scopes: TOOL_SCOPES[definition.name] ?? null,
+                  })),
+                ),
+              )
+              .digest("hex")
+              .slice(0, 16);
+            const baseUrl = getMcpBaseUrl();
+            return ok({
+              principal: {
+                grantedOrganizationIds: organizationIds,
+                grantedScopes: (scopes ?? []).map(scopeToWire),
+                isAdmin,
+                userId,
+              },
+              server: {
+                canonicalUrl: `${baseUrl.replace(/\/$/, "")}/api/mcp`,
+                catalogRevision,
+                environment:
+                  process.env.VERCEL_ENV ??
+                  (baseUrl.includes("localhost") ? "development" : "unknown"),
+              },
+              tools: toolNames.map((toolName) =>
+                inspectToolAccess(toolName, scopes, isAdmin),
+              ),
             });
           }
 

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -371,6 +371,8 @@ const DISABLED_TOOLS = new Set([
   "mergeDuplicatePeople",
 ]);
 
+const TOOL_ACCESS_INSPECTION_MAX_NAMES = 200;
+
 function hasScope(
   grantedScopes: McpScope[] | undefined,
   toolName: string,
@@ -6146,7 +6148,7 @@ const TASK_TOOL_DEFINITIONS = [
           description:
             "Optional tool names to inspect. Omit to inspect the complete compact catalog.",
           items: { type: "string" },
-          maxItems: 200,
+          maxItems: TOOL_ACCESS_INSPECTION_MAX_NAMES,
           uniqueItems: true,
         },
       },
@@ -11756,11 +11758,43 @@ export function createMcpServer(
                 name,
                 "This tool explains access for the authenticated connection.",
               );
+            if (
+              a.toolNames !== undefined &&
+              (!Array.isArray(a.toolNames) ||
+                a.toolNames.some((value) => typeof value !== "string"))
+            ) {
+              return err("toolNames must be an array of strings.", {
+                code: "INVALID_ARGUMENT",
+                details: { field: "toolNames", itemType: "string" },
+              });
+            }
             const requestedNames = Array.isArray(a.toolNames)
-              ? a.toolNames.filter(
-                  (value): value is string => typeof value === "string",
-                )
+              ? (a.toolNames as string[])
               : null;
+            if (
+              requestedNames &&
+              requestedNames.length > TOOL_ACCESS_INSPECTION_MAX_NAMES
+            ) {
+              return err(
+                `toolNames must contain at most ${TOOL_ACCESS_INSPECTION_MAX_NAMES} entries.`,
+                {
+                  code: "INVALID_ARGUMENT",
+                  details: {
+                    field: "toolNames",
+                    maxItems: TOOL_ACCESS_INSPECTION_MAX_NAMES,
+                  },
+                },
+              );
+            }
+            if (
+              requestedNames &&
+              new Set(requestedNames).size !== requestedNames.length
+            ) {
+              return err("toolNames entries must be unique.", {
+                code: "INVALID_ARGUMENT",
+                details: { field: "toolNames", uniqueItems: true },
+              });
+            }
             const toolNames =
               requestedNames ??
               TASK_TOOL_DEFINITIONS.map((definition) => definition.name);


### PR DESCRIPTION
### Motivation
- Provide a single MCP-callable diagnostic that explains why a given tool is or is not accessible instead of forcing clients to join `/api/mcp/tools`, `tools/list`, and `getMe` themselves. 
- Make denial reasons deterministic and machine-readable so agents and integrators can programmatically diagnose missing scopes, admin gating, disabled tools, unknown tools, and argument-dependent organization access. 

### Description
- Add a new MCP tool registration and input schema named `inspectToolAccess` that accepts an optional `toolNames` filter and returns a compact access matrix for the requested tools. 
- Implement `inspectToolAccess` handler in the MCP server that returns `principal` (granted scopes, organization IDs, isAdmin, userId), `server` (canonical URL, environment, catalog revision), and `tools` (per-tool access entries). 
- Add `inspectToolAccess` runtime helper `inspectToolAccess(...)` that derives `accessible`, `enabled`, `adminOnly`, `requiredScopes`, `missingScopes`, and stable `reasonCodes` such as `AVAILABLE`, `MISSING_REQUIRED_SCOPE`, `ADMIN_USER_REQUIRED`, `TOOL_DISABLED`, `TOOL_NOT_FOUND`, and `ARGUMENT_DEPENDENT_ACCESS`. 
- Register `inspectToolAccess` in the `TOOL_SCOPES` and in the `TASK_TOOL_DEFINITIONS` compact catalog (no input-schema bloat for full catalog), and ensure the handler does not expose any bearer-token material. 
- Add focused tests in `src/lib/__tests__/mcp-server.test.ts` exercising authenticated and anonymous calls, missing-scope reporting, admin vs non-admin distinctions, unknown-tool reporting, and an argument-dependent organization-scope case. 

### Testing
- Ran workspace dependency build with `pnpm run build:workspace-deps`, which completed successfully. 
- Ran the unit test for the MCP server with `pnpm exec vitest run src/lib/__tests__/mcp-server.test.ts`, and the suite passed (211 tests passed). 
- Ran type checking with `pnpm run typecheck:fast`, which succeeded. 
- Ran formatting checks with `pnpm exec prettier --check src/lib/mcp-server.ts src/lib/__tests__/mcp-server.test.ts` and `git diff --check`, both of which passed; no UI screenshots were required because no UI surface changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6791f3784c832a8346d96cc351abc0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an MCP access inspection tool that explains which tools are available to a connection and why.
  * Reports authentication status, granted permissions, administrator access, server metadata, required permissions, and access reasons.
  * Supports inspecting all tools or filtering results by specific tool names.
* **Bug Fixes**
  * Unauthenticated access now returns a structured authentication-required error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->