### PR TITLE
Fix stale visual review baselines

### DIFF
--- a/.github/scripts/generate-pr-preview-links.mjs
+++ b/.github/scripts/generate-pr-preview-links.mjs
@@ -22,6 +22,15 @@ const VISUAL_REVIEW_MANIFEST_PATH =
   process.env.VISUAL_REVIEW_MANIFEST_PATH ?? "";
 const VISUAL_REVIEW_MANIFEST_JSON =
   process.env.VISUAL_REVIEW_MANIFEST_JSON ?? "";
+const VISUAL_REVIEW_BASELINE_COMMIT_SHA = normalizeCommitSha(
+  process.env.VISUAL_REVIEW_BASELINE_COMMIT_SHA,
+);
+const VISUAL_REVIEW_REQUESTED_BASE_COMMIT_SHA = normalizeCommitSha(
+  process.env.VISUAL_REVIEW_REQUESTED_BASE_COMMIT_SHA,
+);
+const VISUAL_REVIEW_BASELINE_RUN_ID = normalizeRunId(
+  process.env.VISUAL_REVIEW_BASELINE_RUN_ID,
+);
 
 if (!PREVIEW_URL) {
   console.error("PREVIEW_URL not set; skipping comment generation.");
@@ -267,6 +276,45 @@ function authLabel(authState) {
   return authState === "demo-logged-in" ? "demo logged-in" : "logged-out";
 }
 
+function normalizeCommitSha(value) {
+  const normalized = String(value ?? "").trim();
+  return /^[0-9a-f]{7,40}$/i.test(normalized) ? normalized : null;
+}
+
+function normalizeRunId(value) {
+  const normalized = String(value ?? "").trim();
+  return /^\d+$/.test(normalized) ? normalized : null;
+}
+
+function shortSha(value) {
+  return value.slice(0, 12);
+}
+
+function buildBaselineSummaryLine() {
+  if (!VISUAL_REVIEW_BASELINE_COMMIT_SHA) return null;
+
+  const baseline = `\`main@${shortSha(VISUAL_REVIEW_BASELINE_COMMIT_SHA)}\``;
+  const run = VISUAL_REVIEW_BASELINE_RUN_ID
+    ? ` from CI run \`${VISUAL_REVIEW_BASELINE_RUN_ID}\``
+    : "";
+
+  if (!VISUAL_REVIEW_REQUESTED_BASE_COMMIT_SHA) {
+    return `- :straight_ruler: Screenshot baseline: ${baseline}${run}.`;
+  }
+
+  if (
+    VISUAL_REVIEW_BASELINE_COMMIT_SHA ===
+    VISUAL_REVIEW_REQUESTED_BASE_COMMIT_SHA
+  ) {
+    return `- :straight_ruler: Screenshot baseline: exact PR base ${baseline}${run}.`;
+  }
+
+  return (
+    `- :warning: Screenshot baseline fallback: ${baseline}${run}; ` +
+    `exact PR base \`main@${shortSha(VISUAL_REVIEW_REQUESTED_BASE_COMMIT_SHA)}\` had no usable artifact.`
+  );
+}
+
 function visualStatusLabel(route) {
   if (route.errored || route.erroredPairs > 0) return "visual review errored";
   const parts = [];
@@ -336,6 +384,8 @@ function renderPacket({
   } else {
     lines.push("- :framed_picture: Visual review link appears here after CI publishes `latest.html`.");
   }
+  const baselineSummaryLine = buildBaselineSummaryLine();
+  if (baselineSummaryLine) lines.push(baselineSummaryLine);
   lines.push(`- :rocket: [Preview deployment](${PREVIEW_URL})`);
   lines.push("- :point_up: Cmd/Ctrl-click review links to keep this PR open.");
   lines.push("- :key: `?login=demo` signs in as the demo user; `?logout=1` clears the session.");

--- a/.github/scripts/generate-pr-preview-links.test.mjs
+++ b/.github/scripts/generate-pr-preview-links.test.mjs
@@ -12,6 +12,9 @@ function runGenerator(env) {
     encoding: "utf8",
     env: {
       ...process.env,
+      VISUAL_REVIEW_BASELINE_COMMIT_SHA: "",
+      VISUAL_REVIEW_REQUESTED_BASE_COMMIT_SHA: "",
+      VISUAL_REVIEW_BASELINE_RUN_ID: "",
       ...env,
     },
   });
@@ -116,4 +119,33 @@ test("reports when no user-facing page or component routes are inferred", () => 
 
   assert.match(output, /No user-facing page or component changes were inferred/);
   assert.doesNotMatch(output, /<!-- review-item:/);
+});
+
+test("identifies exact and fallback screenshot baselines", () => {
+  const exactBase = "a21b72d83b4207cd89481d84a0cff952c6107bc4";
+  const staleBase = "6fb97658853ac6114047a7b0642f27be646b1580";
+  const sharedEnv = {
+    PREVIEW_URL: "https://preview.example.vercel.app",
+    CHANGED_FILES: JSON.stringify([]),
+    VISUAL_REVIEW_REQUESTED_BASE_COMMIT_SHA: exactBase,
+    VISUAL_REVIEW_BASELINE_RUN_ID: "30252000160",
+  };
+
+  const exactOutput = runGenerator({
+    ...sharedEnv,
+    VISUAL_REVIEW_BASELINE_COMMIT_SHA: exactBase,
+  });
+  assert.match(
+    exactOutput,
+    /Screenshot baseline: exact PR base `main@a21b72d83b42` from CI run `30252000160`\./,
+  );
+
+  const fallbackOutput = runGenerator({
+    ...sharedEnv,
+    VISUAL_REVIEW_BASELINE_COMMIT_SHA: staleBase,
+  });
+  assert.match(
+    fallbackOutput,
+    /Screenshot baseline fallback: `main@6fb97658853a` from CI run `30252000160`; exact PR base `main@a21b72d83b42` had no usable artifact\./,
+  );
 });

--- a/.github/scripts/preview-masking-workflow-order.test.mjs
+++ b/.github/scripts/preview-masking-workflow-order.test.mjs
@@ -182,3 +182,45 @@ test("keeps visual review status pending until the Pages URL is live", () => {
     "visual review should use commit statuses, not a GitHub deployment that retriggers deploy smoke",
   );
 });
+
+test("prefers the exact PR-base visual artifact regardless of overall run status", () => {
+  const workflow = readFileSync(WORKFLOW, "utf8");
+  const baselineStepStart = workflow.indexOf(
+    "- name: Resolve main visual baseline",
+  );
+  const baselineStepEnd = workflow.indexOf("- name: Resolve PR preview URL");
+  assert.notEqual(baselineStepStart, -1, "visual baseline step is missing");
+  assert.notEqual(
+    baselineStepEnd,
+    -1,
+    "visual baseline step boundary is missing",
+  );
+  const baselineStep = workflow.slice(baselineStepStart, baselineStepEnd);
+
+  assert.match(
+    baselineStep,
+    /base_sha="\$\{\{ github\.event\.pull_request\.base\.sha \}\}"/u,
+  );
+  assert.match(baselineStep, /--commit "\$base_sha"/u);
+  assert.doesNotMatch(
+    baselineStep,
+    /--status success/u,
+    "an unrelated failed job must not hide a usable visual artifact",
+  );
+
+  const exactBaseQuery = baselineStep.indexOf('--commit "$base_sha"');
+  const fallbackQuery = baselineStep.indexOf("--limit 20");
+  assert.ok(
+    exactBaseQuery < fallbackQuery,
+    "the exact PR-base run should be tried before recent-main fallbacks",
+  );
+  assert.match(
+    baselineStep,
+    /VISUAL_REVIEW_BASELINE_COMMIT_SHA=\$baseline_sha/u,
+  );
+  assert.match(
+    baselineStep,
+    /VISUAL_REVIEW_REQUESTED_BASE_COMMIT_SHA=\$base_sha/u,
+  );
+  assert.match(baselineStep, /VISUAL_REVIEW_BASELINE_RUN_ID=\$run_id/u);
+});

--- a/.github/scripts/preview-masking-workflow-order.test.mjs
+++ b/.github/scripts/preview-masking-workflow-order.test.mjs
@@ -204,6 +204,18 @@ test("prefers the exact PR-base visual artifact regardless of overall run status
   assert.match(baselineStep, /--commit "\$base_sha"/u);
   assert.doesNotMatch(
     baselineStep,
+    /mapfile -t run_candidates < <\(/u,
+    "process substitution must not hide a failed GitHub run query",
+  );
+  assert.match(baselineStep, /exact_run_candidates="\$\(/u);
+  assert.match(baselineStep, /fallback_run_candidates="\$\(/u);
+  assert.match(
+    baselineStep,
+    /if \[ -n "\$run_candidates_output" \]; then\s+mapfile -t run_candidates/u,
+    "an empty successful query should leave the candidate array empty",
+  );
+  assert.doesNotMatch(
+    baselineStep,
     /--status success/u,
     "an unrelated failed job must not hide a usable visual artifact",
   );

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,18 +491,33 @@ jobs:
         run: |
           baseline_root="packages/web/output/playwright/main-baseline"
           pr_screenshots="packages/web/output/playwright/pr-screenshots"
+          base_sha="${{ github.event.pull_request.base.sha }}"
           rm -rf "$baseline_root"
           mkdir -p "$baseline_root"
 
-          mapfile -t run_ids < <(gh run list \
-            --workflow CI \
-            --branch main \
-            --status success \
-            --limit 5 \
-            --json databaseId \
-            --jq '.[].databaseId')
+          # Prefer the artifact produced for this PR's exact base commit. The
+          # overall workflow may still be red because production deployment
+          # failed after web-e2e-validate successfully uploaded its artifact.
+          mapfile -t run_candidates < <(
+            {
+              gh run list \
+                --workflow CI \
+                --branch main \
+                --commit "$base_sha" \
+                --limit 5 \
+                --json databaseId,headSha \
+                --jq '.[] | "\(.databaseId)\t\(.headSha)"'
+              gh run list \
+                --workflow CI \
+                --branch main \
+                --limit 20 \
+                --json databaseId,headSha \
+                --jq '.[] | "\(.databaseId)\t\(.headSha)"'
+            } | awk -F '\t' '!seen[$1]++'
+          )
 
-          for run_id in "${run_ids[@]}"; do
+          for candidate in "${run_candidates[@]}"; do
+            IFS=$'\t' read -r run_id baseline_sha <<< "$candidate"
             run_root="$baseline_root/run-$run_id"
             rm -rf "$run_root"
             mkdir -p "$run_root"
@@ -513,6 +528,9 @@ jobs:
               for screenshots_dir in "$run_root/screenshots" "$run_root/packages/web/screenshots"; do
                 if [ -d "$screenshots_dir" ]; then
                   echo "VISUAL_BEFORE_ROOT=$GITHUB_WORKSPACE/$screenshots_dir" >> "$GITHUB_ENV"
+                  echo "VISUAL_REVIEW_BASELINE_COMMIT_SHA=$baseline_sha" >> "$GITHUB_ENV"
+                  echo "VISUAL_REVIEW_REQUESTED_BASE_COMMIT_SHA=$base_sha" >> "$GITHUB_ENV"
+                  echo "VISUAL_REVIEW_BASELINE_RUN_ID=$run_id" >> "$GITHUB_ENV"
                   for copy_dir in \
                     "$run_root/copy-snapshots" \
                     "$run_root/output/playwright/copy-snapshots" \
@@ -523,7 +541,7 @@ jobs:
                       break
                     fi
                   done
-                  echo "Downloaded visual baseline from main run $run_id."
+                  echo "Downloaded visual baseline main@$baseline_sha from run $run_id (requested main@$base_sha)."
                   rm -rf packages/web/screenshots
                   cp -R "$pr_screenshots" packages/web/screenshots
                   exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,23 +498,31 @@ jobs:
           # Prefer the artifact produced for this PR's exact base commit. The
           # overall workflow may still be red because production deployment
           # failed after web-e2e-validate successfully uploaded its artifact.
-          mapfile -t run_candidates < <(
-            {
-              gh run list \
-                --workflow CI \
-                --branch main \
-                --commit "$base_sha" \
-                --limit 5 \
-                --json databaseId,headSha \
-                --jq '.[] | "\(.databaseId)\t\(.headSha)"'
-              gh run list \
-                --workflow CI \
-                --branch main \
-                --limit 20 \
-                --json databaseId,headSha \
-                --jq '.[] | "\(.databaseId)\t\(.headSha)"'
-            } | awk -F '\t' '!seen[$1]++'
-          )
+          exact_run_candidates="$(
+            gh run list \
+              --workflow CI \
+              --branch main \
+              --commit "$base_sha" \
+              --limit 5 \
+              --json databaseId,headSha \
+              --jq '.[] | "\(.databaseId)\t\(.headSha)"'
+          )"
+          fallback_run_candidates="$(
+            gh run list \
+              --workflow CI \
+              --branch main \
+              --limit 20 \
+              --json databaseId,headSha \
+              --jq '.[] | "\(.databaseId)\t\(.headSha)"'
+          )"
+          run_candidates_output="$(
+            printf '%s\n%s\n' "$exact_run_candidates" "$fallback_run_candidates" |
+              awk -F '\t' 'NF && !seen[$1]++'
+          )"
+          run_candidates=()
+          if [ -n "$run_candidates_output" ]; then
+            mapfile -t run_candidates <<< "$run_candidates_output"
+          fi
 
           for candidate in "${run_candidates[@]}"; do
             IFS=$'\t' read -r run_id baseline_sha <<< "$candidate"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ Before writing or editing any public-facing website, email, metadata, CTA, empty
 
 - Before changing existing public copy, preserve its strategic job. Identify audience, desired action, motivation, old strategic job, and source/quantitative anchor. Do not replace purpose or motivation with mechanism-only copy.
 - Treat the human owner as the copy merge gate. When strategy is unclear, ask the shortest missing question with a recommended default. Do not set `COPY_REVIEW_APPROVED=1` or bypass the copy gate without explicit approval.
+- Internal development text—PRs, CI, logs, tests, and developer tooling—does not require copy approval.
 - Be concise. Cut filler, throat-clearing, internal process language, and generic nonprofit/consultant copy.
 - Speak directly to the specific human or organization that should do something.
 - Make the action obvious, then show the value to them for doing it.


### PR DESCRIPTION
## Summary

- Prefer the visual artifact from the pull request's exact base commit, even when a later production-deployment job made that workflow run fail.
- Fall back to recent `main` artifacts only when the exact-base artifact is unavailable.
- Show whether the screenshot baseline is exact or a fallback in the sticky PR review packet.
- Clarify that internal development text does not require human copy approval.

## Root cause

The baseline resolver filtered for entirely successful CI workflow runs. Recent `main` runs had successfully uploaded visual artifacts but were marked failed by a later `deploy-production` job, so new PRs were compared with an older baseline and inherited unrelated UI differences.

## Validation

- `node --test .github/scripts/*.test.mjs` — 38 tests passed.
- Parsed `.github/workflows/ci.yml` successfully with PyYAML.
- `git diff --check` passed.
- Confirmed `gh run list --commit` returns an exact-base run even when its overall conclusion is `failure`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Visual reviews now prioritize screenshots generated from the exact pull request base commit.
  * Added clearer fallback messaging when an exact baseline is unavailable.
  * Improved baseline selection to avoid overlooking usable visual artifacts due to unrelated workflow failures.

* **Tests**
  * Added coverage for exact-base and fallback screenshot baseline scenarios.
  * Added workflow checks validating baseline selection order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->