### PR TITLE
Add exact-version document review workflow

### DIFF
--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -5,7 +5,6 @@ import {
 } from "@optimitron/db/constants";
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { SiteKey } from "@/lib/site";
 import {
   filterRedirectOnlyRoutes,
@@ -39,10 +38,7 @@ type DocumentReviewFixtureManifest = {
   version: 1;
 };
 
-const WEB_ROOT = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../..",
-);
+const WEB_ROOT = path.resolve(__dirname, "../..");
 const DOCUMENT_REVIEW_FIXTURE_MANIFEST_PATH = path.resolve(
   WEB_ROOT,
   "output",

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -38,6 +38,26 @@ type DocumentReviewFixtureManifest = {
   version: 1;
 };
 
+function isDocumentReviewFixtureManifest(
+  value: unknown,
+): value is DocumentReviewFixtureManifest {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    candidate.version === 1 &&
+    isNonEmptyString(candidate.managerTaskId) &&
+    isNonEmptyString(candidate.activeReviewTaskId) &&
+    isNonEmptyString(candidate.staleReviewTaskId)
+  );
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 const WEB_ROOT = path.resolve(__dirname, "../..");
 const DOCUMENT_REVIEW_FIXTURE_MANIFEST_PATH = path.resolve(
   WEB_ROOT,
@@ -295,11 +315,11 @@ function loadDocumentReviewRoutes(): VisualRoute[] {
     return [];
   }
 
-  let manifest: DocumentReviewFixtureManifest;
+  let manifest: unknown;
   try {
     manifest = JSON.parse(
       readFileSync(DOCUMENT_REVIEW_FIXTURE_MANIFEST_PATH, "utf8"),
-    ) as DocumentReviewFixtureManifest;
+    );
   } catch (error) {
     throw new Error(
       `Document-review visual fixture manifest is missing at ${DOCUMENT_REVIEW_FIXTURE_MANIFEST_PATH}. The visual fixture seeder must run before Playwright.`,
@@ -307,12 +327,7 @@ function loadDocumentReviewRoutes(): VisualRoute[] {
     );
   }
 
-  if (
-    manifest.version !== 1 ||
-    !manifest.managerTaskId ||
-    !manifest.activeReviewTaskId ||
-    !manifest.staleReviewTaskId
-  ) {
+  if (!isDocumentReviewFixtureManifest(manifest)) {
     throw new Error(
       `Document-review visual fixture manifest is invalid at ${DOCUMENT_REVIEW_FIXTURE_MANIFEST_PATH}.`,
     );

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -5,6 +5,7 @@ import {
 } from "@optimitron/db/constants";
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { SiteKey } from "@/lib/site";
 import {
   filterRedirectOnlyRoutes,
@@ -38,8 +39,12 @@ type DocumentReviewFixtureManifest = {
   version: 1;
 };
 
+const WEB_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
 const DOCUMENT_REVIEW_FIXTURE_MANIFEST_PATH = path.resolve(
-  process.cwd(),
+  WEB_ROOT,
   "output",
   "playwright",
   "visual-fixtures",

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -3,6 +3,8 @@ import {
   MANAGED_DEMO_COLLECTION_ID,
   MANAGED_DEMO_DOCUMENT_ID,
 } from "@optimitron/db/constants";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import type { SiteKey } from "@/lib/site";
 import {
   filterRedirectOnlyRoutes,
@@ -12,6 +14,8 @@ import { ALL_PAGE_PATHS, PUBLIC_PAGE_PATHS } from "./static-pages";
 
 export type VisualRoute = {
   authenticated?: boolean;
+  /** UI source files whose rendered states this route is required to exercise. */
+  covers?: string[];
   createTaskMode?: "person";
   expectSettings?: boolean;
   name: string;
@@ -26,6 +30,28 @@ export type VisualRoute = {
   siteVariant?: SiteKey;
   waitForImages?: boolean;
 };
+
+type DocumentReviewFixtureManifest = {
+  activeReviewTaskId: string;
+  managerTaskId: string;
+  staleReviewTaskId: string;
+  version: 1;
+};
+
+const DOCUMENT_REVIEW_FIXTURE_MANIFEST_PATH = path.resolve(
+  process.cwd(),
+  "output",
+  "playwright",
+  "visual-fixtures",
+  "document-review.json",
+);
+const TASK_DETAIL_PAGE_FILE = "packages/web/src/app/tasks/[id]/page.tsx";
+const DOCUMENT_REVIEW_MANAGER_FILE =
+  "packages/web/src/components/tasks/document-review-manager-panel.tsx";
+const DOCUMENT_REVIEW_REVIEWER_FILE =
+  "packages/web/src/components/tasks/document-review-reviewer-panel.tsx";
+const TASK_COMMENT_FEED_FILE =
+  "packages/web/src/components/tasks/task-comment-feed.tsx";
 
 const PRESIDENT_TASK_LIST_SELECTOR =
   '[data-visual-section="president-task-list"]';
@@ -164,6 +190,7 @@ const SEEDED_DYNAMIC_ROUTES: VisualRoute[] = [
     path: "/tasks/1-pct-treaty-signer-ca",
     required: false,
   },
+  ...loadDocumentReviewRoutes(),
 ];
 
 const PUBLIC_SCREENSHOT_ROUTES: VisualRoute[] = filterRedirectOnlyRoutes(
@@ -260,4 +287,72 @@ function dedupeRoutes(routes: VisualRoute[]): VisualRoute[] {
     deduped.push(route);
   }
   return deduped;
+}
+
+function loadDocumentReviewRoutes(): VisualRoute[] {
+  if (process.env.ROUTE_VISUAL_REVIEW !== "1") {
+    return [];
+  }
+
+  let manifest: DocumentReviewFixtureManifest;
+  try {
+    manifest = JSON.parse(
+      readFileSync(DOCUMENT_REVIEW_FIXTURE_MANIFEST_PATH, "utf8"),
+    ) as DocumentReviewFixtureManifest;
+  } catch (error) {
+    throw new Error(
+      `Document-review visual fixture manifest is missing at ${DOCUMENT_REVIEW_FIXTURE_MANIFEST_PATH}. The visual fixture seeder must run before Playwright.`,
+      { cause: error },
+    );
+  }
+
+  if (
+    manifest.version !== 1 ||
+    !manifest.managerTaskId ||
+    !manifest.activeReviewTaskId ||
+    !manifest.staleReviewTaskId
+  ) {
+    throw new Error(
+      `Document-review visual fixture manifest is invalid at ${DOCUMENT_REVIEW_FIXTURE_MANIFEST_PATH}.`,
+    );
+  }
+
+  return [
+    {
+      authenticated: true,
+      covers: [
+        TASK_DETAIL_PAGE_FILE,
+        DOCUMENT_REVIEW_MANAGER_FILE,
+        TASK_COMMENT_FEED_FILE,
+      ],
+      name: "document-review-manager",
+      path: `/tasks/${manifest.managerTaskId}`,
+      required: true,
+      requiredSelector: "#document-review-manager-heading",
+    },
+    {
+      authenticated: true,
+      covers: [
+        TASK_DETAIL_PAGE_FILE,
+        DOCUMENT_REVIEW_REVIEWER_FILE,
+        TASK_COMMENT_FEED_FILE,
+      ],
+      name: "document-review-reviewer",
+      path: `/tasks/${manifest.activeReviewTaskId}`,
+      required: true,
+      requiredSelector:
+        '[data-document-review-state="active"] #document-review-heading',
+      requiredText: /^Review this version$/,
+    },
+    {
+      authenticated: true,
+      covers: [TASK_DETAIL_PAGE_FILE, DOCUMENT_REVIEW_REVIEWER_FILE],
+      name: "document-review-stale",
+      path: `/tasks/${manifest.staleReviewTaskId}`,
+      required: true,
+      requiredSelector:
+        '[data-document-review-state="stale"] #document-review-heading',
+      requiredText: /^Past review$/,
+    },
+  ];
 }

--- a/packages/web/e2e/visual-regression.spec.ts
+++ b/packages/web/e2e/visual-regression.spec.ts
@@ -98,6 +98,12 @@ function buildRouteReviewManifest() {
     name: route.name,
     path: route.path,
     authenticated: route.authenticated === true,
+    required: route.required,
+    requiredProjects: ["default", "visual-mobile"],
+    ...(route.requiredSelector
+      ? { activationSelector: route.requiredSelector }
+      : {}),
+    ...(route.covers?.length ? { covers: route.covers } : {}),
     ...(route.siteVariant ? { siteVariant: route.siteVariant } : {}),
   }));
   const representedStates = new Set(
@@ -121,6 +127,8 @@ function buildRouteReviewManifest() {
           authenticated && hasLoggedOutState ? `${spec.name}-auth` : spec.name,
         path: spec.path,
         authenticated,
+        required: false,
+        requiredProjects: ["default", "visual-mobile"],
       });
       representedStates.add(stateKey);
     }

--- a/packages/web/e2e/visual-review-page.spec.ts
+++ b/packages/web/e2e/visual-review-page.spec.ts
@@ -78,7 +78,99 @@ test("collapsed variant routes remain available while filtering", async ({
 
   await variantRoute.click();
   await page
-    .getByRole("button", { name: "Load live compare (production + preview link)" })
+    .getByRole("button", {
+      name: "Load live compare (production + preview link)",
+    })
     .click();
-  await expect(page.locator('iframe[src="https://dfda.earth/"]')).toHaveCount(1);
+  await expect(page.locator('iframe[src="https://dfda.earth/"]')).toHaveCount(
+    1,
+  );
+});
+
+test("route verdicts persist and advance through every unreviewed route", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "default");
+
+  await page.goto(`${pathToFileURL(SMOKE_HTML)}#route=variant-dfda-home`);
+
+  const approve = () =>
+    page.getByRole("button", { name: "Looks right 👍", exact: true }).click();
+
+  await approve();
+  await expect(page).toHaveURL(/#route=home$/);
+  await expect(page.getByRole("status")).toContainText("Saved locally 👍");
+  await expect(page.getByRole("status")).toContainText("Next unreviewed: Home");
+
+  await approve();
+  await expect(page).toHaveURL(/#route=calendar$/);
+
+  await approve();
+  await expect(page).toHaveURL(/#route=prize$/);
+
+  await page
+    .getByRole("button", { name: "Needs work 👎", exact: true })
+    .click();
+  await expect(page).toHaveURL(/#route=prize$/);
+  await expect(page.getByRole("status")).toContainText(
+    "Review pass complete. Copy the PR comment or export the notes.",
+  );
+  await expect(page.locator("#chip-reviewed")).toHaveText(
+    "4/4 reviewed · 1 flagged",
+  );
+
+  const savedVerdicts = await page.evaluate(() => {
+    const saved = localStorage.getItem(
+      "visualReview:abc1234def5678900000000000000000000000ff",
+    );
+    return saved ? JSON.parse(saved).verdicts : null;
+  });
+  expect(savedVerdicts).toMatchObject({
+    calendar: { v: "looks-right" },
+    home: { v: "looks-right" },
+    prize: { v: "needs-work" },
+    "variant-dfda-home": { v: "looks-right" },
+  });
+
+  await page.reload();
+  await expect(page.locator("#chip-reviewed")).toHaveText(
+    "4/4 reviewed · 1 flagged",
+  );
+  await expect(
+    page.getByRole("button", { name: "Needs work 👎", exact: true }),
+  ).toHaveClass(/\bon\b/);
+});
+
+test("copies one consolidated pull request comment", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "default");
+
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (text: string) => {
+          (window as Window & { copiedReview?: string }).copiedReview = text;
+        },
+      },
+    });
+  });
+  await page.goto(`${pathToFileURL(SMOKE_HTML)}#route=home`);
+  await page
+    .getByRole("button", { name: "Looks right 👍", exact: true })
+    .click();
+  await page
+    .getByRole("button", { name: "Copy PR comment", exact: true })
+    .click();
+
+  await expect(
+    page.getByRole("button", { name: "Copied PR comment", exact: true }),
+  ).toBeVisible();
+  const copiedReview = await page.evaluate(
+    () => (window as Window & { copiedReview?: string }).copiedReview,
+  );
+  expect(copiedReview).toContain("# Review notes — PR #123 (abc1234)");
+  expect(copiedReview).toContain("| Home");
+  expect(copiedReview).toContain("looks right");
 });

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,7 +26,7 @@
     "typecheck:app": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit --project tsconfig.next.json",
     "typecheck:tests": "cross-env NODE_OPTIONS=--max-old-space-size=6144 tsc --noEmit --project tsconfig.tests.json",
     "typecheck:full": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit",
-    "test": "pnpm exec vitest run",
+    "test": "node --test scripts/visual-review-coverage.test.mjs && pnpm exec vitest run",
     "generate": "tsx scripts/generate-web-data.ts",
     "fetch": "tsx scripts/fetch-and-generate.ts",
     "causal": "tsx scripts/generate-causal-reports.ts",

--- a/packages/web/scripts/build-visual-review.mjs
+++ b/packages/web/scripts/build-visual-review.mjs
@@ -1046,7 +1046,15 @@ function getBaselineRef() {
 function loadChangedFiles() {
   const envJson = process.env.VISUAL_REVIEW_CHANGED_FILES_JSON?.trim();
   if (envJson) {
-    const parsed = JSON.parse(envJson);
+    let parsed;
+    try {
+      parsed = JSON.parse(envJson);
+    } catch (error) {
+      throw new TypeError(
+        "VISUAL_REVIEW_CHANGED_FILES_JSON must be a JSON array of file paths",
+        { cause: error },
+      );
+    }
     if (
       !Array.isArray(parsed) ||
       parsed.some((entry) => typeof entry !== "string")

--- a/packages/web/scripts/build-visual-review.mjs
+++ b/packages/web/scripts/build-visual-review.mjs
@@ -19,6 +19,10 @@ import {
   isSignificantDimensionChange,
   normalizeVisualReviewMarkdown,
 } from "./visual-review-diff.mjs";
+import {
+  buildChangedFileDiscoveryArgs,
+  buildVisualCoverage,
+} from "./visual-review-coverage.mjs";
 import { renderReviewHtml } from "./visual-review-page.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -43,7 +47,7 @@ const pageLinkBaseUrl = parseOptionalUrl(
   process.env.VISUAL_REVIEW_BASE_URL ??
     (process.env.CI === "true"
       ? null
-      : process.env.BASE_URL ?? process.env.NEXTAUTH_URL),
+      : (process.env.BASE_URL ?? process.env.NEXTAUTH_URL)),
 );
 const outputRoot = path.resolve(webRoot, "output", "playwright", "review");
 const assetRoot = path.join(outputRoot, "assets");
@@ -62,7 +66,10 @@ const diffPixelRatioThreshold = parseNumberEnv(
   "VISUAL_REVIEW_DIFF_RATIO",
   0.002,
 );
-const pixelmatchThreshold = parseNumberEnv("VISUAL_REVIEW_PIXEL_THRESHOLD", 0.12);
+const pixelmatchThreshold = parseNumberEnv(
+  "VISUAL_REVIEW_PIXEL_THRESHOLD",
+  0.12,
+);
 // Full-page height deltas below this are treated as rendering drift, not a
 // change, so a sub-pixel reflow in shared chrome stops force-flagging every
 // route with "0% overlap". See isSignificantDimensionChange in
@@ -149,6 +156,9 @@ const routeOrder = [
   "task-optimize-earth",
   "task-one-percent-treaty",
   "task-signer-canada",
+  "document-review-manager",
+  "document-review-reviewer",
+  "document-review-stale",
   "variant-optimitron-home",
   "variant-optimitron-tasks",
   "variant-dfda-home",
@@ -166,7 +176,9 @@ const VARIANT_DOMAIN_LABELS = {
 };
 
 main().catch((error) => {
-  console.error(error instanceof Error ? error.stack ?? error.message : error);
+  console.error(
+    error instanceof Error ? (error.stack ?? error.message) : error,
+  );
   process.exitCode = 1;
 });
 
@@ -183,9 +195,23 @@ async function main() {
   const grouped = appendCopyOnlyGroups(
     await analyzeGroups(groupScreenshots(screenshots)),
   );
-  const html = renderHtml(grouped);
-  const manifest = buildReviewManifest(grouped);
-  const blockingIssues = getBlockingReviewIssues(grouped, screenshots);
+  const coverage = buildVisualCoverage({
+    afterCaptures: screenshots.filter(
+      (screenshot) => screenshot.version === "after",
+    ),
+    changedFiles: loadChangedFiles(),
+    routes: [...routeSpecs.entries()].map(([name, spec]) => ({
+      name,
+      ...spec,
+    })),
+  });
+  const html = renderHtml(grouped, coverage);
+  const manifest = buildReviewManifest(grouped, coverage);
+  const blockingIssues = getBlockingReviewIssues(
+    grouped,
+    screenshots,
+    coverage,
+  );
 
   writeFileSync(latestHtmlPath, html, "utf8");
   writeFileSync(reviewManifestPath, JSON.stringify(manifest, null, 2), "utf8");
@@ -194,6 +220,9 @@ async function main() {
   console.log(`[visual-review] screenshots=${screenshots.length}`);
   console.log(
     `[visual-review] changed=${grouped.filter((group) => group.changed).length} unchanged=${grouped.filter((group) => !group.changed).length}`,
+  );
+  console.log(
+    `[visual-review] UI coverage=${coverage.coveredUiFiles.length}/${coverage.changedUiFiles.length} changed source files`,
   );
 
   if (!allowIncompleteReview && blockingIssues.length > 0) {
@@ -245,7 +274,8 @@ function collectScreenshots(root, version) {
   }
 
   return files.sort((a, b) => {
-    const routeDelta = routeSortIndex(a.routeName) - routeSortIndex(b.routeName);
+    const routeDelta =
+      routeSortIndex(a.routeName) - routeSortIndex(b.routeName);
     if (routeDelta !== 0) {
       return routeDelta;
     }
@@ -281,12 +311,13 @@ function groupScreenshots(screenshots) {
   return [...grouped.entries()].map(([routeName, projectMap]) => ({
     routeName,
     pairs: [...projectMap.values()].sort(
-      (a, b) => projectSortIndex(a.projectName) - projectSortIndex(b.projectName),
+      (a, b) =>
+        projectSortIndex(a.projectName) - projectSortIndex(b.projectName),
     ),
   }));
 }
 
-function renderHtml(groups) {
+function renderHtml(groups, coverage) {
   if (groups.length === 0) {
     return `<!doctype html>
 <html lang="en">
@@ -302,7 +333,7 @@ function renderHtml(groups) {
 </html>
 `;
   }
-  return renderReviewHtml(buildReviewPageInput(groups));
+  return renderReviewHtml(buildReviewPageInput(groups, coverage));
 }
 
 /**
@@ -311,7 +342,7 @@ function renderHtml(groups) {
  * ordered changed -> copy-only -> unchanged; the sort is stable, so
  * routeOrder is preserved within each rank.
  */
-function buildReviewPageInput(groups) {
+function buildReviewPageInput(groups, coverage) {
   const reviewBase = getPublishedReviewBase();
   const routes = groups.map((group) => buildReviewPageRoute(group));
   // Changed variant routes rank 0 with everything else (they must surface);
@@ -347,6 +378,7 @@ function buildReviewPageInput(groups) {
       erroredRoutes: routes.filter((route) => route.errored).length,
       totalRoutes: routes.length,
     },
+    coverage,
     routes,
   };
 }
@@ -506,8 +538,16 @@ async function comparePair(pair) {
     });
     const compareWidth = Math.min(before.width, after.width);
     const compareHeight = Math.min(before.height, after.height);
-    const beforeData = getComparableImageData(before, compareWidth, compareHeight);
-    const afterData = getComparableImageData(after, compareWidth, compareHeight);
+    const beforeData = getComparableImageData(
+      before,
+      compareWidth,
+      compareHeight,
+    );
+    const afterData = getComparableImageData(
+      after,
+      compareWidth,
+      compareHeight,
+    );
     const diffData = new Uint8Array(compareWidth * compareHeight * 4);
     const diffPixels = pixelmatch(
       beforeData,
@@ -525,7 +565,11 @@ async function comparePair(pair) {
     let alignmentAnchors = buildDefaultAlignmentAnchors(before, after);
     if (changed) {
       try {
-        const extracted = extractHunksAndAlignment({ before, after, noiseFloorPct: 0 });
+        const extracted = extractHunksAndAlignment({
+          before,
+          after,
+          noiseFloorPct: 0,
+        });
         hunks = extracted.hunks;
         alignmentAnchors = extracted.alignmentAnchors;
       } catch (error) {
@@ -543,7 +587,10 @@ async function comparePair(pair) {
       const afterDir = path.dirname(pair.after.assetPath);
       const diffPng = new PNG({ width: compareWidth, height: compareHeight });
       diffPng.data = Buffer.from(diffData);
-      const diffAssetPath = path.join(afterDir, buildDiffFileName(pair.after.fileName));
+      const diffAssetPath = path.join(
+        afterDir,
+        buildDiffFileName(pair.after.fileName),
+      );
       writeFileSync(diffAssetPath, PNG.sync.write(diffPng));
       diffRelPath = toPosix(path.relative(outputRoot, diffAssetPath));
       beforeRegions = buildDiffRegions(
@@ -564,11 +611,21 @@ async function comparePair(pair) {
     if (dimensionChanged) {
       beforeRegions = [
         ...beforeRegions,
-        ...buildDimensionExtraRegions(before.width, before.height, compareWidth, compareHeight),
+        ...buildDimensionExtraRegions(
+          before.width,
+          before.height,
+          compareWidth,
+          compareHeight,
+        ),
       ];
       afterRegions = [
         ...afterRegions,
-        ...buildDimensionExtraRegions(after.width, after.height, compareWidth, compareHeight),
+        ...buildDimensionExtraRegions(
+          after.width,
+          after.height,
+          compareWidth,
+          compareHeight,
+        ),
       ];
     }
     return {
@@ -618,12 +675,20 @@ function getComparableImageData(image, width, height) {
   const rowLength = width * 4;
   for (let y = 0; y < height; y += 1) {
     const sourceStart = y * image.width * 4;
-    data.set(image.data.subarray(sourceStart, sourceStart + rowLength), y * rowLength);
+    data.set(
+      image.data.subarray(sourceStart, sourceStart + rowLength),
+      y * rowLength,
+    );
   }
   return data;
 }
 
-function buildDimensionExtraRegions(width, height, compareWidth, compareHeight) {
+function buildDimensionExtraRegions(
+  width,
+  height,
+  compareWidth,
+  compareHeight,
+) {
   const regions = [];
   if (height > compareHeight) {
     regions.push({
@@ -678,10 +743,7 @@ function buildDiffRegions(
       const index = tileY * columns + tileX;
       const tileWidth = Math.min(tileSize, compareWidth - tileX * tileSize);
       const tileHeight = Math.min(tileSize, compareHeight - tileY * tileSize);
-      const minPixels = Math.max(
-        3,
-        Math.ceil(tileWidth * tileHeight * 0.006),
-      );
+      const minPixels = Math.max(3, Math.ceil(tileWidth * tileHeight * 0.006));
       if (tileCounts[index] >= minPixels) {
         dirtyTiles[index] = 1;
       }
@@ -799,14 +861,12 @@ function compactDiffRegions(regions, width, height) {
     selected.push(mergeDiffRegions(sortedRegions.slice(maxRegions)));
   }
 
-  return selected
-    .filter(Boolean)
-    .map((region) => ({
-      height: roundPercent(((region.bottom - region.top) / height) * 100),
-      left: roundPercent((region.left / width) * 100),
-      top: roundPercent((region.top / height) * 100),
-      width: roundPercent(((region.right - region.left) / width) * 100),
-    }));
+  return selected.filter(Boolean).map((region) => ({
+    height: roundPercent(((region.bottom - region.top) / height) * 100),
+    left: roundPercent((region.left / width) * 100),
+    top: roundPercent((region.top / height) * 100),
+    width: roundPercent(((region.right - region.left) / width) * 100),
+  }));
 }
 
 function mergeDiffRegions(regions) {
@@ -981,6 +1041,43 @@ function getBaselineRef() {
   }
   cachedBaselineRef = "main";
   return cachedBaselineRef;
+}
+
+function loadChangedFiles() {
+  const envJson = process.env.VISUAL_REVIEW_CHANGED_FILES_JSON?.trim();
+  if (envJson) {
+    const parsed = JSON.parse(envJson);
+    if (
+      !Array.isArray(parsed) ||
+      parsed.some((entry) => typeof entry !== "string")
+    ) {
+      throw new TypeError(
+        "VISUAL_REVIEW_CHANGED_FILES_JSON must be a JSON array of file paths",
+      );
+    }
+    return parsed;
+  }
+
+  try {
+    const output = execFileSync(
+      "git",
+      buildChangedFileDiscoveryArgs(getBaselineRef()),
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+    return output
+      .split(/\r?\n/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  } catch {
+    console.warn(
+      "[visual-review] changed-file analysis unavailable; screenshot coverage cannot be proven",
+    );
+    return null;
+  }
 }
 
 function readMainFile(repoRelativePath) {
@@ -1173,22 +1270,25 @@ function formatUnifiedRange(start, count) {
 function renderMarkdownDiffLines(lines) {
   return lines
     .map((line) => {
-      const className = line.kind === "add" || line.kind === "added"
-        ? "added"
-        : line.kind === "del" || line.kind === "removed"
-          ? "removed"
-          : line.kind === "hunk"
-            ? "hunk"
-            : line.kind === "header"
-              ? "header"
-              : "context";
+      const className =
+        line.kind === "add" || line.kind === "added"
+          ? "added"
+          : line.kind === "del" || line.kind === "removed"
+            ? "removed"
+            : line.kind === "hunk"
+              ? "hunk"
+              : line.kind === "header"
+                ? "header"
+                : "context";
       return `<span class="markdown-diff-line ${className}">${escapeHtml(line.text)}</span>`;
     })
     .join("");
 }
 
 function buildDiffFileName(fileName) {
-  const baseName = path.basename(fileName, ".png").replace(/-(before|after)$/i, "");
+  const baseName = path
+    .basename(fileName, ".png")
+    .replace(/-(before|after)$/i, "");
   return `${baseName}-diff.png`;
 }
 
@@ -1204,15 +1304,13 @@ function summarizeGroups(groups) {
     erroredRoutes: groups.filter((group) => group.errored).length,
     unchangedRoutes: groups.filter(
       (group) =>
-        !group.changed &&
-        !group.errored &&
-        !buildMarkdownDiff(group.routeName),
+        !group.changed && !group.errored && !buildMarkdownDiff(group.routeName),
     ).length,
     missingPairs: groups.reduce((sum, group) => sum + group.missingPairs, 0),
   };
 }
 
-function buildReviewManifest(groups) {
+function buildReviewManifest(groups, coverage) {
   const reviewBase = getPublishedReviewBase();
   return {
     version: 1,
@@ -1226,6 +1324,7 @@ function buildReviewManifest(groups) {
     previewBaseUrl: pageLinkBaseUrl ? pageLinkBaseUrl.toString() : null,
     reviewUrl: reviewBase ? `${reviewBase}/latest.html` : null,
     summary: summarizeGroups(groups),
+    coverage,
     routes: groups.map((group) => {
       const markdownDiff = buildMarkdownDiff(group.routeName);
       const copyChanged = Boolean(markdownDiff);
@@ -1269,8 +1368,8 @@ function reviewStatusLabel(group, markdownDiff) {
   return routeStatusLabel(group);
 }
 
-function getBlockingReviewIssues(groups, screenshots) {
-  const issues = [];
+function getBlockingReviewIssues(groups, screenshots, coverage) {
+  const issues = [...coverage.blockingIssues];
   const afterCount = screenshots.filter(
     (screenshot) => screenshot.version === "after",
   ).length;
@@ -1414,16 +1513,30 @@ function loadRouteSpecs() {
 
     return new Map(
       parsed
-        .filter((entry) => (
-          entry &&
-          typeof entry.name === "string" &&
-          typeof entry.path === "string"
-        ))
+        .filter(
+          (entry) =>
+            entry &&
+            typeof entry.name === "string" &&
+            typeof entry.path === "string",
+        )
         .map((entry) => [
           entry.name,
           {
             path: entry.path,
             authenticated: entry.authenticated === true,
+            activationSelector:
+              typeof entry.activationSelector === "string"
+                ? entry.activationSelector
+                : "",
+            covers: Array.isArray(entry.covers)
+              ? entry.covers.filter((filePath) => typeof filePath === "string")
+              : [],
+            required: entry.required === true,
+            requiredProjects: Array.isArray(entry.requiredProjects)
+              ? entry.requiredProjects.filter(
+                  (projectName) => typeof projectName === "string",
+                )
+              : [],
             siteVariant:
               typeof entry.siteVariant === "string" ? entry.siteVariant : null,
           },
@@ -1444,7 +1557,10 @@ function getPublishedReviewBase() {
 }
 
 function getRouteAuthState(routeName) {
-  if (routeSpecs.get(routeName)?.authenticated || isAuthenticatedMarkdownRoute(routeName)) {
+  if (
+    routeSpecs.get(routeName)?.authenticated ||
+    isAuthenticatedMarkdownRoute(routeName)
+  ) {
     return "demo-logged-in";
   }
   return "logged-out";
@@ -1512,7 +1628,9 @@ function parseOptionalUrl(value) {
   try {
     return new URL(value);
   } catch {
-    console.warn(`[visual-review] Ignoring invalid page link base URL: ${value}`);
+    console.warn(
+      `[visual-review] Ignoring invalid page link base URL: ${value}`,
+    );
     return null;
   }
 }

--- a/packages/web/scripts/run-playwright.mjs
+++ b/packages/web/scripts/run-playwright.mjs
@@ -14,11 +14,14 @@ const WEB_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
 );
+const REPO_ROOT = path.resolve(WEB_ROOT, "../..");
 const scriptArgs = process.argv
   .slice(2)
   .filter((arg, index) => !(index === 0 && arg === "--"));
 const requestedMode = scriptArgs[0];
-if (requestedMode === "visual") loadEnvFile({ quiet: true });
+if (requestedMode === "visual") {
+  loadEnvFile({ path: path.resolve(REPO_ROOT, ".env"), quiet: true });
+}
 const DEFAULT_BASE_URL = "http://127.0.0.1:3001";
 const NEW_USER_FLOW_ARTIFACT_DIR = path.resolve(
   process.cwd(),

--- a/packages/web/scripts/run-playwright.mjs
+++ b/packages/web/scripts/run-playwright.mjs
@@ -2,21 +2,38 @@
 
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { config as loadEnvFile } from "dotenv";
 
 const require = createRequire(import.meta.url);
+const WEB_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const scriptArgs = process.argv
+  .slice(2)
+  .filter((arg, index) => !(index === 0 && arg === "--"));
+const requestedMode = scriptArgs[0];
+if (requestedMode === "visual") loadEnvFile({ quiet: true });
 const DEFAULT_BASE_URL = "http://127.0.0.1:3001";
 const NEW_USER_FLOW_ARTIFACT_DIR = path.resolve(
   process.cwd(),
   "../../screenshots/new-user-flow/_playwright-artifacts",
 );
-const LOCAL_REACHABILITY_PATHS = [
-  "/favicon.ico",
-  "/manifest.json",
-  "/",
-];
+const VISUAL_FIXTURE_MANIFEST_PATH = path.resolve(
+  WEB_ROOT,
+  "output",
+  "playwright",
+  "visual-fixtures",
+  "document-review.json",
+);
+const VISUAL_SCREENSHOT_DIR = path.resolve(WEB_ROOT, "screenshots");
+const VISUAL_FIXTURE_RUNNER_ENV = "OPTIMITRON_VISUAL_FIXTURE_RUNNER";
+const LOCAL_REACHABILITY_PATHS = ["/favicon.ico", "/manifest.json", "/"];
 const LOCAL_REACHABILITY_RETRIES = 3;
 const LOCAL_REACHABILITY_TIMEOUT_MS = 5_000;
 const LOCAL_REACHABILITY_RETRY_DELAY_MS = 750;
@@ -39,10 +56,7 @@ const MODE_SPECS = {
         "e2e/contrast-audit.spec.ts",
         "e2e/treaty-page-structure.spec.ts",
       ]
-    : [
-        "e2e/smoke.spec.ts",
-        "e2e/treaty-page-structure.spec.ts",
-      ],
+    : ["e2e/smoke.spec.ts", "e2e/treaty-page-structure.spec.ts"],
   contrast: ["e2e/contrast-audit.spec.ts"],
   mobile: ["e2e/mobile-responsiveness-audit.spec.ts"],
   "new-user-flow-screenshots": ["e2e/new-user-flow-screenshots.spec.ts"],
@@ -63,13 +77,13 @@ const PLAYWRIGHT_DEFAULT_ARGS = ["--project=default"];
 const PLAYWRIGHT_MODE_DEFAULT_ARGS = {
   visual: ["--project=default", "--project=visual-mobile"],
 };
-const scriptArgs = process.argv.slice(2).filter((arg, index) => !(index === 0 && arg === "--"));
-const requestedMode = scriptArgs[0];
 const helpRequested = ["-h", "--help", "help"].includes(requestedMode ?? "");
-const mode = requestedMode && requestedMode in MODE_SPECS ? requestedMode : "all";
-const passthroughArgs = requestedMode && requestedMode in MODE_SPECS
-  ? scriptArgs.slice(1)
-  : scriptArgs;
+const mode =
+  requestedMode && requestedMode in MODE_SPECS ? requestedMode : "all";
+const passthroughArgs =
+  requestedMode && requestedMode in MODE_SPECS
+    ? scriptArgs.slice(1)
+    : scriptArgs;
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
@@ -109,16 +123,42 @@ async function main() {
   }
 
   if (mode === "new-user-flow-screenshots") {
-    env.PLAYWRIGHT_OUTPUT_DIR = process.env.PLAYWRIGHT_OUTPUT_DIR ?? NEW_USER_FLOW_ARTIFACT_DIR;
+    env.PLAYWRIGHT_OUTPUT_DIR =
+      process.env.PLAYWRIGHT_OUTPUT_DIR ?? NEW_USER_FLOW_ARTIFACT_DIR;
   }
 
   if (mode === "visual") {
     env.ROUTE_VISUAL_REVIEW = "1";
+    delete env[VISUAL_FIXTURE_RUNNER_ENV];
+    await Promise.all([
+      rm(VISUAL_FIXTURE_MANIFEST_PATH, { force: true }),
+      rm(VISUAL_SCREENSHOT_DIR, { force: true, recursive: true }),
+    ]);
+    let fixtureExitCode;
+    try {
+      fixtureExitCode = await runNodeModule(
+        resolveTsxCli(),
+        [path.resolve(WEB_ROOT, "scripts", "seed-visual-review-fixtures.ts")],
+        { ...env, [VISUAL_FIXTURE_RUNNER_ENV]: "1" },
+        "Visual review fixture seeder",
+      );
+    } catch (error) {
+      await rm(VISUAL_FIXTURE_MANIFEST_PATH, { force: true });
+      throw error;
+    }
+    if (fixtureExitCode !== 0) {
+      await rm(VISUAL_FIXTURE_MANIFEST_PATH, { force: true });
+      process.exit(fixtureExitCode);
+    }
   } else {
     delete env.ROUTE_VISUAL_REVIEW;
   }
 
-  const playwrightArgs = ["test", ...MODE_SPECS[mode], ...appendDefaultProjectArg(passthroughArgs, mode)];
+  const playwrightArgs = [
+    "test",
+    ...MODE_SPECS[mode],
+    ...appendDefaultProjectArg(passthroughArgs, mode),
+  ];
 
   console.log(`[e2e] mode=${mode}`);
   console.log(`[e2e] baseUrl=${execution.baseUrl}`);
@@ -163,16 +203,21 @@ async function resolveLocalExecution(options = {}) {
   return {
     baseUrl: process.env.BASE_URL ?? DEFAULT_BASE_URL,
     reuseExistingServer: false,
-    reason: "No running dev server detected; using existing production build via Playwright",
+    reason:
+      "No running dev server detected; using existing production build via Playwright",
   };
 }
 
 function appendDefaultProjectArg(args, selectedMode) {
-  const hasProjectArg = args.some((arg, index) => (
-    arg === "--project" || arg.startsWith("--project=") || (index > 0 && args[index - 1] === "--project")
-  ));
+  const hasProjectArg = args.some(
+    (arg, index) =>
+      arg === "--project" ||
+      arg.startsWith("--project=") ||
+      (index > 0 && args[index - 1] === "--project"),
+  );
 
-  const defaultArgs = PLAYWRIGHT_MODE_DEFAULT_ARGS[selectedMode] ?? PLAYWRIGHT_DEFAULT_ARGS;
+  const defaultArgs =
+    PLAYWRIGHT_MODE_DEFAULT_ARGS[selectedMode] ?? PLAYWRIGHT_DEFAULT_ARGS;
   return hasProjectArg ? args : [...defaultArgs, ...args];
 }
 
@@ -215,7 +260,10 @@ function buildReachabilityProbeUrls(baseUrl) {
 
 async function isReachableProbe(probeUrl) {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), LOCAL_REACHABILITY_TIMEOUT_MS);
+  const timeout = setTimeout(
+    () => controller.abort(),
+    LOCAL_REACHABILITY_TIMEOUT_MS,
+  );
 
   try {
     const response = await fetch(probeUrl, {
@@ -245,8 +293,12 @@ function dedupe(values) {
 }
 
 function runCommand(args, env) {
+  return runNodeModule(resolvePlaywrightCli(), args, env, "Playwright");
+}
+
+function runNodeModule(modulePath, args, env, label) {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [resolvePlaywrightCli(), ...args], {
+    const child = spawn(process.execPath, [modulePath, ...args], {
       cwd: process.cwd(),
       env,
       stdio: "inherit",
@@ -255,7 +307,7 @@ function runCommand(args, env) {
     child.on("error", reject);
     child.on("exit", (code, signal) => {
       if (signal) {
-        reject(new Error(`Playwright exited from signal ${signal}`));
+        reject(new Error(`${label} exited from signal ${signal}`));
         return;
       }
       resolve(code ?? 1);
@@ -264,7 +316,14 @@ function runCommand(args, env) {
 }
 
 function resolvePlaywrightCli() {
-  return path.join(path.dirname(require.resolve("@playwright/test/package.json")), "cli.js");
+  return path.join(
+    path.dirname(require.resolve("@playwright/test/package.json")),
+    "cli.js",
+  );
+}
+
+function resolveTsxCli() {
+  return require.resolve("tsx/cli");
 }
 
 function printHelp() {

--- a/packages/web/scripts/seed-visual-review-fixtures.ts
+++ b/packages/web/scripts/seed-visual-review-fixtures.ts
@@ -1,0 +1,504 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ContentVisibility } from "@optimitron/db";
+import { createDocument, updateDocument } from "@/lib/documents.server";
+import { prisma } from "@/lib/prisma";
+import { postComment } from "@/lib/tasks/task-comments.server";
+import {
+  DOCUMENT_PROPOSAL_ARTIFACT_KIND,
+  readDocumentProposal,
+} from "@/lib/tasks/document-review-contracts";
+import {
+  createDocumentProposal,
+  requestDocumentReview,
+  submitDocumentReview,
+} from "@/lib/tasks/document-review.server";
+
+const DEMO_EMAIL = "demo@thinkbynumbers.org";
+const FIXTURE_PREFIX = "visual_document_review_";
+const FIXTURE_RUNNER_ENV = "OPTIMITRON_VISUAL_FIXTURE_RUNNER";
+const WEB_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const FIXTURE_MANIFEST_PATH = path.resolve(
+  WEB_ROOT,
+  "output",
+  "playwright",
+  "visual-fixtures",
+  "document-review.json",
+);
+
+const ids = {
+  activeTask: `${FIXTURE_PREFIX}active_task`,
+  fixtureManagerPerson: `${FIXTURE_PREFIX}manager_person`,
+  fixtureManagerUser: `${FIXTURE_PREFIX}manager_user`,
+  managerTask: `${FIXTURE_PREFIX}manager_task`,
+  staleTask: `${FIXTURE_PREFIX}stale_task`,
+};
+
+function assertFixtureRunner() {
+  if (process.env[FIXTURE_RUNNER_ENV] !== "1") {
+    throw new Error(
+      "Visual review fixtures may only be seeded through scripts/run-playwright.mjs visual.",
+    );
+  }
+}
+
+function assertLocalFixtureDatabase() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required to seed visual review fixtures.");
+  }
+  const hostname = new URL(databaseUrl).hostname;
+  if (
+    !new Set(["localhost", "127.0.0.1", "::1", "host.docker.internal"]).has(
+      hostname,
+    )
+  ) {
+    throw new Error(
+      `Refusing to seed visual review fixtures into non-local database host ${hostname}.`,
+    );
+  }
+}
+
+async function removeFixtureManifest() {
+  await rm(FIXTURE_MANIFEST_PATH, { force: true });
+}
+
+async function resetVisualReviewFixtures() {
+  const deleted = await prisma.$transaction(async (tx) => {
+    const fixtureTasks = await tx.task.findMany({
+      where: {
+        OR: [
+          { id: { startsWith: FIXTURE_PREFIX } },
+          { taskKey: { contains: FIXTURE_PREFIX } },
+        ],
+      },
+      select: { id: true },
+    });
+    const taskIds = new Set(fixtureTasks.map((task) => task.id));
+    let parentTaskIds = [...taskIds];
+    while (parentTaskIds.length > 0) {
+      const children = await tx.task.findMany({
+        where: { parentTaskId: { in: parentTaskIds } },
+        select: { id: true },
+      });
+      parentTaskIds = children
+        .map((task) => task.id)
+        .filter((taskId) => !taskIds.has(taskId));
+      for (const taskId of parentTaskIds) taskIds.add(taskId);
+    }
+
+    const taskIdList = [...taskIds];
+    const [documents, artifacts] = await Promise.all([
+      tx.document.findMany({
+        where: {
+          OR: [
+            { idempotencyKey: { startsWith: FIXTURE_PREFIX } },
+            { taskId: { in: taskIdList } },
+          ],
+        },
+        select: { id: true },
+      }),
+      tx.taskExecutionArtifact.findMany({
+        where: {
+          metadataJson: {
+            equals: DOCUMENT_PROPOSAL_ARTIFACT_KIND,
+            path: ["kind"],
+          },
+          taskExecutionAttempt: {
+            metadata: {
+              equals: DOCUMENT_PROPOSAL_ARTIFACT_KIND,
+              path: ["kind"],
+            },
+            status: "COMPLETED",
+            taskId: { in: taskIdList },
+          },
+        },
+        select: {
+          structuredResultJson: true,
+          taskExecutionAttempt: { select: { taskId: true } },
+        },
+      }),
+    ]);
+    const documentIds = new Set(documents.map((document) => document.id));
+    for (const artifact of artifacts) {
+      const proposal = readDocumentProposal(artifact.structuredResultJson);
+      if (
+        !proposal ||
+        proposal.authorityTaskId !== artifact.taskExecutionAttempt.taskId ||
+        !documentIds.has(proposal.base.documentId) ||
+        !proposal.sourceComments.every((comment) => taskIds.has(comment.taskId))
+      ) {
+        continue;
+      }
+      documentIds.add(proposal.proposal.documentId);
+    }
+    const documentIdList = [...documentIds];
+
+    await tx.taskExecutionAttempt.deleteMany({
+      where: { taskId: { in: taskIdList } },
+    });
+    await tx.taskCommentAttachment.deleteMany({
+      where: { taskId: { in: taskIdList } },
+    });
+    const tasks = await tx.task.deleteMany({
+      where: { id: { in: taskIdList } },
+    });
+
+    await tx.contentAttachment.deleteMany({
+      where: { documentId: { in: documentIdList } },
+    });
+    await tx.document.updateMany({
+      where: { id: { in: documentIdList } },
+      data: { currentRevisionId: null },
+    });
+    const removedDocuments = await tx.document.deleteMany({
+      where: { id: { in: documentIdList } },
+    });
+
+    return { documents: removedDocuments.count, tasks: tasks.count };
+  });
+
+  console.log(
+    `[visual-review] reset ${deleted.tasks} fixture tasks and ${deleted.documents} fixture documents`,
+  );
+}
+
+async function ensureFixtureManager() {
+  const email = `${FIXTURE_PREFIX}manager@example.test`;
+  const person = await prisma.person.upsert({
+    where: { id: ids.fixtureManagerPerson },
+    update: {
+      deletedAt: null,
+      displayName: "Ada Reviewer",
+      email,
+    },
+    create: {
+      displayName: "Ada Reviewer",
+      email,
+      id: ids.fixtureManagerPerson,
+    },
+  });
+  const user = await prisma.user.upsert({
+    where: { id: ids.fixtureManagerUser },
+    update: {
+      deletedAt: null,
+      email,
+      personId: person.id,
+    },
+    create: {
+      email,
+      id: ids.fixtureManagerUser,
+      personId: person.id,
+    },
+  });
+  return { person, user };
+}
+
+async function loadDemoActor() {
+  const user = await prisma.user.findUnique({
+    where: { email: DEMO_EMAIL },
+    select: {
+      id: true,
+      person: { select: { id: true } },
+    },
+  });
+  if (!user?.person) {
+    throw new Error(
+      `Visual review fixtures require the managed demo user (${DEMO_EMAIL}). Run managed-data sync first.`,
+    );
+  }
+  return { person: user.person, user: { id: user.id } };
+}
+
+async function ensureAuthorityTask(input: {
+  createdByUserId: string;
+  description: string;
+  id: string;
+  title: string;
+}) {
+  const data = {
+    createdByUserId: input.createdByUserId,
+    deletedAt: null,
+    description: input.description,
+    isPublic: false,
+    title: input.title,
+  };
+  return prisma.task.upsert({
+    where: { id: input.id },
+    update: data,
+    create: { ...data, id: input.id },
+  });
+}
+
+async function ensureComment(input: {
+  authorUserId: string;
+  message: string;
+  parentCommentId?: string;
+  taskId: string;
+}) {
+  const parentCommentId = input.parentCommentId ?? null;
+  const existing = await prisma.taskComment.findFirst({
+    where: {
+      authorUserId: input.authorUserId,
+      deletedAt: null,
+      message: input.message,
+      parentCommentId,
+      taskId: input.taskId,
+    },
+    orderBy: { createdAt: "asc" },
+    select: { id: true },
+  });
+  if (existing) return existing;
+  return postComment(input);
+}
+
+async function seedManagerState(input: {
+  demo: Awaited<ReturnType<typeof loadDemoActor>>;
+  fixtureManager: Awaited<ReturnType<typeof ensureFixtureManager>>;
+}) {
+  const task = await ensureAuthorityTask({
+    createdByUserId: input.demo.user.id,
+    description:
+      "Turn public comments into exact text, get an independent review, and record the working version.",
+    id: ids.managerTask,
+    title: "Approve the Earth Optimization Services charter",
+  });
+  const document = await createDocument({
+    body: [
+      "# Purpose",
+      "",
+      "Earth Optimization Services helps humanity choose and fund work that saves lives and raises real income.",
+      "",
+      "# Shared ownership",
+      "",
+      "Every person has an equal right to propose improvements, comment on the governing text, and inspect adopted working versions.",
+      "",
+      "# Decisions",
+      "",
+      "Managers may record an internal decision after an independent review.",
+    ].join("\n"),
+    createdByUserId: input.demo.user.id,
+    idempotencyKey: `${FIXTURE_PREFIX}manager_document`,
+    taskId: task.id,
+    title: "Earth Optimization Services Charter",
+    visibility: ContentVisibility.PRIVATE,
+  });
+  const sourceComment = await ensureComment({
+    authorUserId: input.demo.user.id,
+    message:
+      "Define what adoption does and does not do before counsel reviews this.",
+    taskId: task.id,
+  });
+  await createDocumentProposal(
+    task.id,
+    {
+      baseDocumentRevisionId: document.revision.id,
+      body: [
+        "# Purpose",
+        "",
+        "Earth Optimization Services helps humanity choose and fund work that saves lives and raises real income.",
+        "",
+        "# Shared ownership",
+        "",
+        "Every person has an equal right to propose improvements, comment on the governing text, and inspect adopted working versions.",
+        "",
+        "# Decisions",
+        "",
+        "Managers may record an internal decision after an independent review. Internal adoption selects the working text; it does not sign, file, enact, or publish the document.",
+      ].join("\n"),
+      sourceCommentIds: [sourceComment.id],
+      summary:
+        "Clarifies that internal adoption selects working text without creating legal effect.",
+      title: "Earth Optimization Services Charter",
+    },
+    input.demo.user.id,
+    { idempotencyKey: `${FIXTURE_PREFIX}manager_proposal` },
+  );
+  const approvedReview = await requestDocumentReview(
+    task.id,
+    {
+      documentRevisionId: document.revision.id,
+      instructions:
+        "Check whether the authority boundary and shared-ownership language are clear and internally consistent.",
+      reviewerPersonId: input.fixtureManager.person.id,
+    },
+    input.demo.user.id,
+    { idempotencyKey: `${FIXTURE_PREFIX}approved_review` },
+  );
+  await submitDocumentReview(
+    approvedReview.reviewTaskId,
+    {
+      explanation:
+        "Approved. The authority boundary is explicit, and the text does not claim filing or legal effect.",
+      verdict: "APPROVE",
+    },
+    input.fixtureManager.user.id,
+    { idempotencyKey: `${FIXTURE_PREFIX}approved_response` },
+  );
+  return task.id;
+}
+
+async function seedActiveReviewerState(input: {
+  demo: Awaited<ReturnType<typeof loadDemoActor>>;
+  fixtureManager: Awaited<ReturnType<typeof ensureFixtureManager>>;
+}) {
+  const task = await ensureAuthorityTask({
+    createdByUserId: input.fixtureManager.user.id,
+    description:
+      "Ask one independent reviewer to check the exact contribution agreement text.",
+    id: ids.activeTask,
+    title: "Review the EOS contribution agreement",
+  });
+  const document = await createDocument({
+    body: [
+      "# Contribution",
+      "",
+      "A contribution funds the work package named on its receipt.",
+      "",
+      "# Work and outcomes",
+      "",
+      "Payment records funding received. It does not state that the work is complete or that impact has occurred.",
+      "",
+      "# Corrections",
+      "",
+      "Refunds, corrections, completion, and measured outcomes are recorded as later addenda. The original receipt remains unchanged.",
+    ].join("\n"),
+    createdByUserId: input.fixtureManager.user.id,
+    idempotencyKey: `${FIXTURE_PREFIX}active_document`,
+    taskId: task.id,
+    title: "EOS Contribution Agreement",
+    visibility: ContentVisibility.PRIVATE,
+  });
+  const review = await requestDocumentReview(
+    task.id,
+    {
+      documentRevisionId: document.revision.id,
+      instructions:
+        "Check the payment, refund, and outcome language. Request changes if any sentence could imply guaranteed impact.",
+      reviewerPersonId: input.demo.person.id,
+    },
+    input.fixtureManager.user.id,
+    { idempotencyKey: `${FIXTURE_PREFIX}active_review` },
+  );
+  const question = await ensureComment({
+    authorUserId: input.demo.user.id,
+    message:
+      "Should the refund sentence cover failed work packages as well as cancelled ones?",
+    taskId: review.reviewTaskId,
+  });
+  const reply = await ensureComment({
+    authorUserId: input.fixtureManager.user.id,
+    message:
+      "Yes. Treat that as a requested change if the current sentence is ambiguous.",
+    parentCommentId: question.id,
+    taskId: review.reviewTaskId,
+  });
+  await ensureComment({
+    authorUserId: input.demo.user.id,
+    message:
+      "Understood. I’ll separate the payment record from the outcome obligation.",
+    parentCommentId: reply.id,
+    taskId: review.reviewTaskId,
+  });
+  return review.reviewTaskId;
+}
+
+async function seedStaleReviewerState(input: {
+  demo: Awaited<ReturnType<typeof loadDemoActor>>;
+  fixtureManager: Awaited<ReturnType<typeof ensureFixtureManager>>;
+}) {
+  const task = await ensureAuthorityTask({
+    createdByUserId: input.fixtureManager.user.id,
+    description:
+      "Preserve the text that was assigned even when the canonical document changes.",
+    id: ids.staleTask,
+    title: "Review EOS governance authority",
+  });
+  const document = await createDocument({
+    body: "# Authority\n\nA manager may adopt a working version after one independent review.",
+    createdByUserId: input.fixtureManager.user.id,
+    idempotencyKey: `${FIXTURE_PREFIX}stale_document`,
+    taskId: task.id,
+    title: "EOS Governance Authority",
+    visibility: ContentVisibility.PRIVATE,
+  });
+  const pinnedRevision = await prisma.documentRevision.findUniqueOrThrow({
+    where: {
+      documentId_version: {
+        documentId: document.document.id,
+        version: 1,
+      },
+    },
+    select: { id: true },
+  });
+  const review = await requestDocumentReview(
+    task.id,
+    {
+      documentRevisionId: pinnedRevision.id,
+      instructions:
+        "Confirm whether this authority statement is complete and appropriately limited.",
+      reviewerPersonId: input.demo.person.id,
+    },
+    input.fixtureManager.user.id,
+    { idempotencyKey: `${FIXTURE_PREFIX}stale_review` },
+  );
+  if (document.document.version === 1) {
+    await updateDocument({
+      body: "# Authority\n\nA manager may adopt a working version only after an independent review, with the decision recorded on the exact version.",
+      documentId: document.document.id,
+      editorUserId: input.fixtureManager.user.id,
+      expectedVersion: 1,
+    });
+  }
+  return review.reviewTaskId;
+}
+
+async function main() {
+  await removeFixtureManifest();
+  assertFixtureRunner();
+  assertLocalFixtureDatabase();
+  await resetVisualReviewFixtures();
+  const [demo, fixtureManager] = await Promise.all([
+    loadDemoActor(),
+    ensureFixtureManager(),
+  ]);
+  const managerTaskId = await seedManagerState({ demo, fixtureManager });
+  const activeReviewTaskId = await seedActiveReviewerState({
+    demo,
+    fixtureManager,
+  });
+  const staleReviewTaskId = await seedStaleReviewerState({
+    demo,
+    fixtureManager,
+  });
+
+  await mkdir(path.dirname(FIXTURE_MANIFEST_PATH), { recursive: true });
+  await writeFile(
+    FIXTURE_MANIFEST_PATH,
+    JSON.stringify(
+      {
+        activeReviewTaskId,
+        managerTaskId,
+        staleReviewTaskId,
+        version: 1,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  console.log(`[visual-review] seeded document review fixtures`);
+  console.log(`[visual-review] wrote ${FIXTURE_MANIFEST_PATH}`);
+}
+
+main()
+  .catch(async (error) => {
+    await removeFixtureManifest();
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => prisma.$disconnect());

--- a/packages/web/scripts/seed-visual-review-fixtures.ts
+++ b/packages/web/scripts/seed-visual-review-fixtures.ts
@@ -1,12 +1,13 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { ContentVisibility } from "@optimitron/db";
+import { ContentVisibility, TaskExecutionAttemptStatus } from "@optimitron/db";
 import { createDocument, updateDocument } from "@/lib/documents.server";
 import { prisma } from "@/lib/prisma";
 import { postComment } from "@/lib/tasks/task-comments.server";
 import {
   DOCUMENT_PROPOSAL_ARTIFACT_KIND,
+  DocumentReviewVerdictSchema,
   readDocumentProposal,
 } from "@/lib/tasks/document-review-contracts";
 import {
@@ -53,9 +54,13 @@ function assertLocalFixtureDatabase() {
   }
   const hostname = new URL(databaseUrl).hostname;
   if (
-    !new Set(["localhost", "127.0.0.1", "::1", "host.docker.internal"]).has(
-      hostname,
-    )
+    !new Set([
+      "localhost",
+      "127.0.0.1",
+      "::1",
+      "[::1]",
+      "host.docker.internal",
+    ]).has(hostname)
   ) {
     throw new Error(
       `Refusing to seed visual review fixtures into non-local database host ${hostname}.`,
@@ -113,7 +118,7 @@ async function resetVisualReviewFixtures() {
               equals: DOCUMENT_PROPOSAL_ARTIFACT_KIND,
               path: ["kind"],
             },
-            status: "COMPLETED",
+            status: TaskExecutionAttemptStatus.COMPLETED,
             taskId: { in: taskIdList },
           },
         },
@@ -334,7 +339,7 @@ async function seedManagerState(input: {
     {
       explanation:
         "Approved. The authority boundary is explicit, and the text does not claim filing or legal effect.",
-      verdict: "APPROVE",
+      verdict: DocumentReviewVerdictSchema.enum.APPROVE,
     },
     input.fixtureManager.user.id,
     { idempotencyKey: `${FIXTURE_PREFIX}approved_response` },
@@ -458,9 +463,9 @@ async function seedStaleReviewerState(input: {
 }
 
 async function main() {
-  await removeFixtureManifest();
   assertFixtureRunner();
   assertLocalFixtureDatabase();
+  await removeFixtureManifest();
   await resetVisualReviewFixtures();
   const [demo, fixtureManager] = await Promise.all([
     loadDemoActor(),

--- a/packages/web/scripts/visual-review-coverage.mjs
+++ b/packages/web/scripts/visual-review-coverage.mjs
@@ -1,0 +1,196 @@
+const WEB_PREFIX = "packages/web/";
+
+export function buildChangedFileDiscoveryArgs(baselineRef) {
+  return ["diff", "--name-only", baselineRef, "--"];
+}
+
+function normalizeRepoPath(filePath) {
+  return String(filePath ?? "")
+    .trim()
+    .replaceAll("\\", "/");
+}
+
+function isTestOrStory(filePath) {
+  return (
+    filePath.includes("/__tests__/") ||
+    filePath.includes("/__stories__/") ||
+    /\.(?:test|spec|story|stories)\.[cm]?[jt]sx?$/i.test(filePath)
+  );
+}
+
+function isServerOnlyJsx(webRelative) {
+  return (
+    /^src\/(?:server|lib\/server)\//.test(webRelative) ||
+    /^src\/app\/api\//.test(webRelative) ||
+    /^src\/(?:emails|lib\/email)\//.test(webRelative) ||
+    /\.(?:email|server)\.(?:jsx|tsx)$/i.test(webRelative) ||
+    /-react-email\.(?:jsx|tsx)$/i.test(webRelative) ||
+    /^src\/app\/(?:.*\/)?(?:apple-icon|icon|opengraph-image|route|twitter-image)\.(?:jsx|tsx)$/i.test(
+      webRelative,
+    ) ||
+    /^src\/lib\/.*-og-image-response\.(?:jsx|tsx)$/i.test(webRelative)
+  );
+}
+
+/** Rendered web source that requires a registered screenshot state when changed. */
+export function isVisualUiSourceFile(filePath) {
+  const normalized = normalizeRepoPath(filePath);
+  if (!normalized.startsWith(WEB_PREFIX) || isTestOrStory(normalized)) {
+    return false;
+  }
+
+  const webRelative = normalized.slice(WEB_PREFIX.length);
+  if (
+    /^src\/.*\.(?:jsx|tsx)$/i.test(webRelative) &&
+    !isServerOnlyJsx(webRelative)
+  ) {
+    return true;
+  }
+  if (/^src\/.*\.css$/.test(webRelative)) {
+    return true;
+  }
+  if (/^public\/.*\.(?:avif|gif|ico|jpe?g|png|svg|webp)$/i.test(webRelative)) {
+    return true;
+  }
+  return /^(?:postcss|tailwind)\.config\.[cm]?[jt]s$/.test(webRelative);
+}
+
+export function getChangedUiFiles(changedFiles) {
+  if (!Array.isArray(changedFiles)) return [];
+  return [...new Set(changedFiles.map(normalizeRepoPath))]
+    .filter(isVisualUiSourceFile)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Proves that every changed UI source file was exercised by required,
+ * state-asserted screenshots in every configured visual viewport.
+ */
+export function buildVisualCoverage({
+  afterCaptures = [],
+  changedFiles,
+  routes = [],
+}) {
+  const analysisAvailable = Array.isArray(changedFiles);
+  const changedUiFiles = getChangedUiFiles(changedFiles);
+  const blockingIssues = [];
+  if (!analysisAvailable) {
+    blockingIssues.push(
+      "changed-file analysis is unavailable, so screenshot coverage cannot be proven",
+    );
+  }
+
+  const normalizedRoutes = routes.map((route) => ({
+    activationSelector:
+      typeof route.activationSelector === "string"
+        ? route.activationSelector.trim()
+        : "",
+    covers: Array.isArray(route.covers)
+      ? [...new Set(route.covers.map(normalizeRepoPath).filter(Boolean))]
+      : [],
+    name: String(route.name ?? "").trim(),
+    required: route.required === true,
+    requiredProjects: Array.isArray(route.requiredProjects)
+      ? [...new Set(route.requiredProjects.map(String).filter(Boolean))]
+      : [],
+  }));
+  const captureKeys = new Set(
+    afterCaptures.map(
+      (capture) =>
+        `${String(capture.routeName)}\u0000${String(capture.projectName)}`,
+    ),
+  );
+  const invalidRouteMap = new Map();
+  const missingCaptureMap = new Map();
+  const routeCoverage = [];
+  const uncoveredUiFiles = [];
+
+  for (const filePath of changedUiFiles) {
+    const matchingRoutes = normalizedRoutes.filter((route) =>
+      route.covers.includes(filePath),
+    );
+    routeCoverage.push({
+      filePath,
+      routeNames: matchingRoutes.map((route) => route.name),
+    });
+    if (matchingRoutes.length === 0) {
+      uncoveredUiFiles.push(filePath);
+      blockingIssues.push(
+        `${filePath}: no required visual state is registered for this changed UI source`,
+      );
+      continue;
+    }
+
+    for (const route of matchingRoutes) {
+      const reasons = [];
+      if (!route.name) reasons.push("route name is missing");
+      if (!route.required) reasons.push("route is optional");
+      if (!route.activationSelector) {
+        reasons.push("activation selector is missing");
+      }
+      if (route.requiredProjects.length === 0) {
+        reasons.push("required visual projects are missing");
+      }
+      if (reasons.length > 0) {
+        invalidRouteMap.set(route.name || "<unnamed>", {
+          reasons,
+          routeName: route.name || "<unnamed>",
+        });
+      }
+
+      for (const projectName of route.requiredProjects) {
+        if (!captureKeys.has(`${route.name}\u0000${projectName}`)) {
+          missingCaptureMap.set(`${route.name}\u0000${projectName}`, {
+            projectName,
+            routeName: route.name,
+          });
+        }
+      }
+    }
+  }
+
+  const invalidRoutes = [...invalidRouteMap.values()].sort((left, right) =>
+    left.routeName.localeCompare(right.routeName),
+  );
+  const missingCaptures = [...missingCaptureMap.values()].sort((left, right) =>
+    `${left.routeName}/${left.projectName}`.localeCompare(
+      `${right.routeName}/${right.projectName}`,
+    ),
+  );
+  for (const route of invalidRoutes) {
+    blockingIssues.push(`${route.routeName}: ${route.reasons.join(", ")}`);
+  }
+  for (const capture of missingCaptures) {
+    blockingIssues.push(
+      `${capture.routeName}/${capture.projectName}: required UI coverage screenshot was not captured`,
+    );
+  }
+
+  const incompleteFiles = new Set(uncoveredUiFiles);
+  for (const mapping of routeCoverage) {
+    if (
+      mapping.routeNames.some(
+        (routeName) =>
+          invalidRouteMap.has(routeName) ||
+          missingCaptures.some((capture) => capture.routeName === routeName),
+      )
+    ) {
+      incompleteFiles.add(mapping.filePath);
+    }
+  }
+  const coveredUiFiles = changedUiFiles.filter(
+    (filePath) => !incompleteFiles.has(filePath),
+  );
+
+  return {
+    analysisAvailable,
+    blockingIssues,
+    changedUiFiles,
+    complete: blockingIssues.length === 0,
+    coveredUiFiles,
+    invalidRoutes,
+    missingCaptures,
+    routeCoverage,
+    uncoveredUiFiles,
+  };
+}

--- a/packages/web/scripts/visual-review-coverage.test.mjs
+++ b/packages/web/scripts/visual-review-coverage.test.mjs
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildChangedFileDiscoveryArgs,
+  buildVisualCoverage,
+  getChangedUiFiles,
+  isVisualUiSourceFile,
+} from "./visual-review-coverage.mjs";
+
+test("discovers deleted UI paths as well as added and modified files", () => {
+  assert.deepEqual(buildChangedFileDiscoveryArgs("origin/main"), [
+    "diff",
+    "--name-only",
+    "origin/main",
+    "--",
+  ]);
+  assert.equal(
+    isVisualUiSourceFile("packages/web/src/components/deleted-panel.tsx"),
+    true,
+  );
+});
+
+const managerFile =
+  "packages/web/src/components/tasks/document-review-manager-panel.tsx";
+const reviewerFile =
+  "packages/web/src/components/tasks/document-review-reviewer-panel.tsx";
+
+function requiredRoute(name, covers) {
+  return {
+    activationSelector: `#${name}`,
+    covers,
+    name,
+    required: true,
+    requiredProjects: ["default", "visual-mobile"],
+  };
+}
+
+function capturesFor(...routeNames) {
+  return routeNames.flatMap((routeName) => [
+    { projectName: "default", routeName },
+    { projectName: "visual-mobile", routeName },
+  ]);
+}
+
+test("classifies rendered JSX throughout src, including app-local and web adapter components", () => {
+  assert.equal(
+    isVisualUiSourceFile("packages/web/src/app/tasks/[id]/page.tsx"),
+    true,
+  );
+  assert.equal(isVisualUiSourceFile(managerFile), true);
+  assert.equal(
+    isVisualUiSourceFile(
+      "packages/web/src/app/admin/organizations/AdminOrgRow.tsx",
+    ),
+    true,
+  );
+  assert.equal(
+    isVisualUiSourceFile(
+      "packages/web/src/lib/humanity-manager-promotion.web.tsx",
+    ),
+    true,
+  );
+  assert.equal(
+    isVisualUiSourceFile(
+      "packages/web/src/lib/humanity-manager-promotion-content.tsx",
+    ),
+    true,
+  );
+  assert.equal(
+    isVisualUiSourceFile(
+      "packages\\web\\src\\components\\tasks\\task-comment-feed.tsx",
+    ),
+    true,
+  );
+});
+
+test("excludes tests, stories, email renderers, and server-only JSX", () => {
+  const excluded = [
+    "packages/web/src/components/tasks/task-comment-feed.test.tsx",
+    "packages/web/src/components/tasks/task-comment-feed.story.tsx",
+    "packages/web/src/components/__stories__/task-comment-feed.tsx",
+    "packages/web/src/emails/components/EmailFooter.tsx",
+    "packages/web/src/lib/humanity-manager-promotion.email.tsx",
+    "packages/web/src/lib/tasks/task-assignment-react-email.tsx",
+    "packages/web/src/lib/example.server.tsx",
+    "packages/web/src/app/api/og/referral/route.tsx",
+    "packages/web/src/app/feed/route.tsx",
+    "packages/web/src/app/icon.tsx",
+    "packages/web/src/app/tasks/[id]/opengraph-image.tsx",
+    "packages/web/src/lib/black-white-text-og-image-response.tsx",
+  ];
+  for (const filePath of excluded) {
+    assert.equal(isVisualUiSourceFile(filePath), false, filePath);
+  }
+
+  assert.equal(
+    isVisualUiSourceFile(
+      "packages/web/src/lib/tasks/document-review.server.ts",
+    ),
+    false,
+  );
+});
+
+test("keeps stylesheet, public image, and styling config coverage", () => {
+  const included = [
+    "packages/web/src/app/globals.css",
+    "packages/web/public/images/treaty-seal.svg",
+    "packages/web/postcss.config.mjs",
+    "packages/web/tailwind.config.ts",
+  ];
+  for (const filePath of included) {
+    assert.equal(isVisualUiSourceFile(filePath), true, filePath);
+  }
+});
+
+test("accepts zero pixel differences when every changed UI file was captured", () => {
+  const routes = [
+    requiredRoute("document-review-manager", [managerFile]),
+    requiredRoute("document-review-reviewer", [reviewerFile]),
+    requiredRoute("document-review-stale", [reviewerFile]),
+  ];
+  const coverage = buildVisualCoverage({
+    afterCaptures: capturesFor(
+      "document-review-manager",
+      "document-review-reviewer",
+      "document-review-stale",
+    ),
+    changedFiles: [managerFile, reviewerFile],
+    routes,
+  });
+
+  assert.equal(coverage.complete, true);
+  assert.deepEqual(coverage.coveredUiFiles, [managerFile, reviewerFile]);
+  assert.deepEqual(coverage.blockingIssues, []);
+});
+
+test("fails when changed UI source has no registered state", () => {
+  const coverage = buildVisualCoverage({
+    afterCaptures: [],
+    changedFiles: [managerFile],
+    routes: [],
+  });
+
+  assert.equal(coverage.complete, false);
+  assert.deepEqual(coverage.uncoveredUiFiles, [managerFile]);
+  assert.match(coverage.blockingIssues[0], /no required visual state/);
+});
+
+test("fails when a mapped state is optional or lacks an activation selector", () => {
+  const coverage = buildVisualCoverage({
+    afterCaptures: capturesFor("document-review-manager"),
+    changedFiles: [managerFile],
+    routes: [
+      {
+        covers: [managerFile],
+        name: "document-review-manager",
+        required: false,
+        requiredProjects: ["default", "visual-mobile"],
+      },
+    ],
+  });
+
+  assert.equal(coverage.complete, false);
+  assert.deepEqual(coverage.invalidRoutes, [
+    {
+      reasons: ["route is optional", "activation selector is missing"],
+      routeName: "document-review-manager",
+    },
+  ]);
+});
+
+test("fails when one required viewport was not captured", () => {
+  const coverage = buildVisualCoverage({
+    afterCaptures: [
+      { projectName: "default", routeName: "document-review-manager" },
+    ],
+    changedFiles: [managerFile],
+    routes: [requiredRoute("document-review-manager", [managerFile])],
+  });
+
+  assert.equal(coverage.complete, false);
+  assert.deepEqual(coverage.missingCaptures, [
+    {
+      projectName: "visual-mobile",
+      routeName: "document-review-manager",
+    },
+  ]);
+});
+
+test("fails closed when changed-file analysis is unavailable", () => {
+  const coverage = buildVisualCoverage({
+    afterCaptures: [],
+    changedFiles: null,
+    routes: [],
+  });
+  assert.equal(coverage.analysisAvailable, false);
+  assert.equal(coverage.complete, false);
+  assert.match(coverage.blockingIssues[0], /analysis is unavailable/);
+});
+
+test("keeps backend-only changes outside the visual coverage contract", () => {
+  const files = [
+    "packages/web/src/lib/tasks/document-review.server.ts",
+    "packages/web/src/lib/tasks/document-review.server.test.ts",
+  ];
+  assert.deepEqual(getChangedUiFiles(files), []);
+  assert.equal(
+    buildVisualCoverage({ afterCaptures: [], changedFiles: files, routes: [] })
+      .complete,
+    true,
+  );
+});

--- a/packages/web/scripts/visual-review-page.mjs
+++ b/packages/web/scripts/visual-review-page.mjs
@@ -19,6 +19,7 @@
  *           generatedAtCentral, previewBaseUrl, productionBaseUrl,
  *           reviewUrl, baselineDescription },
  *   summary: { changedRoutes, copyOnlyRoutes, unchangedRoutes, variantRoutes, erroredRoutes, totalRoutes },
+ *   coverage: { analysisAvailable, complete, changedUiFiles, coveredUiFiles, blockingIssues },
  *   routes: [{
  *     routeName, routeLabel, routePath, routeUrl, productionUrl, authState,
  *     siteVariant,     // null for the default surface; site key for variant-delta shots
@@ -118,6 +119,8 @@ const CSS = `
   }
   .chip.changed { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
   .chip.errored { border-color: var(--err); color: var(--err); }
+  .chip.coverage-complete { border-color: var(--good); color: var(--good); background: var(--good-soft); }
+  .chip.coverage-failed { border-color: var(--err); color: var(--err); background: var(--bad-soft); }
   .chip.reviewed { border-color: var(--good); color: var(--good); background: var(--good-soft); }
   .hdr-spacer { flex: 1 1 auto; }
   .noise-label { font-size: 12px; color: var(--dim); display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; }
@@ -135,6 +138,17 @@ const CSS = `
   .hdr-row2 code { font-family: var(--mono); font-size: 11px; }
   body.condensed .hdr-row2 { display: none; }
   body.condensed header#hdr { box-shadow: 0 1px 4px rgba(0,0,0,.08); }
+
+  .coverage-failure {
+    flex: 0 0 auto;
+    border-bottom: 1px solid var(--err);
+    background: var(--bad-soft);
+    color: var(--ink);
+    padding: 10px 16px;
+  }
+  .coverage-failure p { margin: 2px 0 0; }
+  .coverage-failure ul { margin: 6px 0 0; padding-left: 22px; }
+  .coverage-failure code { font-family: var(--mono); font-size: 12px; overflow-wrap: anywhere; }
 
   /* ---------- layout ---------- */
   .app { flex: 1 1 auto; display: flex; min-height: 0; }
@@ -434,11 +448,14 @@ const CSS = `
   }
   .vbtn { border: 1px solid var(--border); border-radius: 4px; background: var(--panel); padding: 6px 12px; white-space: nowrap; }
   .vbtn.btn-good { border-color: var(--good); color: var(--good); }
-  .vbtn.btn-good.on, .vbtn.btn-good:hover { background: var(--good-soft); }
+  .vbtn.btn-good:hover { background: var(--good-soft); }
+  .vbtn.btn-good.on { background: var(--good); color: #fff; font-weight: 700; }
   .vbtn.btn-bad { border-color: var(--bad); color: var(--bad); }
-  .vbtn.btn-bad.on, .vbtn.btn-bad:hover { background: var(--bad-soft); }
+  .vbtn.btn-bad:hover { background: var(--bad-soft); }
+  .vbtn.btn-bad.on { background: var(--bad); color: #fff; font-weight: 700; }
   .vbtn.btn-skip { border-style: dashed; }
-  .vbtn.btn-skip.on { background: var(--bg); }
+  .vbtn.btn-skip.on { background: var(--ink); color: #fff; font-weight: 700; }
+  .review-status { flex: 1 1 100%; font-size: 12px; font-weight: 700; color: var(--ink); }
   .note-box { flex: 1 1 200px; min-width: 160px; }
   .note-box input {
     width: 100%; font: inherit;
@@ -518,6 +535,7 @@ const CLIENT_JS = `
   var minimap = null;           // { el, update(startFrac, lenFrac), setActive(origIdx) }
   var fullWells = null;         // linked-scroll wells for the current full-page render
   var verdicts = {};            // routeName -> { v, note, ts, commit }
+  var reviewStatus = "";        // visible confirmation after a route verdict
   var storeKey = "visualReview:" + (meta.commitSha || meta.shortSha || "unknown");
   var MOBILE_MQ = "(max-width: 700px)";
   var STRIP_CONTEXT_PX = 16;    // extra context cropped around each hunk band
@@ -649,8 +667,12 @@ const CLIENT_JS = `
     } catch (e) { /* corrupted state loses politely */ }
   }
   function saveVerdicts() {
-    try { localStorage.setItem(storeKey, JSON.stringify({ verdicts: verdicts })); }
-    catch (e) { /* private mode: verdicts live for the session only */ }
+    try {
+      localStorage.setItem(storeKey, JSON.stringify({ verdicts: verdicts }));
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
   function verdictOf(r) { return verdicts[r.routeName] || null; }
   function verdictMark(v) {
@@ -661,14 +683,17 @@ const CLIENT_JS = `
   }
   function updateReviewedChip() {
     var pool = reviewable();
-    var done = 0, flagged = 0;
+    var done = 0, flagged = 0, skipped = 0;
     pool.forEach(function (r) {
       var v = verdictOf(r);
-      if (v && v.v !== "skipped") done++;
+      if (v) done++;
       if (v && v.v === "needs-work") flagged++;
+      if (v && v.v === "skipped") skipped++;
     });
     var chip = document.getElementById("chip-reviewed");
-    chip.textContent = done + "/" + pool.length + " reviewed" + (flagged ? " \\u00b7 " + flagged + " flagged" : "");
+    chip.textContent = done + "/" + pool.length + " reviewed" +
+      (flagged ? " \\u00b7 " + flagged + " flagged" : "") +
+      (skipped ? " \\u00b7 " + skipped + " skipped" : "");
     chip.classList.toggle("reviewed", done > 0);
   }
 
@@ -699,6 +724,13 @@ const CLIENT_JS = `
       noise = parseFloat(noiseSel.value) || 0;
       refreshRailBadges();
       renderPane(true);
+    });
+    var copyReview = document.getElementById("copy-review-btn");
+    copyReview.addEventListener("click", function () {
+      copyText(buildReviewMarkdown(), function (ok) {
+        copyReview.textContent = ok ? "Copied PR comment" : "Copy failed";
+        setTimeout(function () { copyReview.textContent = "Copy PR comment"; }, 1500);
+      });
     });
     document.getElementById("export-btn").addEventListener("click", exportNotes);
     document.getElementById("reset-btn").addEventListener("click", function () {
@@ -897,6 +929,7 @@ const CLIENT_JS = `
     opts = opts || {};
     var r = routeByName(name);
     if (!r) return;
+    reviewStatus = typeof opts.reviewStatus === "string" ? opts.reviewStatus : "";
     selectedName = name;
     pairName = (opts.pair && pairOf(r, opts.pair)) ? opts.pair : defaultPairFor(r);
     if (opts.mode) cmpMode = opts.mode;
@@ -1183,14 +1216,14 @@ const CLIENT_JS = `
     });
     wrap.appendChild(copy);
 
-    var complainAttrs = { type: "button", class: "context-btn", text: "Complain", title: "Open a GitHub issue with visual-review context" };
+    var complainAttrs = { type: "button", class: "context-btn", text: "Open GitHub issue", title: "Open a GitHub issue with visual-review context" };
     if (!meta.repo) complainAttrs.disabled = "disabled";
     var complain = el("button", complainAttrs);
     complain.addEventListener("click", function () {
       var ok = openComplaint(buildContext(r));
       if (!ok) {
         complain.textContent = "No repo";
-        setTimeout(function () { complain.textContent = "Complain"; }, 1500);
+        setTimeout(function () { complain.textContent = "Open GitHub issue"; }, 1500);
       }
     });
     wrap.appendChild(complain);
@@ -1798,6 +1831,9 @@ const CLIENT_JS = `
       var cur = verdicts[r.routeName];
       if (cur) { cur.note = note.value.trim(); saveVerdicts(); }
     });
+    if (reviewStatus) {
+      bar.appendChild(el("span", { class: "review-status", role: "status", text: reviewStatus }));
+    }
     bar.appendChild(good);
     bar.appendChild(bad);
     bar.appendChild(skip);
@@ -1816,21 +1852,41 @@ const CLIENT_JS = `
       ts: new Date().toISOString(),
       commit: meta.shortSha
     };
-    saveVerdicts();
+    var persisted = saveVerdicts();
     updateReviewedChip();
     refreshRailMarks();
-    // auto-advance to the next route in nav order
-    var names = navNames();
-    var idx = names.indexOf(selectedName);
-    if (idx !== -1 && idx + 1 < names.length) selectRoute(names[idx + 1]);
-    else renderPane(true);
+    var mark = verdictMark(verdicts[r.routeName]);
+    var saved = (persisted ? "Saved locally " : "Saved for this open page ") +
+      mark + " for " + r.routeLabel + ".";
+    var nextName = nextUnreviewedRouteName(r.routeName);
+    if (nextName) {
+      var next = routeByName(nextName);
+      selectRoute(nextName, {
+        reviewStatus: saved + " Next unreviewed: " + next.routeLabel + "."
+      });
+      return;
+    }
+    reviewStatus = saved + " Review pass complete. Copy the PR comment or export the notes.";
+    renderPane(true);
+  }
+
+  function nextUnreviewedRouteName(currentName) {
+    var names = reviewable().map(function (r) { return r.routeName; });
+    if (!names.length) return null;
+    var currentIndex = names.indexOf(currentName);
+    if (currentIndex === -1) currentIndex = 0;
+    for (var offset = 1; offset <= names.length; offset++) {
+      var candidate = names[(currentIndex + offset) % names.length];
+      if (!verdicts[candidate]) return candidate;
+    }
+    return null;
   }
 
   /* ---------------- export ---------------- */
-  function exportNotes() {
+  function buildReviewMarkdown() {
     var pool = reviewable();
     var good = 0, bad = 0, skip = 0;
-    routes.forEach(function (r) {
+    pool.forEach(function (r) {
       var v = verdictOf(r);
       if (!v) return;
       if (v.v === "looks-right") good++;
@@ -1839,17 +1895,21 @@ const CLIENT_JS = `
     });
     var tick = String.fromCharCode(96); // backtick; literal would end the server template literal
     var lines = [];
-    lines.push("# Review notes \\u2014 PR #" + meta.prNumber + " (" + meta.shortSha + ")");
+    var heading = "# Review notes";
+    if (meta.prNumber) heading += " \\u2014 PR #" + meta.prNumber;
+    if (meta.shortSha) heading += " (" + meta.shortSha + ")";
+    lines.push(heading);
     lines.push("");
-    lines.push("- Branch: " + tick + meta.headBranch + tick + " @ " + tick + meta.shortSha + tick);
+    if (meta.headBranch) lines.push("- Branch: " + tick + meta.headBranch + tick);
+    if (meta.shortSha) lines.push("- Commit: " + tick + meta.shortSha + tick);
     lines.push("- Generated: " + (meta.generatedAtCentral || meta.generatedAt));
     lines.push("- Baseline: " + (meta.baselineDescription || "n/a"));
     if (meta.reviewUrl) lines.push("- Artifact: " + meta.reviewUrl);
     lines.push("- Routes: " + routes.length + " total \\u00b7 " + pool.length + " with visual or copy changes");
     lines.push("- Verdicts: " + good + " looks right \\u00b7 " + bad + " needs work \\u00b7 " + skip + " skipped \\u00b7 " +
-      (routes.length - good - bad - skip) + " not reviewed");
+      (pool.length - good - bad - skip) + " not reviewed");
     lines.push("");
-    var flagged = routes.filter(function (r) { var v = verdictOf(r); return v && v.v === "needs-work"; });
+    var flagged = pool.filter(function (r) { var v = verdictOf(r); return v && v.v === "needs-work"; });
     if (flagged.length) {
       lines.push("## Needs work");
       lines.push("");
@@ -1859,11 +1919,11 @@ const CLIENT_JS = `
       });
       lines.push("");
     }
-    lines.push("## All verdicts");
+    lines.push("## All review verdicts");
     lines.push("");
     lines.push("| Route | Path | Status | Verdict | Note |");
     lines.push("| --- | --- | --- | --- | --- |");
-    routes.forEach(function (r) {
+    pool.forEach(function (r) {
       var v = verdictOf(r);
       var label = v
         ? (v.v === "looks-right" ? "looks right" : v.v === "needs-work" ? "NEEDS WORK" : "skipped")
@@ -1872,10 +1932,16 @@ const CLIENT_JS = `
       lines.push("| " + r.routeLabel + " | " + tick + r.routePath + tick + " | " + r.statusLabel + " | " + label + " | " + noteTxt + " |");
     });
     lines.push("");
-    var blob = new Blob([lines.join("\\n")], { type: "text/markdown" });
+    return lines.join("\\n");
+  }
+
+  function exportNotes() {
+    var blob = new Blob([buildReviewMarkdown()], { type: "text/markdown" });
     var a = document.createElement("a");
     a.href = URL.createObjectURL(blob);
-    a.download = "pr-" + meta.prNumber + "-review-" + meta.shortSha + ".md";
+    a.download = meta.prNumber
+      ? "pr-" + meta.prNumber + "-review-" + (meta.shortSha || "notes") + ".md"
+      : "visual-review-notes.md";
     document.body.appendChild(a);
     a.click();
     a.remove();
@@ -1955,14 +2021,42 @@ const CLIENT_JS = `
 })();
 `;
 
-function renderHeaderHtml(meta, summary) {
+function renderHeaderHtml(meta, summary, coverage) {
   const chips = [];
-  chips.push(`<span class="chip changed">${escapeHtml(summary.changedRoutes)} changed</span>`);
-  if (summary.copyOnlyRoutes) chips.push(`<span class="chip">${escapeHtml(summary.copyOnlyRoutes)} copy-only</span>`);
-  chips.push(`<span class="chip">${escapeHtml(summary.unchangedRoutes)} unchanged</span>`);
-  if (summary.variantRoutes) chips.push(`<span class="chip">${escapeHtml(summary.variantRoutes)} variant</span>`);
-  if (summary.erroredRoutes) chips.push(`<span class="chip errored">${escapeHtml(summary.erroredRoutes)} errored</span>`);
-  chips.push(`<span class="chip">${escapeHtml(summary.totalRoutes)} routes</span>`);
+  chips.push(
+    `<span class="chip changed">${escapeHtml(summary.changedRoutes)} screenshot difference${Number(summary.changedRoutes) === 1 ? "" : "s"}</span>`,
+  );
+  if (summary.copyOnlyRoutes)
+    chips.push(
+      `<span class="chip">${escapeHtml(summary.copyOnlyRoutes)} copy-only</span>`,
+    );
+  chips.push(
+    `<span class="chip">${escapeHtml(summary.unchangedRoutes)} unchanged</span>`,
+  );
+  if (summary.variantRoutes)
+    chips.push(
+      `<span class="chip">${escapeHtml(summary.variantRoutes)} variant</span>`,
+    );
+  if (summary.erroredRoutes)
+    chips.push(
+      `<span class="chip errored">${escapeHtml(summary.erroredRoutes)} errored</span>`,
+    );
+  chips.push(
+    `<span class="chip">${escapeHtml(summary.totalRoutes)} routes</span>`,
+  );
+  if (coverage?.changedUiFiles?.length) {
+    const coveredCount = coverage.coveredUiFiles?.length ?? 0;
+    const changedCount = coverage.changedUiFiles.length;
+    chips.push(
+      coverage.complete
+        ? `<span class="chip coverage-complete">${escapeHtml(coveredCount)}/${escapeHtml(changedCount)} changed UI files captured</span>`
+        : `<span class="chip coverage-failed">capture contract failed · ${escapeHtml(coveredCount)}/${escapeHtml(changedCount)} UI files</span>`,
+    );
+  } else if (coverage && coverage.complete === false) {
+    chips.push(
+      `<span class="chip coverage-failed">capture contract failed</span>`,
+    );
+  }
   chips.push(`<span class="chip" id="chip-reviewed">0 reviewed</span>`);
 
   const noteBits = [
@@ -1970,8 +2064,12 @@ function renderHeaderHtml(meta, summary) {
     `<code>${escapeHtml(meta.headBranch)}</code> @ <code>${escapeHtml(meta.shortSha)}</code>`,
     `generated ${escapeHtml(meta.generatedAtCentral || meta.generatedAt)}`,
   ];
-  if (meta.baselineDescription) noteBits.push(escapeHtml(meta.baselineDescription));
-  if (meta.reviewUrl) noteBits.push(`<a href="${escapeHtml(meta.reviewUrl)}" target="_blank" rel="noopener">artifact</a>`);
+  if (meta.baselineDescription)
+    noteBits.push(escapeHtml(meta.baselineDescription));
+  if (meta.reviewUrl)
+    noteBits.push(
+      `<a href="${escapeHtml(meta.reviewUrl)}" target="_blank" rel="noopener">artifact</a>`,
+    );
 
   return `<header id="hdr">
   <div class="hdr-row1">
@@ -1986,11 +2084,28 @@ function renderHeaderHtml(meta, summary) {
         <option value="1">hide diffs under 1%</option>
       </select>
     </label>
+    <button type="button" id="copy-review-btn" class="hbtn" title="Copy every verdict and note as one pull request comment">Copy PR comment</button>
     <button type="button" id="export-btn" class="hbtn" title="Download every verdict + note as a markdown review packet">Export review notes</button>
     <button type="button" id="reset-btn" class="hbtn" title="Clear saved verdicts for this commit">Reset</button>
   </div>
   <div class="hdr-row2" id="gen-note">${noteBits.join(" · ")}</div>
 </header>`;
+}
+
+function renderCoverageFailureHtml(coverage) {
+  if (!coverage || coverage.complete !== false) return "";
+  const blockingIssues = Array.isArray(coverage.blockingIssues)
+    ? coverage.blockingIssues
+    : ["Visual capture coverage could not be proven."];
+  const issueItems = blockingIssues
+    .map((issue) => `<li><code>${escapeHtml(issue)}</code></li>`)
+    .join("");
+
+  return `<section class="coverage-failure" role="alert" aria-labelledby="coverage-failure-title">
+  <strong id="coverage-failure-title">Visual capture contract failed</strong>
+  <p>This report is incomplete and the visual-review check must fail until every changed UI file has its required desktop and mobile state.</p>
+  <ul>${issueItems}</ul>
+</section>`;
 }
 
 /**
@@ -1999,10 +2114,13 @@ function renderHeaderHtml(meta, summary) {
  * @returns {string} full HTML document
  */
 export function renderReviewHtml(input) {
-  if (!input || typeof input !== "object") throw new TypeError("renderReviewHtml: input must be an object");
+  if (!input || typeof input !== "object")
+    throw new TypeError("renderReviewHtml: input must be an object");
   const meta = input.meta || {};
   const summary = input.summary || {};
-  if (!Array.isArray(input.routes)) throw new TypeError("renderReviewHtml: input.routes must be an array");
+  const coverage = input.coverage || {};
+  if (!Array.isArray(input.routes))
+    throw new TypeError("renderReviewHtml: input.routes must be an array");
 
   const title = `PR #${meta.prNumber ?? "?"} review — ${meta.shortSha ?? "?"}`;
 
@@ -2015,7 +2133,8 @@ export function renderReviewHtml(input) {
 <style>${CSS}</style>
 </head>
 <body>
-${renderHeaderHtml(meta, summary)}
+${renderHeaderHtml(meta, summary, coverage)}
+${renderCoverageFailureHtml(coverage)}
 <div class="app">
   <button id="rail-toggle" type="button" aria-expanded="false" aria-controls="rail">
     <span class="rt-caret" aria-hidden="true">▾</span>

--- a/packages/web/scripts/visual-review-page.smoke.mjs
+++ b/packages/web/scripts/visual-review-page.smoke.mjs
@@ -14,6 +14,7 @@ import { renderReviewHtml } from "./visual-review-page.mjs";
 const here = dirname(fileURLToPath(import.meta.url));
 const outDir = join(here, "..", "output");
 const htmlPath = join(outDir, "visual-page-smoke.html");
+const coverageHtmlPath = join(outDir, "visual-page-coverage-smoke.html");
 const clientJsPath = join(outDir, "visual-page-smoke.client.js");
 
 const XSS = 'Home <script>alert("xss")</script> & "quotes" \'single\'';
@@ -30,15 +31,31 @@ const input = {
     previewBaseUrl: "https://optimitron-git-feature-preview.vercel.app",
     productionBaseUrl: "https://warondisease.org",
     reviewUrl: "https://mikepsinn.github.io/optimitron/pr-123/abc1234/",
-    baselineDescription: "screenshots vs main @ 871661d, copy vs pre-merge snapshots",
+    baselineDescription:
+      "screenshots vs main @ 871661d, copy vs pre-merge snapshots",
   },
-  summary: { changedRoutes: 2, copyOnlyRoutes: 1, unchangedRoutes: 0, variantRoutes: 1, erroredRoutes: 0, totalRoutes: 4 },
+  summary: {
+    changedRoutes: 2,
+    copyOnlyRoutes: 1,
+    unchangedRoutes: 0,
+    variantRoutes: 1,
+    erroredRoutes: 0,
+    totalRoutes: 4,
+  },
+  coverage: {
+    analysisAvailable: true,
+    blockingIssues: [],
+    changedUiFiles: [],
+    complete: true,
+    coveredUiFiles: [],
+  },
   routes: [
     {
       routeName: "home",
       routeLabel: XSS,
       routePath: "/",
-      routeUrl: "https://optimitron-git-feature-preview.vercel.app/?logout=1&site=reset",
+      routeUrl:
+        "https://optimitron-git-feature-preview.vercel.app/?logout=1&site=reset",
       authState: "logged-out",
       changed: true,
       copyChanged: true,
@@ -47,14 +64,22 @@ const input = {
       markdownDiff: {
         addedLines: 3,
         removedLines: 1,
-        metaChanges: [{ field: "title", before: "Old <title>", after: "New & improved" }],
+        metaChanges: [
+          { field: "title", before: "Old <title>", after: "New & improved" },
+        ],
         lines: [
           { kind: "header", text: "--- a/page.logged-out.md" },
           { kind: "header", text: "+++ b/page.logged-out.md" },
           { kind: "hunk", text: "@@ -1,4 +1,6 @@" },
-          { kind: "context", text: " Humanity still has about 121 spare apocalypses." },
+          {
+            kind: "context",
+            text: " Humanity still has about 121 spare apocalypses.",
+          },
           { kind: "del", text: "-Old line" },
-          { kind: "add", text: "+New line with <script>alert(1)</script> markup" },
+          {
+            kind: "add",
+            text: "+New line with <script>alert(1)</script> markup",
+          },
           { kind: "add", text: "+Another added line" },
         ],
       },
@@ -74,9 +99,24 @@ const input = {
           afterWidth: 1440,
           afterHeight: 4200,
           hunks: [
-            { before: { yStart: 300, yEnd: 520 }, after: { yStart: 300, yEnd: 560 }, kind: "changed", pctOfPage: 5.2 },
-            { before: { yStart: 2000, yEnd: 2000 }, after: { yStart: 2100, yEnd: 2400 }, kind: "inserted", pctOfPage: 7.1 },
-            { before: { yStart: 3600, yEnd: 3700 }, after: { yStart: 3980, yEnd: 3980 }, kind: "deleted", pctOfPage: 0.3 },
+            {
+              before: { yStart: 300, yEnd: 520 },
+              after: { yStart: 300, yEnd: 560 },
+              kind: "changed",
+              pctOfPage: 5.2,
+            },
+            {
+              before: { yStart: 2000, yEnd: 2000 },
+              after: { yStart: 2100, yEnd: 2400 },
+              kind: "inserted",
+              pctOfPage: 7.1,
+            },
+            {
+              before: { yStart: 3600, yEnd: 3700 },
+              after: { yStart: 3980, yEnd: 3980 },
+              kind: "deleted",
+              pctOfPage: 0.3,
+            },
           ],
           alignmentAnchors: [
             { beforeY: 0, afterY: 0 },
@@ -101,7 +141,10 @@ const input = {
           afterWidth: 390,
           afterHeight: 7000,
           hunks: [],
-          alignmentAnchors: [{ beforeY: 0, afterY: 0 }, { beforeY: 7000, afterY: 7000 }],
+          alignmentAnchors: [
+            { beforeY: 0, afterY: 0 },
+            { beforeY: 7000, afterY: 7000 },
+          ],
         },
       ],
     },
@@ -109,7 +152,8 @@ const input = {
       routeName: "calendar",
       routeLabel: "Calendar",
       routePath: "/calendar",
-      routeUrl: "https://optimitron-git-feature-preview.vercel.app/calendar?login=demo&site=reset",
+      routeUrl:
+        "https://optimitron-git-feature-preview.vercel.app/calendar?login=demo&site=reset",
       authState: "demo-logged-in",
       changed: true,
       copyChanged: false,
@@ -162,7 +206,8 @@ const input = {
       routeName: "variant-dfda-home",
       routeLabel: "dfda.earth · Home",
       routePath: "/",
-      routeUrl: "https://optimitron-git-feature-preview.vercel.app/?logout=1&site=dfda",
+      routeUrl:
+        "https://optimitron-git-feature-preview.vercel.app/?logout=1&site=dfda",
       productionUrl: "https://dfda.earth/",
       authState: "logged-out",
       siteVariant: "dfda",
@@ -179,9 +224,24 @@ const input = {
 
 // ---------- render ----------
 const html = renderReviewHtml(input);
+const coverageHtml = renderReviewHtml({
+  ...input,
+  summary: { ...input.summary, changedRoutes: 0 },
+  coverage: {
+    analysisAvailable: true,
+    blockingIssues: [
+      "packages/web/src/app/tasks/[id]/page.tsx: no required visual state is registered for this changed UI source",
+      '<script>alert("coverage")</script>: invalid capture state',
+    ],
+    changedUiFiles: ["packages/web/src/app/tasks/[id]/page.tsx"],
+    complete: false,
+    coveredUiFiles: [],
+  },
+});
 
 mkdirSync(outDir, { recursive: true });
 writeFileSync(htmlPath, html, "utf8");
+writeFileSync(coverageHtmlPath, coverageHtml, "utf8");
 
 // ---------- assertions ----------
 const failures = [];
@@ -195,37 +255,98 @@ assert(html.includes("PR #123 review"), "server-rendered header title");
 assert(html.includes('id="review-data"'), "JSON island present");
 assert(html.includes('id="noise"'), "noise select present");
 assert(html.includes('id="export-btn"'), "export button present");
-assert(html.includes("data-live-toggle"), "live-compare toggle keyword in client JS");
+assert(html.includes('id="copy-review-btn"'), "copy PR comment button present");
+assert(
+  html.includes("data-live-toggle"),
+  "live-compare toggle keyword in client JS",
+);
 assert(html.includes("Copy context"), "context copy action present");
-assert(html.includes("Complain"), "complaint issue action present");
-assert(html.includes("Originating PR: #"), "complaint payload preserves originating PR marker");
-assert(!html.includes('<script>alert("xss")</script>'), "route label XSS not raw in HTML");
-assert(!/<script>alert\(1\)<\/script>/.test(html), "copy-diff XSS not raw in HTML");
+assert(html.includes("Open GitHub issue"), "complaint issue action present");
+assert(
+  html.includes("Originating PR: #"),
+  "complaint payload preserves originating PR marker",
+);
+assert(
+  !html.includes('<script>alert("xss")</script>'),
+  "route label XSS not raw in HTML",
+);
+assert(
+  !/<script>alert\(1\)<\/script>/.test(html),
+  "copy-diff XSS not raw in HTML",
+);
 assert(html.includes("\\u003c"), "JSON island escapes < sequences");
-assert(html.includes("2 changed"), "summary chip: changed");
+assert(
+  html.includes("2 screenshot differences"),
+  "summary chip: screenshot differences",
+);
 assert(html.includes("1 copy-only"), "summary chip: copy-only");
 assert(html.includes("4 routes"), "summary chip: total");
+assert(
+  !html.includes("Visual capture contract failed"),
+  "complete review omits coverage failure",
+);
+assert(
+  coverageHtml.includes("0 screenshot differences"),
+  "coverage failure preserves screenshot-diff count",
+);
+assert(
+  coverageHtml.includes("capture contract failed · 0/1 UI files"),
+  "coverage failure chip",
+);
+assert(
+  coverageHtml.includes("Visual capture contract failed"),
+  "coverage failure heading",
+);
+assert(
+  coverageHtml.includes("the visual-review check must fail"),
+  "coverage failure explains the gate",
+);
+assert(
+  coverageHtml.includes("packages/web/src/app/tasks/[id]/page.tsx"),
+  "coverage failure lists blocking UI file",
+);
+assert(
+  !coverageHtml.includes('<script>alert("coverage")</script>'),
+  "coverage file XSS not raw in HTML",
+);
 
 // ---------- extract inline JS and node --check it ----------
 const scripts = [];
 const re = /<script(?![^>]*application\/json)[^>]*>([\s\S]*?)<\/script>/g;
 let m;
 while ((m = re.exec(html)) !== null) scripts.push(m[1]);
-assert(scripts.length === 1, "exactly one inline client <script> (got " + scripts.length + ")");
+assert(
+  scripts.length === 1,
+  "exactly one inline client <script> (got " + scripts.length + ")",
+);
 
 const clientJs = scripts.join("\n;\n");
 writeFileSync(clientJsPath, clientJs, "utf8");
 
-const check = spawnSync(process.execPath, ["--check", clientJsPath], { encoding: "utf8" });
-assert(check.status === 0, "node --check on extracted client JS: " + (check.stderr || "").trim());
+const check = spawnSync(process.execPath, ["--check", clientJsPath], {
+  encoding: "utf8",
+});
+assert(
+  check.status === 0,
+  "node --check on extracted client JS: " + (check.stderr || "").trim(),
+);
 
 // JSON island round-trips
 try {
-  const island = /<script type="application\/json" id="review-data">([\s\S]*?)<\/script>/.exec(html);
+  const island =
+    /<script type="application\/json" id="review-data">([\s\S]*?)<\/script>/.exec(
+      html,
+    );
   const parsed = JSON.parse(island[1]);
   assert(parsed.routes.length === 4, "JSON island round-trips (routes)");
-  assert(parsed.routes[0].pairs[0].hunks.length === 3, "JSON island round-trips (hunks)");
-  assert(parsed.routes[0].routeLabel === XSS, "JSON island preserves raw strings");
+  assert(
+    parsed.routes[0].pairs[0].hunks.length === 3,
+    "JSON island round-trips (hunks)",
+  );
+  assert(
+    parsed.routes[0].routeLabel === XSS,
+    "JSON island preserves raw strings",
+  );
 } catch (err) {
   failures.push("JSON island parse failed: " + err.message);
 }
@@ -234,6 +355,7 @@ try {
 const summary = {
   ok: failures.length === 0,
   htmlPath,
+  coverageHtmlPath,
   htmlBytes: Buffer.byteLength(html, "utf8"),
   clientJsPath,
   clientJsBytes: Buffer.byteLength(clientJs, "utf8"),

--- a/packages/web/src/app/api/documents/[id]/route.test.ts
+++ b/packages/web/src/app/api/documents/[id]/route.test.ts
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  getCurrentUser: vi.fn(),
   getDocumentForViewer: vi.fn(),
+  getTaskRequestIdentity: vi.fn(),
+  requireTaskRequestAuth: vi.fn(),
   updateDocument: vi.fn(),
 }));
 
 vi.mock("@/lib/auth-utils", () => ({
-  getCurrentUser: mocks.getCurrentUser,
+  getTaskRequestIdentity: mocks.getTaskRequestIdentity,
+  requireTaskRequestAuth: mocks.requireTaskRequestAuth,
 }));
 
 vi.mock("@/lib/documents.server", () => ({
@@ -33,7 +35,7 @@ beforeEach(() => {
 
 describe("GET /api/documents/[id]", () => {
   it("returns 404 for an anonymous viewer on a private document", async () => {
-    mocks.getCurrentUser.mockResolvedValue(null);
+    mocks.getTaskRequestIdentity.mockResolvedValue({ userId: null });
     mocks.getDocumentForViewer.mockResolvedValue(null);
 
     const response = await GET(
@@ -49,7 +51,14 @@ describe("GET /api/documents/[id]", () => {
   });
 
   it("returns the document for a permitted viewer", async () => {
-    mocks.getCurrentUser.mockResolvedValue({ id: "creator_1" });
+    const clientAccessBoundary = {
+      allowPersonalPrivate: false,
+      organizationIds: ["organization_1"],
+    };
+    mocks.getTaskRequestIdentity.mockResolvedValue({
+      clientAccessBoundary,
+      userId: "creator_1",
+    });
     mocks.getDocumentForViewer.mockResolvedValue({
       document: { id: "doc_1" },
       versions: [],
@@ -65,13 +74,14 @@ describe("GET /api/documents/[id]", () => {
     expect(mocks.getDocumentForViewer).toHaveBeenCalledWith(
       "doc_1",
       "creator_1",
+      { clientAccessBoundary },
     );
   });
 });
 
 describe("POST /api/documents/[id]", () => {
   it("requires authentication", async () => {
-    mocks.getCurrentUser.mockResolvedValue(null);
+    mocks.requireTaskRequestAuth.mockRejectedValue(new Error("Unauthorized"));
 
     const response = await POST(
       new Request("http://localhost/api/documents/doc_1", {
@@ -86,7 +96,7 @@ describe("POST /api/documents/[id]", () => {
   });
 
   it("maps the not-found error from non-creator edits to 404", async () => {
-    mocks.getCurrentUser.mockResolvedValue({ id: "stranger_1" });
+    mocks.requireTaskRequestAuth.mockResolvedValue({ userId: "stranger_1" });
     mocks.updateDocument.mockRejectedValue(new Error("Document not found"));
 
     const response = await POST(
@@ -101,11 +111,9 @@ describe("POST /api/documents/[id]", () => {
   });
 
   it("maps the empty-patch rejection to 400", async () => {
-    mocks.getCurrentUser.mockResolvedValue({ id: "creator_1" });
+    mocks.requireTaskRequestAuth.mockResolvedValue({ userId: "creator_1" });
     mocks.updateDocument.mockRejectedValue(
-      new Error(
-        "At least one editable document field must be provided",
-      ),
+      new Error("At least one editable document field must be provided"),
     );
 
     const response = await POST(
@@ -120,7 +128,7 @@ describe("POST /api/documents/[id]", () => {
   });
 
   it("maps the public-visibility-on-a-private-task rejection to 400", async () => {
-    mocks.getCurrentUser.mockResolvedValue({ id: "creator_1" });
+    mocks.requireTaskRequestAuth.mockResolvedValue({ userId: "creator_1" });
     mocks.updateDocument.mockRejectedValue(
       new Error("Cannot make a document attached to a private task public"),
     );
@@ -137,7 +145,14 @@ describe("POST /api/documents/[id]", () => {
   });
 
   it("maps an optimistic concurrency conflict to 409", async () => {
-    mocks.getCurrentUser.mockResolvedValue({ id: "creator_1" });
+    const clientAccessBoundary = {
+      allowPersonalPrivate: true,
+      organizationIds: [],
+    };
+    mocks.requireTaskRequestAuth.mockResolvedValue({
+      clientAccessBoundary,
+      userId: "creator_1",
+    });
     mocks.updateDocument.mockRejectedValue(
       new Error("Document changed since it was loaded. Refresh and try again."),
     );
@@ -151,5 +166,13 @@ describe("POST /api/documents/[id]", () => {
     );
 
     expect(response.status).toBe(409);
+    expect(mocks.updateDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: "doc_1",
+        editorUserId: "creator_1",
+        expectedVersion: 2,
+      }),
+      { clientAccessBoundary },
+    );
   });
 });

--- a/packages/web/src/app/api/documents/[id]/route.ts
+++ b/packages/web/src/app/api/documents/[id]/route.ts
@@ -3,12 +3,11 @@
  * POST /api/documents/[id] - append a revision using optimistic concurrency.
  */
 
-import { getCurrentUser } from "@/lib/auth-utils";
 import {
-  contentErrorResponse,
-  noStoreJson,
-} from "@/lib/content-http.server";
-import { McpScope } from "@/lib/mcp-scopes";
+  getTaskRequestIdentity,
+  requireTaskRequestAuth,
+} from "@/lib/auth-utils";
+import { contentErrorResponse, noStoreJson } from "@/lib/content-http.server";
 import {
   getDocumentForViewer,
   toDocumentDto,
@@ -23,12 +22,11 @@ export async function GET(
 ) {
   try {
     const { id } = await context.params;
-    const currentUser = await getCurrentUser(request, [
-      McpScope.TASKS_PERSONAL,
-      McpScope.TASKS_ADMIN,
-    ]);
+    const identity = await getTaskRequestIdentity(request);
 
-    const result = await getDocumentForViewer(id, currentUser?.id ?? null);
+    const result = await getDocumentForViewer(id, identity.userId, {
+      clientAccessBoundary: identity.clientAccessBoundary,
+    });
     if (!result) {
       return noStoreJson(
         { code: "CONTENT_NOT_FOUND", error: "Content not found." },
@@ -45,10 +43,7 @@ export async function GET(
     const response = contentErrorResponse(error);
     if (response) return response;
     console.error("[DOCUMENTS] Failed to fetch document:", error);
-    return noStoreJson(
-      { error: "Failed to fetch document." },
-      { status: 500 },
-    );
+    return noStoreJson({ error: "Failed to fetch document." }, { status: 500 });
   }
 }
 
@@ -57,16 +52,7 @@ export async function POST(
   context: { params: Promise<{ id: string }> },
 ) {
   try {
-    const currentUser = await getCurrentUser(request, [
-      McpScope.TASKS_PERSONAL,
-      McpScope.TASKS_ADMIN,
-    ]);
-    if (!currentUser) {
-      return noStoreJson(
-        { error: "Authentication required." },
-        { status: 401 },
-      );
-    }
+    const identity = await requireTaskRequestAuth(request);
 
     const { id } = await context.params;
     const body = (await request.json().catch(() => null)) as {
@@ -88,28 +74,31 @@ export async function POST(
         ? body.visibility
         : null;
 
-    const updated = await updateDocument({
-      documentId: id,
-      editorUserId: currentUser.id,
-      title,
-      body: markdown,
-      expectedVersion,
-      organizationId:
-        typeof body?.organizationId === "string" ||
-        body?.organizationId === null
-          ? body.organizationId
-          : undefined,
-      parentDocumentId:
-        typeof body?.parentDocumentId === "string" ||
-        body?.parentDocumentId === null
-          ? body.parentDocumentId
-          : undefined,
-      taskId:
-        typeof body?.taskId === "string" || body?.taskId === null
-          ? body.taskId
-          : undefined,
-      visibility,
-    });
+    const updated = await updateDocument(
+      {
+        documentId: id,
+        editorUserId: identity.userId,
+        title,
+        body: markdown,
+        expectedVersion,
+        organizationId:
+          typeof body?.organizationId === "string" ||
+          body?.organizationId === null
+            ? body.organizationId
+            : undefined,
+        parentDocumentId:
+          typeof body?.parentDocumentId === "string" ||
+          body?.parentDocumentId === null
+            ? body.parentDocumentId
+            : undefined,
+        taskId:
+          typeof body?.taskId === "string" || body?.taskId === null
+            ? body.taskId
+            : undefined,
+        visibility,
+      },
+      { clientAccessBoundary: identity.clientAccessBoundary },
+    );
 
     return noStoreJson({ document: toDocumentDto(updated) });
   } catch (error) {

--- a/packages/web/src/app/api/documents/route.test.ts
+++ b/packages/web/src/app/api/documents/route.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createDocument: vi.fn(),
+  getTaskRequestIdentity: vi.fn(),
+  listDocumentsForViewer: vi.fn(),
+  requireTaskRequestAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-utils", () => ({
+  getTaskRequestIdentity: mocks.getTaskRequestIdentity,
+  requireTaskRequestAuth: mocks.requireTaskRequestAuth,
+}));
+
+vi.mock("@/lib/documents.server", () => ({
+  createDocument: mocks.createDocument,
+  listDocumentsForViewer: mocks.listDocumentsForViewer,
+  toDocumentDto: (row: unknown) => row,
+}));
+
+import { GET, POST } from "./route";
+
+beforeEach(() => {
+  for (const fn of Object.values(mocks)) fn.mockReset();
+});
+
+describe("GET /api/documents", () => {
+  it("forwards bearer client access boundaries to document listing", async () => {
+    const clientAccessBoundary = {
+      allowPersonalPrivate: false,
+      organizationIds: ["organization_1"],
+    };
+    mocks.getTaskRequestIdentity.mockResolvedValue({
+      clientAccessBoundary,
+      userId: "user_1",
+    });
+    mocks.listDocumentsForViewer.mockResolvedValue([]);
+
+    const response = await GET(
+      new Request("http://localhost/api/documents?taskId=task_1&limit=12"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.listDocumentsForViewer).toHaveBeenCalledWith({
+      clientAccessBoundary,
+      limit: 12,
+      taskId: "task_1",
+      userId: "user_1",
+    });
+  });
+});
+
+describe("POST /api/documents", () => {
+  it("forwards bearer client access boundaries to document creation", async () => {
+    const clientAccessBoundary = {
+      allowPersonalPrivate: false,
+      organizationIds: ["organization_1"],
+    };
+    mocks.requireTaskRequestAuth.mockResolvedValue({
+      clientAccessBoundary,
+      userId: "user_1",
+    });
+    mocks.createDocument.mockResolvedValue({ id: "document_1" });
+
+    const response = await POST(
+      new Request("http://localhost/api/documents", {
+        body: JSON.stringify({
+          body: "Text",
+          organizationId: "organization_1",
+          taskId: "task_1",
+          title: "Charter",
+        }),
+        headers: { "Idempotency-Key": "create-document-1" },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mocks.createDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        createdByUserId: "user_1",
+        idempotencyKey: "create-document-1",
+        organizationId: "organization_1",
+        taskId: "task_1",
+      }),
+      { clientAccessBoundary },
+    );
+  });
+
+  it("requires authentication before creating a document", async () => {
+    mocks.requireTaskRequestAuth.mockRejectedValue(new Error("Unauthorized"));
+
+    const response = await POST(
+      new Request("http://localhost/api/documents", {
+        body: JSON.stringify({ title: "Charter" }),
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.createDocument).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/app/api/documents/route.ts
+++ b/packages/web/src/app/api/documents/route.ts
@@ -1,5 +1,8 @@
 import { ContentVisibility } from "@optimitron/db/enums";
-import { getCurrentUser } from "@/lib/auth-utils";
+import {
+  getTaskRequestIdentity,
+  requireTaskRequestAuth,
+} from "@/lib/auth-utils";
 import {
   contentErrorResponse,
   noStoreJson,
@@ -10,11 +13,8 @@ import {
   listDocumentsForViewer,
   toDocumentDto,
 } from "@/lib/documents.server";
-import { McpScope } from "@/lib/mcp-scopes";
 
 export const runtime = "nodejs";
-
-const CONTENT_SCOPES = [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN];
 
 function optionalString(value: unknown): string | null | undefined {
   if (value === null) return null;
@@ -23,10 +23,11 @@ function optionalString(value: unknown): string | null | undefined {
 
 export async function GET(request: Request) {
   try {
-    const currentUser = await getCurrentUser(request, CONTENT_SCOPES);
+    const identity = await getTaskRequestIdentity(request);
     const url = new URL(request.url);
     const documents = await listDocumentsForViewer({
-      userId: currentUser?.id ?? null,
+      clientAccessBoundary: identity.clientAccessBoundary,
+      userId: identity.userId,
       taskId: url.searchParams.get("taskId"),
       limit: parseOptionalPositiveInteger(
         url.searchParams.get("limit"),
@@ -47,27 +48,29 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const currentUser = await getCurrentUser(request, CONTENT_SCOPES);
-    if (!currentUser) throw new Error("Unauthorized");
+    const identity = await requireTaskRequestAuth(request);
     const body = (await request.json()) as Record<string, unknown>;
     const idempotencyKey =
       request.headers.get("Idempotency-Key") ??
       optionalString(body.idempotencyKey);
     if (!idempotencyKey) throw new Error("Idempotency-Key is required");
-    const document = await createDocument({
-      body: typeof body.body === "string" ? body.body : "",
-      createdByUserId: currentUser.id,
-      idempotencyKey,
-      jurisdictionId: optionalString(body.jurisdictionId),
-      organizationId: optionalString(body.organizationId),
-      parentDocumentId: optionalString(body.parentDocumentId),
-      taskId: optionalString(body.taskId),
-      title: typeof body.title === "string" ? body.title : "",
-      visibility:
-        body.visibility === ContentVisibility.PUBLIC
-          ? ContentVisibility.PUBLIC
-          : ContentVisibility.PRIVATE,
-    });
+    const document = await createDocument(
+      {
+        body: typeof body.body === "string" ? body.body : "",
+        createdByUserId: identity.userId,
+        idempotencyKey,
+        jurisdictionId: optionalString(body.jurisdictionId),
+        organizationId: optionalString(body.organizationId),
+        parentDocumentId: optionalString(body.parentDocumentId),
+        taskId: optionalString(body.taskId),
+        title: typeof body.title === "string" ? body.title : "",
+        visibility:
+          body.visibility === ContentVisibility.PUBLIC
+            ? ContentVisibility.PUBLIC
+            : ContentVisibility.PRIVATE,
+      },
+      { clientAccessBoundary: identity.clientAccessBoundary },
+    );
     return noStoreJson({ document: toDocumentDto(document) }, { status: 201 });
   } catch (error) {
     const response = contentErrorResponse(error);

--- a/packages/web/src/app/api/people/search/route.test.ts
+++ b/packages/web/src/app/api/people/search/route.test.ts
@@ -77,17 +77,27 @@ describe("people search route", () => {
         orderBy: [{ isPublicFigure: "desc" }, { displayName: "asc" }],
         take: 8,
         where: expect.objectContaining({
-          deletedAt: null,
-          lifeStatus: { not: PersonLifeStatus.DECEASED },
-          OR: expect.arrayContaining([
-            { email: { equals: "ada@example.org" } },
+          AND: expect.arrayContaining([
+            expect.objectContaining({
+              OR: expect.arrayContaining([
+                { email: { equals: "ada@example.org" } },
+                {
+                  handle: {
+                    contains: "ada@example.org",
+                    mode: "insensitive",
+                  },
+                },
+              ]),
+            }),
             {
-              handle: {
-                contains: "ada@example.org",
-                mode: "insensitive",
-              },
+              OR: [
+                { email: { not: null } },
+                { user: { is: { deletedAt: null } } },
+              ],
             },
           ]),
+          deletedAt: null,
+          lifeStatus: { not: PersonLifeStatus.DECEASED },
         }),
       }),
     );

--- a/packages/web/src/app/api/people/search/route.ts
+++ b/packages/web/src/app/api/people/search/route.ts
@@ -38,17 +38,34 @@ export async function GET(request: Request) {
       },
       take: 8,
       where: {
+        AND: [
+          {
+            OR: [
+              { displayName: { contains: query, mode: "insensitive" } },
+              { firstName: { contains: query, mode: "insensitive" } },
+              { lastName: { contains: query, mode: "insensitive" } },
+              {
+                handle: {
+                  contains: query.replace(/^@/u, ""),
+                  mode: "insensitive",
+                },
+              },
+              { headline: { contains: query, mode: "insensitive" } },
+              {
+                currentAffiliation: { contains: query, mode: "insensitive" },
+              },
+              ...(emailSearch ? [{ email: { equals: emailSearch } }] : []),
+            ],
+          },
+          {
+            OR: [
+              { email: { not: null } },
+              { user: { is: { deletedAt: null } } },
+            ],
+          },
+        ],
         deletedAt: null,
         lifeStatus: { not: PersonLifeStatus.DECEASED },
-        OR: [
-          { displayName: { contains: query, mode: "insensitive" } },
-          { firstName: { contains: query, mode: "insensitive" } },
-          { lastName: { contains: query, mode: "insensitive" } },
-          { handle: { contains: query.replace(/^@/u, ""), mode: "insensitive" } },
-          { headline: { contains: query, mode: "insensitive" } },
-          { currentAffiliation: { contains: query, mode: "insensitive" } },
-          ...(emailSearch ? [{ email: { equals: emailSearch } }] : []),
-        ],
       },
     });
 

--- a/packages/web/src/app/api/tasks/[id]/document-reviews/decision/route.ts
+++ b/packages/web/src/app/api/tasks/[id]/document-reviews/decision/route.ts
@@ -1,0 +1,16 @@
+import { decideDocumentRevision } from "@/lib/tasks/document-review.server";
+import { runDocumentReviewOperation } from "../http";
+
+export const runtime = "nodejs";
+
+export function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  return runDocumentReviewOperation(
+    request,
+    context,
+    decideDocumentRevision,
+    "Failed to decide document revision.",
+  );
+}

--- a/packages/web/src/app/api/tasks/[id]/document-reviews/http.test.ts
+++ b/packages/web/src/app/api/tasks/[id]/document-reviews/http.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireTaskRequestAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-utils", () => ({
+  requireTaskRequestAuth: mocks.requireTaskRequestAuth,
+}));
+
+import { runDocumentReviewRead } from "./http";
+
+beforeEach(() => {
+  mocks.requireTaskRequestAuth.mockReset();
+  mocks.requireTaskRequestAuth.mockResolvedValue({
+    clientAccessBoundary: {
+      allowPersonalPrivate: false,
+      organizationIds: ["organization_1"],
+    },
+    userId: "reviewer_user_1",
+  });
+});
+
+describe("document review HTTP reads", () => {
+  it("passes authenticated review-task and client-boundary context without an idempotency key", async () => {
+    const operation = vi.fn().mockResolvedValue({
+      reviewTaskId: "review_task_1",
+      target: { revisionId: "revision_1" },
+    });
+    const request = new Request(
+      "https://optimitron.test/api/tasks/review_task_1/document-reviews",
+    );
+    const response = await runDocumentReviewRead(
+      request,
+      { params: Promise.resolve({ id: "review_task_1" }) },
+      operation,
+      "Failed to load document review.",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    expect(await response.json()).toMatchObject({
+      reviewTaskId: "review_task_1",
+      target: { revisionId: "revision_1" },
+    });
+    expect(operation).toHaveBeenCalledWith("review_task_1", "reviewer_user_1", {
+      clientAccessBoundary: {
+        allowPersonalPrivate: false,
+        organizationIds: ["organization_1"],
+      },
+    });
+  });
+});

--- a/packages/web/src/app/api/tasks/[id]/document-reviews/http.ts
+++ b/packages/web/src/app/api/tasks/[id]/document-reviews/http.ts
@@ -13,6 +13,14 @@ type DocumentReviewOperation = (
   },
 ) => Promise<unknown>;
 
+type DocumentReviewReadOperation = (
+  reviewTaskId: string,
+  actorUserId: string,
+  options: {
+    clientAccessBoundary?: TaskClientAccessBoundary;
+  },
+) => Promise<unknown>;
+
 interface ReviewHttpError {
   code?: unknown;
   message?: unknown;
@@ -39,6 +47,23 @@ export async function runDocumentReviewOperation(
       },
     );
     return noStoreJson(result, { status: 201 });
+  } catch (error) {
+    return documentReviewErrorResponse(error, fallbackMessage);
+  }
+}
+
+export async function runDocumentReviewRead(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+  operation: DocumentReviewReadOperation,
+  fallbackMessage: string,
+) {
+  try {
+    const { clientAccessBoundary, userId } =
+      await requireTaskRequestAuth(request);
+    const { id } = await context.params;
+    const result = await operation(id, userId, { clientAccessBoundary });
+    return noStoreJson(result);
   } catch (error) {
     return documentReviewErrorResponse(error, fallbackMessage);
   }

--- a/packages/web/src/app/api/tasks/[id]/document-reviews/http.ts
+++ b/packages/web/src/app/api/tasks/[id]/document-reviews/http.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+import { requireTaskRequestAuth } from "@/lib/auth-utils";
+import { noStoreJson } from "@/lib/content-http.server";
+import type { TaskClientAccessBoundary } from "@/lib/tasks/task-visibility.server";
+
+type DocumentReviewOperation = (
+  authorityTaskId: string,
+  rawInput: unknown,
+  actorUserId: string,
+  options: {
+    clientAccessBoundary?: TaskClientAccessBoundary;
+    idempotencyKey: string;
+  },
+) => Promise<unknown>;
+
+interface ReviewHttpError {
+  code?: unknown;
+  message?: unknown;
+  status?: unknown;
+}
+
+export async function runDocumentReviewOperation(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+  operation: DocumentReviewOperation,
+  fallbackMessage: string,
+) {
+  try {
+    const { clientAccessBoundary, userId } =
+      await requireTaskRequestAuth(request);
+    const { id } = await context.params;
+    const result = await operation(
+      id,
+      await request.json().catch(() => null),
+      userId,
+      {
+        clientAccessBoundary,
+        idempotencyKey: request.headers.get("Idempotency-Key") ?? "",
+      },
+    );
+    return noStoreJson(result, { status: 201 });
+  } catch (error) {
+    return documentReviewErrorResponse(error, fallbackMessage);
+  }
+}
+
+export function documentReviewErrorResponse(
+  error: unknown,
+  fallbackMessage: string,
+) {
+  if (error instanceof Error && error.message === "Unauthorized") {
+    return noStoreJson(
+      { code: "UNAUTHORIZED", error: "Authentication required." },
+      { status: 401 },
+    );
+  }
+  if (error instanceof z.ZodError) {
+    return noStoreJson(
+      {
+        code: "VALIDATION_ERROR",
+        error: error.issues[0]?.message ?? "Invalid document review request.",
+      },
+      { status: 400 },
+    );
+  }
+  const candidate = error as ReviewHttpError | null;
+  if (
+    candidate &&
+    typeof candidate.message === "string" &&
+    typeof candidate.status === "number" &&
+    [400, 404, 409].includes(candidate.status)
+  ) {
+    return noStoreJson(
+      {
+        code:
+          typeof candidate.code === "string"
+            ? candidate.code
+            : "DOCUMENT_REVIEW_ERROR",
+        error: candidate.message,
+      },
+      { status: candidate.status },
+    );
+  }
+  console.error("[DOCUMENT_REVIEW] Request failed:", error);
+  return noStoreJson(
+    { code: "INTERNAL_ERROR", error: fallbackMessage },
+    { status: 500 },
+  );
+}

--- a/packages/web/src/app/api/tasks/[id]/document-reviews/proposal/route.ts
+++ b/packages/web/src/app/api/tasks/[id]/document-reviews/proposal/route.ts
@@ -1,0 +1,16 @@
+import { applyDocumentProposal } from "@/lib/tasks/document-review.server";
+import { runDocumentReviewOperation } from "../http";
+
+export const runtime = "nodejs";
+
+export function PATCH(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  return runDocumentReviewOperation(
+    request,
+    context,
+    applyDocumentProposal,
+    "Failed to apply document proposal.",
+  );
+}

--- a/packages/web/src/app/api/tasks/[id]/document-reviews/response/route.ts
+++ b/packages/web/src/app/api/tasks/[id]/document-reviews/response/route.ts
@@ -1,0 +1,16 @@
+import { submitDocumentReview } from "@/lib/tasks/document-review.server";
+import { runDocumentReviewOperation } from "../http";
+
+export const runtime = "nodejs";
+
+export function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  return runDocumentReviewOperation(
+    request,
+    context,
+    submitDocumentReview,
+    "Failed to submit document review.",
+  );
+}

--- a/packages/web/src/app/api/tasks/[id]/document-reviews/route.ts
+++ b/packages/web/src/app/api/tasks/[id]/document-reviews/route.ts
@@ -1,0 +1,16 @@
+import { requestDocumentReview } from "@/lib/tasks/document-review.server";
+import { runDocumentReviewOperation } from "./http";
+
+export const runtime = "nodejs";
+
+export function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  return runDocumentReviewOperation(
+    request,
+    context,
+    requestDocumentReview,
+    "Failed to request document review.",
+  );
+}

--- a/packages/web/src/app/api/tasks/[id]/document-reviews/route.ts
+++ b/packages/web/src/app/api/tasks/[id]/document-reviews/route.ts
@@ -1,7 +1,22 @@
-import { requestDocumentReview } from "@/lib/tasks/document-review.server";
-import { runDocumentReviewOperation } from "./http";
+import {
+  getAssignedDocumentReview,
+  requestDocumentReview,
+} from "@/lib/tasks/document-review.server";
+import { runDocumentReviewOperation, runDocumentReviewRead } from "./http";
 
 export const runtime = "nodejs";
+
+export function GET(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  return runDocumentReviewRead(
+    request,
+    context,
+    getAssignedDocumentReview,
+    "Failed to load document review.",
+  );
+}
 
 export function POST(
   request: Request,

--- a/packages/web/src/app/tasks/[id]/page.tsx
+++ b/packages/web/src/app/tasks/[id]/page.tsx
@@ -12,6 +12,8 @@ import {
 import { getServerSession } from "next-auth";
 import { TaskFundingCheckoutForm } from "@/components/task-funding/TaskFundingCheckoutForm";
 import { TaskFundingProgress } from "@/components/task-funding/TaskFundingProgress";
+import { DocumentReviewManagerPanel } from "@/components/tasks/document-review-manager-panel";
+import { DocumentReviewReviewerPanel } from "@/components/tasks/document-review-reviewer-panel";
 import { type TaskCardTask } from "@/components/tasks/task-card";
 import { TaskCommentFeed } from "@/components/tasks/task-comment-feed";
 import { TaskDescription } from "@/components/tasks/task-description";
@@ -48,6 +50,7 @@ import {
   getTaskCommentFeed,
 } from "@/lib/tasks/task-comments.server";
 import { getTaskFundingStatus } from "@/lib/task-funding/status.server";
+import { getDocumentReviewPageData } from "@/lib/tasks/document-review-ui.server";
 import { normalizeTaskCommunicationEndpointUrl } from "@/lib/tasks/task-communication-endpoints.server";
 import { OUTBOUND_MESSAGE_OPERATION } from "@/lib/email/outbound-message-approval.server";
 import { listExternalActionRequestsForHuman } from "@/lib/tasks/external-action.server";
@@ -392,6 +395,7 @@ export default async function TaskDetailPage({
     wishoniaUserId,
     ancestors,
     viewerIsAdmin,
+    documentReviewPageData,
   ] = userId
     ? await Promise.all([
         getTaskDetailData(id, userId),
@@ -413,6 +417,7 @@ export default async function TaskDetailPage({
         prisma.user
           .findUnique({ where: { id: userId }, select: { isAdmin: true } })
           .then((u) => u?.isAdmin ?? false),
+        getDocumentReviewPageData(id, userId),
       ])
     : [
         publicPageData?.data ?? null,
@@ -421,6 +426,7 @@ export default async function TaskDetailPage({
         await getWishoniaUserId().catch(() => null),
         publicPageData?.ancestors ?? [],
         false,
+        null,
       ];
 
   if (!data) {
@@ -439,9 +445,18 @@ export default async function TaskDetailPage({
   }
 
   const { task, viewer, viewerClaim } = data;
+  const isAssignedDocumentReviewer =
+    documentReviewPageData?.panel.mode === "REVIEWER";
+  const showDocumentReviewManager =
+    documentReviewPageData?.panel.mode === "MANAGER" &&
+    documentReviewPageData.setup != null &&
+    (documentReviewPageData.setup.documents.length > 0 ||
+      documentReviewPageData.panel.proposals.length > 0 ||
+      documentReviewPageData.panel.reviews.length > 0);
   const hasOtherPersonAssignee =
     task.assigneePerson != null && task.assigneePerson.id !== viewer?.personId;
-  const canShowClaimButton = !hasOtherPersonAssignee;
+  const canShowClaimButton =
+    !hasOtherPersonAssignee && !isAssignedDocumentReviewer;
   const canClaim = canTaskAcceptMoreClaims({
     activeClaimCount: task.activeClaimCount,
     claimPolicy: task.claimPolicy,
@@ -524,7 +539,7 @@ export default async function TaskDetailPage({
           >
             Tasks
           </Link>
-          {ancestors.map((ancestor) => (
+          {(isAssignedDocumentReviewer ? [] : ancestors).map((ancestor) => (
             <span key={ancestor.id} className="flex items-center gap-2">
               <span>/</span>
               <Link
@@ -629,6 +644,17 @@ export default async function TaskDetailPage({
 
         <TaskExternalActionApprovals approvals={outboundApprovals} />
 
+        {showDocumentReviewManager &&
+        documentReviewPageData?.panel.mode === "MANAGER" &&
+        documentReviewPageData.setup ? (
+          <DocumentReviewManagerPanel
+            panel={documentReviewPageData.panel}
+            setup={documentReviewPageData.setup}
+          />
+        ) : documentReviewPageData?.panel.mode === "REVIEWER" ? (
+          <DocumentReviewReviewerPanel panel={documentReviewPageData.panel} />
+        ) : null}
+
         {/* Delay-cost stats — kept (motivational, not duplicated in
             header). Owner/Progress/Time-needed/Area/Completed/Updates were
             previously listed in a verbose `<dl>` enterprise-CRM sidebar
@@ -727,17 +753,22 @@ export default async function TaskDetailPage({
           </section>
         ) : null}
 
-        <section className="border-b border-foreground py-6">
-          <article className="min-w-0">
-            <TaskDescription markdown={task.description} />
-          </article>
-        </section>
+        {!isAssignedDocumentReviewer ? (
+          <>
+            <section className="border-b border-foreground py-6">
+              <article className="min-w-0">
+                <TaskDescription markdown={task.description} />
+              </article>
+            </section>
 
-        <TaskDocumentsList taskId={task.id} userId={userId} />
+            <TaskDocumentsList taskId={task.id} userId={userId} />
 
-        <TaskDependenciesSection task={task} viewer={viewer} />
+            <TaskDependenciesSection task={task} viewer={viewer} />
+          </>
+        ) : null}
 
-        {viewer?.isAdmin &&
+        {!isAssignedDocumentReviewer &&
+        viewer?.isAdmin &&
         task.claimPolicy === TaskClaimPolicy.ASSIGNED_ONLY &&
         task.status !== TaskStatus.VERIFIED ? (
           <details className="border-b border-foreground py-5">
@@ -755,7 +786,9 @@ export default async function TaskDetailPage({
           </details>
         ) : null}
 
-        {viewer?.isAdmin && reviewableClaims.length > 0 ? (
+        {!isAssignedDocumentReviewer &&
+        viewer?.isAdmin &&
+        reviewableClaims.length > 0 ? (
           <details className="border-b border-foreground py-5">
             <summary className="cursor-pointer text-sm font-black uppercase tracking-[0.12em] text-foreground">
               Pending claim reviews ({reviewableClaims.length})
@@ -787,7 +820,7 @@ export default async function TaskDetailPage({
           </details>
         ) : null}
 
-        {task.childTasks.length > 0 ? (
+        {!isAssignedDocumentReviewer && task.childTasks.length > 0 ? (
           <section id="subtasks" className="border-b border-foreground py-8">
             <h2 className="mb-4 text-base font-semibold">
               Steps ({task.childTasks.length})
@@ -834,6 +867,11 @@ export default async function TaskDetailPage({
             currentUserIsAdmin={viewerIsAdmin}
             wishoniaUserId={wishoniaUserId}
             signInHref={signInHref}
+            heading={
+              showDocumentReviewManager || isAssignedDocumentReviewer
+                ? "Discussion"
+                : undefined
+            }
           />
         </section>
       </div>

--- a/packages/web/src/components/tasks/document-review-manager-panel.test.tsx
+++ b/packages/web/src/components/tasks/document-review-manager-panel.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Simulate } from "react-dom/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DocumentReviewManagerSetupData } from "@/lib/tasks/document-review-ui.server";
+import type { DocumentReviewPanelData } from "@/lib/tasks/document-review.server";
+
+const mocks = vi.hoisted(() => ({ refresh: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mocks.refresh }),
+}));
+
+import { DocumentReviewManagerPanel } from "./document-review-manager-panel";
+
+type ManagerPanel = Extract<DocumentReviewPanelData, { mode: "MANAGER" }>;
+
+function fixtures(): {
+  panel: ManagerPanel;
+  setup: DocumentReviewManagerSetupData;
+} {
+  const target = {
+    contentHash: "sha256:reviewed-version",
+    documentId: "document-1",
+    revisionId: "revision-2",
+    version: 2,
+  };
+  return {
+    panel: {
+      authorityTaskId: "authority-task",
+      decisions: [],
+      mode: "MANAGER",
+      proposals: [
+        {
+          artifactId: "proposal-artifact",
+          base: target,
+          baseStale: false,
+          proposed: {
+            ...target,
+            body: "Proposed exact text",
+            contentHash: "sha256:proposal",
+            documentId: "proposal-document",
+            revisionId: "proposal-revision",
+            title: "Revised operating agreement",
+            version: 1,
+          },
+          sourceComments: [
+            {
+              commentId: "comment-1",
+              contentHash: "sha256:comment",
+              taskId: "authority-task",
+            },
+          ],
+          summary: "Clarifies who may approve financing.",
+        },
+      ],
+      reviews: [
+        {
+          request: {
+            authorityTaskId: "authority-task",
+            instructions: "Check the authority and conflicts provisions.",
+            requestedAt: "2026-07-27T12:00:00.000Z",
+            requestedByUserId: "manager-user",
+            schema: "optimitron.review-request.v1",
+            target,
+          },
+          response: {
+            artifactId: "review-artifact",
+            comment: { contentHash: "sha256:comment", id: "comment-1" },
+            explanation: "The revision is ready to adopt.",
+            reviewerPersonId: "reviewer-person",
+            reviewerUserId: "reviewer-user",
+            reviewTaskId: "review-task",
+            schema: "optimitron.review-response.v1",
+            submittedAt: "2026-07-27T13:00:00.000Z",
+            target,
+            verdict: "APPROVE",
+          },
+          reviewTaskId: "review-task",
+          reviewer: {
+            displayName: "Ada Reviewer",
+            id: "reviewer-person",
+          },
+          state: "APPROVED",
+          target: {
+            ...target,
+            body: "Exact text",
+            stale: false,
+            title: "Operating agreement",
+          },
+        },
+      ],
+    },
+    setup: {
+      documents: [
+        {
+          ...target,
+          revisionId: target.revisionId,
+          title: "Operating agreement",
+        },
+      ],
+    },
+  };
+}
+
+function findButton(container: HTMLElement, label: string) {
+  return Array.from(container.querySelectorAll("button")).find(
+    (button) => button.textContent?.trim() === label,
+  );
+}
+
+describe("DocumentReviewManagerPanel", () => {
+  let container: HTMLDivElement;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+        React: typeof React;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    (globalThis as typeof globalThis & { React: typeof React }).React = React;
+    mocks.refresh.mockReset();
+    fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("crypto", { randomUUID: () => "decision-key" });
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => true),
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows the compact review and internal decision controls", async () => {
+    const { panel, setup } = fixtures();
+    await act(async () => {
+      root.render(<DocumentReviewManagerPanel panel={panel} setup={setup} />);
+    });
+
+    expect(container.textContent).toContain("Get an independent review");
+    expect(container.textContent).toContain("Proposed changes");
+    expect(findButton(container, "Create version 3")).toBeDefined();
+    expect(container.textContent).toContain("Ada Reviewer");
+    expect(
+      findButton(container, "Use version 2 as working text"),
+    ).toBeDefined();
+    expect(findButton(container, "Reject version")).toBeDefined();
+    expect(container.textContent).not.toContain("Waiver");
+    expect(container.textContent).not.toContain("Invitation batch");
+  });
+
+  it("applies the exact proposal artifact", async () => {
+    const { panel, setup } = fixtures();
+    await act(async () => {
+      root.render(<DocumentReviewManagerPanel panel={panel} setup={setup} />);
+    });
+    await act(async () => {
+      Simulate.click(findButton(container, "Create version 3")!);
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/tasks/authority-task/document-reviews/proposal",
+    );
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(request.method).toBe("PATCH");
+    expect(JSON.parse(String(request.body))).toEqual({
+      proposalArtifactId: "proposal-artifact",
+    });
+  });
+
+  it("does not write or refresh when version creation is cancelled", async () => {
+    const { panel, setup } = fixtures();
+    vi.mocked(confirm).mockReturnValueOnce(false);
+    await act(async () => {
+      root.render(<DocumentReviewManagerPanel panel={panel} setup={setup} />);
+    });
+    await act(async () => {
+      Simulate.click(findButton(container, "Create version 3")!);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.refresh).not.toHaveBeenCalled();
+    expect(findButton(container, "Create version 3")?.disabled).toBe(false);
+  });
+
+  it("records adoption against the exact approval artifact", async () => {
+    const { panel, setup } = fixtures();
+    await act(async () => {
+      root.render(<DocumentReviewManagerPanel panel={panel} setup={setup} />);
+    });
+    await act(async () => {
+      Simulate.click(findButton(container, "Use version 2 as working text")!);
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(request.body))).toEqual({
+      action: "ADOPT",
+      documentRevisionId: "revision-2",
+      reviewArtifactId: "review-artifact",
+    });
+  });
+});

--- a/packages/web/src/components/tasks/document-review-manager-panel.tsx
+++ b/packages/web/src/components/tasks/document-review-manager-panel.tsx
@@ -1,0 +1,592 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState, useTransition } from "react";
+import { RichMarkdown } from "@/components/markdown/rich-markdown";
+import { API_ROUTES } from "@/lib/api-routes";
+import type { DocumentReviewManagerSetupData } from "@/lib/tasks/document-review-ui.server";
+import type {
+  DocumentProposalPreview,
+  DocumentReviewPanelData,
+  DocumentReviewPanelReview,
+} from "@/lib/tasks/document-review.server";
+
+type ManagerPanel = Extract<DocumentReviewPanelData, { mode: "MANAGER" }>;
+type DecisionAction = "ADOPT" | "REJECT";
+type Verdict = "APPROVE" | "CHANGES_REQUESTED" | "REJECT" | "ABSTAIN";
+
+interface PersonSearchResult {
+  affiliation: string | null;
+  displayName: string;
+  handle: string | null;
+  headline: string | null;
+  id: string;
+}
+
+interface IdempotencyState {
+  fingerprint: string;
+  key: string;
+}
+
+const fieldClassName =
+  "w-full rounded-none border border-foreground bg-background px-3 py-2 text-sm text-foreground outline-none focus:ring-2 focus:ring-foreground focus:ring-offset-2 focus:ring-offset-background";
+const primaryButtonClassName =
+  "inline-flex min-h-10 items-center justify-center rounded-none border border-foreground bg-foreground px-4 py-2 text-sm font-semibold text-background disabled:cursor-not-allowed disabled:opacity-50";
+const secondaryButtonClassName =
+  "inline-flex min-h-10 items-center justify-center rounded-none border border-foreground bg-background px-4 py-2 text-sm font-semibold text-foreground disabled:cursor-not-allowed disabled:opacity-50";
+
+const stateLabels: Record<DocumentReviewPanelReview["state"], string> = {
+  ABSTAINED: "Abstained",
+  APPROVED: "Approved",
+  AWAITING_RESPONSE: "Awaiting review",
+  CHANGES_REQUESTED: "Changes requested",
+  REJECTED: "Rejected",
+  STALE: "Version changed",
+};
+
+const verdictLabels: Record<Verdict, string> = {
+  ABSTAIN: "Abstained",
+  APPROVE: "Approved",
+  CHANGES_REQUESTED: "Changes requested",
+  REJECT: "Rejected",
+};
+
+async function expectOk(response: Response, fallback: string) {
+  const payload = (await response.json().catch(() => null)) as {
+    error?: string;
+  } | null;
+  if (!response.ok) throw new Error(payload?.error ?? fallback);
+}
+
+function getIdempotencyKey(
+  state: { current: IdempotencyState | null },
+  prefix: string,
+  fingerprint: string,
+) {
+  if (state.current?.fingerprint !== fingerprint) {
+    state.current = {
+      fingerprint,
+      key: `${prefix}:${crypto.randomUUID()}`,
+    };
+  }
+  return state.current.key;
+}
+
+export function DocumentReviewManagerPanel({
+  panel,
+  setup,
+}: {
+  panel: ManagerPanel;
+  setup: DocumentReviewManagerSetupData;
+}) {
+  const router = useRouter();
+  const requestIdempotency = useRef<IdempotencyState | null>(null);
+  const proposalIdempotency = useRef<IdempotencyState | null>(null);
+  const decisionIdempotency = useRef<IdempotencyState | null>(null);
+  const [documentRevisionId, setDocumentRevisionId] = useState(
+    setup.documents[0]?.revisionId ?? "",
+  );
+  const [instructions, setInstructions] = useState("");
+  const [personQuery, setPersonQuery] = useState("");
+  const [people, setPeople] = useState<PersonSearchResult[]>([]);
+  const [selectedPerson, setSelectedPerson] =
+    useState<PersonSearchResult | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [rejectReasons, setRejectReasons] = useState<Record<string, string>>(
+    {},
+  );
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isRefreshing, startRefresh] = useTransition();
+  const isBusy = busyKey != null || isRefreshing;
+
+  useEffect(() => {
+    if (selectedPerson || personQuery.trim().length < 2) {
+      setPeople([]);
+      setSearching(false);
+      return;
+    }
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      setSearching(true);
+      void fetch(
+        `/api/people/search?q=${encodeURIComponent(personQuery.trim())}`,
+      )
+        .then(async (response) => {
+          if (!response.ok) return [];
+          const payload = (await response.json()) as {
+            data?: PersonSearchResult[];
+          };
+          return payload.data ?? [];
+        })
+        .then((results) => {
+          if (!cancelled) setPeople(results);
+        })
+        .catch(() => {
+          if (!cancelled) setPeople([]);
+        })
+        .finally(() => {
+          if (!cancelled) setSearching(false);
+        });
+    }, 250);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [personQuery, selectedPerson]);
+
+  async function runAction(key: string, action: () => Promise<boolean | void>) {
+    if (isBusy) return;
+    setError(null);
+    setBusyKey(key);
+    try {
+      const changed = await action();
+      if (changed !== false) startRefresh(() => router.refresh());
+    } catch (actionError) {
+      setError(
+        actionError instanceof Error
+          ? actionError.message
+          : "The action did not finish.",
+      );
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  async function requestReview() {
+    if (!selectedPerson || !documentRevisionId || !instructions.trim()) {
+      return false;
+    }
+    const body = {
+      documentRevisionId,
+      instructions: instructions.trim(),
+      reviewerPersonId: selectedPerson.id,
+    };
+    const fingerprint = JSON.stringify(body);
+    const response = await fetch(
+      API_ROUTES.tasks.documentReviews(panel.authorityTaskId),
+      {
+        body: JSON.stringify(body),
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": getIdempotencyKey(
+            requestIdempotency,
+            "document-review",
+            fingerprint,
+          ),
+        },
+        method: "POST",
+      },
+    );
+    await expectOk(response, "Could not request the review.");
+    requestIdempotency.current = null;
+    setInstructions("");
+    setPersonQuery("");
+    setSelectedPerson(null);
+    return true;
+  }
+
+  async function applyProposal(proposal: DocumentProposalPreview) {
+    if (
+      !window.confirm(
+        `Create version ${proposal.base.version + 1} from this proposal? Any open reviews of version ${proposal.base.version} will close.`,
+      )
+    ) {
+      return false;
+    }
+    const body = { proposalArtifactId: proposal.artifactId };
+    const fingerprint = JSON.stringify(body);
+    const response = await fetch(
+      API_ROUTES.tasks.documentReviewProposal(panel.authorityTaskId),
+      {
+        body: JSON.stringify(body),
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": getIdempotencyKey(
+            proposalIdempotency,
+            "document-proposal-application",
+            fingerprint,
+          ),
+        },
+        method: "PATCH",
+      },
+    );
+    await expectOk(response, "Could not apply the proposed changes.");
+    proposalIdempotency.current = null;
+    return true;
+  }
+
+  async function decide(
+    action: DecisionAction,
+    review: DocumentReviewPanelReview,
+  ) {
+    if (!review.response) return false;
+    const reason = rejectReasons[review.reviewTaskId]?.trim() ?? "";
+    if (action === "REJECT" && !reason) {
+      setError("Explain why this revision should be rejected.");
+      return false;
+    }
+    if (
+      action === "ADOPT" &&
+      !window.confirm(
+        `Use version ${review.target.version} as the working text? This does not sign, file, enact, or publish the document.`,
+      )
+    ) {
+      return false;
+    }
+    const body = {
+      action,
+      documentRevisionId: review.target.revisionId,
+      reason: action === "REJECT" ? reason : undefined,
+      reviewArtifactId: review.response.artifactId,
+    };
+    const fingerprint = JSON.stringify(body);
+    const response = await fetch(
+      API_ROUTES.tasks.documentReviewDecision(panel.authorityTaskId),
+      {
+        body: JSON.stringify(body),
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": getIdempotencyKey(
+            decisionIdempotency,
+            "document-decision",
+            fingerprint,
+          ),
+        },
+        method: "POST",
+      },
+    );
+    await expectOk(response, "Could not record the decision.");
+    decisionIdempotency.current = null;
+    return true;
+  }
+
+  return (
+    <section
+      aria-labelledby="document-review-manager-heading"
+      className="border-b border-foreground py-6"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+            Document review
+          </p>
+          <h2
+            className="mt-2 text-xl font-semibold"
+            id="document-review-manager-heading"
+          >
+            Get an independent review
+          </h2>
+        </div>
+        <a
+          className="text-sm font-semibold underline underline-offset-4"
+          href="#discussion"
+        >
+          Read discussion
+        </a>
+      </div>
+      <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+        Assign one exact version. The reviewer can approve it, request changes,
+        reject it, or abstain. Votes only help sort the discussion.
+      </p>
+
+      {panel.proposals.length > 0 ? (
+        <div className="mt-6 space-y-4">
+          <h3 className="text-base font-semibold">Proposed changes</h3>
+          {panel.proposals.map((proposal) => (
+            <article
+              className="border border-foreground p-4"
+              key={proposal.artifactId}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="font-semibold">{proposal.proposed.title}</p>
+                  <p className="text-sm text-muted-foreground">
+                    Based on version {proposal.base.version} · drawn from{" "}
+                    {proposal.sourceComments.length}{" "}
+                    {proposal.sourceComments.length === 1
+                      ? "comment"
+                      : "comments"}
+                  </p>
+                </div>
+                {proposal.baseStale ? (
+                  <span className="text-xs font-semibold uppercase tracking-[0.1em]">
+                    Out of date
+                  </span>
+                ) : null}
+              </div>
+              <p className="mt-3 whitespace-pre-wrap text-sm">
+                {proposal.summary}
+              </p>
+              <details className="mt-4 border-t border-foreground pt-3">
+                <summary className="cursor-pointer text-sm font-semibold">
+                  Read proposed text
+                </summary>
+                <div className="mt-3 max-h-96 overflow-y-auto text-sm">
+                  <RichMarkdown markdown={proposal.proposed.body} />
+                </div>
+              </details>
+              <p className="mt-4 text-xs text-muted-foreground">
+                This creates a new version. It does not approve or adopt it.
+              </p>
+              <div className="mt-2 flex flex-wrap items-center gap-4">
+                {proposal.baseStale ? (
+                  <p className="text-sm text-muted-foreground">
+                    This proposal cannot be applied to the newer version.
+                  </p>
+                ) : (
+                  <button
+                    className={primaryButtonClassName}
+                    disabled={isBusy}
+                    onClick={() =>
+                      void runAction(`proposal-${proposal.artifactId}`, () =>
+                        applyProposal(proposal),
+                      )
+                    }
+                    type="button"
+                  >
+                    {busyKey === `proposal-${proposal.artifactId}`
+                      ? "Creating version…"
+                      : `Create version ${proposal.base.version + 1}`}
+                  </button>
+                )}
+                <a
+                  className="text-sm font-semibold underline underline-offset-4"
+                  href={
+                    proposal.sourceComments[0]
+                      ? proposal.sourceComments[0].taskId ===
+                        panel.authorityTaskId
+                        ? `#comment-${proposal.sourceComments[0].commentId}`
+                        : `/tasks/${proposal.sourceComments[0].taskId}#comment-${proposal.sourceComments[0].commentId}`
+                      : "#discussion"
+                  }
+                >
+                  {proposal.baseStale
+                    ? "Request an update"
+                    : "Read source comments"}
+                </a>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+
+      {setup.documents.length === 0 ? (
+        <p className="mt-5 border border-foreground p-4 text-sm">
+          Attach a versioned document to this task before requesting a review.
+        </p>
+      ) : (
+        <div className="mt-5 grid gap-4 border border-foreground p-4 md:grid-cols-2">
+          <label className="space-y-1">
+            <span className="text-sm font-semibold">Document version</span>
+            <select
+              className={fieldClassName}
+              onChange={(event) => setDocumentRevisionId(event.target.value)}
+              value={documentRevisionId}
+            >
+              {setup.documents.map((document) => (
+                <option key={document.revisionId} value={document.revisionId}>
+                  Version {document.version} · {document.title}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="relative space-y-1">
+            <label className="block text-sm font-semibold" htmlFor="reviewer">
+              Reviewer
+            </label>
+            <input
+              className={fieldClassName}
+              id="reviewer"
+              onChange={(event) => {
+                setPersonQuery(event.target.value);
+                setSelectedPerson(null);
+              }}
+              placeholder="Search by name or email"
+              value={selectedPerson?.displayName ?? personQuery}
+            />
+            {searching ? (
+              <p className="text-xs text-muted-foreground">Searching…</p>
+            ) : null}
+            {!selectedPerson && people.length > 0 ? (
+              <div className="absolute z-10 mt-1 max-h-56 w-full overflow-y-auto border border-foreground bg-background">
+                {people.map((person) => (
+                  <button
+                    className="block w-full border-b border-foreground px-3 py-2 text-left last:border-b-0 hover:bg-foreground hover:text-background"
+                    key={person.id}
+                    onClick={() => {
+                      setSelectedPerson(person);
+                      setPeople([]);
+                    }}
+                    type="button"
+                  >
+                    <span className="block text-sm font-semibold">
+                      {person.displayName}
+                    </span>
+                    {(person.affiliation ?? person.headline) ? (
+                      <span className="block text-xs opacity-70">
+                        {person.affiliation ?? person.headline}
+                      </span>
+                    ) : null}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+
+          <label className="space-y-1 md:col-span-2">
+            <span className="text-sm font-semibold">
+              What should they check?
+            </span>
+            <textarea
+              className={fieldClassName}
+              onChange={(event) => setInstructions(event.target.value)}
+              placeholder="Describe the questions this reviewer should answer."
+              rows={3}
+              value={instructions}
+            />
+          </label>
+
+          <div className="md:col-span-2">
+            <button
+              className={primaryButtonClassName}
+              disabled={
+                isBusy ||
+                !selectedPerson ||
+                !documentRevisionId ||
+                !instructions.trim()
+              }
+              onClick={() => void runAction("request", requestReview)}
+              type="button"
+            >
+              {busyKey === "request" ? "Assigning…" : "Assign review"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error ? (
+        <p className="mt-4 border border-foreground p-3 text-sm" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {panel.reviews.length > 0 ? (
+        <div className="mt-6 space-y-4">
+          <h3 className="text-base font-semibold">Reviews</h3>
+          <p className="text-sm text-muted-foreground">
+            These decisions only choose the working text inside Optimitron. They
+            do not sign, file, enact, or publish the document.
+          </p>
+          {panel.reviews.map((review) => {
+            const decided = panel.decisions.find(
+              ({ decision }) =>
+                decision.target.revisionId === review.target.revisionId,
+            );
+            return (
+              <article
+                className="border-t border-foreground pt-4"
+                key={review.reviewTaskId}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="font-semibold">
+                      {review.reviewer.displayName}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {review.target.title} · version {review.target.version}
+                    </p>
+                  </div>
+                  <span className="text-xs font-semibold uppercase tracking-[0.1em]">
+                    {stateLabels[review.state]}
+                  </span>
+                </div>
+                <p className="mt-3 whitespace-pre-wrap text-sm">
+                  {review.request.instructions}
+                </p>
+                {review.response ? (
+                  <div className="mt-3 border-l border-foreground pl-3 text-sm">
+                    <p className="font-semibold">
+                      {verdictLabels[review.response.verdict]}
+                    </p>
+                    <p className="mt-1 whitespace-pre-wrap">
+                      {review.response.explanation}
+                    </p>
+                  </div>
+                ) : null}
+
+                {decided ? (
+                  <p className="mt-3 text-sm font-semibold">
+                    Internal decision: {decided.decision.action.toLowerCase()}ed
+                  </p>
+                ) : review.response && review.state !== "STALE" ? (
+                  <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
+                    {review.response.verdict === "APPROVE" ? (
+                      <button
+                        className={primaryButtonClassName}
+                        disabled={isBusy}
+                        onClick={() =>
+                          void runAction(`adopt-${review.reviewTaskId}`, () =>
+                            decide("ADOPT", review),
+                          )
+                        }
+                        type="button"
+                      >
+                        Use version {review.target.version} as working text
+                      </button>
+                    ) : null}
+                    <label className="min-w-0 flex-1 space-y-1">
+                      <span className="text-sm font-semibold">
+                        Reason to reject
+                      </span>
+                      <input
+                        className={fieldClassName}
+                        onChange={(event) =>
+                          setRejectReasons((current) => ({
+                            ...current,
+                            [review.reviewTaskId]: event.target.value,
+                          }))
+                        }
+                        placeholder="Why should this version stop here?"
+                        value={rejectReasons[review.reviewTaskId] ?? ""}
+                      />
+                    </label>
+                    <button
+                      className={secondaryButtonClassName}
+                      disabled={isBusy}
+                      onClick={() =>
+                        void runAction(`reject-${review.reviewTaskId}`, () =>
+                          decide("REJECT", review),
+                        )
+                      }
+                      type="button"
+                    >
+                      Reject version
+                    </button>
+                  </div>
+                ) : null}
+
+                <details className="mt-3 text-xs text-muted-foreground">
+                  <summary className="cursor-pointer font-semibold text-foreground">
+                    Integrity details
+                  </summary>
+                  <dl className="mt-2 grid gap-1 break-all">
+                    <div>
+                      <dt className="inline font-semibold">Revision: </dt>
+                      <dd className="inline">{review.target.revisionId}</dd>
+                    </div>
+                    <div>
+                      <dt className="inline font-semibold">Content hash: </dt>
+                      <dd className="inline">{review.target.contentHash}</dd>
+                    </div>
+                  </dl>
+                </details>
+              </article>
+            );
+          })}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/packages/web/src/components/tasks/document-review-reviewer-panel.test.tsx
+++ b/packages/web/src/components/tasks/document-review-reviewer-panel.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Simulate } from "react-dom/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DocumentReviewPanelData } from "@/lib/tasks/document-review.server";
+
+const mocks = vi.hoisted(() => ({ refresh: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mocks.refresh }),
+}));
+
+vi.mock("@/components/markdown/rich-markdown", () => ({
+  RichMarkdown: ({ markdown }: { markdown: string }) => <div>{markdown}</div>,
+}));
+
+import { DocumentReviewReviewerPanel } from "./document-review-reviewer-panel";
+
+type ReviewerPanel = Extract<DocumentReviewPanelData, { mode: "REVIEWER" }>;
+
+function panelFixture(): ReviewerPanel {
+  const target = {
+    contentHash: "sha256:reviewed-version",
+    documentId: "document-1",
+    revisionId: "revision-2",
+    version: 2,
+  };
+  return {
+    authorityTaskId: "authority-task",
+    canSubmit: true,
+    mode: "REVIEWER",
+    review: {
+      request: {
+        authorityTaskId: "authority-task",
+        instructions: "Check the claims and leave specific feedback.",
+        requestedAt: "2026-07-27T12:00:00.000Z",
+        requestedByUserId: "manager-user",
+        schema: "optimitron.review-request.v1",
+        target,
+      },
+      response: null,
+      reviewTaskId: "review-task",
+      reviewer: {
+        displayName: "Ada Reviewer",
+        id: "reviewer-person",
+      },
+      state: "AWAITING_RESPONSE",
+      target: {
+        ...target,
+        body: "# Operating agreement\n\nExact pinned text.",
+        stale: false,
+        title: "Operating agreement",
+      },
+    },
+  };
+}
+
+function findButton(container: HTMLElement, label: string) {
+  return Array.from(container.querySelectorAll("button")).find(
+    (button) => button.textContent?.trim() === label,
+  );
+}
+
+describe("DocumentReviewReviewerPanel", () => {
+  let container: HTMLDivElement;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+        React: typeof React;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    (globalThis as typeof globalThis & { React: typeof React }).React = React;
+    mocks.refresh.mockReset();
+    fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("crypto", { randomUUID: () => "response-key" });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("leads with the pinned text and two common decisions", async () => {
+    await act(async () => {
+      root.render(<DocumentReviewReviewerPanel panel={panelFixture()} />);
+    });
+
+    expect(container.textContent).toContain("Exact pinned text.");
+    expect(container.textContent).toContain(
+      "Votes help sort discussion; they do not approve the document.",
+    );
+    expect(findButton(container, "Approve")).toBeDefined();
+    expect(findButton(container, "Request changes")).toBeDefined();
+    expect(container.textContent).not.toContain("Verify delivery");
+    expect(container.textContent).not.toContain("Propose a revision");
+  });
+
+  it("submits change feedback and the verdict in one request", async () => {
+    await act(async () => {
+      root.render(<DocumentReviewReviewerPanel panel={panelFixture()} />);
+    });
+    const feedback = container.querySelector("textarea");
+    expect(feedback).not.toBeNull();
+    await act(async () => {
+      Simulate.change(feedback!, {
+        target: {
+          value: "Cite the source for the central claim.",
+        } as EventTarget & { value: string },
+      });
+    });
+    await act(async () => {
+      Simulate.click(findButton(container, "Request changes")!);
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(request.body))).toEqual({
+      explanation: "Cite the source for the central claim.",
+      verdict: "CHANGES_REQUESTED",
+    });
+  });
+
+  it("keeps stale text readable without offering a new verdict", async () => {
+    const panel = panelFixture();
+    panel.canSubmit = false;
+    panel.review.state = "STALE";
+    panel.review.target.stale = true;
+
+    await act(async () => {
+      root.render(<DocumentReviewReviewerPanel panel={panel} />);
+    });
+
+    expect(container.textContent).toContain("Past review");
+    expect(container.textContent).toContain("Exact pinned text.");
+    expect(findButton(container, "Approve")).toBeUndefined();
+    expect(findButton(container, "Request changes")).toBeUndefined();
+  });
+});

--- a/packages/web/src/components/tasks/document-review-reviewer-panel.test.tsx
+++ b/packages/web/src/components/tasks/document-review-reviewer-panel.test.tsx
@@ -67,6 +67,7 @@ function findButton(container: HTMLElement, label: string) {
 describe("DocumentReviewReviewerPanel", () => {
   let container: HTMLDivElement;
   let fetchMock: ReturnType<typeof vi.fn>;
+  let randomUUIDMock: ReturnType<typeof vi.fn>;
   let root: Root;
 
   beforeEach(() => {
@@ -85,7 +86,11 @@ describe("DocumentReviewReviewerPanel", () => {
       }),
     );
     vi.stubGlobal("fetch", fetchMock);
-    vi.stubGlobal("crypto", { randomUUID: () => "response-key" });
+    randomUUIDMock = vi
+      .fn()
+      .mockReturnValueOnce("response-key-1")
+      .mockReturnValueOnce("response-key-2");
+    vi.stubGlobal("crypto", { randomUUID: randomUUIDMock });
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -135,6 +140,57 @@ describe("DocumentReviewReviewerPanel", () => {
       explanation: "Cite the source for the central claim.",
       verdict: "CHANGES_REQUESTED",
     });
+  });
+
+  it("changes the idempotency key when a failed submission body changes", async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error("Network interrupted"))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true }), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        }),
+      );
+    await act(async () => {
+      root.render(<DocumentReviewReviewerPanel panel={panelFixture()} />);
+    });
+    const feedback = container.querySelector("textarea");
+    await act(async () => {
+      Simulate.change(feedback!, {
+        target: { value: "First explanation." } as EventTarget & {
+          value: string;
+        },
+      });
+    });
+    await act(async () => {
+      Simulate.click(findButton(container, "Request changes")!);
+    });
+    await act(async () => {
+      Simulate.change(feedback!, {
+        target: { value: "Corrected explanation." } as EventTarget & {
+          value: string;
+        },
+      });
+    });
+    await act(async () => {
+      Simulate.click(findButton(container, "Request changes")!);
+    });
+
+    const firstHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Record<
+      string,
+      string
+    >;
+    const secondHeaders = fetchMock.mock.calls[1]?.[1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(firstHeaders["Idempotency-Key"]).toBe(
+      "document-review-response:response-key-1",
+    );
+    expect(secondHeaders["Idempotency-Key"]).toBe(
+      "document-review-response:response-key-2",
+    );
+    expect(randomUUIDMock).toHaveBeenCalledTimes(2);
   });
 
   it("keeps stale text readable without offering a new verdict", async () => {

--- a/packages/web/src/components/tasks/document-review-reviewer-panel.tsx
+++ b/packages/web/src/components/tasks/document-review-reviewer-panel.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useRef, useState, useTransition } from "react";
+import { RichMarkdown } from "@/components/markdown/rich-markdown";
+import { API_ROUTES } from "@/lib/api-routes";
+import type { DocumentReviewPanelData } from "@/lib/tasks/document-review.server";
+
+type ReviewerPanel = Extract<DocumentReviewPanelData, { mode: "REVIEWER" }>;
+type Verdict = "APPROVE" | "CHANGES_REQUESTED" | "REJECT" | "ABSTAIN";
+
+const fieldClassName =
+  "w-full rounded-none border border-foreground bg-background px-3 py-2 text-sm text-foreground outline-none focus:ring-2 focus:ring-foreground focus:ring-offset-2 focus:ring-offset-background";
+const primaryButtonClassName =
+  "inline-flex min-h-10 items-center justify-center rounded-none border border-foreground bg-foreground px-4 py-2 text-sm font-semibold text-background disabled:cursor-not-allowed disabled:opacity-50";
+const secondaryButtonClassName =
+  "inline-flex min-h-10 items-center justify-center rounded-none border border-foreground bg-background px-4 py-2 text-sm font-semibold text-foreground disabled:cursor-not-allowed disabled:opacity-50";
+
+const stateLabels: Record<ReviewerPanel["review"]["state"], string> = {
+  ABSTAINED: "Abstained",
+  APPROVED: "Approved",
+  AWAITING_RESPONSE: "Awaiting your review",
+  CHANGES_REQUESTED: "Changes requested",
+  REJECTED: "Rejected",
+  STALE: "Version changed",
+};
+
+const verdictLabels: Record<Verdict, string> = {
+  ABSTAIN: "Abstained",
+  APPROVE: "Approved",
+  CHANGES_REQUESTED: "Changes requested",
+  REJECT: "Rejected",
+};
+
+async function expectOk(response: Response) {
+  const payload = (await response.json().catch(() => null)) as {
+    error?: string;
+  } | null;
+  if (!response.ok) {
+    throw new Error(payload?.error ?? "Could not submit the review.");
+  }
+}
+
+export function DocumentReviewReviewerPanel({
+  panel,
+}: {
+  panel: ReviewerPanel;
+}) {
+  const router = useRouter();
+  const idempotencyKey = useRef<string | null>(null);
+  const [feedback, setFeedback] = useState("");
+  const [busyVerdict, setBusyVerdict] = useState<Verdict | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isRefreshing, startRefresh] = useTransition();
+  const { review } = panel;
+  const isBusy = busyVerdict != null || isRefreshing;
+  const isStale = review.state === "STALE";
+
+  async function submit(verdict: Verdict) {
+    if (isBusy) return;
+    const explanation =
+      verdict === "APPROVE"
+        ? feedback.trim() || "Approved as written."
+        : feedback.trim();
+    if (!explanation) {
+      setError("Explain your decision before submitting it.");
+      return;
+    }
+    setError(null);
+    setBusyVerdict(verdict);
+    idempotencyKey.current ??= `document-review-response:${crypto.randomUUID()}`;
+    try {
+      const response = await fetch(
+        API_ROUTES.tasks.documentReviewResponse(review.reviewTaskId),
+        {
+          body: JSON.stringify({ explanation, verdict }),
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": idempotencyKey.current,
+          },
+          method: "POST",
+        },
+      );
+      await expectOk(response);
+      startRefresh(() => router.refresh());
+    } catch (submitError) {
+      setError(
+        submitError instanceof Error
+          ? submitError.message
+          : "Could not submit the review.",
+      );
+    } finally {
+      setBusyVerdict(null);
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby="document-review-heading"
+      className="border-b border-foreground py-6"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold" id="document-review-heading">
+            {isStale ? "Past review" : "Review this version"}
+          </h2>
+        </div>
+        {review.state === "AWAITING_RESPONSE" ? null : (
+          <span className="text-xs font-semibold uppercase tracking-[0.1em]">
+            {stateLabels[review.state]}
+          </span>
+        )}
+      </div>
+      <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+        {isStale
+          ? "This review closed when a newer revision was created. Your pinned copy remains readable."
+          : "Read the exact text below. Add questions or evidence in the discussion. Then record one decision for this version."}
+      </p>
+
+      <div className="mt-5 border border-foreground p-4">
+        <h3 className="text-sm font-semibold">What to check</h3>
+        <p className="mt-2 whitespace-pre-wrap text-sm">
+          {review.request.instructions}
+        </p>
+      </div>
+
+      <div className="mt-6">
+        <div>
+          <h3 className="text-base font-semibold">{review.target.title}</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Version {review.target.version} · exact text for this review
+          </p>
+        </div>
+        <div className="mt-4 border-y border-foreground py-5">
+          <RichMarkdown markdown={review.target.body} />
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border border-foreground p-4">
+        <p className="text-sm text-muted-foreground">
+          Votes help sort discussion; they do not approve the document.
+        </p>
+        <Link className={secondaryButtonClassName} href="#discussion">
+          Open discussion
+        </Link>
+      </div>
+
+      {review.response && !panel.canSubmit ? (
+        <div className="mt-5 border border-foreground p-4">
+          <h3 className="text-sm font-semibold">Your decision</h3>
+          <p className="mt-2 text-base font-semibold">
+            {verdictLabels[review.response.verdict]}
+          </p>
+          <p className="mt-2 whitespace-pre-wrap text-sm">
+            {review.response.explanation}
+          </p>
+        </div>
+      ) : panel.canSubmit && !isStale ? (
+        <div className="mt-6" id="review-decision">
+          <h3 className="text-base font-semibold">Your decision</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Approval can be one click. Add a note if useful. Other decisions
+            require an explanation.
+          </p>
+          <label className="mt-4 block space-y-1">
+            <span className="text-sm font-semibold">Feedback</span>
+            <textarea
+              className={fieldClassName}
+              onChange={(event) => {
+                setFeedback(event.target.value);
+                setError(null);
+              }}
+              placeholder="What is right, what should change, or why you cannot decide"
+              rows={4}
+              value={feedback}
+            />
+          </label>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              className={primaryButtonClassName}
+              disabled={isBusy}
+              onClick={() => void submit("APPROVE")}
+              type="button"
+            >
+              {busyVerdict === "APPROVE" ? "Submitting…" : "Approve"}
+            </button>
+            <button
+              className={secondaryButtonClassName}
+              disabled={isBusy}
+              onClick={() => void submit("CHANGES_REQUESTED")}
+              type="button"
+            >
+              {busyVerdict === "CHANGES_REQUESTED"
+                ? "Submitting…"
+                : "Request changes"}
+            </button>
+            <details className="relative">
+              <summary className={`${secondaryButtonClassName} cursor-pointer`}>
+                Other decision
+              </summary>
+              <div className="absolute right-0 z-10 mt-1 flex min-w-44 flex-col border border-foreground bg-background p-2">
+                <button
+                  className={secondaryButtonClassName}
+                  disabled={isBusy}
+                  onClick={() => void submit("REJECT")}
+                  type="button"
+                >
+                  Reject
+                </button>
+                <button
+                  className={`${secondaryButtonClassName} mt-2`}
+                  disabled={isBusy}
+                  onClick={() => void submit("ABSTAIN")}
+                  type="button"
+                >
+                  Abstain
+                </button>
+              </div>
+            </details>
+          </div>
+          {error ? (
+            <p
+              className="mt-3 border border-foreground p-3 text-sm"
+              role="alert"
+            >
+              {error}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <details className="mt-5 text-xs text-muted-foreground">
+        <summary className="cursor-pointer font-semibold text-foreground">
+          Integrity details
+        </summary>
+        <dl className="mt-2 grid gap-1 break-all">
+          <div>
+            <dt className="inline font-semibold">Revision: </dt>
+            <dd className="inline">{review.target.revisionId}</dd>
+          </div>
+          <div>
+            <dt className="inline font-semibold">Content hash: </dt>
+            <dd className="inline">{review.target.contentHash}</dd>
+          </div>
+        </dl>
+      </details>
+    </section>
+  );
+}

--- a/packages/web/src/components/tasks/document-review-reviewer-panel.tsx
+++ b/packages/web/src/components/tasks/document-review-reviewer-panel.tsx
@@ -107,6 +107,7 @@ export function DocumentReviewReviewerPanel({
     <section
       aria-labelledby="document-review-heading"
       className="border-b border-foreground py-6"
+      data-document-review-state={isStale ? "stale" : "active"}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>

--- a/packages/web/src/components/tasks/document-review-reviewer-panel.tsx
+++ b/packages/web/src/components/tasks/document-review-reviewer-panel.tsx
@@ -9,6 +9,7 @@ import type { DocumentReviewPanelData } from "@/lib/tasks/document-review.server
 
 type ReviewerPanel = Extract<DocumentReviewPanelData, { mode: "REVIEWER" }>;
 type Verdict = "APPROVE" | "CHANGES_REQUESTED" | "REJECT" | "ABSTAIN";
+type IdempotencyState = { fingerprint: string; key: string };
 
 const fieldClassName =
   "w-full rounded-none border border-foreground bg-background px-3 py-2 text-sm text-foreground outline-none focus:ring-2 focus:ring-foreground focus:ring-offset-2 focus:ring-offset-background";
@@ -48,7 +49,7 @@ export function DocumentReviewReviewerPanel({
   panel: ReviewerPanel;
 }) {
   const router = useRouter();
-  const idempotencyKey = useRef<string | null>(null);
+  const responseIdempotency = useRef<IdempotencyState | null>(null);
   const [feedback, setFeedback] = useState("");
   const [busyVerdict, setBusyVerdict] = useState<Verdict | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -69,15 +70,22 @@ export function DocumentReviewReviewerPanel({
     }
     setError(null);
     setBusyVerdict(verdict);
-    idempotencyKey.current ??= `document-review-response:${crypto.randomUUID()}`;
+    const body = { explanation, verdict };
+    const fingerprint = JSON.stringify(body);
+    if (responseIdempotency.current?.fingerprint !== fingerprint) {
+      responseIdempotency.current = {
+        fingerprint,
+        key: `document-review-response:${crypto.randomUUID()}`,
+      };
+    }
     try {
       const response = await fetch(
         API_ROUTES.tasks.documentReviewResponse(review.reviewTaskId),
         {
-          body: JSON.stringify({ explanation, verdict }),
+          body: JSON.stringify(body),
           headers: {
             "Content-Type": "application/json",
-            "Idempotency-Key": idempotencyKey.current,
+            "Idempotency-Key": responseIdempotency.current.key,
           },
           method: "POST",
         },

--- a/packages/web/src/components/tasks/task-comment-feed.test.tsx
+++ b/packages/web/src/components/tasks/task-comment-feed.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { TaskCommentFeed } from "./task-comment-feed";
+
+function comment({
+  createdAt,
+  id,
+  message,
+  parentCommentId,
+}: {
+  createdAt: string;
+  id: string;
+  message: string;
+  parentCommentId: string | null;
+}) {
+  return {
+    attachments: [],
+    authorUser: {
+      email: null,
+      id: `author-${id}`,
+      person: {
+        displayName: `Author ${id}`,
+        handle: `author-${id}`,
+        id: `person-${id}`,
+        image: null,
+      },
+    },
+    authorUserId: `author-${id}`,
+    citationsJson: null,
+    createdAt,
+    deletedAt: null,
+    downvoteCount: 0,
+    editedAt: null,
+    hiddenByCurator: false,
+    id,
+    mediaUrl: null,
+    message,
+    parentCommentId,
+    path: id,
+    replyCount: 0,
+    taskId: "task-1",
+    upvoteCount: 0,
+    viewerVote: 0 as const,
+    voteScore: 0,
+  };
+}
+
+describe("TaskCommentFeed", () => {
+  it("renders replies at arbitrary depth in chronological sibling order", () => {
+    (globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+    const comments = [
+      comment({
+        createdAt: "2026-01-01T00:04:00.000Z",
+        id: "reply-later",
+        message: "reply-later-marker",
+        parentCommentId: "root",
+      }),
+      comment({
+        createdAt: "2026-01-01T00:06:00.000Z",
+        id: "great-grandchild",
+        message: "great-grandchild-marker",
+        parentCommentId: "grandchild-earlier",
+      }),
+      comment({
+        createdAt: "2026-01-01T00:00:00.000Z",
+        id: "root",
+        message: "root-marker",
+        parentCommentId: null,
+      }),
+      comment({
+        createdAt: "2026-01-01T00:05:00.000Z",
+        id: "grandchild-later",
+        message: "grandchild-later-marker",
+        parentCommentId: "reply-earlier",
+      }),
+      comment({
+        createdAt: "2026-01-01T00:02:00.000Z",
+        id: "reply-earlier",
+        message: "reply-earlier-marker",
+        parentCommentId: "root",
+      }),
+      comment({
+        createdAt: "2026-01-01T00:03:00.000Z",
+        id: "grandchild-earlier",
+        message: "grandchild-earlier-marker",
+        parentCommentId: "reply-earlier",
+      }),
+    ];
+
+    const html = renderToStaticMarkup(
+      <TaskCommentFeed
+        taskId="task-1"
+        initialComments={comments}
+        initialActivities={[]}
+        currentUserId="viewer"
+        currentUserIsAdmin={false}
+        wishoniaUserId={null}
+        signInHref="/api/auth/signin"
+        heading="Discussion"
+      />,
+    );
+
+    expect(html).toContain("Discussion");
+    const expectedDepthFirstOrder = [
+      "root-marker",
+      "reply-earlier-marker",
+      "grandchild-earlier-marker",
+      "great-grandchild-marker",
+      "grandchild-later-marker",
+      "reply-later-marker",
+    ];
+    for (const [index, marker] of expectedDepthFirstOrder.entries()) {
+      expect(html).toContain(marker);
+      if (index > 0) {
+        expect(html.indexOf(expectedDepthFirstOrder[index - 1]!)).toBeLessThan(
+          html.indexOf(marker),
+        );
+      }
+    }
+  });
+});

--- a/packages/web/src/components/tasks/task-comment-feed.test.tsx
+++ b/packages/web/src/components/tasks/task-comment-feed.test.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/markdown/rich-markdown", () => ({
+  RichMarkdown: ({ markdown }: { markdown: string }) => <div>{markdown}</div>,
+}));
+
 import { TaskCommentFeed } from "./task-comment-feed";
 
 function comment({
@@ -48,8 +53,6 @@ function comment({
 
 describe("TaskCommentFeed", () => {
   it("renders replies at arbitrary depth in chronological sibling order", () => {
-    (globalThis as typeof globalThis & { React: typeof React }).React = React;
-
     const comments = [
       comment({
         createdAt: "2026-01-01T00:04:00.000Z",

--- a/packages/web/src/components/tasks/task-comment-feed.tsx
+++ b/packages/web/src/components/tasks/task-comment-feed.tsx
@@ -996,6 +996,7 @@ function CommentNode({
           ) : null}
           <span
             className="text-xs font-bold text-muted-foreground"
+            data-volatile="time"
             suppressHydrationWarning
           >
             · {formatRelative(comment.createdAt)}
@@ -1297,7 +1298,7 @@ function ActivityRow({ activity }: { activity: TaskActivityRow }) {
         <span>@{handle}</span>
       )}
       <span>{label}</span>
-      <span className="ml-auto" suppressHydrationWarning>
+      <span className="ml-auto" data-volatile="time" suppressHydrationWarning>
         {formatRelative(activity.createdAt)}
       </span>
     </div>

--- a/packages/web/src/components/tasks/task-comment-feed.tsx
+++ b/packages/web/src/components/tasks/task-comment-feed.tsx
@@ -2,7 +2,13 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   ArrowDown,
   ArrowUp,

--- a/packages/web/src/components/tasks/task-comment-feed.tsx
+++ b/packages/web/src/components/tasks/task-comment-feed.tsx
@@ -99,6 +99,7 @@ interface TaskCommentFeedProps {
   currentUserIsAdmin: boolean;
   wishoniaUserId: string | null;
   signInHref: string;
+  heading?: string;
 }
 
 type SortMode = "new" | "top";
@@ -239,6 +240,7 @@ export function TaskCommentFeed({
   currentUserIsAdmin,
   wishoniaUserId,
   signInHref,
+  heading = "Updates",
 }: TaskCommentFeedProps) {
   const [comments, setComments] = useState<TaskCommentRow[]>(initialComments);
   const [activities] = useState<TaskActivityRow[]>(initialActivities);
@@ -714,7 +716,7 @@ export function TaskCommentFeed({
   return (
     <section className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-black">Updates</h2>
+        <h2 className="text-xl font-black">{heading}</h2>
         <div className="flex gap-1 text-xs font-bold uppercase">
           <button
             type="button"
@@ -823,6 +825,7 @@ export function TaskCommentFeed({
           <CommentNode
             key={comment.id}
             comment={comment}
+            repliesByParent={threaded.repliesByParent}
             replies={threaded.repliesByParent.get(comment.id) ?? []}
             wishoniaUserId={wishoniaUserId}
             currentUserId={currentUserId}
@@ -895,6 +898,7 @@ export function TaskCommentFeed({
 function CommentNode({
   comment,
   replies,
+  repliesByParent,
   wishoniaUserId,
   currentUserId,
   currentUserIsAdmin,
@@ -914,6 +918,7 @@ function CommentNode({
 }: {
   comment: TaskCommentRow;
   replies: TaskCommentRow[];
+  repliesByParent: Map<string, TaskCommentRow[]>;
   wishoniaUserId: string | null;
   currentUserId: string | null;
   currentUserIsAdmin: boolean;
@@ -946,7 +951,10 @@ function CommentNode({
 
   return (
     <div className={depth > 0 ? "ml-6 border-l-2 border-primary/40 pl-4" : ""}>
-      <article className="border-2 border-primary bg-background p-3">
+      <article
+        className="scroll-mt-24 border-2 border-primary bg-background p-3"
+        id={`comment-${comment.id}`}
+      >
         <header className="mb-2 flex items-center gap-2">
           {personHref ? (
             <Link href={personHref} className="shrink-0">
@@ -980,7 +988,10 @@ function CommentNode({
               Wishonia
             </span>
           ) : null}
-          <span className="text-xs font-bold text-muted-foreground">
+          <span
+            className="text-xs font-bold text-muted-foreground"
+            suppressHydrationWarning
+          >
             · {formatRelative(comment.createdAt)}
           </span>
           {comment.editedAt ? (
@@ -1232,7 +1243,8 @@ function CommentNode({
             <CommentNode
               key={reply.id}
               comment={reply}
-              replies={[]}
+              replies={repliesByParent.get(reply.id) ?? []}
+              repliesByParent={repliesByParent}
               wishoniaUserId={wishoniaUserId}
               currentUserId={currentUserId}
               currentUserIsAdmin={currentUserIsAdmin}
@@ -1279,7 +1291,9 @@ function ActivityRow({ activity }: { activity: TaskActivityRow }) {
         <span>@{handle}</span>
       )}
       <span>{label}</span>
-      <span className="ml-auto">{formatRelative(activity.createdAt)}</span>
+      <span className="ml-auto" suppressHydrationWarning>
+        {formatRelative(activity.createdAt)}
+      </span>
     </div>
   );
 }

--- a/packages/web/src/lib/__tests__/documents.server.test.ts
+++ b/packages/web/src/lib/__tests__/documents.server.test.ts
@@ -10,6 +10,9 @@ const mocks = vi.hoisted(() => ({
   },
   canManageOrganization: vi.fn(),
   canUserViewTask: vi.fn(),
+  getTaskClientAccessWhere: vi.fn(() => ({})),
+  invalidateDocumentReviewsForDocument: vi.fn(),
+  isTaskWithinClientAccessBoundary: vi.fn(() => true),
   prisma: {
     documentCreate: vi.fn(),
     documentFindFirst: vi.fn(),
@@ -48,9 +51,16 @@ vi.mock("@/lib/organization.server", () => ({
   canManageOrganization: mocks.canManageOrganization,
 }));
 
+vi.mock("@/lib/tasks/document-review-invalidation.server", () => ({
+  invalidateDocumentReviewsForDocument:
+    mocks.invalidateDocumentReviewsForDocument,
+}));
+
 vi.mock("@/lib/tasks/task-visibility.server", () => ({
   assertUserCanViewTask: vi.fn(),
   canUserViewTask: mocks.canUserViewTask,
+  getTaskClientAccessWhere: mocks.getTaskClientAccessWhere,
+  isTaskWithinClientAccessBoundary: mocks.isTaskWithinClientAccessBoundary,
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -139,9 +149,12 @@ beforeEach(() => {
   mocks.canManageOrganization.mockResolvedValue(true);
   mocks.canUserViewTask.mockReset();
   mocks.canUserViewTask.mockResolvedValue(true);
+  mocks.invalidateDocumentReviewsForDocument.mockReset();
+  mocks.invalidateDocumentReviewsForDocument.mockResolvedValue(undefined);
   mocks.prisma.taskFindFirst.mockResolvedValue({
     isPublic: true,
     jurisdictionId: "jurisdiction_1",
+    ownerOrganizationId: null,
   });
   mocks.access.assertDocumentAccess.mockResolvedValue("FULL_ACCESS");
   mocks.access.assertValidDocumentParent.mockResolvedValue(undefined);
@@ -195,8 +208,27 @@ describe("stable document reads", () => {
     mocks.prisma.documentFindFirst.mockResolvedValue(DOCUMENT);
     mocks.access.resolveDocumentAccess.mockResolvedValue(null);
 
-    await expect(getDocumentForViewer("document_1", "stranger")).resolves.toBeNull();
+    await expect(
+      getDocumentForViewer("document_1", "stranger"),
+    ).resolves.toBeNull();
     expect(mocks.prisma.documentRevisionFindMany).not.toHaveBeenCalled();
+  });
+
+  it("does not let a personal-scope client read an organization-private revision", async () => {
+    mocks.prisma.documentFindFirst.mockResolvedValue({
+      ...DOCUMENT,
+      organizationId: "organization_1",
+    });
+
+    const result = await getDocumentForViewer("document_1", "counsel_1", {
+      clientAccessBoundary: {
+        allowPersonalPrivate: true,
+        organizationIds: [],
+      },
+    });
+
+    expect(result).toBeNull();
+    expect(mocks.access.resolveDocumentAccess).not.toHaveBeenCalled();
   });
 });
 
@@ -212,7 +244,9 @@ describe("document creation", () => {
       currentRevision: { ...REVISION, id: "revision_new", version: 1 },
     };
     mocks.prisma.documentCreate.mockResolvedValue({ id: created.id });
-    mocks.prisma.documentRevisionCreate.mockResolvedValue({ id: "revision_new" });
+    mocks.prisma.documentRevisionCreate.mockResolvedValue({
+      id: "revision_new",
+    });
     mocks.prisma.documentUpdate.mockResolvedValue(created);
     mocks.prisma.documentFindFirst.mockResolvedValue(created);
 
@@ -281,7 +315,7 @@ describe("optimistic document updates", () => {
     expect(mocks.prisma.transaction).not.toHaveBeenCalled();
   });
 
-  it("claims the expected version and appends an immutable revision", async () => {
+  it("appends a revision and stales prior exact-revision reviews", async () => {
     const nextRevision = {
       ...REVISION,
       id: "revision_4",
@@ -298,7 +332,9 @@ describe("optimistic document updates", () => {
       .mockResolvedValueOnce(DOCUMENT)
       .mockResolvedValueOnce(updatedDocument);
     mocks.prisma.documentUpdateMany.mockResolvedValue({ count: 1 });
-    mocks.prisma.documentRevisionCreate.mockResolvedValue({ id: nextRevision.id });
+    mocks.prisma.documentRevisionCreate.mockResolvedValue({
+      id: nextRevision.id,
+    });
     mocks.prisma.documentUpdate.mockResolvedValue(updatedDocument);
 
     const result = await updateDocument({
@@ -320,7 +356,28 @@ describe("optimistic document updates", () => {
       }),
       select: { id: true },
     });
+    expect(mocks.invalidateDocumentReviewsForDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ document: expect.any(Object) }),
+      DOCUMENT.id,
+    );
     expect(result.revision.id).toBe("revision_4");
+  });
+
+  it("does not stale reviews when the optimistic version claim loses a race", async () => {
+    mocks.prisma.documentFindFirst.mockResolvedValue(DOCUMENT);
+    mocks.prisma.documentUpdateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      updateDocument({
+        body: "New body",
+        documentId: DOCUMENT.id,
+        editorUserId: "user_1",
+        expectedVersion: 3,
+      }),
+    ).rejects.toThrow(DOCUMENT_CONFLICT_MESSAGE);
+
+    expect(mocks.prisma.documentRevisionCreate).not.toHaveBeenCalled();
+    expect(mocks.invalidateDocumentReviewsForDocument).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/lib/__tests__/documents.server.test.ts
+++ b/packages/web/src/lib/__tests__/documents.server.test.ts
@@ -12,7 +12,9 @@ const mocks = vi.hoisted(() => ({
   canUserViewTask: vi.fn(),
   getTaskClientAccessWhere: vi.fn(() => ({})),
   invalidateDocumentReviewsForDocument: vi.fn(),
-  isTaskWithinClientAccessBoundary: vi.fn(() => true),
+  isTaskWithinClientAccessBoundary: vi.fn(
+    (_task: unknown, _boundary: unknown) => true,
+  ),
   prisma: {
     documentCreate: vi.fn(),
     documentFindFirst: vi.fn(),
@@ -24,6 +26,7 @@ const mocks = vi.hoisted(() => ({
     documentUpdate: vi.fn(),
     documentUpdateMany: vi.fn(),
     taskFindFirst: vi.fn(),
+    taskFindMany: vi.fn(),
     transaction: vi.fn(),
   },
 }));
@@ -79,7 +82,10 @@ vi.mock("@/lib/prisma", () => ({
       findFirst: mocks.prisma.documentRevisionFindFirst,
       findMany: mocks.prisma.documentRevisionFindMany,
     },
-    task: { findFirst: mocks.prisma.taskFindFirst },
+    task: {
+      findFirst: mocks.prisma.taskFindFirst,
+      findMany: mocks.prisma.taskFindMany,
+    },
   },
 }));
 
@@ -151,6 +157,8 @@ beforeEach(() => {
   mocks.canUserViewTask.mockResolvedValue(true);
   mocks.invalidateDocumentReviewsForDocument.mockReset();
   mocks.invalidateDocumentReviewsForDocument.mockResolvedValue(undefined);
+  mocks.isTaskWithinClientAccessBoundary.mockReset();
+  mocks.isTaskWithinClientAccessBoundary.mockReturnValue(true);
   mocks.prisma.taskFindFirst.mockResolvedValue({
     isPublic: true,
     jurisdictionId: "jurisdiction_1",
@@ -448,5 +456,96 @@ describe("document boundaries", () => {
       ["visible", "private"],
       null,
     );
+  });
+
+  it("batch-checks task boundaries for an unfiltered document list", async () => {
+    mocks.prisma.documentFindMany.mockResolvedValue([
+      {
+        id: "allowed",
+        organizationId: null,
+        taskId: "task_allowed",
+        title: "Allowed",
+        updatedAt: DOCUMENT.updatedAt,
+        version: 1,
+        visibility: "PRIVATE",
+      },
+      {
+        id: "blocked",
+        organizationId: null,
+        taskId: "task_blocked",
+        title: "Blocked",
+        updatedAt: DOCUMENT.updatedAt,
+        version: 1,
+        visibility: "PRIVATE",
+      },
+    ]);
+    mocks.prisma.taskFindMany.mockResolvedValue([
+      {
+        id: "task_allowed",
+        isPublic: false,
+        ownerOrganizationId: "organization_allowed",
+      },
+      {
+        id: "task_blocked",
+        isPublic: false,
+        ownerOrganizationId: "organization_blocked",
+      },
+    ]);
+    mocks.isTaskWithinClientAccessBoundary.mockImplementation(
+      (task: unknown) => (task as { id: string }).id === "task_allowed",
+    );
+    mocks.access.resolveDocumentAccessBatch.mockResolvedValue(
+      new Map([
+        ["allowed", "VIEW"],
+        ["blocked", "VIEW"],
+      ]),
+    );
+
+    const result = await listDocumentsForViewer({
+      clientAccessBoundary: {
+        allowPersonalPrivate: false,
+        organizationIds: ["organization_allowed"],
+      },
+      userId: "viewer_1",
+    });
+
+    expect(result.map((row) => row.id)).toEqual(["allowed"]);
+    expect(mocks.prisma.taskFindMany).toHaveBeenCalledOnce();
+    expect(mocks.prisma.taskFindMany).toHaveBeenCalledWith({
+      where: {
+        deletedAt: null,
+        id: { in: ["task_allowed", "task_blocked"] },
+      },
+      select: { id: true, isPublic: true, ownerOrganizationId: true },
+    });
+  });
+
+  it("keeps organization boundaries on a task-filtered document list", async () => {
+    mocks.prisma.documentFindMany.mockResolvedValue([
+      {
+        id: "organization-private",
+        organizationId: "organization_blocked",
+        taskId: "task_1",
+        title: "Organization private",
+        updatedAt: DOCUMENT.updatedAt,
+        version: 1,
+        visibility: "PRIVATE",
+      },
+    ]);
+    mocks.access.resolveDocumentAccessBatch.mockResolvedValue(
+      new Map([["organization-private", "VIEW"]]),
+    );
+
+    const result = await listDocumentsForViewer({
+      clientAccessBoundary: {
+        allowPersonalPrivate: true,
+        organizationIds: [],
+      },
+      taskId: "task_1",
+      userId: "viewer_1",
+    });
+
+    expect(result).toEqual([]);
+    expect(mocks.prisma.taskFindMany).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/lib/__tests__/documents.server.test.ts
+++ b/packages/web/src/lib/__tests__/documents.server.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   canManageOrganization: vi.fn(),
   canUserViewTask: vi.fn(),
   getTaskClientAccessWhere: vi.fn(() => ({})),
+  hasDocumentGovernanceHistory: vi.fn(),
   invalidateDocumentReviewsForDocument: vi.fn(),
   isTaskWithinClientAccessBoundary: vi.fn(
     (_task: unknown, _boundary: unknown) => true,
@@ -55,6 +56,7 @@ vi.mock("@/lib/organization.server", () => ({
 }));
 
 vi.mock("@/lib/tasks/document-review-invalidation.server", () => ({
+  hasDocumentGovernanceHistory: mocks.hasDocumentGovernanceHistory,
   invalidateDocumentReviewsForDocument:
     mocks.invalidateDocumentReviewsForDocument,
 }));
@@ -155,6 +157,8 @@ beforeEach(() => {
   mocks.canManageOrganization.mockResolvedValue(true);
   mocks.canUserViewTask.mockReset();
   mocks.canUserViewTask.mockResolvedValue(true);
+  mocks.hasDocumentGovernanceHistory.mockReset();
+  mocks.hasDocumentGovernanceHistory.mockResolvedValue(false);
   mocks.invalidateDocumentReviewsForDocument.mockReset();
   mocks.invalidateDocumentReviewsForDocument.mockResolvedValue(undefined);
   mocks.isTaskWithinClientAccessBoundary.mockReset();
@@ -386,6 +390,30 @@ describe("optimistic document updates", () => {
 
     expect(mocks.prisma.documentRevisionCreate).not.toHaveBeenCalled();
     expect(mocks.invalidateDocumentReviewsForDocument).not.toHaveBeenCalled();
+  });
+
+  it("does not relink a document after review or decision history exists", async () => {
+    mocks.prisma.documentFindFirst.mockResolvedValue(DOCUMENT);
+    mocks.hasDocumentGovernanceHistory.mockResolvedValue(true);
+
+    await expect(
+      updateDocument({
+        documentId: DOCUMENT.id,
+        editorUserId: "user_1",
+        expectedVersion: 3,
+        taskId: "task_2",
+      }),
+    ).rejects.toThrow(
+      "Documents with review or decision history cannot be linked to another task",
+    );
+
+    expect(mocks.hasDocumentGovernanceHistory).toHaveBeenCalledWith(
+      expect.objectContaining({ document: expect.any(Object) }),
+      DOCUMENT.id,
+      "task_1",
+    );
+    expect(mocks.prisma.documentUpdateMany).not.toHaveBeenCalled();
+    expect(mocks.prisma.documentRevisionCreate).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -27,6 +27,7 @@ import {
   TaskStatus,
 } from "@optimitron/db/enums";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DOCUMENT_REVIEW_TASK_KEY_PREFIX } from "../tasks/document-review-contracts";
 
 const mocks = vi.hoisted(() => ({
   listTasks: vi.fn(),
@@ -3823,6 +3824,31 @@ describe("MCP server tool dispatch", () => {
       expect(mocks.taskCreate).not.toHaveBeenCalled();
     });
 
+    it("reserves document review task keys from proposal bundles", async () => {
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "proposeTaskBundle",
+        arguments: {
+          candidates: [
+            {
+              description: "A generic proposal cannot impersonate a review.",
+              estimatedEffortHours: 1,
+              parentTaskRef: "$target-root",
+              taskKey: `${DOCUMENT_REVIEW_TASK_KEY_PREFIX}authority:revision:reviewer`,
+              title: "Spoofed document review",
+            },
+          ],
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).message).toContain(
+        "reserved document-review namespace",
+      );
+      expect(mocks.taskFindFirst).not.toHaveBeenCalled();
+      expect(mocks.taskCreate).not.toHaveBeenCalled();
+    });
+
     it("reuses a source-identical proposal instead of creating another draft", async () => {
       mocks.taskFindFirst.mockImplementation(
         (args: { where?: { taskKey?: string } }) =>
@@ -4236,6 +4262,23 @@ describe("MCP server tool dispatch", () => {
     });
 
     describe("createTask required-field validation", () => {
+      it("reserves document review task keys for requestDocumentReview", async () => {
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "createTask",
+          arguments: makeCreateTaskArguments({
+            taskKey: `${DOCUMENT_REVIEW_TASK_KEY_PREFIX}authority:revision:reviewer`,
+          }),
+        });
+
+        expect(result.isError).toBe(true);
+        expect(parseToolBody(result).message).toContain(
+          "Use requestDocumentReview",
+        );
+        expect(mocks.taskFindFirst).not.toHaveBeenCalled();
+        expect(mocks.taskCreate).not.toHaveBeenCalled();
+      });
+
       it("rejects when description is missing", async () => {
         const client = await setup("user-1", ALL_SCOPES);
         const result = await client.callTool({
@@ -5439,6 +5482,52 @@ describe("MCP server tool dispatch", () => {
       expect(parseToolBody(result).message).toContain(
         "Updating public tasks requires an admin user",
       );
+      expect(mocks.taskUpdate).not.toHaveBeenCalled();
+    });
+
+    it("rejects generic admin updates to document review tasks", async () => {
+      mocks.getTaskDetailData.mockResolvedValue(null);
+      mocks.taskFindFirst.mockResolvedValue(
+        makeCreatedTask({
+          id: "review-task",
+          isPublic: true,
+          taskKey: `${DOCUMENT_REVIEW_TASK_KEY_PREFIX}authority-1:revision-1:reviewer-1`,
+        }),
+      );
+
+      const client = await setup("admin-1", [McpScope.TASKS_ADMIN], {
+        isAdmin: true,
+      });
+      const result = await client.callTool({
+        name: "updateTask",
+        arguments: { taskId: "review-task", title: "Nope" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).message).toBe(
+        "Document review tasks can only be changed through document review operations.",
+      );
+      expect(mocks.taskUpdate).not.toHaveBeenCalled();
+      expect(mocks.canUserManageTask).not.toHaveBeenCalled();
+    });
+
+    it("rejects changing an ordinary task into a document review task", async () => {
+      const client = await setup("admin-1", [McpScope.TASKS_ADMIN], {
+        isAdmin: true,
+      });
+      const result = await client.callTool({
+        name: "updateTask",
+        arguments: {
+          taskId: "ordinary-task",
+          taskKey: `${DOCUMENT_REVIEW_TASK_KEY_PREFIX}authority:revision:reviewer`,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).message).toContain(
+        "Use requestDocumentReview",
+      );
+      expect(mocks.getTaskDetailData).not.toHaveBeenCalled();
       expect(mocks.taskUpdate).not.toHaveBeenCalled();
     });
 

--- a/packages/web/src/lib/__tests__/mcp-tool-catalog.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-tool-catalog.test.ts
@@ -29,6 +29,7 @@ describe("MCP tool catalog", () => {
     for (const name of [
       "createDocumentProposal",
       "applyDocumentProposal",
+      "getDocumentReview",
       "requestDocumentReview",
       "submitDocumentReview",
       "decideDocumentRevision",

--- a/packages/web/src/lib/__tests__/mcp-tool-catalog.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-tool-catalog.test.ts
@@ -23,12 +23,27 @@ describe("MCP tool catalog", () => {
     }
   });
 
+  it("registers the complete governance review transport", () => {
+    const registered = new Set(getToolDefinitions().map((tool) => tool.name));
+
+    for (const name of [
+      "createDocumentProposal",
+      "applyDocumentProposal",
+      "requestDocumentReview",
+      "submitDocumentReview",
+      "decideDocumentRevision",
+    ]) {
+      expect(registered.has(name)).toBe(true);
+    }
+  });
+
   it("only references real tools in the server instructions", () => {
     // The docs-drift class this prevents: MCP_SERVER.md once documented a
     // phantom updateMilestone tool. Instructions ship to every client on
     // initialize, so every backticked-or-bare tool mention must exist.
     const registered = new Set(getToolDefinitions().map((tool) => tool.name));
-    const mentioned = MCP_SERVER_INSTRUCTIONS.match(/\bget[A-Z]\w+|\b[a-z]+[A-Z]\w+/g) ?? [];
+    const mentioned =
+      MCP_SERVER_INSTRUCTIONS.match(/\bget[A-Z]\w+|\b[a-z]+[A-Z]\w+/g) ?? [];
     const phantom = [...new Set(mentioned)].filter(
       (word) =>
         /^(get|list|create|update|propose|post|claim|complete|search|record|upsert|respond|fire|evaluate)[A-Z]/.test(

--- a/packages/web/src/lib/__tests__/task-visibility.server.test.ts
+++ b/packages/web/src/lib/__tests__/task-visibility.server.test.ts
@@ -1,4 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@optimitron/db";
+import {
+  DOCUMENT_REVIEW_CONTEXT_KEY,
+  DOCUMENT_REVIEW_TASK_KEY_PREFIX,
+} from "@/lib/tasks/document-review-contracts";
+
+const DOCUMENT_REVIEW_REQUEST_SCHEMA = "optimitron.review-request.v1";
 
 const mocks = vi.hoisted(() => ({
   prisma: {
@@ -153,10 +160,7 @@ describe("getTaskVisibilityWhere", () => {
           ],
         },
         {
-          OR: [
-            { createdByUserId: "user_1" },
-            { assigneePersonId: "person_1" },
-          ],
+          OR: [{ createdByUserId: "user_1" }, { assigneePersonId: "person_1" }],
         },
       ],
     });
@@ -166,10 +170,16 @@ describe("getTaskVisibilityWhere", () => {
     // Walk the where tree and collect membership role filters so the
     // assertion targets the actual query constraint, not string rendering.
     const collectMembershipRoleFilters = (node: unknown): string[][] => {
-      if (Array.isArray(node)) return node.flatMap(collectMembershipRoleFilters);
+      if (Array.isArray(node))
+        return node.flatMap(collectMembershipRoleFilters);
       if (!node || typeof node !== "object") return [];
       return Object.entries(node).flatMap(([key, value]) => {
-        if (key === "role" && value && typeof value === "object" && "in" in value) {
+        if (
+          key === "role" &&
+          value &&
+          typeof value === "object" &&
+          "in" in value
+        ) {
           return [[...(value as { in: string[] }).in]];
         }
         return collectMembershipRoleFilters(value);
@@ -189,8 +199,12 @@ describe("getTaskVisibilityWhere", () => {
       userId: "viewer_1",
     });
 
-    // READ membership is unfiltered by role (viewers may read).
-    expect(collectMembershipRoleFilters(readable)).toEqual([]);
+    // Ordinary members can read ordinary tasks, but only organization
+    // managers can read service-managed review tasks through membership.
+    for (const roles of collectMembershipRoleFilters(readable)) {
+      expect(roles).toEqual(["OWNER", "ADMIN"]);
+    }
+    expect(JSON.stringify(readable)).toContain(DOCUMENT_REVIEW_TASK_KEY_PREFIX);
     for (const roles of collectMembershipRoleFilters(executable)) {
       expect(roles).toEqual(["OWNER", "ADMIN", "MEMBER"]);
     }
@@ -199,6 +213,93 @@ describe("getTaskVisibilityWhere", () => {
     }
     expect(collectMembershipRoleFilters(executable)).not.toHaveLength(0);
     expect(collectMembershipRoleFilters(manageable)).not.toHaveLength(0);
+  });
+
+  it("classifies a task as a document review only when its key and signed context agree", () => {
+    const executable = getTaskAccessWhere({
+      action: "EXECUTE",
+      personId: "reviewer_person",
+      userId: "reviewer_user",
+    });
+
+    expect(executable.AND).toContainEqual({
+      OR: [
+        { taskKey: null },
+        {
+          taskKey: {
+            not: { startsWith: DOCUMENT_REVIEW_TASK_KEY_PREFIX },
+          },
+        },
+        {
+          AND: [
+            {
+              taskKey: {
+                startsWith: DOCUMENT_REVIEW_TASK_KEY_PREFIX,
+              },
+            },
+            {
+              OR: [
+                { contextJson: { equals: Prisma.DbNull } },
+                {
+                  contextJson: {
+                    equals: Prisma.AnyNull,
+                    path: [DOCUMENT_REVIEW_CONTEXT_KEY, "schema"],
+                  },
+                },
+                {
+                  NOT: {
+                    contextJson: {
+                      equals: DOCUMENT_REVIEW_REQUEST_SCHEMA,
+                      path: [DOCUMENT_REVIEW_CONTEXT_KEY, "schema"],
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it.each(["EXECUTE", "MANAGE", "VERIFY"] as const)(
+    "blocks generic %s access to document review tasks",
+    (action) => {
+      const where = getTaskAccessWhere({
+        action,
+        personId: "reviewer_person",
+        userId: "reviewer_user",
+      });
+
+      expect(JSON.stringify(where)).toContain(DOCUMENT_REVIEW_TASK_KEY_PREFIX);
+      expect(JSON.stringify(where)).toContain(DOCUMENT_REVIEW_REQUEST_SCHEMA);
+    },
+  );
+
+  it("keeps review tasks readable and commentable by direct collaborators", () => {
+    const readable = getTaskAccessWhere({
+      action: "READ",
+      personId: "reviewer_person",
+      userId: "reviewer_user",
+    });
+    const commentable = getTaskAccessWhere({
+      action: "COMMENT",
+      personId: "reviewer_person",
+      userId: "reviewer_user",
+    });
+
+    expect(readable).toMatchObject({
+      OR: expect.arrayContaining([
+        { createdByUserId: "reviewer_user" },
+        { assigneePersonId: "reviewer_person" },
+      ]),
+    });
+    expect(commentable).toMatchObject({
+      OR: expect.arrayContaining([
+        { createdByUserId: "reviewer_user" },
+        { assigneePersonId: "reviewer_person" },
+      ]),
+    });
   });
 
   it("defaults to public-only when no visibility is given", () => {

--- a/packages/web/src/lib/__tests__/task-visibility.server.test.ts
+++ b/packages/web/src/lib/__tests__/task-visibility.server.test.ts
@@ -201,7 +201,9 @@ describe("getTaskVisibilityWhere", () => {
 
     // Ordinary members can read ordinary tasks, but only organization
     // managers can read service-managed review tasks through membership.
-    for (const roles of collectMembershipRoleFilters(readable)) {
+    const readableRoleFilters = collectMembershipRoleFilters(readable);
+    expect(readableRoleFilters).not.toHaveLength(0);
+    for (const roles of readableRoleFilters) {
       expect(roles).toEqual(["OWNER", "ADMIN"]);
     }
     expect(JSON.stringify(readable)).toContain(DOCUMENT_REVIEW_TASK_KEY_PREFIX);

--- a/packages/web/src/lib/api-routes.ts
+++ b/packages/web/src/lib/api-routes.ts
@@ -31,6 +31,14 @@ export const API_ROUTES = {
     applications: (id: string) => `/api/tasks/${id}/applications`,
     application: (id: string, applicationId: string) =>
       `/api/tasks/${id}/applications/${applicationId}`,
+    documentReviews: (taskId: string) =>
+      `/api/tasks/${taskId}/document-reviews`,
+    documentReviewResponse: (reviewTaskId: string) =>
+      `/api/tasks/${reviewTaskId}/document-reviews/response`,
+    documentReviewProposal: (authorityTaskId: string) =>
+      `/api/tasks/${authorityTaskId}/document-reviews/proposal`,
+    documentReviewDecision: (authorityTaskId: string) =>
+      `/api/tasks/${authorityTaskId}/document-reviews/decision`,
   },
   documents: {
     root: "/api/documents",

--- a/packages/web/src/lib/documents.server.ts
+++ b/packages/web/src/lib/documents.server.ts
@@ -12,7 +12,10 @@ import {
 } from "@/lib/content-access.server";
 import { canManageOrganization } from "@/lib/organization.server";
 import { prisma } from "@/lib/prisma";
-import { invalidateDocumentReviewsForDocument } from "@/lib/tasks/document-review-invalidation.server";
+import {
+  hasDocumentGovernanceHistory,
+  invalidateDocumentReviewsForDocument,
+} from "@/lib/tasks/document-review-invalidation.server";
 import type { TaskClientAccessBoundary } from "@/lib/tasks/task-visibility.server";
 
 export const DOCUMENT_NOT_FOUND_MESSAGE = "Document not found";
@@ -191,12 +194,13 @@ function clientCanAccessOrganization(
   );
 }
 
-async function isDocumentWithinClientAccessBoundary(
+export async function isDocumentWithinClientAccessBoundary(
   document: Pick<
     DocumentWithCurrentRevision,
     "organizationId" | "taskId" | "visibility"
   >,
   boundary?: TaskClientAccessBoundary,
+  db: Pick<Prisma.TransactionClient, "task"> = prisma,
 ): Promise<boolean> {
   if (!boundary || document.visibility === ContentVisibility.PUBLIC) {
     return true;
@@ -206,7 +210,7 @@ async function isDocumentWithinClientAccessBoundary(
   }
   if (!document.taskId) return boundary.allowPersonalPrivate;
 
-  const task = await prisma.task.findFirst({
+  const task = await db.task.findFirst({
     where: { deletedAt: null, id: document.taskId },
     select: { isPublic: true, ownerOrganizationId: true },
   });
@@ -731,6 +735,14 @@ export async function updateDocument(
           input.editorUserId,
           ContentAccessLevel.EDIT,
           tx,
+        );
+      }
+      if (
+        taskId !== current.taskId &&
+        (await hasDocumentGovernanceHistory(tx, current.id, current.taskId))
+      ) {
+        throw new Error(
+          "Documents with review or decision history cannot be linked to another task",
         );
       }
     } catch (error) {

--- a/packages/web/src/lib/documents.server.ts
+++ b/packages/web/src/lib/documents.server.ts
@@ -12,6 +12,8 @@ import {
 } from "@/lib/content-access.server";
 import { canManageOrganization } from "@/lib/organization.server";
 import { prisma } from "@/lib/prisma";
+import { invalidateDocumentReviewsForDocument } from "@/lib/tasks/document-review-invalidation.server";
+import type { TaskClientAccessBoundary } from "@/lib/tasks/task-visibility.server";
 
 export const DOCUMENT_NOT_FOUND_MESSAGE = "Document not found";
 export const DOCUMENT_EMPTY_PATCH_MESSAGE =
@@ -68,6 +70,7 @@ export interface DocumentSummary {
   effectivePermission: ContentAccessLevel;
   id: string;
   organizationId: string | null;
+  revisionId: string | null;
   taskId: string | null;
   title: string;
   updatedAt: string;
@@ -143,23 +146,101 @@ async function assertDocumentAccessOrNotFound(
 }
 
 async function assertTaskLink(input: {
+  clientAccessBoundary?: TaskClientAccessBoundary;
   taskId: string | null;
   userId: string;
   visibility: ContentVisibility;
-}): Promise<{ jurisdictionId: string | null } | null> {
+}): Promise<{
+  isPublic: boolean;
+  jurisdictionId: string | null;
+  ownerOrganizationId: string | null;
+} | null> {
   if (!input.taskId) return null;
-  const { assertUserCanViewTask } =
+  const { assertUserCanViewTask, getTaskClientAccessWhere } =
     await import("@/lib/tasks/task-visibility.server");
   await assertUserCanViewTask(input.taskId, input.userId);
   const task = await prisma.task.findFirst({
-    where: { id: input.taskId, deletedAt: null },
-    select: { isPublic: true, jurisdictionId: true },
+    where: input.clientAccessBoundary
+      ? {
+          AND: [
+            { id: input.taskId, deletedAt: null },
+            getTaskClientAccessWhere(input.clientAccessBoundary),
+          ],
+        }
+      : { id: input.taskId, deletedAt: null },
+    select: {
+      isPublic: true,
+      jurisdictionId: true,
+      ownerOrganizationId: true,
+    },
   });
   if (!task) throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
   if (input.visibility === ContentVisibility.PUBLIC && !task.isPublic) {
     throw new Error(DOCUMENT_PRIVATE_TASK_MESSAGE);
   }
   return task;
+}
+
+function clientCanAccessOrganization(
+  organizationId: string,
+  boundary: TaskClientAccessBoundary,
+): boolean {
+  return (
+    boundary.organizationIds === null ||
+    boundary.organizationIds.includes(organizationId)
+  );
+}
+
+async function isDocumentWithinClientAccessBoundary(
+  document: Pick<
+    DocumentWithCurrentRevision,
+    "organizationId" | "taskId" | "visibility"
+  >,
+  boundary?: TaskClientAccessBoundary,
+): Promise<boolean> {
+  if (!boundary || document.visibility === ContentVisibility.PUBLIC) {
+    return true;
+  }
+  if (document.organizationId) {
+    return clientCanAccessOrganization(document.organizationId, boundary);
+  }
+  if (!document.taskId) return boundary.allowPersonalPrivate;
+
+  const task = await prisma.task.findFirst({
+    where: { deletedAt: null, id: document.taskId },
+    select: { isPublic: true, ownerOrganizationId: true },
+  });
+  if (!task) return false;
+  const { isTaskWithinClientAccessBoundary } =
+    await import("@/lib/tasks/task-visibility.server");
+  return isTaskWithinClientAccessBoundary(task, boundary);
+}
+
+async function assertDocumentCreationWithinClientAccessBoundary(input: {
+  boundary?: TaskClientAccessBoundary;
+  organizationId: string | null;
+  task: {
+    isPublic: boolean;
+    ownerOrganizationId: string | null;
+  } | null;
+  visibility: ContentVisibility;
+}): Promise<void> {
+  if (!input.boundary || input.visibility === ContentVisibility.PUBLIC) return;
+  if (input.organizationId) {
+    if (clientCanAccessOrganization(input.organizationId, input.boundary)) {
+      return;
+    }
+    throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
+  }
+  if (input.task) {
+    const { isTaskWithinClientAccessBoundary } =
+      await import("@/lib/tasks/task-visibility.server");
+    if (isTaskWithinClientAccessBoundary(input.task, input.boundary)) return;
+    throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
+  }
+  if (!input.boundary.allowPersonalPrivate) {
+    throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
+  }
 }
 
 async function assertOrganizationOwner(
@@ -234,10 +315,19 @@ export function toDocumentDto(view: DocumentView): DocumentDto {
 }
 
 async function buildDocumentView(input: {
+  clientAccessBoundary?: TaskClientAccessBoundary;
   document: DocumentWithCurrentRevision;
   revision: NonNullable<DocumentWithCurrentRevision["currentRevision"]>;
   userId: string | null;
 }): Promise<DocumentView | null> {
+  if (
+    !(await isDocumentWithinClientAccessBoundary(
+      input.document,
+      input.clientAccessBoundary,
+    ))
+  ) {
+    return null;
+  }
   const effectivePermission = await resolveDocumentAccess(
     input.document.id,
     input.userId,
@@ -245,7 +335,10 @@ async function buildDocumentView(input: {
   if (!effectivePermission) return null;
 
   const versions = await prisma.documentRevision.findMany({
-    where: { documentId: input.document.id, deletedAt: null },
+    where: {
+      documentId: input.document.id,
+      deletedAt: null,
+    },
     orderBy: { version: "desc" },
     select: { id: true, version: true, title: true, createdAt: true },
   });
@@ -287,27 +380,35 @@ async function buildDocumentView(input: {
 export async function getDocumentForViewer(
   documentOrRevisionId: string,
   userId?: string | null,
+  options: { clientAccessBoundary?: TaskClientAccessBoundary } = {},
 ): Promise<DocumentView | null> {
   const loaded = await loadDocumentAndRevision(documentOrRevisionId);
   if (!loaded) return null;
-  return buildDocumentView({ ...loaded, userId: userId?.trim() || null });
+  return buildDocumentView({
+    ...loaded,
+    clientAccessBoundary: options.clientAccessBoundary,
+    userId: userId?.trim() || null,
+  });
 }
 
-export async function createDocument(input: {
-  body: string;
-  createdByUserId: string;
-  idempotencyKey?: string | null;
-  jurisdictionId?: string | null;
-  organizationId?: string | null;
-  parentDocumentId?: string | null;
-  requestHash?: string | null;
-  sourceArtifactId?: string | null;
-  sourceKey?: string | null;
-  sourceUrl?: string | null;
-  taskId?: string | null;
-  title: string;
-  visibility?: ContentVisibility | null;
-}): Promise<DocumentView> {
+export async function createDocument(
+  input: {
+    body: string;
+    createdByUserId: string;
+    idempotencyKey?: string | null;
+    jurisdictionId?: string | null;
+    organizationId?: string | null;
+    parentDocumentId?: string | null;
+    requestHash?: string | null;
+    sourceArtifactId?: string | null;
+    sourceKey?: string | null;
+    sourceUrl?: string | null;
+    taskId?: string | null;
+    title: string;
+    visibility?: ContentVisibility | null;
+  },
+  options: { clientAccessBoundary?: TaskClientAccessBoundary } = {},
+): Promise<DocumentView> {
   const title = input.title.trim();
   const body = input.body;
   validateTitleAndBody(title, body);
@@ -325,7 +426,12 @@ export async function createDocument(input: {
   );
 
   const [task] = await Promise.all([
-    assertTaskLink({ taskId, userId: input.createdByUserId, visibility }),
+    assertTaskLink({
+      clientAccessBoundary: options.clientAccessBoundary,
+      taskId,
+      userId: input.createdByUserId,
+      visibility,
+    }),
     assertOrganizationOwner({
       organizationId,
       userId: input.createdByUserId,
@@ -338,6 +444,12 @@ export async function createDocument(input: {
         )
       : Promise.resolve(null),
   ]);
+  await assertDocumentCreationWithinClientAccessBoundary({
+    boundary: options.clientAccessBoundary,
+    organizationId,
+    task,
+    visibility,
+  });
 
   const jurisdictionId =
     normalizeOptional(input.jurisdictionId) ?? task?.jurisdictionId ?? null;
@@ -392,7 +504,11 @@ export async function createDocument(input: {
     if (existing.requestHash !== requestHash) {
       throw new Error(DOCUMENT_IDEMPOTENCY_CONFLICT_MESSAGE);
     }
-    const view = await getDocumentForViewer(existing.id, input.createdByUserId);
+    const view = await getDocumentForViewer(
+      existing.id,
+      input.createdByUserId,
+      options,
+    );
     if (!view) throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
     return view;
   };
@@ -464,25 +580,32 @@ export async function createDocument(input: {
     return returnExisting(raced);
   }
 
-  const view = await getDocumentForViewer(documentId, input.createdByUserId);
+  const view = await getDocumentForViewer(
+    documentId,
+    input.createdByUserId,
+    options,
+  );
   if (!view) throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
   return view;
 }
 
-export async function updateDocument(input: {
-  body?: string | null;
-  documentId: string;
-  editorUserId: string;
-  expectedVersion: number;
-  organizationId?: string | null;
-  parentDocumentId?: string | null;
-  requestHash?: string | null;
-  sourceArtifactId?: string | null;
-  sourceUrl?: string | null;
-  taskId?: string | null;
-  title?: string | null;
-  visibility?: ContentVisibility | null;
-}): Promise<DocumentView> {
+export async function updateDocument(
+  input: {
+    body?: string | null;
+    documentId: string;
+    editorUserId: string;
+    expectedVersion: number;
+    organizationId?: string | null;
+    parentDocumentId?: string | null;
+    requestHash?: string | null;
+    sourceArtifactId?: string | null;
+    sourceUrl?: string | null;
+    taskId?: string | null;
+    title?: string | null;
+    visibility?: ContentVisibility | null;
+  },
+  options: { clientAccessBoundary?: TaskClientAccessBoundary } = {},
+): Promise<DocumentView> {
   const hasContentPatch = input.title != null || input.body != null;
   const hasMetadataPatch =
     input.visibility != null ||
@@ -499,6 +622,19 @@ export async function updateDocument(input: {
     throw new Error("expectedVersion must be a positive integer");
   }
 
+  const current = await prisma.document.findFirst({
+    where: { id: input.documentId, deletedAt: null },
+    include: documentInclude,
+  });
+  if (!current?.currentRevision) throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
+  if (
+    !(await isDocumentWithinClientAccessBoundary(
+      current,
+      options.clientAccessBoundary,
+    ))
+  ) {
+    throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
+  }
   await assertDocumentAccessOrNotFound(
     input.documentId,
     input.editorUserId,
@@ -506,12 +642,6 @@ export async function updateDocument(input: {
       ? ContentAccessLevel.FULL_ACCESS
       : ContentAccessLevel.EDIT_CONTENT,
   );
-
-  const current = await prisma.document.findFirst({
-    where: { id: input.documentId, deletedAt: null },
-    include: documentInclude,
-  });
-  if (!current?.currentRevision) throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
   if (current.version !== input.expectedVersion) {
     throw new Error(DOCUMENT_CONFLICT_MESSAGE);
   }
@@ -543,8 +673,13 @@ export async function updateDocument(input: {
       ? current.sourceUrl
       : normalizeOptional(input.sourceUrl);
 
-  await Promise.all([
-    assertTaskLink({ taskId, userId: input.editorUserId, visibility }),
+  const [task] = await Promise.all([
+    assertTaskLink({
+      clientAccessBoundary: options.clientAccessBoundary,
+      taskId,
+      userId: input.editorUserId,
+      visibility,
+    }),
     assertOrganizationOwner({ organizationId, userId: input.editorUserId }),
     assertValidDocumentParent({
       documentId: current.id,
@@ -558,6 +693,12 @@ export async function updateDocument(input: {
         )
       : Promise.resolve(null),
   ]);
+  await assertDocumentCreationWithinClientAccessBoundary({
+    boundary: options.clientAccessBoundary,
+    organizationId,
+    task,
+    visibility,
+  });
 
   const nextVersion = current.version + 1;
   await prisma.$transaction(async (tx) => {
@@ -631,14 +772,20 @@ export async function updateDocument(input: {
       where: { id: current.id },
       data: { currentRevisionId: revision.id },
     });
+    await invalidateDocumentReviewsForDocument(tx, current.id);
   });
 
-  const view = await getDocumentForViewer(current.id, input.editorUserId);
+  const view = await getDocumentForViewer(
+    current.id,
+    input.editorUserId,
+    options,
+  );
   if (!view) throw new Error(DOCUMENT_NOT_FOUND_MESSAGE);
   return view;
 }
 
 export async function listDocumentsForViewer(input: {
+  clientAccessBoundary?: TaskClientAccessBoundary;
   limit?: number | null;
   taskId?: string | null;
   userId?: string | null;
@@ -647,9 +794,23 @@ export async function listDocumentsForViewer(input: {
   const taskId = normalizeOptional(input.taskId);
 
   if (taskId) {
-    const { canUserViewTask } =
+    const { canUserViewTask, getTaskClientAccessWhere } =
       await import("@/lib/tasks/task-visibility.server");
     if (!(await canUserViewTask(taskId, input.userId ?? null))) return [];
+    if (
+      input.clientAccessBoundary &&
+      !(await prisma.task.findFirst({
+        where: {
+          AND: [
+            { deletedAt: null, id: taskId },
+            getTaskClientAccessWhere(input.clientAccessBoundary),
+          ],
+        },
+        select: { id: true },
+      }))
+    ) {
+      return [];
+    }
   }
 
   const viewerUserId = input.userId?.trim() || null;
@@ -671,6 +832,9 @@ export async function listDocumentsForViewer(input: {
       take,
       ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
       select: {
+        currentRevision: {
+          select: { id: true },
+        },
         id: true,
         organizationId: true,
         taskId: true,
@@ -689,12 +853,21 @@ export async function listDocumentsForViewer(input: {
       viewerUserId,
     );
     for (const document of rows) {
+      if (
+        !(await isDocumentWithinClientAccessBoundary(
+          document,
+          input.clientAccessBoundary,
+        ))
+      ) {
+        continue;
+      }
       const effectivePermission = accessById.get(document.id) ?? null;
       if (!effectivePermission) continue;
       summaries.push({
         effectivePermission,
         id: document.id,
         organizationId: document.organizationId,
+        revisionId: document.currentRevision?.id ?? null,
         taskId:
           document.taskId &&
           (taskId || (await canViewerSeeTask(document.taskId, viewerUserId)))

--- a/packages/web/src/lib/documents.server.ts
+++ b/packages/web/src/lib/documents.server.ts
@@ -815,6 +815,7 @@ export async function listDocumentsForViewer(input: {
 
   const viewerUserId = input.userId?.trim() || null;
   const summaries: DocumentSummary[] = [];
+  const boundaryTaskAccess = new Map<string, boolean>();
   let cursor: string | undefined;
   let scanned = 0;
 
@@ -852,14 +853,60 @@ export async function listDocumentsForViewer(input: {
       rows.map((document) => document.id),
       viewerUserId,
     );
+    if (input.clientAccessBoundary && !taskId) {
+      const unresolvedTaskIds = [
+        ...new Set(
+          rows.flatMap((document) =>
+            document.visibility === ContentVisibility.PRIVATE &&
+            !document.organizationId &&
+            document.taskId &&
+            !boundaryTaskAccess.has(document.taskId)
+              ? [document.taskId]
+              : [],
+          ),
+        ),
+      ];
+      if (unresolvedTaskIds.length > 0) {
+        const tasks = await prisma.task.findMany({
+          where: { deletedAt: null, id: { in: unresolvedTaskIds } },
+          select: { id: true, isPublic: true, ownerOrganizationId: true },
+        });
+        const taskById = new Map(tasks.map((task) => [task.id, task]));
+        const { isTaskWithinClientAccessBoundary } =
+          await import("@/lib/tasks/task-visibility.server");
+        for (const unresolvedTaskId of unresolvedTaskIds) {
+          const task = taskById.get(unresolvedTaskId);
+          boundaryTaskAccess.set(
+            unresolvedTaskId,
+            Boolean(
+              task &&
+              isTaskWithinClientAccessBoundary(
+                task,
+                input.clientAccessBoundary,
+              ),
+            ),
+          );
+        }
+      }
+    }
     for (const document of rows) {
-      if (
-        !(await isDocumentWithinClientAccessBoundary(
-          document,
-          input.clientAccessBoundary,
-        ))
-      ) {
-        continue;
+      if (input.clientAccessBoundary) {
+        if (document.visibility !== ContentVisibility.PUBLIC) {
+          if (document.organizationId) {
+            if (
+              !clientCanAccessOrganization(
+                document.organizationId,
+                input.clientAccessBoundary,
+              )
+            ) {
+              continue;
+            }
+          } else if (document.taskId) {
+            if (!taskId && !boundaryTaskAccess.get(document.taskId)) continue;
+          } else if (!input.clientAccessBoundary.allowPersonalPrivate) {
+            continue;
+          }
+        }
       }
       const effectivePermission = accessById.get(document.id) ?? null;
       if (!effectivePermission) continue;

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -89,6 +89,12 @@ import {
   isDocumentToolName,
 } from "./mcp-tools/documents";
 import {
+  DOCUMENT_REVIEW_TOOL_DEFINITIONS,
+  DOCUMENT_REVIEW_TOOL_SCOPES,
+  handleDocumentReviewToolCall,
+  isDocumentReviewToolName,
+} from "./mcp-tools/document-reviews";
+import {
   COLLECTION_TOOL_DEFINITIONS,
   COLLECTION_TOOL_SCOPES,
   handleCollectionToolCall,
@@ -135,6 +141,7 @@ import {
   type TaskClientAccessBoundary,
 } from "./tasks/task-visibility.server";
 import { resolveTaskClaimSettings } from "./tasks/task-claim-policy";
+import { DOCUMENT_REVIEW_TASK_KEY_PREFIX } from "./tasks/document-review-contracts";
 import type { PlanningCommitment } from "./tasks/execution-planner";
 import {
   auditExecutionGraph,
@@ -328,6 +335,7 @@ const TOOL_SCOPES: Record<string, McpScope[]> = {
   ...TASK_TRIGGER_TOOL_SCOPES,
   ...COLLECTION_TOOL_SCOPES,
   ...DOCUMENT_TOOL_SCOPES,
+  ...DOCUMENT_REVIEW_TOOL_SCOPES,
   ...CONTENT_TOOL_SCOPES,
   ...PRIVATE_EXECUTION_TOOL_SCOPES,
   ...FORM_RESPONSE_TOOL_SCOPES,
@@ -926,6 +934,15 @@ function asStringArray(value: unknown) {
 function optionalString(value: unknown) {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
+
+function isReservedDocumentReviewTaskKey(value: unknown) {
+  return (
+    optionalString(value)?.startsWith(DOCUMENT_REVIEW_TASK_KEY_PREFIX) === true
+  );
+}
+
+const RESERVED_DOCUMENT_REVIEW_TASK_KEY_MESSAGE =
+  "taskKey uses the reserved document-review namespace. Use requestDocumentReview to create review tasks.";
 
 function optionalStringInput(
   input: Record<string, unknown>,
@@ -8043,6 +8060,7 @@ Posting a comment automatically sends comment notifications to task recipients a
   ...TASK_TRIGGER_TOOL_DEFINITIONS,
   ...COLLECTION_TOOL_DEFINITIONS,
   ...DOCUMENT_TOOL_DEFINITIONS,
+  ...DOCUMENT_REVIEW_TOOL_DEFINITIONS,
   ...CONTENT_TOOL_DEFINITIONS,
   ...PRIVATE_EXECUTION_TOOL_DEFINITIONS,
   ...FORM_RESPONSE_TOOL_DEFINITIONS,
@@ -8232,6 +8250,18 @@ export function createMcpServer(
           return normalizeDelegatedToolResponse(
             await handleDocumentToolCall({
               args: a,
+              clientAccessBoundary: taskClientBoundary,
+              name,
+              userId: userId ?? null,
+            }),
+            err,
+          );
+        }
+        if (isDocumentReviewToolName(name)) {
+          return normalizeDelegatedToolResponse(
+            await handleDocumentReviewToolCall({
+              args: a,
+              clientAccessBoundary: taskClientBoundary,
               name,
               userId: userId ?? null,
             }),
@@ -9176,9 +9206,8 @@ export function createMcpServer(
 
           // ── getTaskTreeAudit ──────────────────────────────────
           case "getTaskTreeAudit": {
-            const { loadTaskTreeAudit } = await import(
-              "./tasks/task-tree-steward.server"
-            );
+            const { loadTaskTreeAudit } =
+              await import("./tasks/task-tree-steward.server");
             return ok(
               await loadTaskTreeAudit({
                 cursor:
@@ -10805,6 +10834,9 @@ export function createMcpServer(
               parseFiniteNumber(a.successProbabilityBase) != null;
             const parentTaskId = optionalString(a.parentTaskId);
             const taskKey = optionalString(a.taskKey);
+            if (isReservedDocumentReviewTaskKey(taskKey)) {
+              return err(RESERVED_DOCUMENT_REVIEW_TASK_KEY_MESSAGE);
+            }
             const validationMissingFields: string[] = [];
             if (!title) validationMissingFields.push("title");
             if (!description.trim())
@@ -12170,6 +12202,9 @@ export function createMcpServer(
                   "taskKey uses a reserved execution-planning branch namespace.",
                 );
               }
+              if (isReservedDocumentReviewTaskKey(candidate.taskKey)) {
+                return err(RESERVED_DOCUMENT_REVIEW_TASK_KEY_MESSAGE);
+              }
               for (const dependency of (candidate.dependencies as Array<
                 Record<string, unknown>
               >) ?? []) {
@@ -12976,6 +13011,9 @@ export function createMcpServer(
                 "Completion and VERIFIED status can only be recorded through execution submission and verification acceptance.",
               );
             }
+            if (isReservedDocumentReviewTaskKey(a.taskKey)) {
+              return err(RESERVED_DOCUMENT_REVIEW_TASK_KEY_MESSAGE);
+            }
             const updates: Record<string, unknown> = {};
             const existingDetail = await tasks.getTaskDetailData(
               a.taskId as string,
@@ -13020,6 +13058,7 @@ export function createMcpServer(
                   isPublic: true,
                   maxClaims: true,
                   ownerOrganizationId: true,
+                  taskKey: true,
                 },
               });
               if (adminVisibleTask) {
@@ -13037,6 +13076,14 @@ export function createMcpServer(
               }
             }
             if (!existingTask) return err("Task not found");
+            if (
+              typeof existingTask.taskKey === "string" &&
+              existingTask.taskKey.startsWith(DOCUMENT_REVIEW_TASK_KEY_PREFIX)
+            ) {
+              return err(
+                "Document review tasks can only be changed through document review operations.",
+              );
+            }
             if (existingTask.isPublic && !isAdminWriter) {
               return err("Updating public tasks requires an admin user.");
             }

--- a/packages/web/src/lib/mcp-tools/document-reviews.test.ts
+++ b/packages/web/src/lib/mcp-tools/document-reviews.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getAssignedDocumentReview: vi.fn(),
+}));
+
+vi.mock("../tasks/document-review.server", () => ({
+  getAssignedDocumentReview: mocks.getAssignedDocumentReview,
+}));
+
+import { handleDocumentReviewToolCall } from "./document-reviews";
+
+function responseBody(
+  response: Awaited<ReturnType<typeof handleDocumentReviewToolCall>>,
+) {
+  return JSON.parse(response.content[0]?.text ?? "{}") as Record<
+    string,
+    unknown
+  >;
+}
+
+beforeEach(() => {
+  mocks.getAssignedDocumentReview.mockReset();
+  mocks.getAssignedDocumentReview.mockResolvedValue({
+    canSubmit: true,
+    reviewTaskId: "review_task_1",
+    target: { body: "Pinned body", revisionId: "revision_1" },
+  });
+});
+
+describe("MCP document review tools", () => {
+  it("reads an assigned exact revision without requiring an idempotency key", async () => {
+    const clientAccessBoundary = {
+      allowPersonalPrivate: false,
+      organizationIds: ["organization_1"],
+    };
+    const response = await handleDocumentReviewToolCall({
+      args: { reviewTaskId: "review_task_1" },
+      clientAccessBoundary,
+      name: "getDocumentReview",
+      userId: "reviewer_user_1",
+    });
+
+    expect(response.isError).not.toBe(true);
+    expect(responseBody(response)).toMatchObject({
+      canSubmit: true,
+      reviewTaskId: "review_task_1",
+      target: { body: "Pinned body", revisionId: "revision_1" },
+    });
+    expect(mocks.getAssignedDocumentReview).toHaveBeenCalledWith(
+      "review_task_1",
+      "reviewer_user_1",
+      { clientAccessBoundary },
+    );
+  });
+
+  it("still requires idempotency for review writes", async () => {
+    const response = await handleDocumentReviewToolCall({
+      args: { reviewTaskId: "review_task_1" },
+      name: "submitDocumentReview",
+      userId: "reviewer_user_1",
+    });
+
+    expect(response.isError).toBe(true);
+    expect(responseBody(response)).toEqual({
+      error: "idempotencyKey is required",
+    });
+    expect(mocks.getAssignedDocumentReview).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/lib/mcp-tools/document-reviews.ts
+++ b/packages/web/src/lib/mcp-tools/document-reviews.ts
@@ -1,0 +1,219 @@
+import { stringifyJsonSafe } from "../json-safe";
+import { McpScope } from "../mcp-scopes";
+import type { TaskClientAccessBoundary } from "../tasks/task-visibility.server";
+
+type ToolResponse = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+const REVIEW_TOOL_SCOPES = [
+  McpScope.TASKS_PERSONAL,
+  McpScope.TASKS_ORGANIZATION,
+  McpScope.TASKS_ADMIN,
+];
+
+export const DOCUMENT_REVIEW_TOOL_SCOPES = {
+  applyDocumentProposal: REVIEW_TOOL_SCOPES,
+  createDocumentProposal: REVIEW_TOOL_SCOPES,
+  decideDocumentRevision: REVIEW_TOOL_SCOPES,
+  requestDocumentReview: REVIEW_TOOL_SCOPES,
+  submitDocumentReview: REVIEW_TOOL_SCOPES,
+} satisfies Record<string, McpScope[]>;
+
+export type DocumentReviewToolName = keyof typeof DOCUMENT_REVIEW_TOOL_SCOPES;
+
+const IDEMPOTENCY_KEY = {
+  type: "string",
+  description: "Stable retry key for this operation.",
+} as const;
+
+const VERDICT = {
+  type: "string",
+  enum: ["APPROVE", "CHANGES_REQUESTED", "REJECT", "ABSTAIN"],
+} as const;
+
+export const DOCUMENT_REVIEW_TOOL_DEFINITIONS = [
+  {
+    name: "createDocumentProposal",
+    description:
+      "Create a separate private proposal document from selected comments on one exact document revision.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        authorityTaskId: { type: "string" },
+        baseDocumentRevisionId: { type: "string" },
+        body: { type: "string" },
+        idempotencyKey: IDEMPOTENCY_KEY,
+        sourceCommentIds: {
+          type: "array",
+          items: { type: "string" },
+          minItems: 1,
+          uniqueItems: true,
+        },
+        summary: { type: "string" },
+        title: { type: "string" },
+      },
+      required: [
+        "authorityTaskId",
+        "baseDocumentRevisionId",
+        "body",
+        "idempotencyKey",
+        "sourceCommentIds",
+        "summary",
+        "title",
+      ],
+    },
+  },
+  {
+    name: "applyDocumentProposal",
+    description:
+      "Apply a pinned proposal artifact to its unchanged base document as a new immutable revision.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        authorityTaskId: { type: "string" },
+        idempotencyKey: IDEMPOTENCY_KEY,
+        proposalArtifactId: { type: "string" },
+      },
+      required: ["authorityTaskId", "idempotencyKey", "proposalArtifactId"],
+    },
+  },
+  {
+    name: "requestDocumentReview",
+    description:
+      "Create a private assigned review task pinned to one exact immutable document revision.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        authorityTaskId: { type: "string" },
+        documentRevisionId: { type: "string" },
+        idempotencyKey: IDEMPOTENCY_KEY,
+        instructions: { type: "string" },
+        reviewerPersonId: { type: "string" },
+      },
+      required: [
+        "authorityTaskId",
+        "documentRevisionId",
+        "idempotencyKey",
+        "instructions",
+        "reviewerPersonId",
+      ],
+    },
+  },
+  {
+    name: "submitDocumentReview",
+    description:
+      "Submit an explained verdict for the exact revision assigned to the authenticated reviewer.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        explanation: { type: "string" },
+        idempotencyKey: IDEMPOTENCY_KEY,
+        reviewTaskId: { type: "string" },
+        verdict: VERDICT,
+      },
+      required: ["explanation", "idempotencyKey", "reviewTaskId", "verdict"],
+    },
+  },
+  {
+    name: "decideDocumentRevision",
+    description:
+      "Record an authorized immutable internal ADOPT or REJECT decision on one exact current revision.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        action: { type: "string", enum: ["ADOPT", "REJECT"] },
+        authorityTaskId: { type: "string" },
+        documentRevisionId: { type: "string" },
+        idempotencyKey: IDEMPOTENCY_KEY,
+        reason: { type: "string" },
+        reviewArtifactId: { type: "string" },
+      },
+      required: [
+        "action",
+        "authorityTaskId",
+        "documentRevisionId",
+        "idempotencyKey",
+        "reviewArtifactId",
+      ],
+    },
+  },
+] as const;
+
+const DOCUMENT_REVIEW_TOOL_NAMES = new Set<string>(
+  Object.keys(DOCUMENT_REVIEW_TOOL_SCOPES),
+);
+
+export function isDocumentReviewToolName(
+  name: string,
+): name is DocumentReviewToolName {
+  return DOCUMENT_REVIEW_TOOL_NAMES.has(name);
+}
+
+function ok(data: unknown): ToolResponse {
+  return { content: [{ type: "text", text: stringifyJsonSafe(data, 2) }] };
+}
+
+function err(message: string): ToolResponse {
+  return {
+    content: [{ type: "text", text: JSON.stringify({ error: message }) }],
+    isError: true,
+  };
+}
+
+function readRequiredString(
+  args: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = args[key];
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+export async function handleDocumentReviewToolCall({
+  args,
+  clientAccessBoundary,
+  name,
+  userId,
+}: {
+  args: Record<string, unknown>;
+  clientAccessBoundary?: TaskClientAccessBoundary;
+  name: DocumentReviewToolName;
+  userId: string | null | undefined;
+}): Promise<ToolResponse> {
+  if (!userId) return err(`${name} requires an identified user`);
+  const idempotencyKey = readRequiredString(args, "idempotencyKey");
+  if (!idempotencyKey) return err("idempotencyKey is required");
+
+  try {
+    const reviews = await import("../tasks/document-review.server");
+    const rawInput = { ...args };
+    delete rawInput.authorityTaskId;
+    delete rawInput.reviewTaskId;
+    delete rawInput.idempotencyKey;
+    const options = { clientAccessBoundary, idempotencyKey };
+    const targetKey =
+      name === "submitDocumentReview" ? "reviewTaskId" : "authorityTaskId";
+    const targetId = readRequiredString(args, targetKey);
+    if (!targetId) return err(`${targetKey} is required`);
+    const operations = {
+      applyDocumentProposal: reviews.applyDocumentProposal,
+      createDocumentProposal: reviews.createDocumentProposal,
+      decideDocumentRevision: reviews.decideDocumentRevision,
+      requestDocumentReview: reviews.requestDocumentReview,
+      submitDocumentReview: reviews.submitDocumentReview,
+    };
+    return ok(await operations[name](targetId, rawInput, userId, options));
+  } catch (error) {
+    return err(
+      error instanceof Error
+        ? error.message
+        : "Document review operation failed",
+    );
+  }
+}

--- a/packages/web/src/lib/mcp-tools/document-reviews.ts
+++ b/packages/web/src/lib/mcp-tools/document-reviews.ts
@@ -17,6 +17,7 @@ export const DOCUMENT_REVIEW_TOOL_SCOPES = {
   applyDocumentProposal: REVIEW_TOOL_SCOPES,
   createDocumentProposal: REVIEW_TOOL_SCOPES,
   decideDocumentRevision: REVIEW_TOOL_SCOPES,
+  getDocumentReview: REVIEW_TOOL_SCOPES,
   requestDocumentReview: REVIEW_TOOL_SCOPES,
   submitDocumentReview: REVIEW_TOOL_SCOPES,
 } satisfies Record<string, McpScope[]>;
@@ -34,6 +35,19 @@ const VERDICT = {
 } as const;
 
 export const DOCUMENT_REVIEW_TOOL_DEFINITIONS = [
+  {
+    name: "getDocumentReview",
+    description:
+      "Read the exact document revision and instructions assigned to the authenticated reviewer.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        reviewTaskId: { type: "string" },
+      },
+      required: ["reviewTaskId"],
+    },
+  },
   {
     name: "createDocumentProposal",
     description:
@@ -187,6 +201,27 @@ export async function handleDocumentReviewToolCall({
   userId: string | null | undefined;
 }): Promise<ToolResponse> {
   if (!userId) return err(`${name} requires an identified user`);
+
+  if (name === "getDocumentReview") {
+    const reviewTaskId = readRequiredString(args, "reviewTaskId");
+    if (!reviewTaskId) return err("reviewTaskId is required");
+
+    try {
+      const reviews = await import("../tasks/document-review.server");
+      return ok(
+        await reviews.getAssignedDocumentReview(reviewTaskId, userId, {
+          clientAccessBoundary,
+        }),
+      );
+    } catch (error) {
+      return err(
+        error instanceof Error
+          ? error.message
+          : "Document review operation failed",
+      );
+    }
+  }
+
   const idempotencyKey = readRequiredString(args, "idempotencyKey");
   if (!idempotencyKey) return err("idempotencyKey is required");
 

--- a/packages/web/src/lib/mcp-tools/documents.test.ts
+++ b/packages/web/src/lib/mcp-tools/documents.test.ts
@@ -29,6 +29,10 @@ beforeEach(() => {
 
 describe("MCP document tools", () => {
   it("updates and clears document ownership links through the shared server path", async () => {
+    const clientAccessBoundary = {
+      allowPersonalPrivate: false,
+      organizationIds: ["organization_1"],
+    };
     const response = await handleDocumentToolCall({
       args: {
         documentId: "document_1",
@@ -37,6 +41,7 @@ describe("MCP document tools", () => {
         parentDocumentId: null,
         taskId: null,
       },
+      clientAccessBoundary,
       name: "updateDocument",
       userId: "user_1",
     });
@@ -45,16 +50,19 @@ describe("MCP document tools", () => {
     expect(responseBody(response)).toEqual({
       document: { id: "document_1", version: 2 },
     });
-    expect(mocks.updateDocument).toHaveBeenCalledWith({
-      body: null,
-      documentId: "document_1",
-      editorUserId: "user_1",
-      expectedVersion: 1,
-      organizationId: "organization_1",
-      parentDocumentId: null,
-      taskId: null,
-      title: null,
-      visibility: null,
-    });
+    expect(mocks.updateDocument).toHaveBeenCalledWith(
+      {
+        body: null,
+        documentId: "document_1",
+        editorUserId: "user_1",
+        expectedVersion: 1,
+        organizationId: "organization_1",
+        parentDocumentId: null,
+        taskId: null,
+        title: null,
+        visibility: null,
+      },
+      { clientAccessBoundary },
+    );
   });
 });

--- a/packages/web/src/lib/mcp-tools/documents.ts
+++ b/packages/web/src/lib/mcp-tools/documents.ts
@@ -5,6 +5,7 @@
 
 import { stringifyJsonSafe } from "../json-safe";
 import { McpScope } from "../mcp-scopes";
+import type { TaskClientAccessBoundary } from "../tasks/task-visibility.server";
 
 type ToolResponse = {
   content: Array<{ type: "text"; text: string }>;
@@ -23,10 +24,26 @@ function err(message: string): ToolResponse {
 }
 
 export const DOCUMENT_TOOL_SCOPES = {
-  createDocument: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
-  updateDocument: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
-  getDocument: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
-  listDocuments: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ADMIN],
+  createDocument: [
+    McpScope.TASKS_PERSONAL,
+    McpScope.TASKS_ORGANIZATION,
+    McpScope.TASKS_ADMIN,
+  ],
+  updateDocument: [
+    McpScope.TASKS_PERSONAL,
+    McpScope.TASKS_ORGANIZATION,
+    McpScope.TASKS_ADMIN,
+  ],
+  getDocument: [
+    McpScope.TASKS_PERSONAL,
+    McpScope.TASKS_ORGANIZATION,
+    McpScope.TASKS_ADMIN,
+  ],
+  listDocuments: [
+    McpScope.TASKS_PERSONAL,
+    McpScope.TASKS_ORGANIZATION,
+    McpScope.TASKS_ADMIN,
+  ],
 } satisfies Record<string, McpScope[]>;
 
 export type DocumentToolName = keyof typeof DOCUMENT_TOOL_SCOPES;
@@ -155,10 +172,12 @@ function readNullableString(value: unknown): string | null | undefined {
 
 export async function handleDocumentToolCall({
   args,
+  clientAccessBoundary,
   name,
   userId,
 }: {
   args: Record<string, unknown>;
+  clientAccessBoundary?: TaskClientAccessBoundary;
   name: DocumentToolName;
   userId: string | null | undefined;
 }): Promise<ToolResponse> {
@@ -173,20 +192,23 @@ export async function handleDocumentToolCall({
         const idempotencyKey = readString(args.idempotencyKey);
         if (!title || !body) return err("title and body are required");
         if (!idempotencyKey) return err("idempotencyKey is required");
-        const row = await documents.createDocument({
-          title,
-          body,
-          createdByUserId: userId,
-          taskId: readString(args.taskId) ?? null,
-          jurisdictionId: readString(args.jurisdictionId) ?? null,
-          organizationId: readString(args.organizationId) ?? null,
-          parentDocumentId: readString(args.parentDocumentId) ?? null,
-          idempotencyKey,
-          visibility:
-            args.visibility === "PUBLIC" || args.visibility === "PRIVATE"
-              ? args.visibility
-              : null,
-        });
+        const row = await documents.createDocument(
+          {
+            title,
+            body,
+            createdByUserId: userId,
+            taskId: readString(args.taskId) ?? null,
+            jurisdictionId: readString(args.jurisdictionId) ?? null,
+            organizationId: readString(args.organizationId) ?? null,
+            parentDocumentId: readString(args.parentDocumentId) ?? null,
+            idempotencyKey,
+            visibility:
+              args.visibility === "PUBLIC" || args.visibility === "PRIVATE"
+                ? args.visibility
+                : null,
+          },
+          { clientAccessBoundary },
+        );
         return ok({ document: documents.toDocumentDto(row) });
       }
 
@@ -202,27 +224,34 @@ export async function handleDocumentToolCall({
         ) {
           return err("expectedVersion must be a positive integer");
         }
-        const row = await documents.updateDocument({
-          documentId,
-          editorUserId: userId,
-          expectedVersion,
-          title: readString(args.title) ?? null,
-          body: typeof args.body === "string" ? args.body : null,
-          organizationId: readNullableString(args.organizationId),
-          parentDocumentId: readNullableString(args.parentDocumentId),
-          taskId: readNullableString(args.taskId),
-          visibility:
-            args.visibility === "PUBLIC" || args.visibility === "PRIVATE"
-              ? args.visibility
-              : null,
-        });
+        const row = await documents.updateDocument(
+          {
+            documentId,
+            editorUserId: userId,
+            expectedVersion,
+            title: readString(args.title) ?? null,
+            body: typeof args.body === "string" ? args.body : null,
+            organizationId: readNullableString(args.organizationId),
+            parentDocumentId: readNullableString(args.parentDocumentId),
+            taskId: readNullableString(args.taskId),
+            visibility:
+              args.visibility === "PUBLIC" || args.visibility === "PRIVATE"
+                ? args.visibility
+                : null,
+          },
+          { clientAccessBoundary },
+        );
         return ok({ document: documents.toDocumentDto(row) });
       }
 
       case "getDocument": {
         const documentId = readString(args.documentId);
         if (!documentId) return err("documentId is required");
-        const result = await documents.getDocumentForViewer(documentId, userId);
+        const result = await documents.getDocumentForViewer(
+          documentId,
+          userId,
+          { clientAccessBoundary },
+        );
         if (!result) return err(documents.DOCUMENT_NOT_FOUND_MESSAGE);
         return ok({
           document: documents.toDocumentDto(result),
@@ -233,6 +262,7 @@ export async function handleDocumentToolCall({
 
       case "listDocuments": {
         const rows = await documents.listDocumentsForViewer({
+          clientAccessBoundary,
           userId: userId ?? null,
           taskId: readString(args.taskId) ?? null,
           limit: typeof args.limit === "number" ? args.limit : null,

--- a/packages/web/src/lib/tasks/document-review-binding.server.test.ts
+++ b/packages/web/src/lib/tasks/document-review-binding.server.test.ts
@@ -1,0 +1,70 @@
+import {
+  TaskApplicationPolicy,
+  TaskClaimPolicy,
+  TaskExecutionMode,
+} from "@optimitron/db";
+import { describe, expect, it } from "vitest";
+import type { ReviewRequestV1 } from "./document-review-contracts";
+import {
+  DOCUMENT_REVIEW_BINDING_HASH_KEY,
+  documentReviewBindingMatches,
+  hashDocumentReviewBinding,
+} from "./document-review-binding.server";
+
+const request: ReviewRequestV1 = {
+  authorityTaskId: "authority_task",
+  instructions: "Review this exact revision.",
+  requestedAt: "2026-07-29T12:00:00.000Z",
+  requestedByUserId: "manager_user",
+  schema: "optimitron.review-request.v1",
+  target: {
+    contentHash: "content_hash_1",
+    documentId: "document_1",
+    revisionId: "revision_1",
+    version: 1,
+  },
+};
+
+const task = {
+  applicationPolicy: TaskApplicationPolicy.CLOSED,
+  assigneePersonId: "reviewer_person",
+  claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
+  createdByUserId: "manager_user",
+  executionMode: TaskExecutionMode.HUMAN_ONLY,
+  isPublic: false,
+  jurisdictionId: null,
+  ownerOrganizationId: null,
+  parentTaskId: "authority_task",
+  taskKey: "document-review:authority_task:manager_user:key",
+};
+
+describe("document review task binding", () => {
+  it("detects revision, assignee, and execution-policy drift", async () => {
+    const bindingHash = await hashDocumentReviewBinding(task, request);
+    const bound = {
+      ...task,
+      contextJson: { [DOCUMENT_REVIEW_BINDING_HASH_KEY]: bindingHash },
+    };
+    await expect(documentReviewBindingMatches(bound, request)).resolves.toBe(
+      true,
+    );
+    await expect(
+      documentReviewBindingMatches(
+        { ...bound, assigneePersonId: "another_person" },
+        request,
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      documentReviewBindingMatches(bound, {
+        ...request,
+        target: { ...request.target, version: 2 },
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      documentReviewBindingMatches(
+        { ...bound, executionMode: TaskExecutionMode.HUMAN_OR_AGENT },
+        request,
+      ),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/web/src/lib/tasks/document-review-binding.server.ts
+++ b/packages/web/src/lib/tasks/document-review-binding.server.ts
@@ -1,0 +1,70 @@
+import {
+  TaskApplicationPolicy,
+  TaskClaimPolicy,
+  TaskExecutionMode,
+} from "@optimitron/db";
+import { sha256CanonicalJson } from "@optimitron/data/parameters";
+import type { ReviewRequestV1 } from "@/lib/tasks/document-review-contracts";
+
+export const DOCUMENT_REVIEW_BINDING_HASH_KEY =
+  "documentReviewBindingHash" as const;
+
+export interface DocumentReviewBindingTask {
+  applicationPolicy: TaskApplicationPolicy;
+  assigneePersonId: string | null;
+  claimPolicy: TaskClaimPolicy;
+  createdByUserId: string;
+  executionMode: TaskExecutionMode;
+  isPublic: boolean;
+  jurisdictionId: string | null;
+  ownerOrganizationId: string | null;
+  parentTaskId: string | null;
+  taskKey: string | null;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null;
+}
+
+export function buildDocumentReviewBinding(
+  task: DocumentReviewBindingTask,
+  request: ReviewRequestV1,
+) {
+  return {
+    applicationPolicy: task.applicationPolicy,
+    assigneePersonId: task.assigneePersonId,
+    claimPolicy: task.claimPolicy,
+    createdByUserId: task.createdByUserId,
+    executionMode: task.executionMode,
+    isPublic: task.isPublic,
+    jurisdictionId: task.jurisdictionId,
+    ownerOrganizationId: task.ownerOrganizationId,
+    parentTaskId: task.parentTaskId,
+    request,
+    taskKey: task.taskKey,
+  };
+}
+
+export function hashDocumentReviewBinding(
+  task: DocumentReviewBindingTask,
+  request: ReviewRequestV1,
+) {
+  return sha256CanonicalJson(buildDocumentReviewBinding(task, request));
+}
+
+export async function documentReviewBindingMatches(
+  task: DocumentReviewBindingTask & { contextJson: unknown },
+  request: ReviewRequestV1,
+) {
+  const storedHash = asRecord(task.contextJson)?.[
+    DOCUMENT_REVIEW_BINDING_HASH_KEY
+  ];
+  return (
+    typeof storedHash === "string" &&
+    storedHash === (await hashDocumentReviewBinding(task, request))
+  );
+}

--- a/packages/web/src/lib/tasks/document-review-contracts.test.ts
+++ b/packages/web/src/lib/tasks/document-review-contracts.test.ts
@@ -69,6 +69,7 @@ describe("document governance contracts", () => {
         version: 1,
       },
       proposedAt: "2026-07-29T13:00:00.000Z",
+      proposedByPersonId: "agent_oauth_person",
       proposedByUserId: "agent_oauth_user",
       schema: "optimitron.document-proposal.v1",
       sourceComments: [sourceComment],

--- a/packages/web/src/lib/tasks/document-review-contracts.test.ts
+++ b/packages/web/src/lib/tasks/document-review-contracts.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertReviewResponseMatchesRequest,
+  CreateDocumentProposalInputSchema,
+  DecideDocumentRevisionInputSchema,
+  DOCUMENT_REVIEW_TASK_KEY_PREFIX,
+  DocumentProposalV1Schema,
+  InternalDocumentDecisionV1Schema,
+  RequestDocumentReviewInputSchema,
+  ReviewRequestV1Schema,
+  ReviewResponseV1Schema,
+} from "./document-review-contracts";
+
+const target = {
+  contentHash: "content_hash_1",
+  documentId: "document_1",
+  revisionId: "revision_1",
+  version: 1,
+};
+
+const request = ReviewRequestV1Schema.parse({
+  authorityTaskId: "authority_task",
+  instructions: "Review this exact revision and explain the verdict.",
+  requestedAt: "2026-07-29T12:00:00.000Z",
+  requestedByUserId: "manager_user",
+  schema: "optimitron.review-request.v1",
+  target,
+});
+
+describe("document governance contracts", () => {
+  it("uses one review task-key prefix and rejects caller-selected executors", () => {
+    expect(DOCUMENT_REVIEW_TASK_KEY_PREFIX).toBe("document-review:");
+    expect(() =>
+      CreateDocumentProposalInputSchema.parse({
+        agentExecutorId: "untrusted_agent",
+        baseDocumentRevisionId: target.revisionId,
+        body: "Proposed body",
+        sourceCommentIds: ["comment_1"],
+        summary: "Applied the comment.",
+        title: "Proposed title",
+      }),
+    ).toThrow();
+  });
+
+  it("derives review task titles instead of accepting caller-selected titles", () => {
+    expect(() =>
+      RequestDocumentReviewInputSchema.parse({
+        documentRevisionId: target.revisionId,
+        instructions: "Review this exact revision.",
+        reviewerPersonId: "reviewer_person",
+        title: "Caller-selected title",
+      }),
+    ).toThrow();
+  });
+
+  it("binds one immutable source-comment snapshot set to the proposal base", () => {
+    const sourceComment = {
+      commentId: "comment_1",
+      contentHash: "comment_hash",
+      taskId: "authority_task",
+    };
+    const value = {
+      authorityTaskId: "authority_task",
+      base: target,
+      proposal: {
+        contentHash: "proposal_hash",
+        documentId: "proposal_document",
+        revisionId: "proposal_revision",
+        version: 1,
+      },
+      proposedAt: "2026-07-29T13:00:00.000Z",
+      proposedByUserId: "agent_oauth_user",
+      schema: "optimitron.document-proposal.v1",
+      sourceComments: [sourceComment],
+      summary: "Applied the comment.",
+    };
+    expect(DocumentProposalV1Schema.parse(value).base).toEqual(target);
+    expect(() =>
+      DocumentProposalV1Schema.parse({
+        ...value,
+        sourceComments: [sourceComment, sourceComment],
+      }),
+    ).toThrow("Source comments must be unique");
+  });
+
+  it("binds the formal verdict to the exact request and rationale comment", () => {
+    const response = ReviewResponseV1Schema.parse({
+      comment: { contentHash: "comment_hash", id: "comment_1" },
+      explanation: "The revision is supported as written.",
+      reviewerPersonId: "reviewer_person",
+      reviewerUserId: "reviewer_user",
+      reviewTaskId: "review_task",
+      schema: "optimitron.review-response.v1",
+      submittedAt: "2026-07-29T13:00:00.000Z",
+      target,
+      verdict: "APPROVE",
+    });
+    expect(() =>
+      assertReviewResponseMatchesRequest(response, request, "review_task"),
+    ).not.toThrow();
+    expect(() =>
+      assertReviewResponseMatchesRequest(
+        { ...response, target: { ...target, contentHash: "changed" } },
+        request,
+        "review_task",
+      ),
+    ).toThrow("does not match");
+  });
+
+  it("allows one-click ADOPT input but requires a reason for REJECT", () => {
+    expect(
+      DecideDocumentRevisionInputSchema.parse({
+        action: "ADOPT",
+        documentRevisionId: target.revisionId,
+        reviewArtifactId: "review_artifact",
+      }),
+    ).toEqual({
+      action: "ADOPT",
+      documentRevisionId: target.revisionId,
+      reviewArtifactId: "review_artifact",
+    });
+    expect(() =>
+      DecideDocumentRevisionInputSchema.parse({
+        action: "REJECT",
+        documentRevisionId: target.revisionId,
+        reviewArtifactId: "review_artifact",
+      }),
+    ).toThrow();
+  });
+
+  it("allows ADOPT only with an APPROVE review in the persisted artifact", () => {
+    const base = {
+      authorityTaskId: "authority_task",
+      decidedAt: "2026-07-29T14:00:00.000Z",
+      decidedByPersonId: "manager_person",
+      decidedByUserId: "manager_user",
+      reason: null,
+      review: {
+        artifactId: "review_artifact",
+        contentHash: "review_hash",
+        reviewerPersonId: "reviewer_person",
+        verdict: "APPROVE",
+      },
+      schema: "optimitron.internal-document-decision.v1",
+      scope: "INTERNAL",
+      target,
+    };
+    expect(
+      InternalDocumentDecisionV1Schema.parse({ action: "ADOPT", ...base })
+        .action,
+    ).toBe("ADOPT");
+    expect(() =>
+      InternalDocumentDecisionV1Schema.parse({
+        action: "ADOPT",
+        ...base,
+        review: { ...base.review, verdict: "REJECT" },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/web/src/lib/tasks/document-review-contracts.ts
+++ b/packages/web/src/lib/tasks/document-review-contracts.ts
@@ -1,0 +1,279 @@
+import { z } from "zod";
+
+export const DOCUMENT_REVIEW_CONTEXT_KEY = "documentReview" as const;
+export const DOCUMENT_REVIEW_TASK_KEY_PREFIX = "document-review:" as const;
+
+export const DocumentRevisionPinSchema = z
+  .object({
+    contentHash: z.string().trim().min(1).max(256),
+    documentId: z.string().trim().min(1),
+    revisionId: z.string().trim().min(1),
+    version: z.number().int().positive(),
+  })
+  .strict();
+
+export const ReviewRequestV1Schema = z
+  .object({
+    authorityTaskId: z.string().trim().min(1),
+    instructions: z.string().trim().min(1).max(20_000),
+    requestedAt: z.string().datetime(),
+    requestedByUserId: z.string().trim().min(1),
+    schema: z.literal("optimitron.review-request.v1"),
+    target: DocumentRevisionPinSchema,
+  })
+  .strict();
+
+export const DocumentReviewVerdictSchema = z.enum([
+  "APPROVE",
+  "CHANGES_REQUESTED",
+  "REJECT",
+  "ABSTAIN",
+]);
+
+export const ReviewResponseV1Schema = z
+  .object({
+    comment: z
+      .object({
+        contentHash: z.string().trim().min(1).max(256),
+        id: z.string().trim().min(1),
+      })
+      .strict(),
+    explanation: z.string().trim().min(1).max(20_000),
+    reviewerPersonId: z.string().trim().min(1),
+    reviewerUserId: z.string().trim().min(1),
+    reviewTaskId: z.string().trim().min(1),
+    schema: z.literal("optimitron.review-response.v1"),
+    submittedAt: z.string().datetime(),
+    target: DocumentRevisionPinSchema,
+    verdict: DocumentReviewVerdictSchema,
+  })
+  .strict();
+
+export const DocumentProposalSourceCommentV1Schema = z
+  .object({
+    commentId: z.string().trim().min(1),
+    contentHash: z.string().trim().min(1).max(256),
+    taskId: z.string().trim().min(1),
+  })
+  .strict();
+
+export const DocumentProposalV1Schema = z
+  .object({
+    authorityTaskId: z.string().trim().min(1),
+    base: DocumentRevisionPinSchema,
+    proposal: DocumentRevisionPinSchema,
+    proposedAt: z.string().datetime(),
+    proposedByUserId: z.string().trim().min(1),
+    schema: z.literal("optimitron.document-proposal.v1"),
+    sourceComments: z
+      .array(DocumentProposalSourceCommentV1Schema)
+      .min(1)
+      .max(500)
+      .refine(
+        (comments) =>
+          new Set(comments.map((comment) => comment.commentId)).size ===
+          comments.length,
+        { message: "Source comments must be unique" },
+      ),
+    summary: z.string().trim().min(1).max(20_000),
+  })
+  .strict();
+
+export const DocumentProposalApplicationV1Schema = z
+  .object({
+    appliedAt: z.string().datetime(),
+    appliedByUserId: z.string().trim().min(1),
+    authorityTaskId: z.string().trim().min(1),
+    base: DocumentRevisionPinSchema,
+    proposalArtifact: z
+      .object({
+        artifactId: z.string().trim().min(1),
+        contentHash: z.string().trim().min(1).max(256),
+      })
+      .strict(),
+    resultingDocument: DocumentRevisionPinSchema,
+    schema: z.literal("optimitron.document-proposal-application.v1"),
+    sourceProposalDocument: DocumentRevisionPinSchema,
+  })
+  .strict();
+
+const InternalDocumentDecisionReviewSchema = z
+  .object({
+    artifactId: z.string().trim().min(1),
+    contentHash: z.string().trim().min(1).max(256),
+    reviewerPersonId: z.string().trim().min(1),
+    verdict: DocumentReviewVerdictSchema,
+  })
+  .strict();
+
+const InternalDocumentDecisionBaseSchema = z
+  .object({
+    authorityTaskId: z.string().trim().min(1),
+    decidedAt: z.string().datetime(),
+    decidedByPersonId: z.string().trim().min(1),
+    decidedByUserId: z.string().trim().min(1),
+    schema: z.literal("optimitron.internal-document-decision.v1"),
+    scope: z.literal("INTERNAL"),
+    target: DocumentRevisionPinSchema,
+  })
+  .strict();
+
+export const InternalDocumentDecisionV1Schema = z.discriminatedUnion("action", [
+  InternalDocumentDecisionBaseSchema.extend({
+    action: z.literal("ADOPT"),
+    reason: z.string().trim().min(1).max(20_000).nullable(),
+    review: InternalDocumentDecisionReviewSchema.extend({
+      verdict: z.literal("APPROVE"),
+    }).strict(),
+  }).strict(),
+  InternalDocumentDecisionBaseSchema.extend({
+    action: z.literal("REJECT"),
+    reason: z.string().trim().min(1).max(20_000),
+    review: InternalDocumentDecisionReviewSchema,
+  }).strict(),
+]);
+
+export const CreateDocumentProposalInputSchema = z
+  .object({
+    baseDocumentRevisionId: z.string().trim().min(1),
+    body: z
+      .string()
+      .min(1)
+      .max(500_000)
+      .refine((value) => value.trim().length > 0, {
+        message: "Proposal body cannot be blank",
+      }),
+    sourceCommentIds: z
+      .array(z.string().trim().min(1))
+      .min(1)
+      .max(500)
+      .refine((ids) => new Set(ids).size === ids.length, {
+        message: "Source comment IDs must be unique",
+      }),
+    summary: z.string().trim().min(1).max(20_000),
+    title: z.string().trim().min(1).max(300),
+  })
+  .strict();
+
+export const ApplyDocumentProposalInputSchema = z
+  .object({ proposalArtifactId: z.string().trim().min(1) })
+  .strict();
+
+export const RequestDocumentReviewInputSchema = z
+  .object({
+    documentRevisionId: z.string().trim().min(1),
+    instructions: z.string().trim().min(1).max(20_000),
+    reviewerPersonId: z.string().trim().min(1),
+  })
+  .strict();
+
+export const SubmitDocumentReviewInputSchema = z
+  .object({
+    explanation: z.string().trim().min(1).max(20_000),
+    verdict: DocumentReviewVerdictSchema,
+  })
+  .strict();
+
+export const DecideDocumentRevisionInputSchema = z.discriminatedUnion(
+  "action",
+  [
+    z
+      .object({
+        action: z.literal("ADOPT"),
+        documentRevisionId: z.string().trim().min(1),
+        reason: z.string().trim().min(1).max(20_000).optional(),
+        reviewArtifactId: z.string().trim().min(1),
+      })
+      .strict(),
+    z
+      .object({
+        action: z.literal("REJECT"),
+        documentRevisionId: z.string().trim().min(1),
+        reason: z.string().trim().min(1).max(20_000),
+        reviewArtifactId: z.string().trim().min(1),
+      })
+      .strict(),
+  ],
+);
+
+export type DocumentRevisionPin = z.infer<typeof DocumentRevisionPinSchema>;
+export type DocumentProposalSourceCommentV1 = z.infer<
+  typeof DocumentProposalSourceCommentV1Schema
+>;
+export type DocumentProposalV1 = z.infer<typeof DocumentProposalV1Schema>;
+export type DocumentProposalApplicationV1 = z.infer<
+  typeof DocumentProposalApplicationV1Schema
+>;
+export type ReviewRequestV1 = z.infer<typeof ReviewRequestV1Schema>;
+export type ReviewResponseV1 = z.infer<typeof ReviewResponseV1Schema>;
+export type InternalDocumentDecisionV1 = z.infer<
+  typeof InternalDocumentDecisionV1Schema
+>;
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null;
+}
+
+export function readReviewRequest(
+  contextJson: unknown,
+): ReviewRequestV1 | null {
+  const parsed = ReviewRequestV1Schema.safeParse(
+    asRecord(contextJson)?.[DOCUMENT_REVIEW_CONTEXT_KEY],
+  );
+  return parsed.success ? parsed.data : null;
+}
+
+export function readReviewResponse(value: unknown): ReviewResponseV1 | null {
+  const parsed = ReviewResponseV1Schema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function readDocumentProposal(
+  value: unknown,
+): DocumentProposalV1 | null {
+  const parsed = DocumentProposalV1Schema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function readDocumentProposalApplication(
+  value: unknown,
+): DocumentProposalApplicationV1 | null {
+  const parsed = DocumentProposalApplicationV1Schema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function readInternalDocumentDecision(
+  value: unknown,
+): InternalDocumentDecisionV1 | null {
+  const parsed = InternalDocumentDecisionV1Schema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function sameDocumentRevisionPin(
+  left: DocumentRevisionPin,
+  right: DocumentRevisionPin,
+): boolean {
+  return (
+    left.documentId === right.documentId &&
+    left.revisionId === right.revisionId &&
+    left.version === right.version &&
+    left.contentHash === right.contentHash
+  );
+}
+
+export function assertReviewResponseMatchesRequest(
+  response: ReviewResponseV1,
+  request: ReviewRequestV1,
+  reviewTaskId: string,
+): void {
+  if (
+    response.reviewTaskId !== reviewTaskId ||
+    !sameDocumentRevisionPin(response.target, request.target)
+  ) {
+    throw new Error("Review response does not match the requested revision");
+  }
+}

--- a/packages/web/src/lib/tasks/document-review-contracts.ts
+++ b/packages/web/src/lib/tasks/document-review-contracts.ts
@@ -2,6 +2,13 @@ import { z } from "zod";
 
 export const DOCUMENT_REVIEW_CONTEXT_KEY = "documentReview" as const;
 export const DOCUMENT_REVIEW_TASK_KEY_PREFIX = "document-review:" as const;
+export const DOCUMENT_PROPOSAL_ARTIFACT_KIND = "document-proposal" as const;
+export const DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND =
+  "document-proposal-application" as const;
+export const DOCUMENT_REVIEW_RESPONSE_ARTIFACT_KIND =
+  "document-review-response" as const;
+export const INTERNAL_DOCUMENT_DECISION_ARTIFACT_KIND =
+  "internal-document-decision" as const;
 
 export const DocumentRevisionPinSchema = z
   .object({
@@ -63,6 +70,7 @@ export const DocumentProposalV1Schema = z
     base: DocumentRevisionPinSchema,
     proposal: DocumentRevisionPinSchema,
     proposedAt: z.string().datetime(),
+    proposedByPersonId: z.string().trim().min(1),
     proposedByUserId: z.string().trim().min(1),
     schema: z.literal("optimitron.document-proposal.v1"),
     sourceComments: z

--- a/packages/web/src/lib/tasks/document-review-invalidation.server.ts
+++ b/packages/web/src/lib/tasks/document-review-invalidation.server.ts
@@ -1,0 +1,32 @@
+import { TaskStatus, type Prisma } from "@optimitron/db";
+import { DOCUMENT_REVIEW_CONTEXT_KEY } from "@/lib/tasks/document-review-contracts";
+
+/** Atomically closes every live review pinned anywhere in this document's history. */
+export function invalidateDocumentReviewsForDocument(
+  tx: Prisma.TransactionClient,
+  documentId: string,
+) {
+  return tx.task.updateMany({
+    where: {
+      AND: [
+        {
+          contextJson: {
+            equals: "optimitron.review-request.v1",
+            path: [DOCUMENT_REVIEW_CONTEXT_KEY, "schema"],
+          },
+        },
+        {
+          contextJson: {
+            equals: documentId,
+            path: [DOCUMENT_REVIEW_CONTEXT_KEY, "target", "documentId"],
+          },
+        },
+      ],
+      deletedAt: null,
+      status: {
+        in: [TaskStatus.DRAFT, TaskStatus.ACTIVE, TaskStatus.VERIFIED],
+      },
+    },
+    data: { status: TaskStatus.STALE },
+  });
+}

--- a/packages/web/src/lib/tasks/document-review-invalidation.server.ts
+++ b/packages/web/src/lib/tasks/document-review-invalidation.server.ts
@@ -1,5 +1,8 @@
 import { TaskStatus, type Prisma } from "@optimitron/db";
-import { DOCUMENT_REVIEW_CONTEXT_KEY } from "@/lib/tasks/document-review-contracts";
+import {
+  DOCUMENT_REVIEW_CONTEXT_KEY,
+  DOCUMENT_REVIEW_TASK_KEY_PREFIX,
+} from "@/lib/tasks/document-review-contracts";
 
 /** Atomically closes every live review pinned anywhere in this document's history. */
 export function invalidateDocumentReviewsForDocument(
@@ -26,6 +29,7 @@ export function invalidateDocumentReviewsForDocument(
       status: {
         in: [TaskStatus.DRAFT, TaskStatus.ACTIVE, TaskStatus.VERIFIED],
       },
+      taskKey: { startsWith: DOCUMENT_REVIEW_TASK_KEY_PREFIX },
     },
     data: { status: TaskStatus.STALE },
   });

--- a/packages/web/src/lib/tasks/document-review-invalidation.server.ts
+++ b/packages/web/src/lib/tasks/document-review-invalidation.server.ts
@@ -1,8 +1,97 @@
-import { TaskStatus, type Prisma } from "@optimitron/db";
 import {
+  TaskExecutionAttemptStatus,
+  TaskStatus,
+  type Prisma,
+} from "@optimitron/db";
+import {
+  DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND,
+  DOCUMENT_PROPOSAL_ARTIFACT_KIND,
   DOCUMENT_REVIEW_CONTEXT_KEY,
   DOCUMENT_REVIEW_TASK_KEY_PREFIX,
+  INTERNAL_DOCUMENT_DECISION_ARTIFACT_KIND,
 } from "@/lib/tasks/document-review-contracts";
+
+function governanceArtifactReferenceWhere(input: {
+  authorityTaskId?: string | null;
+  documentId: string;
+  kind: string;
+  resultPath: string[];
+}): Prisma.TaskExecutionArtifactWhereInput {
+  return {
+    metadataJson: { equals: input.kind, path: ["kind"] },
+    structuredResultJson: {
+      equals: input.documentId,
+      path: input.resultPath,
+    },
+    taskExecutionAttempt: {
+      metadata: { equals: input.kind, path: ["kind"] },
+      status: TaskExecutionAttemptStatus.COMPLETED,
+      ...(input.authorityTaskId ? { taskId: input.authorityTaskId } : {}),
+    },
+  };
+}
+
+export async function hasDocumentGovernanceHistory(
+  tx: Prisma.TransactionClient,
+  documentId: string,
+  authorityTaskId?: string | null,
+): Promise<boolean> {
+  if (authorityTaskId) {
+    const reviewTask = await tx.task.findFirst({
+      where: {
+        contextJson: {
+          equals: documentId,
+          path: [DOCUMENT_REVIEW_CONTEXT_KEY, "target", "documentId"],
+        },
+        parentTaskId: authorityTaskId,
+        taskKey: {
+          startsWith: `${DOCUMENT_REVIEW_TASK_KEY_PREFIX}${authorityTaskId}:`,
+        },
+      },
+      select: { id: true },
+    });
+    if (reviewTask) return true;
+  }
+
+  const artifact = await tx.taskExecutionArtifact.findFirst({
+    where: {
+      OR: [
+        governanceArtifactReferenceWhere({
+          authorityTaskId,
+          documentId,
+          kind: DOCUMENT_PROPOSAL_ARTIFACT_KIND,
+          resultPath: ["base", "documentId"],
+        }),
+        governanceArtifactReferenceWhere({
+          authorityTaskId,
+          documentId,
+          kind: DOCUMENT_PROPOSAL_ARTIFACT_KIND,
+          resultPath: ["proposal", "documentId"],
+        }),
+        governanceArtifactReferenceWhere({
+          authorityTaskId,
+          documentId,
+          kind: DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND,
+          resultPath: ["resultingDocument", "documentId"],
+        }),
+        governanceArtifactReferenceWhere({
+          authorityTaskId,
+          documentId,
+          kind: DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND,
+          resultPath: ["sourceProposalDocument", "documentId"],
+        }),
+        governanceArtifactReferenceWhere({
+          authorityTaskId,
+          documentId,
+          kind: INTERNAL_DOCUMENT_DECISION_ARTIFACT_KIND,
+          resultPath: ["target", "documentId"],
+        }),
+      ],
+    },
+    select: { id: true },
+  });
+  return artifact != null;
+}
 
 /** Atomically closes every live review pinned anywhere in this document's history. */
 export function invalidateDocumentReviewsForDocument(

--- a/packages/web/src/lib/tasks/document-review-ui.server.ts
+++ b/packages/web/src/lib/tasks/document-review-ui.server.ts
@@ -1,0 +1,45 @@
+import { listDocumentsForViewer } from "@/lib/documents.server";
+import {
+  getDocumentReviewPanelData,
+  type DocumentReviewPanelData,
+} from "@/lib/tasks/document-review.server";
+
+export interface DocumentReviewSetupDocument {
+  revisionId: string;
+  title: string;
+  version: number;
+}
+
+export interface DocumentReviewManagerSetupData {
+  documents: DocumentReviewSetupDocument[];
+}
+
+export async function getDocumentReviewPageData(
+  taskId: string,
+  userId: string,
+): Promise<{
+  panel: DocumentReviewPanelData;
+  setup: DocumentReviewManagerSetupData | null;
+} | null> {
+  const panel = await getDocumentReviewPanelData(taskId, userId);
+  if (!panel) return null;
+  if (panel.mode === "REVIEWER") return { panel, setup: null };
+
+  const summaries = await listDocumentsForViewer({
+    limit: 100,
+    taskId: panel.authorityTaskId,
+    userId,
+  });
+  const documents = summaries.flatMap((summary) => {
+    if (!summary.revisionId) return [];
+    return [
+      {
+        revisionId: summary.revisionId,
+        title: summary.title,
+        version: summary.version,
+      },
+    ];
+  });
+
+  return { panel, setup: { documents } };
+}

--- a/packages/web/src/lib/tasks/document-review.integration.test.ts
+++ b/packages/web/src/lib/tasks/document-review.integration.test.ts
@@ -1,5 +1,6 @@
 import {
   ContentVisibility,
+  TaskCommentVisibility,
   TaskStatus,
   TaskVerificationMethod,
   TaskVerificationResult,
@@ -332,6 +333,12 @@ describe.sequential("document governance kernel integration", () => {
       fixture.secondReviewer.user.id,
       { idempotencyKey: "approval" },
     );
+    await expect(
+      prisma.taskComment.findUniqueOrThrow({
+        where: { id: submitted.comment.id },
+        select: { visibility: true },
+      }),
+    ).resolves.toEqual({ visibility: TaskCommentVisibility.INTERNAL });
     const persistedReview = await prisma.task.findUniqueOrThrow({
       where: { id: review.reviewTaskId },
       select: {

--- a/packages/web/src/lib/tasks/document-review.integration.test.ts
+++ b/packages/web/src/lib/tasks/document-review.integration.test.ts
@@ -1,6 +1,12 @@
 import {
+  ContentAccessLevel,
   ContentVisibility,
+  OrganizationMemberRole,
+  OrgStatus,
+  OrgType,
+  TaskCandidateKind,
   TaskCommentVisibility,
+  TaskExecutionAttemptStatus,
   TaskStatus,
   TaskVerificationMethod,
   TaskVerificationResult,
@@ -17,6 +23,7 @@ import {
   applyDocumentProposal,
   createDocumentProposal,
   decideDocumentRevision,
+  getAssignedDocumentReview,
   getDocumentReviewPanelData,
   requestDocumentReview,
   submitDocumentReview,
@@ -50,6 +57,17 @@ async function cleanup() {
   await prisma.task.deleteMany({
     where: { id: { startsWith: TEST_PREFIX } },
   });
+  await prisma.organizationMember.deleteMany({
+    where: {
+      OR: [
+        { organizationId: { startsWith: TEST_PREFIX } },
+        { userId: { startsWith: TEST_PREFIX } },
+      ],
+    },
+  });
+  await prisma.organization.deleteMany({
+    where: { id: { startsWith: TEST_PREFIX } },
+  });
   await prisma.user.deleteMany({
     where: { id: { startsWith: TEST_PREFIX } },
   });
@@ -73,6 +91,27 @@ async function createUser(suffix: string) {
     },
   });
   return { person, user };
+}
+
+async function createOrganization(suffix: string, creatorId: string) {
+  const organization = await prisma.organization.create({
+    data: {
+      creatorId,
+      id: `${TEST_PREFIX}organization_${suffix}`,
+      name: `Document review organization ${suffix}`,
+      slug: `${TEST_PREFIX}organization_${suffix}`,
+      status: OrgStatus.APPROVED,
+      type: OrgType.OTHER,
+    },
+  });
+  await prisma.organizationMember.create({
+    data: {
+      organizationId: organization.id,
+      role: OrganizationMemberRole.OWNER,
+      userId: creatorId,
+    },
+  });
+  return organization;
 }
 
 async function createFixture() {
@@ -312,6 +351,20 @@ describe.sequential("document governance kernel integration", () => {
       fixture.manager.user.id,
       { idempotencyKey: "current-review" },
     );
+    await expect(
+      getAssignedDocumentReview(
+        review.reviewTaskId,
+        fixture.secondReviewer.user.id,
+      ),
+    ).resolves.toMatchObject({
+      canSubmit: true,
+      request: { instructions: "Approve only if the revised text is sound." },
+      reviewTaskId: review.reviewTaskId,
+      target: {
+        body: "Revised governing text.",
+        revisionId: current.revisionId,
+      },
+    });
     const reviewerPanel = await getDocumentReviewPanelData(
       review.reviewTaskId,
       fixture.secondReviewer.user.id,
@@ -393,6 +446,361 @@ describe.sequential("document governance kernel integration", () => {
         select: { status: true },
       }),
     ).resolves.toEqual({ status: TaskStatus.ACTIVE });
+  });
+
+  it("does not expose pinned document bodies to task-only managers", async () => {
+    const fixture = await createFixture();
+    const taskOnlyManager = await createUser("task_only_manager");
+    const review = await requestDocumentReview(
+      fixture.authorityTask.id,
+      {
+        documentRevisionId: fixture.document.revision.id,
+        instructions: "Review text the task-only manager must not see.",
+        reviewerPersonId: fixture.firstReviewer.person.id,
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "manager-document-boundary" },
+    );
+    await prisma.taskManager.create({
+      data: {
+        createdByUserId: fixture.manager.user.id,
+        taskId: fixture.authorityTask.id,
+        userId: taskOnlyManager.user.id,
+      },
+    });
+    await expect(
+      updateDocument({
+        documentId: fixture.document.document.id,
+        editorUserId: fixture.manager.user.id,
+        expectedVersion: fixture.document.document.version,
+        taskId: null,
+      }),
+    ).rejects.toThrow(
+      "Documents with review or decision history cannot be linked to another task",
+    );
+
+    const panel = await getDocumentReviewPanelData(
+      fixture.authorityTask.id,
+      taskOnlyManager.user.id,
+    );
+    expect(panel).toMatchObject({
+      authorityTaskId: fixture.authorityTask.id,
+      mode: "MANAGER",
+    });
+    expect(panel?.mode === "MANAGER" ? panel.reviews : null).toEqual([]);
+    await expect(
+      getAssignedDocumentReview(review.reviewTaskId, taskOnlyManager.user.id),
+    ).rejects.toThrow("Document review not found");
+  });
+
+  it("enforces the OAuth organization boundary on exact review reads and writes", async () => {
+    const manager = await createUser("boundary_manager");
+    const firstReviewer = await createUser("boundary_reviewer_1");
+    const secondReviewer = await createUser("boundary_reviewer_2");
+    const organizationA = await createOrganization("a", manager.user.id);
+    const organizationB = await createOrganization("b", manager.user.id);
+    const authorityTask = await prisma.task.create({
+      data: {
+        createdByUserId: manager.user.id,
+        description: "Organization A authority task.",
+        id: `${TEST_PREFIX}boundary_authority`,
+        isPublic: false,
+        ownerOrganizationId: organizationA.id,
+        title: "Organization A authority",
+      },
+    });
+    const document = await createDocument({
+      body: "Organization B confidential text.",
+      createdByUserId: manager.user.id,
+      organizationId: organizationB.id,
+      taskId: authorityTask.id,
+      title: "Cross-organization document",
+      visibility: ContentVisibility.PRIVATE,
+    });
+    const review = await requestDocumentReview(
+      authorityTask.id,
+      {
+        documentRevisionId: document.revision.id,
+        instructions: "Review through the normal browser session.",
+        reviewerPersonId: firstReviewer.person.id,
+      },
+      manager.user.id,
+      { idempotencyKey: "boundary-browser-review" },
+    );
+    const organizationABoundary = {
+      allowPersonalPrivate: false,
+      organizationIds: [organizationA.id],
+    };
+
+    await expect(
+      getAssignedDocumentReview(review.reviewTaskId, firstReviewer.user.id, {
+        clientAccessBoundary: organizationABoundary,
+      }),
+    ).rejects.toThrow("Document review not found");
+    await expect(
+      requestDocumentReview(
+        authorityTask.id,
+        {
+          documentRevisionId: document.revision.id,
+          instructions: "This scoped client must not cross organizations.",
+          reviewerPersonId: secondReviewer.person.id,
+        },
+        manager.user.id,
+        {
+          clientAccessBoundary: organizationABoundary,
+          idempotencyKey: "boundary-scoped-review",
+        },
+      ),
+    ).rejects.toThrow("Document review not found");
+  });
+
+  it("treats an organization review assignment as personal MCP access for its external reviewer", async () => {
+    const manager = await createUser("external_review_manager");
+    const reviewer = await createUser("external_review_reviewer");
+    const organization = await createOrganization(
+      "external_review",
+      manager.user.id,
+    );
+    const authorityTask = await prisma.task.create({
+      data: {
+        createdByUserId: manager.user.id,
+        description: "Organization review for an external assignee.",
+        id: `${TEST_PREFIX}external_review_authority`,
+        isPublic: false,
+        ownerOrganizationId: organization.id,
+        title: "External exact-revision review",
+      },
+    });
+    const document = await createDocument({
+      body: "Organization text assigned to external counsel.",
+      createdByUserId: manager.user.id,
+      organizationId: organization.id,
+      taskId: authorityTask.id,
+      title: "External review document",
+      visibility: ContentVisibility.PRIVATE,
+    });
+    const review = await requestDocumentReview(
+      authorityTask.id,
+      {
+        documentRevisionId: document.revision.id,
+        instructions: "Review the exact assigned text.",
+        reviewerPersonId: reviewer.person.id,
+      },
+      manager.user.id,
+      { idempotencyKey: "external-review-assignment" },
+    );
+    const personalBoundary = {
+      allowPersonalPrivate: true,
+      organizationIds: [] as string[],
+    };
+
+    await expect(
+      getAssignedDocumentReview(review.reviewTaskId, reviewer.user.id, {
+        clientAccessBoundary: personalBoundary,
+      }),
+    ).resolves.toMatchObject({
+      canSubmit: true,
+      target: { body: "Organization text assigned to external counsel." },
+    });
+    await expect(
+      submitDocumentReview(
+        review.reviewTaskId,
+        { explanation: "The assigned text is sound.", verdict: "APPROVE" },
+        reviewer.user.id,
+        {
+          clientAccessBoundary: personalBoundary,
+          idempotencyKey: "external-review-response",
+        },
+      ),
+    ).resolves.toMatchObject({ response: { verdict: "APPROVE" } });
+  });
+
+  it("lets an organization MCP manager apply an authentic personal proposal", async () => {
+    const manager = await createUser("scoped_apply_manager");
+    const organization = await createOrganization(
+      "scoped_apply",
+      manager.user.id,
+    );
+    const authorityTask = await prisma.task.create({
+      data: {
+        createdByUserId: manager.user.id,
+        description: "Organization authority with a browser proposal.",
+        id: `${TEST_PREFIX}scoped_apply_authority`,
+        isPublic: false,
+        ownerOrganizationId: organization.id,
+        title: "Apply a submitted proposal",
+      },
+    });
+    const document = await createDocument({
+      body: "Original organization text.",
+      createdByUserId: manager.user.id,
+      organizationId: organization.id,
+      taskId: authorityTask.id,
+      title: "Organization document",
+      visibility: ContentVisibility.PRIVATE,
+    });
+    const comment = await postComment({
+      authorUserId: manager.user.id,
+      message: "Use the clearer wording.",
+      taskId: authorityTask.id,
+    });
+    const proposalInput = {
+      baseDocumentRevisionId: document.revision.id,
+      body: "Clearer organization text.",
+      sourceCommentIds: [comment.id],
+      summary: "Applied the requested clarification.",
+      title: "Organization document",
+    };
+    const proposal = await createDocumentProposal(
+      authorityTask.id,
+      proposalInput,
+      manager.user.id,
+      { idempotencyKey: "browser-personal-proposal" },
+    );
+    const organizationBoundary = {
+      allowPersonalPrivate: false,
+      organizationIds: [organization.id],
+    };
+    await expect(
+      createDocumentProposal(authorityTask.id, proposalInput, manager.user.id, {
+        clientAccessBoundary: organizationBoundary,
+        idempotencyKey: "browser-personal-proposal",
+      }),
+    ).resolves.toMatchObject({ artifact: { id: proposal.artifact.id } });
+    await expect(
+      getDocumentReviewPanelData(authorityTask.id, manager.user.id, {
+        clientAccessBoundary: organizationBoundary,
+      }),
+    ).resolves.toMatchObject({
+      mode: "MANAGER",
+      proposals: [{ artifactId: proposal.artifact.id }],
+    });
+
+    const apply = () =>
+      applyDocumentProposal(
+        authorityTask.id,
+        { proposalArtifactId: proposal.artifact.id },
+        manager.user.id,
+        {
+          clientAccessBoundary: organizationBoundary,
+          idempotencyKey: "organization-scoped-apply",
+        },
+      );
+    await expect(apply()).resolves.toMatchObject({
+      application: {
+        resultingDocument: { documentId: document.document.id, version: 2 },
+      },
+    });
+    await expect(apply()).resolves.toMatchObject({
+      application: {
+        resultingDocument: { documentId: document.document.id, version: 2 },
+      },
+    });
+  });
+
+  it("does not treat caller-authored artifact metadata as governance history", async () => {
+    const fixture = await createFixture();
+    const now = new Date();
+    const attempt = await prisma.taskExecutionAttempt.create({
+      data: {
+        completedAt: now,
+        executorKey: `user:${fixture.manager.user.id}`,
+        executorKind: TaskCandidateKind.USER,
+        executorPersonId: fixture.manager.person.id,
+        executorUserId: fixture.manager.user.id,
+        metadata: { startedByUserId: fixture.manager.user.id },
+        startedAt: now,
+        status: TaskExecutionAttemptStatus.COMPLETED,
+        taskId: fixture.authorityTask.id,
+      },
+    });
+    await prisma.taskExecutionArtifact.create({
+      data: {
+        contentHash: "caller-controlled-lookalike",
+        metadataJson: { kind: "document-proposal" },
+        structuredResultJson: {
+          base: { documentId: fixture.document.document.id },
+        },
+        submittedByUserId: fixture.manager.user.id,
+        taskExecutionAttemptId: attempt.id,
+      },
+    });
+
+    await expect(
+      updateDocument({
+        documentId: fixture.document.document.id,
+        editorUserId: fixture.manager.user.id,
+        expectedVersion: fixture.document.document.version,
+        taskId: null,
+      }),
+    ).resolves.toMatchObject({ document: { taskId: null, version: 2 } });
+  });
+
+  it("does not let a proposal author review the applied version of their own text", async () => {
+    const fixture = await createFixture();
+    await Promise.all([
+      prisma.taskManager.create({
+        data: {
+          createdByUserId: fixture.manager.user.id,
+          taskId: fixture.authorityTask.id,
+          userId: fixture.firstReviewer.user.id,
+        },
+      }),
+      prisma.contentAccessGrant.create({
+        data: {
+          accessLevel: ContentAccessLevel.VIEW,
+          documentId: fixture.document.document.id,
+          grantedByUserId: fixture.manager.user.id,
+          userId: fixture.firstReviewer.user.id,
+        },
+      }),
+    ]);
+    const comment = await postComment({
+      authorUserId: fixture.firstReviewer.user.id,
+      message: "Replace the original language with my proposed text.",
+      taskId: fixture.authorityTask.id,
+    });
+    const proposal = await createDocumentProposal(
+      fixture.authorityTask.id,
+      {
+        baseDocumentRevisionId: fixture.document.revision.id,
+        body: "Text authored by the proposed reviewer.",
+        sourceCommentIds: [comment.id],
+        summary: "Replace the original language.",
+        title: "Governing document",
+      },
+      fixture.firstReviewer.user.id,
+      { idempotencyKey: "reviewer-authored-proposal" },
+    );
+    await expect(
+      updateDocument({
+        documentId: proposal.proposal.proposal.documentId,
+        editorUserId: fixture.firstReviewer.user.id,
+        expectedVersion: proposal.proposal.proposal.version,
+        taskId: fixture.authorityTask.id,
+      }),
+    ).rejects.toThrow(
+      "Documents with review or decision history cannot be linked to another task",
+    );
+    const applied = await applyDocumentProposal(
+      fixture.authorityTask.id,
+      { proposalArtifactId: proposal.artifact.id },
+      fixture.manager.user.id,
+      { idempotencyKey: "manager-applies-reviewer-proposal" },
+    );
+
+    await expect(
+      requestDocumentReview(
+        fixture.authorityTask.id,
+        {
+          documentRevisionId: applied.application.resultingDocument.revisionId,
+          instructions: "Independently review the applied text.",
+          reviewerPersonId: fixture.firstReviewer.person.id,
+        },
+        fixture.manager.user.id,
+        { idempotencyKey: "proposal-author-self-review" },
+      ),
+    ).rejects.toThrow("based on their own proposal");
   });
 
   it("ignores forged duplicates and keeps unrelated children out of the manager review list", async () => {

--- a/packages/web/src/lib/tasks/document-review.integration.test.ts
+++ b/packages/web/src/lib/tasks/document-review.integration.test.ts
@@ -1,0 +1,713 @@
+import {
+  ContentVisibility,
+  TaskStatus,
+  TaskVerificationMethod,
+  TaskVerificationResult,
+} from "@optimitron/db";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createDocument, updateDocument } from "@/lib/documents.server";
+import { prisma } from "@/lib/prisma";
+import { postComment } from "@/lib/tasks/task-comments.server";
+import { DOCUMENT_REVIEW_TASK_KEY_PREFIX } from "./document-review-contracts";
+import {
+  applyDocumentProposal,
+  createDocumentProposal,
+  decideDocumentRevision,
+  getDocumentReviewPanelData,
+  requestDocumentReview,
+  submitDocumentReview,
+} from "./document-review.server";
+
+const TEST_PREFIX = "document_review_kernel_";
+
+async function cleanup() {
+  const taskWhere = {
+    OR: [
+      { id: { startsWith: TEST_PREFIX } },
+      { parentTaskId: { startsWith: TEST_PREFIX } },
+    ],
+  };
+  await prisma.taskVerification.deleteMany({
+    where: { taskExecutionAttempt: { task: taskWhere } },
+  });
+  await prisma.taskExecutionArtifact.deleteMany({
+    where: { taskExecutionAttempt: { task: taskWhere } },
+  });
+  await prisma.taskExecutionAttempt.deleteMany({
+    where: { task: taskWhere },
+  });
+  await prisma.taskComment.deleteMany({ where: { task: taskWhere } });
+  await prisma.document.deleteMany({
+    where: { createdByUserId: { startsWith: TEST_PREFIX } },
+  });
+  await prisma.task.deleteMany({
+    where: { parentTaskId: { startsWith: TEST_PREFIX } },
+  });
+  await prisma.task.deleteMany({
+    where: { id: { startsWith: TEST_PREFIX } },
+  });
+  await prisma.user.deleteMany({
+    where: { id: { startsWith: TEST_PREFIX } },
+  });
+  await prisma.person.deleteMany({
+    where: { id: { startsWith: TEST_PREFIX } },
+  });
+}
+
+async function createUser(suffix: string) {
+  const person = await prisma.person.create({
+    data: {
+      displayName: `Document review ${suffix}`,
+      id: `${TEST_PREFIX}person_${suffix}`,
+    },
+  });
+  const user = await prisma.user.create({
+    data: {
+      email: `${TEST_PREFIX}${suffix}@example.test`,
+      id: `${TEST_PREFIX}user_${suffix}`,
+      personId: person.id,
+    },
+  });
+  return { person, user };
+}
+
+async function createFixture() {
+  const manager = await createUser("manager");
+  const firstReviewer = await createUser("reviewer_1");
+  const secondReviewer = await createUser("reviewer_2");
+  const authorityTask = await prisma.task.create({
+    data: {
+      createdByUserId: manager.user.id,
+      description: "Own the exact-revision document decision workflow.",
+      id: `${TEST_PREFIX}authority`,
+      isPublic: false,
+      title: "Decide the governing document",
+    },
+  });
+  const document = await createDocument({
+    body: "Original governing text.",
+    createdByUserId: manager.user.id,
+    taskId: authorityTask.id,
+    title: "Governing document",
+    visibility: ContentVisibility.PRIVATE,
+  });
+  return {
+    authorityTask,
+    document,
+    firstReviewer,
+    manager,
+    secondReviewer,
+  };
+}
+
+async function removeForcedArtifactFailure() {
+  await prisma.$executeRawUnsafe(
+    'DROP TRIGGER IF EXISTS "document_review_kernel_fail_artifact" ON "TaskExecutionArtifact"',
+  );
+  await prisma.$executeRawUnsafe(
+    'DROP FUNCTION IF EXISTS "document_review_kernel_fail_artifact"()',
+  );
+}
+
+async function installForcedArtifactFailure() {
+  await removeForcedArtifactFailure();
+  await prisma.$executeRawUnsafe(`
+    CREATE FUNCTION "document_review_kernel_fail_artifact"()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      IF NEW."label" = 'Document review response'
+        AND EXISTS (
+          SELECT 1
+          FROM "TaskExecutionAttempt" attempt
+          JOIN "Task" task ON task."id" = attempt."taskId"
+          WHERE attempt."id" = NEW."taskExecutionAttemptId"
+            AND (
+              attempt."taskId" LIKE '${TEST_PREFIX}%'
+              OR task."parentTaskId" LIKE '${TEST_PREFIX}%'
+            )
+        )
+      THEN
+        RAISE EXCEPTION 'forced document-review artifact failure';
+      END IF;
+      RETURN NEW;
+    END;
+    $$
+  `);
+  await prisma.$executeRawUnsafe(`
+    CREATE TRIGGER "document_review_kernel_fail_artifact"
+    BEFORE INSERT ON "TaskExecutionArtifact"
+    FOR EACH ROW
+    EXECUTE FUNCTION "document_review_kernel_fail_artifact"()
+  `);
+}
+
+describe.sequential("document governance kernel integration", () => {
+  beforeEach(cleanup);
+  afterAll(async () => {
+    await removeForcedArtifactFailure();
+    await cleanup();
+  });
+
+  it("turns comments into an optimistic proposal, stales old reviews, and adopts an independent approval", async () => {
+    const fixture = await createFixture();
+    await expect(
+      requestDocumentReview(
+        fixture.authorityTask.id,
+        {
+          documentRevisionId: fixture.document.revision.id,
+          instructions: "Check this exact revision.",
+          reviewerPersonId: fixture.manager.person.id,
+        },
+        fixture.manager.user.id,
+        { idempotencyKey: "self-review" },
+      ),
+    ).rejects.toThrow("cannot review their own");
+
+    const oldReview = await requestDocumentReview(
+      fixture.authorityTask.id,
+      {
+        documentRevisionId: fixture.document.revision.id,
+        instructions: "Check this exact revision before it changes.",
+        reviewerPersonId: fixture.firstReviewer.person.id,
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "old-review" },
+    );
+    const comment = await postComment({
+      authorUserId: fixture.manager.user.id,
+      message: "Replace 'Original' with 'Revised' and explain the change.",
+      taskId: fixture.authorityTask.id,
+    });
+    const proposalResult = await createDocumentProposal(
+      fixture.authorityTask.id,
+      {
+        baseDocumentRevisionId: fixture.document.revision.id,
+        body: "Revised governing text.",
+        sourceCommentIds: [comment.id],
+        summary: "Applied the requested wording change.",
+        title: "Governing document",
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "proposal" },
+    );
+    const proposalDocument = await prisma.document.findUniqueOrThrow({
+      where: { id: proposalResult.proposal.proposal.documentId },
+      select: { taskId: true, visibility: true },
+    });
+    expect(proposalDocument).toEqual({
+      taskId: null,
+      visibility: ContentVisibility.PRIVATE,
+    });
+    expect(proposalResult.proposal.sourceComments).toEqual([
+      {
+        commentId: comment.id,
+        contentHash: expect.any(String),
+        taskId: fixture.authorityTask.id,
+      },
+    ]);
+    const pendingPanel = await getDocumentReviewPanelData(
+      fixture.authorityTask.id,
+      fixture.manager.user.id,
+    );
+    expect(pendingPanel?.mode).toBe("MANAGER");
+    if (pendingPanel?.mode !== "MANAGER") {
+      throw new Error("Expected manager panel");
+    }
+    expect(pendingPanel.proposals.map((item) => item.artifactId)).toEqual([
+      proposalResult.artifact.id,
+    ]);
+    expect(pendingPanel.proposals[0]?.proposed).toMatchObject({
+      body: "Revised governing text.",
+      title: "Governing document",
+    });
+    await expect(
+      getDocumentReviewPanelData(
+        fixture.authorityTask.id,
+        fixture.firstReviewer.user.id,
+      ),
+    ).resolves.toBeNull();
+
+    const applied = await applyDocumentProposal(
+      fixture.authorityTask.id,
+      { proposalArtifactId: proposalResult.artifact.id },
+      fixture.manager.user.id,
+      { idempotencyKey: "apply" },
+    );
+    const replay = await applyDocumentProposal(
+      fixture.authorityTask.id,
+      { proposalArtifactId: proposalResult.artifact.id },
+      fixture.manager.user.id,
+      { idempotencyKey: "apply" },
+    );
+    expect(replay.artifact.id).toBe(applied.artifact.id);
+    expect(replay.application.resultingDocument).toEqual(
+      applied.application.resultingDocument,
+    );
+    const appliedPanel = await getDocumentReviewPanelData(
+      fixture.authorityTask.id,
+      fixture.manager.user.id,
+    );
+    expect(
+      appliedPanel?.mode === "MANAGER" ? appliedPanel.proposals : null,
+    ).toEqual([]);
+    await expect(
+      prisma.task.findUniqueOrThrow({
+        where: { id: oldReview.reviewTaskId },
+        select: { status: true },
+      }),
+    ).resolves.toEqual({ status: TaskStatus.STALE });
+
+    const current = applied.application.resultingDocument;
+    const review = await requestDocumentReview(
+      fixture.authorityTask.id,
+      {
+        documentRevisionId: current.revisionId,
+        instructions: "Approve only if the revised text is sound.",
+        reviewerPersonId: fixture.secondReviewer.person.id,
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "current-review" },
+    );
+    const reviewerPanel = await getDocumentReviewPanelData(
+      review.reviewTaskId,
+      fixture.secondReviewer.user.id,
+    );
+    expect(reviewerPanel?.mode).toBe("REVIEWER");
+    expect(
+      reviewerPanel?.mode === "REVIEWER" ? reviewerPanel.review.target : null,
+    ).toMatchObject({
+      body: "Revised governing text.",
+      revisionId: current.revisionId,
+      stale: false,
+    });
+    const submitted = await submitDocumentReview(
+      review.reviewTaskId,
+      {
+        explanation: "The revised text matches the requested change.",
+        verdict: "APPROVE",
+      },
+      fixture.secondReviewer.user.id,
+      { idempotencyKey: "approval" },
+    );
+    const persistedReview = await prisma.task.findUniqueOrThrow({
+      where: { id: review.reviewTaskId },
+      select: {
+        status: true,
+        executionAttempts: {
+          select: {
+            verifications: {
+              select: { method: true, result: true },
+            },
+          },
+        },
+      },
+    });
+    expect(persistedReview.status).toBe(TaskStatus.VERIFIED);
+    expect(persistedReview.executionAttempts[0]?.verifications[0]).toEqual({
+      method: TaskVerificationMethod.DETERMINISTIC,
+      result: TaskVerificationResult.ACCEPTED,
+    });
+
+    const decision = await decideDocumentRevision(
+      fixture.authorityTask.id,
+      {
+        action: "ADOPT",
+        documentRevisionId: current.revisionId,
+        reviewArtifactId: submitted.artifact.id,
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "adopt" },
+    );
+    expect(decision.decision).toMatchObject({
+      action: "ADOPT",
+      reason: null,
+      scope: "INTERNAL",
+      target: current,
+    });
+    await expect(
+      decideDocumentRevision(
+        fixture.authorityTask.id,
+        {
+          action: "REJECT",
+          documentRevisionId: current.revisionId,
+          reason: "Attempted conflicting terminal decision.",
+          reviewArtifactId: submitted.artifact.id,
+        },
+        fixture.manager.user.id,
+        { idempotencyKey: "reject-after-adopt" },
+      ),
+    ).rejects.toThrow("already has an internal decision");
+    await expect(
+      prisma.task.findUniqueOrThrow({
+        where: { id: fixture.authorityTask.id },
+        select: { status: true },
+      }),
+    ).resolves.toEqual({ status: TaskStatus.ACTIVE });
+  });
+
+  it("ignores forged duplicates and keeps unrelated children out of the manager review list", async () => {
+    const fixture = await createFixture();
+    const contentHash = fixture.document.revision.contentHash;
+    if (!contentHash)
+      throw new Error("Fixture revision must have a content hash");
+    const target = {
+      contentHash,
+      documentId: fixture.document.document.id,
+      revisionId: fixture.document.revision.id,
+      version: fixture.document.revision.version,
+    };
+    await prisma.task.create({
+      data: {
+        assigneePersonId: fixture.firstReviewer.person.id,
+        contextJson: {
+          documentReview: {
+            authorityTaskId: fixture.authorityTask.id,
+            instructions: "Forged review lookalike.",
+            requestedAt: "2026-07-29T12:00:00.000Z",
+            requestedByUserId: fixture.manager.user.id,
+            schema: "optimitron.review-request.v1",
+            target,
+          },
+        },
+        createdByUserId: fixture.manager.user.id,
+        description: "This task has no authentic immutable binding.",
+        id: `${TEST_PREFIX}forged_review`,
+        isPublic: false,
+        parentTaskId: fixture.authorityTask.id,
+        taskKey: `${DOCUMENT_REVIEW_TASK_KEY_PREFIX}${fixture.authorityTask.id}:forged`,
+        title: "Forged review",
+      },
+    });
+
+    const review = await requestDocumentReview(
+      fixture.authorityTask.id,
+      {
+        documentRevisionId: fixture.document.revision.id,
+        instructions: "Perform the authentic exact-revision review.",
+        reviewerPersonId: fixture.firstReviewer.person.id,
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "authentic-after-forgery" },
+    );
+    await expect(
+      prisma.task.findUniqueOrThrow({
+        where: { id: review.reviewTaskId },
+        select: { title: true },
+      }),
+    ).resolves.toEqual({ title: "Review: Governing document" });
+    await expect(
+      requestDocumentReview(
+        fixture.authorityTask.id,
+        {
+          documentRevisionId: fixture.document.revision.id,
+          instructions: "Attempt a duplicate authentic review.",
+          reviewerPersonId: fixture.firstReviewer.person.id,
+        },
+        fixture.manager.user.id,
+        { idempotencyKey: "authentic-duplicate" },
+      ),
+    ).rejects.toThrow("already has a review task");
+
+    await prisma.task.create({
+      data: {
+        createdByUserId: fixture.manager.user.id,
+        description: "Ordinary work under the same authority task.",
+        id: `${TEST_PREFIX}unrelated_child`,
+        isPublic: false,
+        parentTaskId: fixture.authorityTask.id,
+        taskKey: `${DOCUMENT_REVIEW_TASK_KEY_PREFIX}${fixture.authorityTask.id}:ordinary-without-context`,
+        title: "Unrelated child task",
+      },
+    });
+    const ordinaryPanel = await getDocumentReviewPanelData(
+      `${TEST_PREFIX}unrelated_child`,
+      fixture.manager.user.id,
+    );
+    expect(ordinaryPanel).toMatchObject({
+      authorityTaskId: `${TEST_PREFIX}unrelated_child`,
+      mode: "MANAGER",
+    });
+    const panel = await getDocumentReviewPanelData(
+      fixture.authorityTask.id,
+      fixture.manager.user.id,
+    );
+    expect(panel?.mode).toBe("MANAGER");
+    expect(
+      panel?.mode === "MANAGER"
+        ? panel.reviews.map((item) => item.reviewTaskId)
+        : null,
+    ).toEqual([review.reviewTaskId]);
+  });
+
+  it("records a reasoned REJECT without mutating the document head", async () => {
+    const fixture = await createFixture();
+    const review = await requestDocumentReview(
+      fixture.authorityTask.id,
+      {
+        documentRevisionId: fixture.document.revision.id,
+        instructions: "Reject the revision if it is not ready.",
+        reviewerPersonId: fixture.firstReviewer.person.id,
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "reject-review" },
+    );
+    const submitted = await submitDocumentReview(
+      review.reviewTaskId,
+      {
+        explanation: "The text needs a defined effective date.",
+        verdict: "CHANGES_REQUESTED",
+      },
+      fixture.firstReviewer.user.id,
+      { idempotencyKey: "changes-requested" },
+    );
+    const before = await prisma.document.findUniqueOrThrow({
+      where: { id: fixture.document.document.id },
+      select: { currentRevisionId: true, version: true },
+    });
+    const rejected = await decideDocumentRevision(
+      fixture.authorityTask.id,
+      {
+        action: "REJECT",
+        documentRevisionId: fixture.document.revision.id,
+        reason: "Revise the text to define an effective date.",
+        reviewArtifactId: submitted.artifact.id,
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "reject" },
+    );
+    expect(rejected.decision).toMatchObject({
+      action: "REJECT",
+      reason: "Revise the text to define an effective date.",
+    });
+    await expect(
+      prisma.document.findUniqueOrThrow({
+        where: { id: fixture.document.document.id },
+        select: { currentRevisionId: true, version: true },
+      }),
+    ).resolves.toEqual(before);
+    await expect(
+      decideDocumentRevision(
+        fixture.authorityTask.id,
+        {
+          action: "ADOPT",
+          documentRevisionId: fixture.document.revision.id,
+          reviewArtifactId: submitted.artifact.id,
+        },
+        fixture.manager.user.id,
+        { idempotencyKey: "adopt-non-approval" },
+      ),
+    ).rejects.toThrow("requires an APPROVE verdict");
+  });
+
+  it("rejects an optimistic apply when a snapshotted comment is edited and restored", async () => {
+    const fixture = await createFixture();
+    const comment = await postComment({
+      authorUserId: fixture.manager.user.id,
+      message: "Make the requested wording change.",
+      taskId: fixture.authorityTask.id,
+    });
+    const proposal = await createDocumentProposal(
+      fixture.authorityTask.id,
+      {
+        baseDocumentRevisionId: fixture.document.revision.id,
+        body: "Changed governing text.",
+        sourceCommentIds: [comment.id],
+        summary: "Applied the requested wording change.",
+        title: "Governing document",
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "comment-drift-proposal" },
+    );
+    await prisma.taskComment.update({
+      where: { id: comment.id },
+      data: {
+        editedAt: new Date(),
+        message: "Make the requested wording change.",
+        version: { increment: 1 },
+      },
+    });
+    const before = await prisma.document.findUniqueOrThrow({
+      where: { id: fixture.document.document.id },
+      select: { currentRevisionId: true, version: true },
+    });
+    await expect(
+      applyDocumentProposal(
+        fixture.authorityTask.id,
+        { proposalArtifactId: proposal.artifact.id },
+        fixture.manager.user.id,
+        { idempotencyKey: "comment-drift-apply" },
+      ),
+    ).rejects.toThrow("source comment changed");
+    await expect(
+      prisma.document.findUniqueOrThrow({
+        where: { id: fixture.document.document.id },
+        select: { currentRevisionId: true, version: true },
+      }),
+    ).resolves.toEqual(before);
+    await expect(
+      prisma.taskExecutionAttempt.count({
+        where: {
+          metadata: {
+            equals: "document-proposal-application",
+            path: ["kind"],
+          },
+          taskId: fixture.authorityTask.id,
+        },
+      }),
+    ).resolves.toBe(0);
+  });
+
+  it("propagates revision integrity failures through reviewer and manager panels", async () => {
+    const fixture = await createFixture();
+    const review = await requestDocumentReview(
+      fixture.authorityTask.id,
+      {
+        documentRevisionId: fixture.document.revision.id,
+        instructions: "Review the exact persisted bytes.",
+        reviewerPersonId: fixture.firstReviewer.person.id,
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "integrity-review" },
+    );
+    await prisma.documentRevision.update({
+      where: { id: fixture.document.revision.id },
+      data: { body: "Tampered without updating the content hash." },
+    });
+    await expect(
+      getDocumentReviewPanelData(
+        review.reviewTaskId,
+        fixture.firstReviewer.user.id,
+      ),
+    ).rejects.toThrow("Document revision integrity check failed");
+    await prisma.documentRevision.update({
+      where: { id: fixture.document.revision.id },
+      data: { body: "Original governing text." },
+    });
+
+    const comment = await postComment({
+      authorUserId: fixture.manager.user.id,
+      message: "Clarify the governing text.",
+      taskId: fixture.authorityTask.id,
+    });
+    const proposal = await createDocumentProposal(
+      fixture.authorityTask.id,
+      {
+        baseDocumentRevisionId: fixture.document.revision.id,
+        body: "Clarified governing text.",
+        sourceCommentIds: [comment.id],
+        summary: "Clarified the requested wording.",
+        title: "Governing document",
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "integrity-proposal" },
+    );
+    await prisma.documentRevision.update({
+      where: { id: proposal.proposal.proposal.revisionId },
+      data: { body: "Tampered proposal body." },
+    });
+    await expect(
+      getDocumentReviewPanelData(
+        fixture.authorityTask.id,
+        fixture.manager.user.id,
+      ),
+    ).rejects.toThrow("Document revision integrity check failed");
+  });
+
+  it("omits a proposal whose private document changed after artifact creation", async () => {
+    const fixture = await createFixture();
+    const comment = await postComment({
+      authorUserId: fixture.manager.user.id,
+      message: "Clarify the governing text.",
+      taskId: fixture.authorityTask.id,
+    });
+    const proposal = await createDocumentProposal(
+      fixture.authorityTask.id,
+      {
+        baseDocumentRevisionId: fixture.document.revision.id,
+        body: "Clarified governing text.",
+        sourceCommentIds: [comment.id],
+        summary: "Clarified the requested wording.",
+        title: "Governing document",
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "tamper-proposal" },
+    );
+    await updateDocument({
+      body: "Changed after proposal creation.",
+      documentId: proposal.proposal.proposal.documentId,
+      editorUserId: fixture.manager.user.id,
+      expectedVersion: 1,
+    });
+    const panel = await getDocumentReviewPanelData(
+      fixture.authorityTask.id,
+      fixture.manager.user.id,
+    );
+    expect(panel?.mode === "MANAGER" ? panel.proposals : null).toEqual([]);
+  });
+
+  it("rolls back the rationale comment and execution rows when artifact creation fails", async () => {
+    const fixture = await createFixture();
+    const review = await requestDocumentReview(
+      fixture.authorityTask.id,
+      {
+        documentRevisionId: fixture.document.revision.id,
+        instructions: "Request changes with a reason if needed.",
+        reviewerPersonId: fixture.firstReviewer.person.id,
+      },
+      fixture.manager.user.id,
+      { idempotencyKey: "rollback-review" },
+    );
+    await installForcedArtifactFailure();
+    try {
+      await expect(
+        submitDocumentReview(
+          review.reviewTaskId,
+          {
+            explanation: "Define the effective date before adoption.",
+            verdict: "CHANGES_REQUESTED",
+          },
+          fixture.firstReviewer.user.id,
+          { idempotencyKey: "rollback-submission" },
+        ),
+      ).rejects.toThrow("forced document-review artifact failure");
+    } finally {
+      await removeForcedArtifactFailure();
+    }
+
+    const [task, commentCount, attemptCount, artifactCount, verificationCount] =
+      await Promise.all([
+        prisma.task.findUniqueOrThrow({
+          where: { id: review.reviewTaskId },
+          select: { status: true },
+        }),
+        prisma.taskComment.count({ where: { taskId: review.reviewTaskId } }),
+        prisma.taskExecutionAttempt.count({
+          where: { taskId: review.reviewTaskId },
+        }),
+        prisma.taskExecutionArtifact.count({
+          where: {
+            taskExecutionAttempt: { taskId: review.reviewTaskId },
+          },
+        }),
+        prisma.taskVerification.count({
+          where: {
+            taskExecutionAttempt: { taskId: review.reviewTaskId },
+          },
+        }),
+      ]);
+    expect(task.status).toBe(TaskStatus.ACTIVE);
+    expect({
+      artifactCount,
+      attemptCount,
+      commentCount,
+      verificationCount,
+    }).toEqual({
+      artifactCount: 0,
+      attemptCount: 0,
+      commentCount: 0,
+      verificationCount: 0,
+    });
+  });
+});

--- a/packages/web/src/lib/tasks/document-review.integration.test.ts
+++ b/packages/web/src/lib/tasks/document-review.integration.test.ts
@@ -8,7 +8,10 @@ import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { createDocument, updateDocument } from "@/lib/documents.server";
 import { prisma } from "@/lib/prisma";
 import { postComment } from "@/lib/tasks/task-comments.server";
-import { DOCUMENT_REVIEW_TASK_KEY_PREFIX } from "./document-review-contracts";
+import {
+  DOCUMENT_REVIEW_CONTEXT_KEY,
+  DOCUMENT_REVIEW_TASK_KEY_PREFIX,
+} from "./document-review-contracts";
 import {
   applyDocumentProposal,
   createDocumentProposal,
@@ -152,6 +155,24 @@ describe.sequential("document governance kernel integration", () => {
 
   it("turns comments into an optimistic proposal, stales old reviews, and adopts an independent approval", async () => {
     const fixture = await createFixture();
+    const unreachableReviewer = await prisma.person.create({
+      data: {
+        displayName: "Unreachable reviewer",
+        id: `${TEST_PREFIX}person_unreachable`,
+      },
+    });
+    await expect(
+      requestDocumentReview(
+        fixture.authorityTask.id,
+        {
+          documentRevisionId: fixture.document.revision.id,
+          instructions: "This assignment must remain reachable.",
+          reviewerPersonId: unreachableReviewer.id,
+        },
+        fixture.manager.user.id,
+        { idempotencyKey: "unreachable-reviewer" },
+      ),
+    ).rejects.toThrow("email address or linked account");
     await expect(
       requestDocumentReview(
         fixture.authorityTask.id,
@@ -175,6 +196,20 @@ describe.sequential("document governance kernel integration", () => {
       fixture.manager.user.id,
       { idempotencyKey: "old-review" },
     );
+    const forgedReview = await prisma.task.create({
+      data: {
+        contextJson: {
+          [DOCUMENT_REVIEW_CONTEXT_KEY]: oldReview.request,
+        },
+        createdByUserId: fixture.manager.user.id,
+        description: "Ordinary task with colliding metadata.",
+        id: `${TEST_PREFIX}forged_review`,
+        parentTaskId: fixture.authorityTask.id,
+        status: TaskStatus.ACTIVE,
+        taskKey: `${TEST_PREFIX}ordinary-task`,
+        title: "Do not stale this ordinary task",
+      },
+    });
     const comment = await postComment({
       authorUserId: fixture.manager.user.id,
       message: "Replace 'Original' with 'Revised' and explain the change.",
@@ -258,6 +293,12 @@ describe.sequential("document governance kernel integration", () => {
         select: { status: true },
       }),
     ).resolves.toEqual({ status: TaskStatus.STALE });
+    await expect(
+      prisma.task.findUniqueOrThrow({
+        where: { id: forgedReview.id },
+        select: { status: true },
+      }),
+    ).resolves.toEqual({ status: TaskStatus.ACTIVE });
 
     const current = applied.application.resultingDocument;
     const review = await requestDocumentReview(

--- a/packages/web/src/lib/tasks/document-review.server.ts
+++ b/packages/web/src/lib/tasks/document-review.server.ts
@@ -17,20 +17,26 @@ import {
   assertDocumentAccess,
   lockContentResources,
 } from "@/lib/content-access.server";
+import { isDocumentWithinClientAccessBoundary } from "@/lib/documents.server";
 import { prisma } from "@/lib/prisma";
 import {
   ApplyDocumentProposalInputSchema,
   assertReviewResponseMatchesRequest,
   CreateDocumentProposalInputSchema,
   DecideDocumentRevisionInputSchema,
+  DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND,
+  DOCUMENT_PROPOSAL_ARTIFACT_KIND,
   DOCUMENT_REVIEW_CONTEXT_KEY,
+  DOCUMENT_REVIEW_RESPONSE_ARTIFACT_KIND,
   DOCUMENT_REVIEW_TASK_KEY_PREFIX,
+  type DocumentProposalApplicationV1,
   DocumentProposalApplicationV1Schema,
   type DocumentProposalSourceCommentV1,
   DocumentProposalV1Schema,
   type DocumentRevisionPin,
   InternalDocumentDecisionV1Schema,
   type InternalDocumentDecisionV1,
+  INTERNAL_DOCUMENT_DECISION_ARTIFACT_KIND,
   readDocumentProposal,
   readDocumentProposalApplication,
   readInternalDocumentDecision,
@@ -58,10 +64,6 @@ import {
   type TaskClientAccessBoundary,
 } from "@/lib/tasks/task-visibility.server";
 
-const PROPOSAL_ARTIFACT_KIND = "document-proposal";
-const PROPOSAL_APPLICATION_ARTIFACT_KIND = "document-proposal-application";
-const REVIEW_RESPONSE_ARTIFACT_KIND = "document-review-response";
-const INTERNAL_DECISION_ARTIFACT_KIND = "internal-document-decision";
 const REVIEW_DELIVERY_RULE_KEY = "document-review-delivery.v1";
 
 type JsonRecord = Record<string, unknown>;
@@ -169,6 +171,28 @@ function taskBoundaryWhere(
 ): Prisma.TaskWhereInput {
   const base: Prisma.TaskWhereInput = { deletedAt: null, id: taskId };
   return boundary ? { AND: [base, getTaskClientAccessWhere(boundary)] } : base;
+}
+
+function assignedReviewTaskBoundaryWhere(
+  taskId: string,
+  assigneePersonId: string,
+  boundary?: TaskClientAccessBoundary,
+): Prisma.TaskWhereInput {
+  const base: Prisma.TaskWhereInput = { deletedAt: null, id: taskId };
+  if (!boundary) return base;
+  const allowed: Prisma.TaskWhereInput[] = [getTaskClientAccessWhere(boundary)];
+  if (boundary.allowPersonalPrivate) {
+    allowed.push({
+      assigneePersonId,
+      contextJson: {
+        equals: "optimitron.review-request.v1",
+        path: [DOCUMENT_REVIEW_CONTEXT_KEY, "schema"],
+      },
+      isPublic: false,
+      taskKey: { startsWith: DOCUMENT_REVIEW_TASK_KEY_PREFIX },
+    });
+  }
+  return { AND: [base, { OR: allowed }] };
 }
 
 function genuineReviewChildWhere(
@@ -365,6 +389,64 @@ async function loadExactRevision(
   return revision;
 }
 
+async function assertRevisionClientBoundary(
+  tx: Prisma.TransactionClient,
+  revision: ExactRevision,
+  boundary?: TaskClientAccessBoundary,
+) {
+  if (
+    !(await isDocumentWithinClientAccessBoundary(
+      revision.document,
+      boundary,
+      tx,
+    ))
+  ) {
+    notFound();
+  }
+}
+
+async function assertAssignedReviewRevisionClientBoundary(
+  tx: Prisma.TransactionClient,
+  revision: ExactRevision,
+  boundary?: TaskClientAccessBoundary,
+) {
+  if (boundary?.allowPersonalPrivate) return;
+  await assertRevisionClientBoundary(tx, revision, boundary);
+}
+
+async function canActorReadDocument(
+  tx: Prisma.TransactionClient,
+  documentId: string,
+  actorUserId: string,
+  boundary?: TaskClientAccessBoundary,
+) {
+  const document = await tx.document.findFirst({
+    where: { deletedAt: null, id: documentId },
+    select: {
+      organizationId: true,
+      taskId: true,
+      visibility: true,
+    },
+  });
+  if (
+    !document ||
+    !(await isDocumentWithinClientAccessBoundary(document, boundary, tx))
+  ) {
+    return false;
+  }
+  try {
+    await assertDocumentAccess(
+      documentId,
+      actorUserId,
+      ContentAccessLevel.VIEW,
+      tx,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function loadExactRevisionOrNull(
   tx: Prisma.TransactionClient,
   pin: DocumentRevisionPin,
@@ -439,6 +521,7 @@ const reviewTaskSelect = {
 } satisfies Prisma.TaskSelect;
 
 type ReviewTask = Prisma.TaskGetPayload<{ select: typeof reviewTaskSelect }>;
+type AppliedProposalAuthorCache = Map<string, Promise<Set<string>>>;
 
 const requestedTaskProbeSelect = {
   assigneePersonId: true,
@@ -450,6 +533,7 @@ async function hasValidReviewTaskProvenance(
   tx: Prisma.TransactionClient,
   task: ReviewTask,
   request = readReviewRequest(task.contextJson),
+  proposalAuthorCache?: AppliedProposalAuthorCache,
 ): Promise<boolean> {
   if (
     !request ||
@@ -492,16 +576,25 @@ async function hasValidReviewTaskProvenance(
       },
     }),
   ]);
-  return Boolean(
+  const validBinding = Boolean(
     requester?.personId &&
-    requester.personId !== task.assigneePersonId &&
     authorityTask &&
     revision &&
+    requester.personId !== task.assigneePersonId &&
     authorityTask.ownerOrganizationId === task.ownerOrganizationId &&
     authorityTask.jurisdictionId === task.jurisdictionId &&
     revision.document.taskId === request.authorityTaskId &&
     revision.createdByUser.personId !== task.assigneePersonId,
   );
+  if (!validBinding) return false;
+
+  const proposalAuthorPersonIds = await getAppliedProposalAuthorPersonIds(
+    tx,
+    request.authorityTaskId,
+    request.target,
+    proposalAuthorCache,
+  );
+  return !proposalAuthorPersonIds.has(task.assigneePersonId);
 }
 
 async function findAuthenticReviewResponse(
@@ -515,7 +608,8 @@ async function findAuthenticReviewResponse(
       attempt.executorKind !== TaskCandidateKind.USER ||
       !attempt.executorUserId ||
       attempt.executorPersonId !== task.assigneePersonId ||
-      asRecord(attempt.metadata)?.kind !== REVIEW_RESPONSE_ARTIFACT_KIND
+      asRecord(attempt.metadata)?.kind !==
+        DOCUMENT_REVIEW_RESPONSE_ARTIFACT_KIND
     ) {
       continue;
     }
@@ -534,7 +628,7 @@ async function findAuthenticReviewResponse(
       if (
         (artifactId && artifact.id !== artifactId) ||
         asRecord(artifact.metadataJson)?.kind !==
-          REVIEW_RESPONSE_ARTIFACT_KIND ||
+          DOCUMENT_REVIEW_RESPONSE_ARTIFACT_KIND ||
         artifact.submittedByAgentExecutorId != null ||
         artifact.submittedByUserId !== attempt.executorUserId
       ) {
@@ -691,14 +785,15 @@ async function readAuthenticProposalArtifact(
     !proposal ||
     proposal.authorityTaskId !== authorityTaskId ||
     artifact.contentHash !== (await sha256CanonicalJson(proposal)) ||
-    asRecord(artifact.metadataJson)?.kind !== PROPOSAL_ARTIFACT_KIND ||
-    asRecord(attempt.metadata)?.kind !== PROPOSAL_ARTIFACT_KIND ||
+    asRecord(artifact.metadataJson)?.kind !== DOCUMENT_PROPOSAL_ARTIFACT_KIND ||
+    asRecord(attempt.metadata)?.kind !== DOCUMENT_PROPOSAL_ARTIFACT_KIND ||
     attempt.status !== TaskExecutionAttemptStatus.COMPLETED ||
     attempt.taskId !== authorityTaskId
   ) {
     return null;
   }
   return attempt.executorKind === TaskCandidateKind.USER &&
+    attempt.executorPersonId === proposal.proposedByPersonId &&
     attempt.executorUserId === proposal.proposedByUserId &&
     artifact.submittedByUserId === proposal.proposedByUserId &&
     artifact.submittedByAgentExecutorId == null
@@ -718,8 +813,9 @@ async function readAuthenticApplicationArtifact(
     application.authorityTaskId === authorityTaskId &&
     artifact.contentHash === (await sha256CanonicalJson(application)) &&
     asRecord(artifact.metadataJson)?.kind ===
-      PROPOSAL_APPLICATION_ARTIFACT_KIND &&
-    asRecord(attempt.metadata)?.kind === PROPOSAL_APPLICATION_ARTIFACT_KIND &&
+      DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND &&
+    asRecord(attempt.metadata)?.kind ===
+      DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND &&
     attempt.status === TaskExecutionAttemptStatus.COMPLETED &&
     attempt.taskId === authorityTaskId &&
     attempt.executorKind === TaskCandidateKind.USER &&
@@ -728,6 +824,108 @@ async function readAuthenticApplicationArtifact(
     artifact.submittedByAgentExecutorId == null
     ? application
     : null;
+}
+
+async function getAppliedProposalAuthorPersonIds(
+  tx: Prisma.TransactionClient,
+  authorityTaskId: string,
+  target: DocumentRevisionPin,
+  cache?: AppliedProposalAuthorCache,
+): Promise<Set<string>> {
+  const cacheKey = `${authorityTaskId}:${target.documentId}:${target.revisionId}:${target.contentHash}`;
+  const cached = cache?.get(cacheKey);
+  if (cached) return cached;
+  const result = loadAppliedProposalAuthorPersonIds(
+    tx,
+    authorityTaskId,
+    target,
+  );
+  cache?.set(cacheKey, result);
+  return result;
+}
+
+async function loadAppliedProposalAuthorPersonIds(
+  tx: Prisma.TransactionClient,
+  authorityTaskId: string,
+  target: DocumentRevisionPin,
+): Promise<Set<string>> {
+  const applicationArtifacts = await tx.taskExecutionArtifact.findMany({
+    where: {
+      structuredResultJson: {
+        equals: target.revisionId,
+        path: ["resultingDocument", "revisionId"],
+      },
+      taskExecutionAttempt: {
+        metadata: {
+          equals: DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND,
+          path: ["kind"],
+        },
+        taskId: authorityTaskId,
+      },
+    },
+    select: artifactWithAttemptSelect,
+  });
+  const applications = (
+    await Promise.all(
+      applicationArtifacts.map(async (artifact) => ({
+        application: await readAuthenticApplicationArtifact(
+          artifact,
+          authorityTaskId,
+        ),
+        artifact,
+      })),
+    )
+  ).filter(
+    (
+      item,
+    ): item is {
+      application: DocumentProposalApplicationV1;
+      artifact: ArtifactWithAttempt;
+    } =>
+      item.application != null &&
+      sameDocumentRevisionPin(item.application.resultingDocument, target),
+  );
+  if (applications.length === 0) return new Set();
+
+  const proposalArtifacts = await tx.taskExecutionArtifact.findMany({
+    where: {
+      id: {
+        in: applications.map(
+          ({ application }) => application.proposalArtifact.artifactId,
+        ),
+      },
+    },
+    select: artifactWithAttemptSelect,
+  });
+  const proposalsById = new Map(
+    proposalArtifacts.map((artifact) => [artifact.id, artifact]),
+  );
+  const authorPersonIds = new Set<string>();
+  for (const { application } of applications) {
+    const artifact = proposalsById.get(application.proposalArtifact.artifactId);
+    if (
+      !artifact ||
+      artifact.contentHash !== application.proposalArtifact.contentHash
+    ) {
+      continue;
+    }
+    const proposal = await readAuthenticProposalArtifact(
+      artifact,
+      authorityTaskId,
+    );
+    if (
+      !proposal ||
+      !sameDocumentRevisionPin(proposal.base, application.base) ||
+      !sameDocumentRevisionPin(
+        proposal.proposal,
+        application.sourceProposalDocument,
+      )
+    ) {
+      continue;
+    }
+    authorPersonIds.add(proposal.proposedByPersonId);
+  }
+  return authorPersonIds;
 }
 
 async function readAuthenticDecisionArtifact(
@@ -739,8 +937,10 @@ async function readAuthenticDecisionArtifact(
   return decision &&
     decision.authorityTaskId === authorityTaskId &&
     artifact.contentHash === (await sha256CanonicalJson(decision)) &&
-    asRecord(artifact.metadataJson)?.kind === INTERNAL_DECISION_ARTIFACT_KIND &&
-    asRecord(attempt.metadata)?.kind === INTERNAL_DECISION_ARTIFACT_KIND &&
+    asRecord(artifact.metadataJson)?.kind ===
+      INTERNAL_DOCUMENT_DECISION_ARTIFACT_KIND &&
+    asRecord(attempt.metadata)?.kind ===
+      INTERNAL_DOCUMENT_DECISION_ARTIFACT_KIND &&
     attempt.status === TaskExecutionAttemptStatus.COMPLETED &&
     attempt.taskId === authorityTaskId &&
     attempt.executorKind === TaskCandidateKind.USER &&
@@ -803,6 +1003,7 @@ async function createPrivateProposalDocument(
     createdByUserId: string;
     idempotencyKey: string;
     jurisdictionId: string | null;
+    organizationId: string | null;
     requestHash: string;
     title: string;
   },
@@ -812,6 +1013,7 @@ async function createPrivateProposalDocument(
       createdByUserId: input.createdByUserId,
       idempotencyKey: input.idempotencyKey,
       jurisdictionId: input.jurisdictionId,
+      organizationId: input.organizationId,
       requestHash: input.requestHash,
       searchText: `${input.title}\n${input.body}`,
       taskId: null,
@@ -882,12 +1084,18 @@ async function snapshotAuthorizedProposalSourceComments(
     select: reviewTaskSelect,
   });
   const validTaskIds = new Set([input.authorityTaskId]);
+  const proposalAuthorCache: AppliedProposalAuthorCache = new Map();
   for (const reviewTask of candidateReviewTasks) {
     const request = readReviewRequest(reviewTask.contextJson);
     if (
       request &&
       sameDocumentRevisionPin(request.target, input.base) &&
-      (await hasValidReviewTaskProvenance(tx, reviewTask, request))
+      (await hasValidReviewTaskProvenance(
+        tx,
+        reviewTask,
+        request,
+        proposalAuthorCache,
+      ))
     ) {
       validTaskIds.add(reviewTask.id);
     }
@@ -1019,7 +1227,7 @@ export async function createDocumentProposal(
     );
     const existingArtifactId = await findIdempotentArtifactId(tx, {
       idempotencyKey,
-      kind: PROPOSAL_ARTIFACT_KIND,
+      kind: DOCUMENT_PROPOSAL_ARTIFACT_KIND,
       requestHash,
       taskId: authorityTask.id,
     });
@@ -1030,6 +1238,15 @@ export async function createDocumentProposal(
         authorityTask.id,
       );
       if (!proposal) conflict("The prior proposal artifact is invalid");
+      const [baseRevision] = await Promise.all([
+        loadExactRevision(tx, proposal.base),
+        loadExactRevision(tx, proposal.proposal),
+      ]);
+      await assertRevisionClientBoundary(
+        tx,
+        baseRevision,
+        options.clientAccessBoundary,
+      );
       return {
         artifact: { contentHash: artifact.contentHash, id: artifact.id },
         proposal,
@@ -1052,6 +1269,11 @@ export async function createDocumentProposal(
     ]);
     const base = revisionPin(baseRevision);
     const lockedBase = await loadExactRevision(tx, base);
+    await assertRevisionClientBoundary(
+      tx,
+      lockedBase,
+      options.clientAccessBoundary,
+    );
     if (
       lockedBase.document.currentRevisionId !== lockedBase.id ||
       lockedBase.document.version !== lockedBase.version
@@ -1072,11 +1294,30 @@ export async function createDocumentProposal(
     const documentIdempotencyKey = `document-proposal:${await sha256CanonicalJson(
       { actorUserId, authorityTaskId, idempotencyKey },
     )}`;
+    const proposalOrganizationId =
+      options.clientAccessBoundary?.allowPersonalPrivate === false
+        ? (lockedBase.document.organizationId ??
+          authorityTask.ownerOrganizationId)
+        : null;
+    if (
+      !(await isDocumentWithinClientAccessBoundary(
+        {
+          organizationId: proposalOrganizationId,
+          taskId: null,
+          visibility: ContentVisibility.PRIVATE,
+        },
+        options.clientAccessBoundary,
+        tx,
+      ))
+    ) {
+      notFound();
+    }
     const proposalPin = await createPrivateProposalDocument(tx, {
       body: input.body,
       createdByUserId: actor.id,
       idempotencyKey: documentIdempotencyKey,
       jurisdictionId: authorityTask.jurisdictionId,
+      organizationId: proposalOrganizationId,
       requestHash,
       title: input.title,
     });
@@ -1085,6 +1326,7 @@ export async function createDocumentProposal(
       base,
       proposal: proposalPin,
       proposedAt: now.toISOString(),
+      proposedByPersonId: actor.personId,
       proposedByUserId: actor.id,
       schema: "optimitron.document-proposal.v1",
       sourceComments,
@@ -1093,7 +1335,7 @@ export async function createDocumentProposal(
     const artifact = await createCompletedArtifact({
       actor,
       idempotencyKey,
-      kind: PROPOSAL_ARTIFACT_KIND,
+      kind: DOCUMENT_PROPOSAL_ARTIFACT_KIND,
       label: "Document revision proposal",
       now,
       requestHash,
@@ -1109,18 +1351,35 @@ async function buildProposalPreview(
   tx: Prisma.TransactionClient,
   artifact: ArtifactWithAttempt,
   authorityTaskId: string,
+  clientAccessBoundary?: TaskClientAccessBoundary,
+  canReadBaseDocument?: (documentId: string) => Promise<boolean>,
 ): Promise<DocumentProposalPreview | null> {
   const proposal = await readAuthenticProposalArtifact(
     artifact,
     authorityTaskId,
   );
   if (!proposal) return null;
+  if (
+    canReadBaseDocument &&
+    !(await canReadBaseDocument(proposal.base.documentId))
+  ) {
+    return null;
+  }
   const revisions = await Promise.all([
     loadExactRevisionOrNull(tx, proposal.base),
     loadExactRevisionOrNull(tx, proposal.proposal),
   ]);
   const [baseRevision, proposalRevision] = revisions;
   if (!baseRevision || !proposalRevision) return null;
+  if (
+    !(await isDocumentWithinClientAccessBoundary(
+      baseRevision.document,
+      clientAccessBoundary,
+      tx,
+    ))
+  ) {
+    return null;
+  }
   if (
     proposalRevision.document.taskId != null ||
     proposalRevision.document.visibility !== ContentVisibility.PRIVATE ||
@@ -1182,7 +1441,7 @@ export async function applyDocumentProposal(
     );
     const existingArtifactId = await findIdempotentArtifactId(tx, {
       idempotencyKey,
-      kind: PROPOSAL_APPLICATION_ARTIFACT_KIND,
+      kind: DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND,
       requestHash,
       taskId: authorityTask.id,
     });
@@ -1193,6 +1452,20 @@ export async function applyDocumentProposal(
         authorityTask.id,
       );
       if (!application) conflict("The prior proposal application is invalid");
+      const [baseRevision, , resultingRevision] = await Promise.all([
+        loadExactRevision(tx, application.base),
+        loadExactRevision(tx, application.sourceProposalDocument),
+        loadExactRevision(tx, application.resultingDocument),
+      ]);
+      await Promise.all(
+        [baseRevision, resultingRevision].map((revision) =>
+          assertRevisionClientBoundary(
+            tx,
+            revision,
+            options.clientAccessBoundary,
+          ),
+        ),
+      );
       return {
         application,
         artifact: { contentHash: artifact.contentHash, id: artifact.id },
@@ -1226,6 +1499,11 @@ export async function applyDocumentProposal(
       loadExactRevision(tx, proposal.base),
       loadExactRevision(tx, proposal.proposal),
     ]);
+    await assertRevisionClientBoundary(
+      tx,
+      baseRevision,
+      options.clientAccessBoundary,
+    );
     if (
       baseRevision.document.taskId !== authorityTask.id ||
       baseRevision.document.currentRevisionId !== baseRevision.id ||
@@ -1327,7 +1605,7 @@ export async function applyDocumentProposal(
     const artifact = await createCompletedArtifact({
       actor,
       idempotencyKey,
-      kind: PROPOSAL_APPLICATION_ARTIFACT_KIND,
+      kind: DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND,
       label: "Applied document revision proposal",
       now,
       requestHash,
@@ -1396,6 +1674,11 @@ export async function requestDocumentReview(
       ) {
         conflict("Idempotency-Key was already used for a different review");
       }
+      await assertRevisionClientBoundary(
+        tx,
+        await loadExactRevision(tx, request.target),
+        options.clientAccessBoundary,
+      );
       return { request, reviewTaskId: existing.id };
     }
     if (
@@ -1438,6 +1721,11 @@ export async function requestDocumentReview(
     );
     const target = revisionPin(revision);
     const lockedRevision = await loadExactRevision(tx, target);
+    await assertRevisionClientBoundary(
+      tx,
+      lockedRevision,
+      options.clientAccessBoundary,
+    );
     if (
       lockedRevision.document.currentRevisionId !== lockedRevision.id ||
       lockedRevision.document.version !== lockedRevision.version
@@ -1449,6 +1737,14 @@ export async function requestDocumentReview(
       reviewer.id === lockedRevision.createdByUser.personId
     ) {
       invalid("A person cannot review their own request or document revision");
+    }
+    const proposalAuthorPersonIds = await getAppliedProposalAuthorPersonIds(
+      tx,
+      authorityTask.id,
+      target,
+    );
+    if (proposalAuthorPersonIds.has(reviewer.id)) {
+      invalid("A person cannot review a revision based on their own proposal");
     }
     const duplicateCandidates = await tx.task.findMany({
       where: {
@@ -1545,7 +1841,11 @@ export async function submitDocumentReview(
   return prisma.$transaction(async (tx) => {
     const actor = await getActor(tx, actorUserId);
     const initialTask = await tx.task.findFirst({
-      where: taskBoundaryWhere(reviewTaskId, options.clientAccessBoundary),
+      where: assignedReviewTaskBoundaryWhere(
+        reviewTaskId,
+        actor.personId,
+        options.clientAccessBoundary,
+      ),
       select: reviewTaskSelect,
     });
     const initialRequest = readReviewRequest(initialTask?.contextJson);
@@ -1560,7 +1860,11 @@ export async function submitDocumentReview(
     }
     await lockTaskRow(tx, initialTask.id);
     const task = await tx.task.findFirst({
-      where: taskBoundaryWhere(reviewTaskId, options.clientAccessBoundary),
+      where: assignedReviewTaskBoundaryWhere(
+        reviewTaskId,
+        actor.personId,
+        options.clientAccessBoundary,
+      ),
       select: reviewTaskSelect,
     });
     const request = readReviewRequest(task?.contextJson);
@@ -1576,7 +1880,7 @@ export async function submitDocumentReview(
 
     const existingArtifactId = await findIdempotentArtifactId(tx, {
       idempotencyKey,
-      kind: REVIEW_RESPONSE_ARTIFACT_KIND,
+      kind: DOCUMENT_REVIEW_RESPONSE_ARTIFACT_KIND,
       requestHash,
       taskId: task.id,
     });
@@ -1587,6 +1891,11 @@ export async function submitDocumentReview(
         existingArtifactId,
       );
       if (!existing) conflict("The prior review response is invalid");
+      await assertAssignedReviewRevisionClientBoundary(
+        tx,
+        await loadExactRevision(tx, request.target),
+        options.clientAccessBoundary,
+      );
       return {
         artifact: {
           contentHash: existing.artifact.contentHash,
@@ -1607,6 +1916,11 @@ export async function submitDocumentReview(
       conflict("The review task is no longer active");
     }
     const revision = await loadExactRevision(tx, request.target);
+    await assertAssignedReviewRevisionClientBoundary(
+      tx,
+      revision,
+      options.clientAccessBoundary,
+    );
     if (
       revision.document.currentRevisionId !== revision.id ||
       revision.document.version !== revision.version
@@ -1652,7 +1966,7 @@ export async function submitDocumentReview(
     assertReviewResponseMatchesRequest(response, request, task.id);
     const metadata = {
       idempotencyKey,
-      kind: REVIEW_RESPONSE_ARTIFACT_KIND,
+      kind: DOCUMENT_REVIEW_RESPONSE_ARTIFACT_KIND,
       requestHash,
     };
     const attempt = await tx.taskExecutionAttempt.create({
@@ -1779,7 +2093,7 @@ export async function decideDocumentRevision(
     );
     const existingArtifactId = await findIdempotentArtifactId(tx, {
       idempotencyKey,
-      kind: INTERNAL_DECISION_ARTIFACT_KIND,
+      kind: INTERNAL_DOCUMENT_DECISION_ARTIFACT_KIND,
       requestHash,
       taskId: authorityTask.id,
     });
@@ -1790,6 +2104,11 @@ export async function decideDocumentRevision(
         authorityTask.id,
       );
       if (!decision) conflict("The prior internal decision is invalid");
+      await assertRevisionClientBoundary(
+        tx,
+        await loadExactRevision(tx, decision.target),
+        options.clientAccessBoundary,
+      );
       return {
         artifact: { contentHash: artifact.contentHash, id: artifact.id },
         decision,
@@ -1809,6 +2128,11 @@ export async function decideDocumentRevision(
     );
     const target = revisionPin(targetRevision);
     const lockedTarget = await loadExactRevision(tx, target);
+    await assertRevisionClientBoundary(
+      tx,
+      lockedTarget,
+      options.clientAccessBoundary,
+    );
     if (
       lockedTarget.document.currentRevisionId !== lockedTarget.id ||
       lockedTarget.document.version !== lockedTarget.version
@@ -1843,7 +2167,7 @@ export async function decideDocumentRevision(
         taskExecutionAttempt: {
           deletedAt: null,
           metadata: {
-            equals: INTERNAL_DECISION_ARTIFACT_KIND,
+            equals: INTERNAL_DOCUMENT_DECISION_ARTIFACT_KIND,
             path: ["kind"],
           },
           taskId: authorityTask.id,
@@ -1881,7 +2205,7 @@ export async function decideDocumentRevision(
     const artifact = await createCompletedArtifact({
       actor,
       idempotencyKey,
-      kind: INTERNAL_DECISION_ARTIFACT_KIND,
+      kind: INTERNAL_DOCUMENT_DECISION_ARTIFACT_KIND,
       label:
         decision.action === "ADOPT"
           ? "Internal document adoption"
@@ -1899,17 +2223,44 @@ export async function decideDocumentRevision(
 async function buildPanelReview(
   tx: Prisma.TransactionClient,
   task: ReviewTask,
+  options: {
+    assignedReviewGrant?: boolean;
+    canReadDocument?: (documentId: string) => Promise<boolean>;
+    clientAccessBoundary?: TaskClientAccessBoundary;
+    proposalAuthorCache?: AppliedProposalAuthorCache;
+  } = {},
 ): Promise<DocumentReviewPanelReview | null> {
   const request = readReviewRequest(task.contextJson);
   if (
     !request ||
     !task.assigneePerson ||
-    !(await hasValidReviewTaskProvenance(tx, task, request))
+    !(await hasValidReviewTaskProvenance(
+      tx,
+      task,
+      request,
+      options.proposalAuthorCache,
+    ))
+  ) {
+    return null;
+  }
+  if (
+    options.canReadDocument &&
+    !(await options.canReadDocument(request.target.documentId))
   ) {
     return null;
   }
   const revision = await loadExactRevisionOrNull(tx, request.target);
   if (!revision) return null;
+  if (
+    !options.assignedReviewGrant &&
+    !(await isDocumentWithinClientAccessBoundary(
+      revision.document,
+      options.clientAccessBoundary,
+      tx,
+    ))
+  ) {
+    return null;
+  }
   const result = await findAuthenticReviewResponse(task, request);
   const stale =
     task.status === TaskStatus.STALE ||
@@ -1954,21 +2305,37 @@ export async function getDocumentReviewPanelData(
       select: { id: true, personId: true },
     });
     const requestedTaskProbe = await tx.task.findFirst({
-      where: taskBoundaryWhere(taskId, options.clientAccessBoundary),
+      where: actor?.personId
+        ? assignedReviewTaskBoundaryWhere(
+            taskId,
+            actor.personId,
+            options.clientAccessBoundary,
+          )
+        : { id: "__unreachable__" },
       select: requestedTaskProbeSelect,
     });
     if (!actor?.personId || !requestedTaskProbe) return null;
+    const proposalAuthorCache: AppliedProposalAuthorCache = new Map();
     const directRequest = readReviewRequest(requestedTaskProbe.contextJson);
     if (
       directRequest &&
       requestedTaskProbe.assigneePersonId === actor.personId
     ) {
       const requestedReviewTask = await tx.task.findFirst({
-        where: taskBoundaryWhere(taskId, options.clientAccessBoundary),
+        where: assignedReviewTaskBoundaryWhere(
+          taskId,
+          actor.personId,
+          options.clientAccessBoundary,
+        ),
         select: reviewTaskSelect,
       });
       if (!requestedReviewTask) return null;
-      const review = await buildPanelReview(tx, requestedReviewTask);
+      const review = await buildPanelReview(tx, requestedReviewTask, {
+        assignedReviewGrant:
+          options.clientAccessBoundary?.allowPersonalPrivate === true,
+        clientAccessBoundary: options.clientAccessBoundary,
+        proposalAuthorCache,
+      });
       if (!review) return null;
       return {
         authorityTaskId: review.request.authorityTaskId,
@@ -1997,6 +2364,19 @@ export async function getDocumentReviewPanelData(
       select: { id: true },
     });
     if (!managed) return null;
+    const readableDocuments = new Map<string, Promise<boolean>>();
+    const canManagerReadDocument = (documentId: string) => {
+      const cached = readableDocuments.get(documentId);
+      if (cached) return cached;
+      const result = canActorReadDocument(
+        tx,
+        documentId,
+        actor.id,
+        options.clientAccessBoundary,
+      );
+      readableDocuments.set(documentId, result);
+      return result;
+    };
     const reviewTasks = await tx.task.findMany({
       where: {
         AND: [
@@ -2010,7 +2390,15 @@ export async function getDocumentReviewPanelData(
       select: reviewTaskSelect,
     });
     const reviews = (
-      await Promise.all(reviewTasks.map((task) => buildPanelReview(tx, task)))
+      await Promise.all(
+        reviewTasks.map((task) =>
+          buildPanelReview(tx, task, {
+            canReadDocument: canManagerReadDocument,
+            clientAccessBoundary: options.clientAccessBoundary,
+            proposalAuthorCache,
+          }),
+        ),
+      )
     ).filter((review): review is DocumentReviewPanelReview => review != null);
 
     const operationArtifacts = (kind: string) =>
@@ -2028,9 +2416,9 @@ export async function getDocumentReviewPanelData(
       });
     const [decisionArtifacts, proposalArtifacts, applicationArtifacts] =
       await Promise.all([
-        operationArtifacts(INTERNAL_DECISION_ARTIFACT_KIND),
-        operationArtifacts(PROPOSAL_ARTIFACT_KIND),
-        operationArtifacts(PROPOSAL_APPLICATION_ARTIFACT_KIND),
+        operationArtifacts(INTERNAL_DOCUMENT_DECISION_ARTIFACT_KIND),
+        operationArtifacts(DOCUMENT_PROPOSAL_ARTIFACT_KIND),
+        operationArtifacts(DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND),
       ]);
     const decisions: Array<{
       artifactId: string;
@@ -2041,7 +2429,12 @@ export async function getDocumentReviewPanelData(
         artifact,
         authorityTaskId,
       );
-      if (decision) decisions.push({ artifactId: artifact.id, decision });
+      if (
+        decision &&
+        (await canManagerReadDocument(decision.target.documentId))
+      ) {
+        decisions.push({ artifactId: artifact.id, decision });
+      }
     }
     const appliedProposalArtifactIds = new Set<string>();
     for (const artifact of applicationArtifacts) {
@@ -2056,7 +2449,13 @@ export async function getDocumentReviewPanelData(
     const proposals: DocumentProposalPreview[] = [];
     for (const artifact of proposalArtifacts) {
       if (appliedProposalArtifactIds.has(artifact.id)) continue;
-      const preview = await buildProposalPreview(tx, artifact, authorityTaskId);
+      const preview = await buildProposalPreview(
+        tx,
+        artifact,
+        authorityTaskId,
+        options.clientAccessBoundary,
+        canManagerReadDocument,
+      );
       if (preview) proposals.push(preview);
     }
     return {
@@ -2067,4 +2466,27 @@ export async function getDocumentReviewPanelData(
       reviews,
     };
   });
+}
+
+export async function getAssignedDocumentReview(
+  reviewTaskId: string,
+  actorUserId: string,
+  options: { clientAccessBoundary?: TaskClientAccessBoundary } = {},
+) {
+  const panel = await getDocumentReviewPanelData(
+    reviewTaskId,
+    actorUserId,
+    options,
+  );
+  if (!panel || panel.mode !== "REVIEWER") notFound();
+  return {
+    authorityTaskId: panel.authorityTaskId,
+    canSubmit: panel.canSubmit,
+    request: panel.review.request,
+    response: panel.review.response,
+    reviewer: panel.review.reviewer,
+    reviewTaskId: panel.review.reviewTaskId,
+    state: panel.review.state,
+    target: panel.review.target,
+  };
 }

--- a/packages/web/src/lib/tasks/document-review.server.ts
+++ b/packages/web/src/lib/tasks/document-review.server.ts
@@ -1,0 +1,2061 @@
+import {
+  ContentAccessLevel,
+  ContentVisibility,
+  Prisma,
+  TaskApplicationPolicy,
+  TaskCandidateKind,
+  TaskClaimPolicy,
+  TaskCommentVisibility,
+  TaskExecutionAttemptStatus,
+  TaskExecutionMode,
+  TaskStatus,
+  TaskVerificationMethod,
+  TaskVerificationResult,
+} from "@optimitron/db";
+import { sha256CanonicalJson } from "@optimitron/data/parameters";
+import {
+  assertDocumentAccess,
+  lockContentResources,
+} from "@/lib/content-access.server";
+import { prisma } from "@/lib/prisma";
+import {
+  ApplyDocumentProposalInputSchema,
+  assertReviewResponseMatchesRequest,
+  CreateDocumentProposalInputSchema,
+  DecideDocumentRevisionInputSchema,
+  DOCUMENT_REVIEW_CONTEXT_KEY,
+  DOCUMENT_REVIEW_TASK_KEY_PREFIX,
+  DocumentProposalApplicationV1Schema,
+  type DocumentProposalSourceCommentV1,
+  DocumentProposalV1Schema,
+  type DocumentRevisionPin,
+  InternalDocumentDecisionV1Schema,
+  type InternalDocumentDecisionV1,
+  readDocumentProposal,
+  readDocumentProposalApplication,
+  readInternalDocumentDecision,
+  readReviewRequest,
+  readReviewResponse,
+  RequestDocumentReviewInputSchema,
+  type ReviewRequestV1,
+  ReviewRequestV1Schema,
+  type ReviewResponseV1,
+  ReviewResponseV1Schema,
+  sameDocumentRevisionPin,
+  SubmitDocumentReviewInputSchema,
+} from "@/lib/tasks/document-review-contracts";
+import {
+  DOCUMENT_REVIEW_BINDING_HASH_KEY,
+  documentReviewBindingMatches,
+  hashDocumentReviewBinding,
+} from "@/lib/tasks/document-review-binding.server";
+import { invalidateDocumentReviewsForDocument } from "@/lib/tasks/document-review-invalidation.server";
+import { createTopLevelTaskCommentInTransaction } from "@/lib/tasks/task-comments.server";
+import {
+  getTaskAccessWhere,
+  getTaskClientAccessWhere,
+  isTaskWithinClientAccessBoundary,
+  type TaskClientAccessBoundary,
+} from "@/lib/tasks/task-visibility.server";
+
+const PROPOSAL_ARTIFACT_KIND = "document-proposal";
+const PROPOSAL_APPLICATION_ARTIFACT_KIND = "document-proposal-application";
+const REVIEW_RESPONSE_ARTIFACT_KIND = "document-review-response";
+const INTERNAL_DECISION_ARTIFACT_KIND = "internal-document-decision";
+const REVIEW_DELIVERY_RULE_KEY = "document-review-delivery.v1";
+
+type JsonRecord = Record<string, unknown>;
+
+export type DocumentReviewState =
+  | "AWAITING_RESPONSE"
+  | "APPROVED"
+  | "CHANGES_REQUESTED"
+  | "REJECTED"
+  | "ABSTAINED"
+  | "STALE";
+
+export interface DocumentReviewPanelReview {
+  request: ReviewRequestV1;
+  response: (ReviewResponseV1 & { artifactId: string }) | null;
+  reviewTaskId: string;
+  reviewer: {
+    displayName: string;
+    id: string;
+  };
+  state: DocumentReviewState;
+  target: DocumentRevisionPin & {
+    body: string;
+    stale: boolean;
+    title: string;
+  };
+}
+
+export interface DocumentProposalPreview {
+  artifactId: string;
+  base: DocumentRevisionPin;
+  baseStale: boolean;
+  proposed: DocumentRevisionPin & { body: string; title: string };
+  sourceComments: DocumentProposalSourceCommentV1[];
+  summary: string;
+}
+
+export type DocumentReviewPanelData =
+  | {
+      authorityTaskId: string;
+      decisions: Array<{
+        artifactId: string;
+        decision: InternalDocumentDecisionV1;
+      }>;
+      mode: "MANAGER";
+      proposals: DocumentProposalPreview[];
+      reviews: DocumentReviewPanelReview[];
+    }
+  | {
+      authorityTaskId: string;
+      canSubmit: boolean;
+      mode: "REVIEWER";
+      review: DocumentReviewPanelReview;
+    };
+
+export class DocumentReviewError extends Error {
+  constructor(
+    message: string,
+    readonly status: 400 | 404 | 409,
+    readonly code:
+      | "DOCUMENT_REVIEW_INVALID"
+      | "DOCUMENT_REVIEW_NOT_FOUND"
+      | "DOCUMENT_REVIEW_CONFLICT",
+  ) {
+    super(message);
+    this.name = "DocumentReviewError";
+  }
+}
+
+function notFound(): never {
+  throw new DocumentReviewError(
+    "Document review not found",
+    404,
+    "DOCUMENT_REVIEW_NOT_FOUND",
+  );
+}
+
+function conflict(message: string): never {
+  throw new DocumentReviewError(message, 409, "DOCUMENT_REVIEW_CONFLICT");
+}
+
+function invalid(message: string): never {
+  throw new DocumentReviewError(message, 400, "DOCUMENT_REVIEW_INVALID");
+}
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null;
+}
+
+function jsonValue(value: unknown): Prisma.InputJsonValue {
+  return value as Prisma.InputJsonValue;
+}
+
+function requireIdempotencyKey(value: string): string {
+  const key = value.trim();
+  if (!key) invalid("Idempotency-Key is required");
+  return key;
+}
+
+function taskBoundaryWhere(
+  taskId: string,
+  boundary?: TaskClientAccessBoundary,
+): Prisma.TaskWhereInput {
+  const base: Prisma.TaskWhereInput = { deletedAt: null, id: taskId };
+  return boundary ? { AND: [base, getTaskClientAccessWhere(boundary)] } : base;
+}
+
+function genuineReviewChildWhere(
+  authorityTaskId: string,
+): Prisma.TaskWhereInput {
+  return {
+    AND: [
+      {
+        contextJson: {
+          equals: "optimitron.review-request.v1",
+          path: [DOCUMENT_REVIEW_CONTEXT_KEY, "schema"],
+        },
+      },
+      {
+        contextJson: {
+          equals: authorityTaskId,
+          path: [DOCUMENT_REVIEW_CONTEXT_KEY, "authorityTaskId"],
+        },
+      },
+    ],
+    deletedAt: null,
+    parentTaskId: authorityTaskId,
+    taskKey: {
+      startsWith: `${DOCUMENT_REVIEW_TASK_KEY_PREFIX}${authorityTaskId}:`,
+    },
+  };
+}
+
+async function assertDocumentPermission(
+  tx: Prisma.TransactionClient,
+  documentId: string,
+  actorUserId: string,
+  required: ContentAccessLevel,
+) {
+  try {
+    await assertDocumentAccess(documentId, actorUserId, required, tx);
+  } catch {
+    notFound();
+  }
+}
+
+async function lockTaskRow(tx: Prisma.TransactionClient, taskId: string) {
+  await tx.$queryRaw<Array<{ id: string }>>`
+    SELECT "id" FROM "Task" WHERE "id" = ${taskId} FOR UPDATE
+  `;
+}
+
+const authorityTaskSelect = {
+  category: true,
+  contextJson: true,
+  id: true,
+  isPublic: true,
+  jurisdictionId: true,
+  ownerOrganizationId: true,
+} satisfies Prisma.TaskSelect;
+
+async function getActor(tx: Prisma.TransactionClient, actorUserId: string) {
+  const actor = await tx.user.findFirst({
+    where: { deletedAt: null, id: actorUserId },
+    select: { id: true, personId: true },
+  });
+  if (!actor?.personId) notFound();
+  return { id: actor.id, personId: actor.personId };
+}
+
+async function getManagedAuthorityTask(
+  tx: Prisma.TransactionClient,
+  authorityTaskId: string,
+  actorUserId: string,
+  boundary?: TaskClientAccessBoundary,
+) {
+  const actor = await getActor(tx, actorUserId);
+  const task = await tx.task.findFirst({
+    where: {
+      AND: [
+        taskBoundaryWhere(authorityTaskId, boundary),
+        getTaskAccessWhere({
+          action: "MANAGE",
+          personId: actor.personId,
+          userId: actor.id,
+        }),
+      ],
+    },
+    select: authorityTaskSelect,
+  });
+  if (!task) notFound();
+  return { actor, task };
+}
+
+async function getProposalAuthorityTask(
+  tx: Prisma.TransactionClient,
+  authorityTaskId: string,
+  actorUserId: string,
+  boundary?: TaskClientAccessBoundary,
+) {
+  const actor = await getActor(tx, actorUserId);
+  const task = await tx.task.findFirst({
+    where: {
+      AND: [
+        taskBoundaryWhere(authorityTaskId, boundary),
+        getTaskAccessWhere({
+          action: "COMMENT",
+          personId: actor.personId,
+          userId: actor.id,
+        }),
+      ],
+    },
+    select: authorityTaskSelect,
+  });
+  if (!task) notFound();
+  return { actor, task };
+}
+
+const exactRevisionSelect = {
+  body: true,
+  contentHash: true,
+  createdByUser: { select: { personId: true } },
+  createdByUserId: true,
+  document: {
+    select: {
+      createdByUserId: true,
+      currentRevisionId: true,
+      id: true,
+      organizationId: true,
+      taskId: true,
+      version: true,
+      visibility: true,
+    },
+  },
+  documentId: true,
+  id: true,
+  title: true,
+  version: true,
+} satisfies Prisma.DocumentRevisionSelect;
+
+type ExactRevision = Prisma.DocumentRevisionGetPayload<{
+  select: typeof exactRevisionSelect;
+}>;
+
+function revisionPin(revision: ExactRevision): DocumentRevisionPin {
+  if (!revision.contentHash) notFound();
+  return {
+    contentHash: revision.contentHash,
+    documentId: revision.documentId,
+    revisionId: revision.id,
+    version: revision.version,
+  };
+}
+
+async function loadRevisionById(
+  tx: Prisma.TransactionClient,
+  revisionId: string,
+): Promise<ExactRevision> {
+  const revision = await tx.documentRevision.findFirst({
+    where: {
+      deletedAt: null,
+      document: { deletedAt: null },
+      id: revisionId,
+    },
+    select: exactRevisionSelect,
+  });
+  if (!revision?.contentHash) notFound();
+  if (
+    revision.contentHash !==
+    (await sha256CanonicalJson({ body: revision.body, title: revision.title }))
+  ) {
+    conflict("Document revision integrity check failed");
+  }
+  return revision;
+}
+
+async function loadExactRevision(
+  tx: Prisma.TransactionClient,
+  pin: DocumentRevisionPin,
+): Promise<ExactRevision> {
+  const revision = await tx.documentRevision.findFirst({
+    where: {
+      contentHash: pin.contentHash,
+      deletedAt: null,
+      document: { deletedAt: null },
+      documentId: pin.documentId,
+      id: pin.revisionId,
+      version: pin.version,
+    },
+    select: exactRevisionSelect,
+  });
+  if (!revision?.contentHash) notFound();
+  if (
+    revision.contentHash !==
+    (await sha256CanonicalJson({ body: revision.body, title: revision.title }))
+  ) {
+    conflict("Document revision integrity check failed");
+  }
+  return revision;
+}
+
+async function loadExactRevisionOrNull(
+  tx: Prisma.TransactionClient,
+  pin: DocumentRevisionPin,
+): Promise<ExactRevision | null> {
+  try {
+    return await loadExactRevision(tx, pin);
+  } catch (error) {
+    if (
+      error instanceof DocumentReviewError &&
+      error.code === "DOCUMENT_REVIEW_NOT_FOUND"
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+const reviewTaskSelect = {
+  applicationPolicy: true,
+  assigneePerson: {
+    select: { displayName: true, id: true },
+  },
+  assigneePersonId: true,
+  claimPolicy: true,
+  contextJson: true,
+  createdByUserId: true,
+  executionMode: true,
+  executionAttempts: {
+    orderBy: { createdAt: "desc" as const },
+    select: {
+      artifacts: {
+        where: { deletedAt: null },
+        select: {
+          contentHash: true,
+          documentRevisionId: true,
+          id: true,
+          metadataJson: true,
+          structuredResultJson: true,
+          submittedByAgentExecutorId: true,
+          submittedByUserId: true,
+        },
+      },
+      executorKind: true,
+      executorPersonId: true,
+      executorUserId: true,
+      id: true,
+      metadata: true,
+      status: true,
+      verifications: {
+        where: { deletedAt: null },
+        orderBy: { createdAt: "desc" as const },
+        select: {
+          id: true,
+          method: true,
+          result: true,
+          reviewerAgentExecutorId: true,
+          reviewerUserId: true,
+          ruleKey: true,
+          selfReviewed: true,
+        },
+      },
+    },
+    where: { deletedAt: null },
+  },
+  id: true,
+  isPublic: true,
+  jurisdictionId: true,
+  ownerOrganizationId: true,
+  parentTaskId: true,
+  status: true,
+  taskKey: true,
+} satisfies Prisma.TaskSelect;
+
+type ReviewTask = Prisma.TaskGetPayload<{ select: typeof reviewTaskSelect }>;
+
+const requestedTaskProbeSelect = {
+  assigneePersonId: true,
+  contextJson: true,
+  id: true,
+} satisfies Prisma.TaskSelect;
+
+async function hasValidReviewTaskProvenance(
+  tx: Prisma.TransactionClient,
+  task: ReviewTask,
+  request = readReviewRequest(task.contextJson),
+): Promise<boolean> {
+  if (
+    !request ||
+    task.isPublic ||
+    task.applicationPolicy !== TaskApplicationPolicy.CLOSED ||
+    task.claimPolicy !== TaskClaimPolicy.ASSIGNED_ONLY ||
+    task.executionMode !== TaskExecutionMode.HUMAN_ONLY ||
+    !task.assigneePersonId ||
+    task.createdByUserId !== request.requestedByUserId ||
+    task.parentTaskId !== request.authorityTaskId ||
+    !task.taskKey?.startsWith(
+      `${DOCUMENT_REVIEW_TASK_KEY_PREFIX}${request.authorityTaskId}:${request.requestedByUserId}:`,
+    ) ||
+    !(await documentReviewBindingMatches(task, request))
+  ) {
+    return false;
+  }
+
+  const [requester, authorityTask, revision] = await Promise.all([
+    tx.user.findFirst({
+      where: { deletedAt: null, id: request.requestedByUserId },
+      select: { id: true, personId: true },
+    }),
+    tx.task.findFirst({
+      where: { deletedAt: null, id: request.authorityTaskId },
+      select: { jurisdictionId: true, ownerOrganizationId: true },
+    }),
+    tx.documentRevision.findFirst({
+      where: {
+        contentHash: request.target.contentHash,
+        deletedAt: null,
+        document: { deletedAt: null },
+        documentId: request.target.documentId,
+        id: request.target.revisionId,
+        version: request.target.version,
+      },
+      select: {
+        createdByUser: { select: { personId: true } },
+        document: { select: { taskId: true } },
+      },
+    }),
+  ]);
+  return Boolean(
+    requester?.personId &&
+    requester.personId !== task.assigneePersonId &&
+    authorityTask &&
+    revision &&
+    authorityTask.ownerOrganizationId === task.ownerOrganizationId &&
+    authorityTask.jurisdictionId === task.jurisdictionId &&
+    revision.document.taskId === request.authorityTaskId &&
+    revision.createdByUser.personId !== task.assigneePersonId,
+  );
+}
+
+async function findAuthenticReviewResponse(
+  task: ReviewTask,
+  request: ReviewRequestV1,
+  artifactId?: string,
+) {
+  for (const attempt of task.executionAttempts) {
+    if (
+      attempt.status !== TaskExecutionAttemptStatus.COMPLETED ||
+      attempt.executorKind !== TaskCandidateKind.USER ||
+      !attempt.executorUserId ||
+      attempt.executorPersonId !== task.assigneePersonId ||
+      asRecord(attempt.metadata)?.kind !== REVIEW_RESPONSE_ARTIFACT_KIND
+    ) {
+      continue;
+    }
+    const verification = attempt.verifications.find(
+      (item) =>
+        item.method === TaskVerificationMethod.DETERMINISTIC &&
+        item.result === TaskVerificationResult.ACCEPTED &&
+        item.ruleKey === REVIEW_DELIVERY_RULE_KEY &&
+        item.reviewerUserId === attempt.executorUserId &&
+        item.reviewerAgentExecutorId == null &&
+        item.selfReviewed,
+    );
+    if (!verification) continue;
+
+    for (const artifact of attempt.artifacts) {
+      if (
+        (artifactId && artifact.id !== artifactId) ||
+        asRecord(artifact.metadataJson)?.kind !==
+          REVIEW_RESPONSE_ARTIFACT_KIND ||
+        artifact.submittedByAgentExecutorId != null ||
+        artifact.submittedByUserId !== attempt.executorUserId
+      ) {
+        continue;
+      }
+      const response = readReviewResponse(artifact.structuredResultJson);
+      if (
+        !response ||
+        response.reviewerUserId !== attempt.executorUserId ||
+        response.reviewerPersonId !== task.assigneePersonId ||
+        artifact.contentHash !== (await sha256CanonicalJson(response))
+      ) {
+        continue;
+      }
+      try {
+        assertReviewResponseMatchesRequest(response, request, task.id);
+      } catch {
+        continue;
+      }
+      return { artifact, attempt, response, verification };
+    }
+  }
+  return null;
+}
+
+async function loadAuthenticReviewArtifact(
+  tx: Prisma.TransactionClient,
+  artifactId: string,
+) {
+  const locator = await tx.taskExecutionArtifact.findFirst({
+    where: { deletedAt: null, id: artifactId },
+    select: {
+      taskExecutionAttempt: { select: { taskId: true } },
+    },
+  });
+  if (!locator) notFound();
+  const task = await tx.task.findFirst({
+    where: {
+      deletedAt: null,
+      id: locator.taskExecutionAttempt.taskId,
+    },
+    select: reviewTaskSelect,
+  });
+  const request = readReviewRequest(task?.contextJson);
+  if (
+    !task ||
+    !request ||
+    !(await hasValidReviewTaskProvenance(tx, task, request))
+  ) {
+    notFound();
+  }
+  const result = await findAuthenticReviewResponse(task, request, artifactId);
+  if (!result) notFound();
+  return { ...result, request, task };
+}
+
+async function findIdempotentArtifactId(
+  tx: Prisma.TransactionClient,
+  input: {
+    idempotencyKey: string;
+    kind: string;
+    requestHash: string;
+    taskId: string;
+  },
+): Promise<string | null> {
+  const attempts = await tx.taskExecutionAttempt.findMany({
+    where: {
+      deletedAt: null,
+      metadata: {
+        equals: input.kind,
+        path: ["kind"],
+      },
+      taskId: input.taskId,
+    },
+    orderBy: { createdAt: "asc" },
+    select: {
+      artifacts: {
+        where: {
+          deletedAt: null,
+          metadataJson: { equals: input.kind, path: ["kind"] },
+        },
+        orderBy: { createdAt: "asc" },
+        select: { id: true },
+      },
+      metadata: true,
+    },
+  });
+  const matching = attempts.filter(
+    (attempt) =>
+      asRecord(attempt.metadata)?.idempotencyKey === input.idempotencyKey,
+  );
+  if (matching.length === 0) return null;
+  if (
+    matching.some(
+      (attempt) =>
+        asRecord(attempt.metadata)?.requestHash !== input.requestHash,
+    )
+  ) {
+    conflict("Idempotency-Key was already used for different input");
+  }
+  const artifactIds = matching.flatMap((attempt) =>
+    attempt.artifacts.map((artifact) => artifact.id),
+  );
+  if (artifactIds.length !== 1) {
+    conflict("The prior idempotent operation is incomplete");
+  }
+  return artifactIds[0] ?? null;
+}
+
+const artifactWithAttemptSelect = {
+  contentHash: true,
+  documentRevisionId: true,
+  id: true,
+  metadataJson: true,
+  structuredResultJson: true,
+  submittedByAgentExecutorId: true,
+  submittedByUserId: true,
+  taskExecutionAttempt: {
+    select: {
+      agentExecutorId: true,
+      executorKind: true,
+      executorPersonId: true,
+      executorUserId: true,
+      metadata: true,
+      status: true,
+      taskId: true,
+    },
+  },
+} satisfies Prisma.TaskExecutionArtifactSelect;
+
+type ArtifactWithAttempt = Prisma.TaskExecutionArtifactGetPayload<{
+  select: typeof artifactWithAttemptSelect;
+}>;
+
+async function loadArtifactWithAttempt(
+  tx: Prisma.TransactionClient,
+  artifactId: string,
+) {
+  const artifact = await tx.taskExecutionArtifact.findFirst({
+    where: { deletedAt: null, id: artifactId },
+    select: artifactWithAttemptSelect,
+  });
+  if (!artifact) notFound();
+  return artifact;
+}
+
+async function readAuthenticProposalArtifact(
+  artifact: ArtifactWithAttempt,
+  authorityTaskId: string,
+) {
+  const attempt = artifact.taskExecutionAttempt;
+  const proposal = readDocumentProposal(artifact.structuredResultJson);
+  if (
+    !proposal ||
+    proposal.authorityTaskId !== authorityTaskId ||
+    artifact.contentHash !== (await sha256CanonicalJson(proposal)) ||
+    asRecord(artifact.metadataJson)?.kind !== PROPOSAL_ARTIFACT_KIND ||
+    asRecord(attempt.metadata)?.kind !== PROPOSAL_ARTIFACT_KIND ||
+    attempt.status !== TaskExecutionAttemptStatus.COMPLETED ||
+    attempt.taskId !== authorityTaskId
+  ) {
+    return null;
+  }
+  return attempt.executorKind === TaskCandidateKind.USER &&
+    attempt.executorUserId === proposal.proposedByUserId &&
+    artifact.submittedByUserId === proposal.proposedByUserId &&
+    artifact.submittedByAgentExecutorId == null
+    ? proposal
+    : null;
+}
+
+async function readAuthenticApplicationArtifact(
+  artifact: ArtifactWithAttempt,
+  authorityTaskId: string,
+) {
+  const attempt = artifact.taskExecutionAttempt;
+  const application = readDocumentProposalApplication(
+    artifact.structuredResultJson,
+  );
+  return application &&
+    application.authorityTaskId === authorityTaskId &&
+    artifact.contentHash === (await sha256CanonicalJson(application)) &&
+    asRecord(artifact.metadataJson)?.kind ===
+      PROPOSAL_APPLICATION_ARTIFACT_KIND &&
+    asRecord(attempt.metadata)?.kind === PROPOSAL_APPLICATION_ARTIFACT_KIND &&
+    attempt.status === TaskExecutionAttemptStatus.COMPLETED &&
+    attempt.taskId === authorityTaskId &&
+    attempt.executorKind === TaskCandidateKind.USER &&
+    attempt.executorUserId === application.appliedByUserId &&
+    artifact.submittedByUserId === application.appliedByUserId &&
+    artifact.submittedByAgentExecutorId == null
+    ? application
+    : null;
+}
+
+async function readAuthenticDecisionArtifact(
+  artifact: ArtifactWithAttempt,
+  authorityTaskId: string,
+) {
+  const attempt = artifact.taskExecutionAttempt;
+  const decision = readInternalDocumentDecision(artifact.structuredResultJson);
+  return decision &&
+    decision.authorityTaskId === authorityTaskId &&
+    artifact.contentHash === (await sha256CanonicalJson(decision)) &&
+    asRecord(artifact.metadataJson)?.kind === INTERNAL_DECISION_ARTIFACT_KIND &&
+    asRecord(attempt.metadata)?.kind === INTERNAL_DECISION_ARTIFACT_KIND &&
+    attempt.status === TaskExecutionAttemptStatus.COMPLETED &&
+    attempt.taskId === authorityTaskId &&
+    attempt.executorKind === TaskCandidateKind.USER &&
+    attempt.executorUserId === decision.decidedByUserId &&
+    attempt.executorPersonId === decision.decidedByPersonId &&
+    artifact.submittedByUserId === decision.decidedByUserId &&
+    artifact.submittedByAgentExecutorId == null
+    ? decision
+    : null;
+}
+
+async function createCompletedArtifact(input: {
+  actor: { id: string; personId: string };
+  idempotencyKey: string;
+  kind: string;
+  label: string;
+  now: Date;
+  requestHash: string;
+  task: { id: string; jurisdictionId: string | null };
+  tx: Prisma.TransactionClient;
+  value: unknown;
+}) {
+  const metadata = {
+    idempotencyKey: input.idempotencyKey,
+    kind: input.kind,
+    requestHash: input.requestHash,
+  };
+  const attempt = await input.tx.taskExecutionAttempt.create({
+    data: {
+      completedAt: input.now,
+      executorKey: `user:${input.actor.id}`,
+      executorKind: TaskCandidateKind.USER,
+      executorPersonId: input.actor.personId,
+      executorUserId: input.actor.id,
+      jurisdictionId: input.task.jurisdictionId,
+      metadata: jsonValue(metadata),
+      startedAt: input.now,
+      status: TaskExecutionAttemptStatus.COMPLETED,
+      taskId: input.task.id,
+    },
+    select: { id: true },
+  });
+  return input.tx.taskExecutionArtifact.create({
+    data: {
+      contentHash: await sha256CanonicalJson(input.value),
+      label: input.label,
+      metadataJson: jsonValue(metadata),
+      structuredResultJson: jsonValue(input.value),
+      submittedByUserId: input.actor.id,
+      taskExecutionAttemptId: attempt.id,
+    },
+    select: { contentHash: true, id: true },
+  });
+}
+
+async function createPrivateProposalDocument(
+  tx: Prisma.TransactionClient,
+  input: {
+    body: string;
+    createdByUserId: string;
+    idempotencyKey: string;
+    jurisdictionId: string | null;
+    requestHash: string;
+    title: string;
+  },
+) {
+  const document = await tx.document.create({
+    data: {
+      createdByUserId: input.createdByUserId,
+      idempotencyKey: input.idempotencyKey,
+      jurisdictionId: input.jurisdictionId,
+      requestHash: input.requestHash,
+      searchText: `${input.title}\n${input.body}`,
+      taskId: null,
+      title: input.title,
+      version: 0,
+      visibility: ContentVisibility.PRIVATE,
+    },
+    select: { id: true },
+  });
+  const contentHash = await sha256CanonicalJson({
+    body: input.body,
+    title: input.title,
+  });
+  const revision = await tx.documentRevision.create({
+    data: {
+      body: input.body,
+      contentHash,
+      createdByUserId: input.createdByUserId,
+      documentId: document.id,
+      title: input.title,
+      version: 1,
+    },
+    select: { id: true },
+  });
+  await tx.document.update({
+    where: { id: document.id },
+    data: { currentRevisionId: revision.id, version: 1 },
+  });
+  return {
+    contentHash,
+    documentId: document.id,
+    revisionId: revision.id,
+    version: 1,
+  } satisfies DocumentRevisionPin;
+}
+
+async function snapshotAuthorizedProposalSourceComments(
+  tx: Prisma.TransactionClient,
+  input: {
+    actor: { id: string; personId: string };
+    authorityTaskId: string;
+    base: DocumentRevisionPin;
+    clientAccessBoundary?: TaskClientAccessBoundary;
+    sourceCommentIds: string[];
+  },
+): Promise<DocumentProposalSourceCommentV1[]> {
+  const candidateReviewTasks = await tx.task.findMany({
+    where: {
+      AND: [
+        genuineReviewChildWhere(input.authorityTaskId),
+        {
+          contextJson: {
+            equals: input.base.documentId,
+            path: [DOCUMENT_REVIEW_CONTEXT_KEY, "target", "documentId"],
+          },
+        },
+        {
+          contextJson: {
+            equals: input.base.revisionId,
+            path: [DOCUMENT_REVIEW_CONTEXT_KEY, "target", "revisionId"],
+          },
+        },
+        ...(input.clientAccessBoundary
+          ? [getTaskClientAccessWhere(input.clientAccessBoundary)]
+          : []),
+      ],
+    },
+    select: reviewTaskSelect,
+  });
+  const validTaskIds = new Set([input.authorityTaskId]);
+  for (const reviewTask of candidateReviewTasks) {
+    const request = readReviewRequest(reviewTask.contextJson);
+    if (
+      request &&
+      sameDocumentRevisionPin(request.target, input.base) &&
+      (await hasValidReviewTaskProvenance(tx, reviewTask, request))
+    ) {
+      validTaskIds.add(reviewTask.id);
+    }
+  }
+
+  const readComments = () =>
+    tx.taskComment.findMany({
+      where: {
+        deletedAt: null,
+        hiddenByCurator: false,
+        id: { in: input.sourceCommentIds },
+        task: {
+          AND: [
+            { deletedAt: null, id: { in: [...validTaskIds] } },
+            getTaskAccessWhere({
+              action: "COMMENT",
+              personId: input.actor.personId,
+              userId: input.actor.id,
+            }),
+            ...(input.clientAccessBoundary
+              ? [getTaskClientAccessWhere(input.clientAccessBoundary)]
+              : []),
+          ],
+        },
+      },
+      select: {
+        id: true,
+        message: true,
+        taskId: true,
+        version: true,
+        visibility: true,
+      },
+    });
+  let comments = await readComments();
+  if (comments.length !== input.sourceCommentIds.length) notFound();
+
+  const internalTaskIds = [
+    ...new Set(
+      comments
+        .filter(
+          (comment) => comment.visibility === TaskCommentVisibility.INTERNAL,
+        )
+        .map((comment) => comment.taskId),
+    ),
+  ];
+  if (internalTaskIds.length > 0) {
+    const authorizedInternalTasks = await tx.task.count({
+      where: {
+        AND: [
+          { deletedAt: null, id: { in: internalTaskIds } },
+          getTaskAccessWhere({
+            action: "READ_INTERNAL",
+            personId: input.actor.personId,
+            userId: input.actor.id,
+          }),
+          ...(input.clientAccessBoundary
+            ? [getTaskClientAccessWhere(input.clientAccessBoundary)]
+            : []),
+        ],
+      },
+    });
+    if (authorizedInternalTasks !== internalTaskIds.length) notFound();
+  }
+
+  await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    SELECT "id"
+    FROM "TaskComment"
+    WHERE "id" IN (${Prisma.join(input.sourceCommentIds)})
+    ORDER BY "id"
+    FOR UPDATE
+  `);
+  comments = await readComments();
+  if (comments.length !== input.sourceCommentIds.length) notFound();
+  const commentsById = new Map(
+    comments.map((comment) => [comment.id, comment]),
+  );
+
+  return Promise.all(
+    input.sourceCommentIds.map(async (commentId) => {
+      const comment = commentsById.get(commentId);
+      if (!comment) notFound();
+      return {
+        commentId: comment.id,
+        contentHash: await sha256CanonicalJson({
+          id: comment.id,
+          message: comment.message,
+          taskId: comment.taskId,
+          version: comment.version,
+          visibility: comment.visibility,
+        }),
+        taskId: comment.taskId,
+      };
+    }),
+  );
+}
+
+export async function createDocumentProposal(
+  authorityTaskId: string,
+  rawInput: unknown,
+  actorUserId: string,
+  options: {
+    clientAccessBoundary?: TaskClientAccessBoundary;
+    idempotencyKey: string;
+    now?: Date;
+  },
+) {
+  const input = CreateDocumentProposalInputSchema.parse(rawInput);
+  const idempotencyKey = requireIdempotencyKey(options.idempotencyKey);
+  const now = options.now ?? new Date();
+  const requestHash = await sha256CanonicalJson({
+    actorUserId,
+    authorityTaskId,
+    input,
+  });
+
+  return prisma.$transaction(async (tx) => {
+    const initial = await getProposalAuthorityTask(
+      tx,
+      authorityTaskId,
+      actorUserId,
+      options.clientAccessBoundary,
+    );
+    await lockTaskRow(tx, initial.task.id);
+    const { actor, task: authorityTask } = await getProposalAuthorityTask(
+      tx,
+      authorityTaskId,
+      actorUserId,
+      options.clientAccessBoundary,
+    );
+    const existingArtifactId = await findIdempotentArtifactId(tx, {
+      idempotencyKey,
+      kind: PROPOSAL_ARTIFACT_KIND,
+      requestHash,
+      taskId: authorityTask.id,
+    });
+    if (existingArtifactId) {
+      const artifact = await loadArtifactWithAttempt(tx, existingArtifactId);
+      const proposal = await readAuthenticProposalArtifact(
+        artifact,
+        authorityTask.id,
+      );
+      if (!proposal) conflict("The prior proposal artifact is invalid");
+      return {
+        artifact: { contentHash: artifact.contentHash, id: artifact.id },
+        proposal,
+      };
+    }
+
+    const baseRevision = await loadRevisionById(
+      tx,
+      input.baseDocumentRevisionId,
+    );
+    if (baseRevision.document.taskId !== authorityTask.id) notFound();
+    await assertDocumentPermission(
+      tx,
+      baseRevision.documentId,
+      actor.id,
+      ContentAccessLevel.VIEW,
+    );
+    await lockContentResources(tx, [
+      { id: baseRevision.documentId, type: "document" },
+    ]);
+    const base = revisionPin(baseRevision);
+    const lockedBase = await loadExactRevision(tx, base);
+    if (
+      lockedBase.document.currentRevisionId !== lockedBase.id ||
+      lockedBase.document.version !== lockedBase.version
+    ) {
+      conflict("The proposal base revision is stale");
+    }
+    if (lockedBase.title === input.title && lockedBase.body === input.body) {
+      invalid("A proposal must change the document");
+    }
+
+    const sourceComments = await snapshotAuthorizedProposalSourceComments(tx, {
+      actor,
+      authorityTaskId: authorityTask.id,
+      base,
+      clientAccessBoundary: options.clientAccessBoundary,
+      sourceCommentIds: input.sourceCommentIds,
+    });
+    const documentIdempotencyKey = `document-proposal:${await sha256CanonicalJson(
+      { actorUserId, authorityTaskId, idempotencyKey },
+    )}`;
+    const proposalPin = await createPrivateProposalDocument(tx, {
+      body: input.body,
+      createdByUserId: actor.id,
+      idempotencyKey: documentIdempotencyKey,
+      jurisdictionId: authorityTask.jurisdictionId,
+      requestHash,
+      title: input.title,
+    });
+    const proposal = DocumentProposalV1Schema.parse({
+      authorityTaskId: authorityTask.id,
+      base,
+      proposal: proposalPin,
+      proposedAt: now.toISOString(),
+      proposedByUserId: actor.id,
+      schema: "optimitron.document-proposal.v1",
+      sourceComments,
+      summary: input.summary,
+    });
+    const artifact = await createCompletedArtifact({
+      actor,
+      idempotencyKey,
+      kind: PROPOSAL_ARTIFACT_KIND,
+      label: "Document revision proposal",
+      now,
+      requestHash,
+      task: authorityTask,
+      tx,
+      value: proposal,
+    });
+    return { artifact, proposal };
+  });
+}
+
+async function buildProposalPreview(
+  tx: Prisma.TransactionClient,
+  artifact: ArtifactWithAttempt,
+  authorityTaskId: string,
+): Promise<DocumentProposalPreview | null> {
+  const proposal = await readAuthenticProposalArtifact(
+    artifact,
+    authorityTaskId,
+  );
+  if (!proposal) return null;
+  const revisions = await Promise.all([
+    loadExactRevisionOrNull(tx, proposal.base),
+    loadExactRevisionOrNull(tx, proposal.proposal),
+  ]);
+  const [baseRevision, proposalRevision] = revisions;
+  if (!baseRevision || !proposalRevision) return null;
+  if (
+    proposalRevision.document.taskId != null ||
+    proposalRevision.document.visibility !== ContentVisibility.PRIVATE ||
+    proposalRevision.document.currentRevisionId !== proposalRevision.id ||
+    proposalRevision.document.version !== proposalRevision.version ||
+    proposalRevision.document.createdByUserId !== proposal.proposedByUserId ||
+    proposalRevision.createdByUserId !== proposal.proposedByUserId
+  ) {
+    return null;
+  }
+  return {
+    artifactId: artifact.id,
+    base: proposal.base,
+    baseStale:
+      baseRevision.document.currentRevisionId !== baseRevision.id ||
+      baseRevision.document.version !== baseRevision.version,
+    proposed: {
+      ...proposal.proposal,
+      body: proposalRevision.body,
+      title: proposalRevision.title,
+    },
+    sourceComments: proposal.sourceComments,
+    summary: proposal.summary,
+  };
+}
+
+export async function applyDocumentProposal(
+  authorityTaskId: string,
+  rawInput: unknown,
+  actorUserId: string,
+  options: {
+    clientAccessBoundary?: TaskClientAccessBoundary;
+    idempotencyKey: string;
+    now?: Date;
+  },
+) {
+  const input = ApplyDocumentProposalInputSchema.parse(rawInput);
+  const idempotencyKey = requireIdempotencyKey(options.idempotencyKey);
+  const now = options.now ?? new Date();
+  const requestHash = await sha256CanonicalJson({
+    actorUserId,
+    authorityTaskId,
+    input,
+  });
+
+  return prisma.$transaction(async (tx) => {
+    const initial = await getManagedAuthorityTask(
+      tx,
+      authorityTaskId,
+      actorUserId,
+      options.clientAccessBoundary,
+    );
+    await lockTaskRow(tx, initial.task.id);
+    const { actor, task: authorityTask } = await getManagedAuthorityTask(
+      tx,
+      authorityTaskId,
+      actorUserId,
+      options.clientAccessBoundary,
+    );
+    const existingArtifactId = await findIdempotentArtifactId(tx, {
+      idempotencyKey,
+      kind: PROPOSAL_APPLICATION_ARTIFACT_KIND,
+      requestHash,
+      taskId: authorityTask.id,
+    });
+    if (existingArtifactId) {
+      const artifact = await loadArtifactWithAttempt(tx, existingArtifactId);
+      const application = await readAuthenticApplicationArtifact(
+        artifact,
+        authorityTask.id,
+      );
+      if (!application) conflict("The prior proposal application is invalid");
+      return {
+        application,
+        artifact: { contentHash: artifact.contentHash, id: artifact.id },
+      };
+    }
+
+    const proposalArtifact = await loadArtifactWithAttempt(
+      tx,
+      input.proposalArtifactId,
+    );
+    const proposal = await readAuthenticProposalArtifact(
+      proposalArtifact,
+      authorityTask.id,
+    );
+    if (!proposal) notFound();
+    if (proposal.base.documentId === proposal.proposal.documentId) {
+      invalid("A proposal must be a separate private document");
+    }
+
+    await lockContentResources(tx, [
+      { id: proposal.base.documentId, type: "document" },
+      { id: proposal.proposal.documentId, type: "document" },
+    ]);
+    await assertDocumentPermission(
+      tx,
+      proposal.base.documentId,
+      actor.id,
+      ContentAccessLevel.FULL_ACCESS,
+    );
+    const [baseRevision, proposalRevision] = await Promise.all([
+      loadExactRevision(tx, proposal.base),
+      loadExactRevision(tx, proposal.proposal),
+    ]);
+    if (
+      baseRevision.document.taskId !== authorityTask.id ||
+      baseRevision.document.currentRevisionId !== baseRevision.id ||
+      baseRevision.document.version !== baseRevision.version
+    ) {
+      conflict("The canonical document changed before proposal application");
+    }
+    if (
+      proposalRevision.document.taskId != null ||
+      proposalRevision.document.visibility !== ContentVisibility.PRIVATE ||
+      proposalRevision.document.currentRevisionId !== proposalRevision.id ||
+      proposalRevision.document.version !== proposalRevision.version ||
+      proposalRevision.document.createdByUserId !== proposal.proposedByUserId ||
+      proposalRevision.createdByUserId !== proposal.proposedByUserId
+    ) {
+      conflict("The proposed document changed before application");
+    }
+    if (proposalRevision.contentHash === baseRevision.contentHash) {
+      invalid("A proposal must change the document");
+    }
+
+    let currentComments: DocumentProposalSourceCommentV1[];
+    try {
+      currentComments = await snapshotAuthorizedProposalSourceComments(tx, {
+        actor,
+        authorityTaskId: authorityTask.id,
+        base: proposal.base,
+        clientAccessBoundary: options.clientAccessBoundary,
+        sourceCommentIds: proposal.sourceComments.map(
+          (comment) => comment.commentId,
+        ),
+      });
+    } catch (error) {
+      if (
+        error instanceof DocumentReviewError &&
+        error.code === "DOCUMENT_REVIEW_NOT_FOUND"
+      ) {
+        conflict("A proposal source comment is no longer available");
+      }
+      throw error;
+    }
+    if (
+      (await sha256CanonicalJson(currentComments)) !==
+      (await sha256CanonicalJson(proposal.sourceComments))
+    ) {
+      conflict("A proposal source comment changed before application");
+    }
+
+    const nextVersion = baseRevision.version + 1;
+    const resultingRevision = await tx.documentRevision.create({
+      data: {
+        body: proposalRevision.body,
+        contentHash: proposalRevision.contentHash,
+        createdByUserId: actor.id,
+        documentId: baseRevision.documentId,
+        title: proposalRevision.title,
+        version: nextVersion,
+      },
+      select: { id: true },
+    });
+    const updated = await tx.document.updateMany({
+      where: {
+        currentRevisionId: baseRevision.id,
+        deletedAt: null,
+        id: baseRevision.documentId,
+        version: baseRevision.version,
+      },
+      data: {
+        currentRevisionId: resultingRevision.id,
+        searchText: `${proposalRevision.title}\n${proposalRevision.body}`,
+        title: proposalRevision.title,
+        version: nextVersion,
+      },
+    });
+    if (updated.count !== 1) {
+      conflict("The canonical document changed before proposal application");
+    }
+    await invalidateDocumentReviewsForDocument(tx, baseRevision.documentId);
+
+    const resultingDocument: DocumentRevisionPin = {
+      contentHash: proposalRevision.contentHash as string,
+      documentId: baseRevision.documentId,
+      revisionId: resultingRevision.id,
+      version: nextVersion,
+    };
+    const application = DocumentProposalApplicationV1Schema.parse({
+      appliedAt: now.toISOString(),
+      appliedByUserId: actor.id,
+      authorityTaskId: authorityTask.id,
+      base: proposal.base,
+      proposalArtifact: {
+        artifactId: proposalArtifact.id,
+        contentHash: proposalArtifact.contentHash,
+      },
+      resultingDocument,
+      schema: "optimitron.document-proposal-application.v1",
+      sourceProposalDocument: proposal.proposal,
+    });
+    const artifact = await createCompletedArtifact({
+      actor,
+      idempotencyKey,
+      kind: PROPOSAL_APPLICATION_ARTIFACT_KIND,
+      label: "Applied document revision proposal",
+      now,
+      requestHash,
+      task: authorityTask,
+      tx,
+      value: application,
+    });
+    return { application, artifact };
+  });
+}
+
+export async function requestDocumentReview(
+  authorityTaskId: string,
+  rawInput: unknown,
+  actorUserId: string,
+  options: {
+    clientAccessBoundary?: TaskClientAccessBoundary;
+    idempotencyKey: string;
+    now?: Date;
+  },
+) {
+  const input = RequestDocumentReviewInputSchema.parse(rawInput);
+  const idempotencyKey = requireIdempotencyKey(options.idempotencyKey);
+  const now = options.now ?? new Date();
+  const requestHash = await sha256CanonicalJson({
+    actorUserId,
+    authorityTaskId,
+    input,
+  });
+  const taskKey = `${DOCUMENT_REVIEW_TASK_KEY_PREFIX}${authorityTaskId}:${actorUserId}:${await sha256CanonicalJson(
+    { idempotencyKey },
+  )}`;
+
+  return prisma.$transaction(async (tx) => {
+    const initial = await getManagedAuthorityTask(
+      tx,
+      authorityTaskId,
+      actorUserId,
+      options.clientAccessBoundary,
+    );
+    await lockTaskRow(tx, initial.task.id);
+    const { actor, task: authorityTask } = await getManagedAuthorityTask(
+      tx,
+      authorityTaskId,
+      actorUserId,
+      options.clientAccessBoundary,
+    );
+    const existing = await tx.task.findFirst({
+      where: {
+        AND: [
+          { deletedAt: null, taskKey },
+          ...(options.clientAccessBoundary
+            ? [getTaskClientAccessWhere(options.clientAccessBoundary)]
+            : []),
+        ],
+      },
+      select: reviewTaskSelect,
+    });
+    if (existing) {
+      const request = readReviewRequest(existing.contextJson);
+      if (
+        !request ||
+        asRecord(existing.contextJson)?.documentReviewRequestHash !==
+          requestHash ||
+        !(await hasValidReviewTaskProvenance(tx, existing, request))
+      ) {
+        conflict("Idempotency-Key was already used for a different review");
+      }
+      return { request, reviewTaskId: existing.id };
+    }
+    if (
+      options.clientAccessBoundary &&
+      !isTaskWithinClientAccessBoundary(
+        {
+          isPublic: false,
+          ownerOrganizationId: authorityTask.ownerOrganizationId,
+        },
+        options.clientAccessBoundary,
+      )
+    ) {
+      notFound();
+    }
+
+    const [revision, reviewer] = await Promise.all([
+      loadRevisionById(tx, input.documentRevisionId),
+      tx.person.findFirst({
+        where: { deletedAt: null, id: input.reviewerPersonId },
+        select: { displayName: true, id: true },
+      }),
+    ]);
+    if (!reviewer || revision.document.taskId !== authorityTask.id) notFound();
+    await lockContentResources(tx, [
+      { id: revision.documentId, type: "document" },
+    ]);
+    await assertDocumentPermission(
+      tx,
+      revision.documentId,
+      actor.id,
+      ContentAccessLevel.FULL_ACCESS,
+    );
+    const target = revisionPin(revision);
+    const lockedRevision = await loadExactRevision(tx, target);
+    if (
+      lockedRevision.document.currentRevisionId !== lockedRevision.id ||
+      lockedRevision.document.version !== lockedRevision.version
+    ) {
+      conflict("The requested document revision is stale");
+    }
+    if (
+      reviewer.id === actor.personId ||
+      reviewer.id === lockedRevision.createdByUser.personId
+    ) {
+      invalid("A person cannot review their own request or document revision");
+    }
+    const duplicateCandidates = await tx.task.findMany({
+      where: {
+        AND: [
+          genuineReviewChildWhere(authorityTask.id),
+          {
+            assigneePersonId: reviewer.id,
+          },
+          {
+            contextJson: {
+              equals: target.revisionId,
+              path: [DOCUMENT_REVIEW_CONTEXT_KEY, "target", "revisionId"],
+            },
+          },
+        ],
+      },
+      select: reviewTaskSelect,
+    });
+    let hasAuthenticDuplicate = false;
+    for (const candidate of duplicateCandidates) {
+      const candidateRequest = readReviewRequest(candidate.contextJson);
+      if (
+        candidateRequest &&
+        sameDocumentRevisionPin(candidateRequest.target, target) &&
+        (await hasValidReviewTaskProvenance(tx, candidate, candidateRequest))
+      ) {
+        hasAuthenticDuplicate = true;
+        break;
+      }
+    }
+    if (hasAuthenticDuplicate) {
+      conflict("This person already has a review task for this revision");
+    }
+
+    const request = ReviewRequestV1Schema.parse({
+      authorityTaskId: authorityTask.id,
+      instructions: input.instructions,
+      requestedAt: now.toISOString(),
+      requestedByUserId: actor.id,
+      schema: "optimitron.review-request.v1",
+      target,
+    });
+    const bindingFields = {
+      applicationPolicy: TaskApplicationPolicy.CLOSED,
+      assigneePersonId: reviewer.id,
+      claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
+      createdByUserId: actor.id,
+      executionMode: TaskExecutionMode.HUMAN_ONLY,
+      isPublic: false,
+      jurisdictionId: authorityTask.jurisdictionId,
+      ownerOrganizationId: authorityTask.ownerOrganizationId,
+      parentTaskId: authorityTask.id,
+      taskKey,
+    };
+    const bindingHash = await hashDocumentReviewBinding(bindingFields, request);
+    const reviewTask = await tx.task.create({
+      data: {
+        ...bindingFields,
+        category: authorityTask.category,
+        contextJson: jsonValue({
+          [DOCUMENT_REVIEW_CONTEXT_KEY]: request,
+          [DOCUMENT_REVIEW_BINDING_HASH_KEY]: bindingHash,
+          documentReviewRequestHash: requestHash,
+        }),
+        description: input.instructions,
+        status: TaskStatus.ACTIVE,
+        title: `Review: ${lockedRevision.title}`.slice(0, 300),
+      },
+      select: { id: true },
+    });
+    return { request, reviewTaskId: reviewTask.id };
+  });
+}
+
+export async function submitDocumentReview(
+  reviewTaskId: string,
+  rawInput: unknown,
+  actorUserId: string,
+  options: {
+    clientAccessBoundary?: TaskClientAccessBoundary;
+    idempotencyKey: string;
+    now?: Date;
+  },
+) {
+  const input = SubmitDocumentReviewInputSchema.parse(rawInput);
+  const idempotencyKey = requireIdempotencyKey(options.idempotencyKey);
+  const now = options.now ?? new Date();
+  const requestHash = await sha256CanonicalJson({
+    actorUserId,
+    input,
+    reviewTaskId,
+  });
+
+  return prisma.$transaction(async (tx) => {
+    const actor = await getActor(tx, actorUserId);
+    const initialTask = await tx.task.findFirst({
+      where: taskBoundaryWhere(reviewTaskId, options.clientAccessBoundary),
+      select: reviewTaskSelect,
+    });
+    const initialRequest = readReviewRequest(initialTask?.contextJson);
+    if (
+      !initialTask ||
+      !initialRequest ||
+      initialTask.assigneePersonId !== actor.personId ||
+      initialTask.createdByUserId === actor.id ||
+      !(await hasValidReviewTaskProvenance(tx, initialTask, initialRequest))
+    ) {
+      notFound();
+    }
+    await lockTaskRow(tx, initialTask.id);
+    const task = await tx.task.findFirst({
+      where: taskBoundaryWhere(reviewTaskId, options.clientAccessBoundary),
+      select: reviewTaskSelect,
+    });
+    const request = readReviewRequest(task?.contextJson);
+    if (
+      !task ||
+      !request ||
+      task.assigneePersonId !== actor.personId ||
+      task.createdByUserId === actor.id ||
+      !(await hasValidReviewTaskProvenance(tx, task, request))
+    ) {
+      notFound();
+    }
+
+    const existingArtifactId = await findIdempotentArtifactId(tx, {
+      idempotencyKey,
+      kind: REVIEW_RESPONSE_ARTIFACT_KIND,
+      requestHash,
+      taskId: task.id,
+    });
+    if (existingArtifactId) {
+      const existing = await findAuthenticReviewResponse(
+        task,
+        request,
+        existingArtifactId,
+      );
+      if (!existing) conflict("The prior review response is invalid");
+      return {
+        artifact: {
+          contentHash: existing.artifact.contentHash,
+          id: existing.artifact.id,
+        },
+        comment: { id: existing.response.comment.id },
+        response: existing.response,
+        verification: {
+          id: existing.verification.id,
+          result: existing.verification.result,
+        },
+      };
+    }
+    if (await findAuthenticReviewResponse(task, request)) {
+      conflict("A review response has already been submitted");
+    }
+    if (task.status !== TaskStatus.ACTIVE) {
+      conflict("The review task is no longer active");
+    }
+    const revision = await loadExactRevision(tx, request.target);
+    if (
+      revision.document.currentRevisionId !== revision.id ||
+      revision.document.version !== revision.version
+    ) {
+      conflict("The reviewed document revision is stale");
+    }
+    if (
+      revision.createdByUserId === actor.id ||
+      revision.createdByUser.personId === actor.personId
+    ) {
+      invalid("A person cannot review their own document revision");
+    }
+
+    const comment = await createTopLevelTaskCommentInTransaction(tx, {
+      authorUserId: actor.id,
+      message: input.explanation,
+      taskId: task.id,
+    });
+    const commentHash = await sha256CanonicalJson({
+      authorNameSnapshot: comment.authorNameSnapshot,
+      authorOrganizationId: comment.authorOrganizationId,
+      authorPersonId: comment.authorPersonId,
+      authorUserId: comment.authorUserId,
+      createdAt: comment.createdAt.toISOString(),
+      editedAt: comment.editedAt?.toISOString() ?? null,
+      id: comment.id,
+      message: comment.message,
+      taskId: comment.taskId,
+      version: comment.version,
+    });
+    const response = ReviewResponseV1Schema.parse({
+      comment: { contentHash: commentHash, id: comment.id },
+      explanation: input.explanation,
+      reviewerPersonId: actor.personId,
+      reviewerUserId: actor.id,
+      reviewTaskId: task.id,
+      schema: "optimitron.review-response.v1",
+      submittedAt: now.toISOString(),
+      target: request.target,
+      verdict: input.verdict,
+    });
+    assertReviewResponseMatchesRequest(response, request, task.id);
+    const metadata = {
+      idempotencyKey,
+      kind: REVIEW_RESPONSE_ARTIFACT_KIND,
+      requestHash,
+    };
+    const attempt = await tx.taskExecutionAttempt.create({
+      data: {
+        completedAt: now,
+        executorKey: `user:${actor.id}`,
+        executorKind: TaskCandidateKind.USER,
+        executorPersonId: actor.personId,
+        executorUserId: actor.id,
+        jurisdictionId: task.jurisdictionId,
+        metadata: jsonValue(metadata),
+        outputSummary: response.explanation,
+        startedAt: now,
+        status: TaskExecutionAttemptStatus.COMPLETED,
+        taskId: task.id,
+      },
+      select: { id: true },
+    });
+    const artifact = await tx.taskExecutionArtifact.create({
+      data: {
+        contentHash: await sha256CanonicalJson(response),
+        label: "Document review response",
+        metadataJson: jsonValue(metadata),
+        structuredResultJson: jsonValue(response),
+        submittedByUserId: actor.id,
+        taskExecutionAttemptId: attempt.id,
+      },
+      select: { contentHash: true, id: true },
+    });
+    const verification = await tx.taskVerification.create({
+      data: {
+        acceptanceCriteriaSnapshotJson: jsonValue({
+          expectedDeliverable:
+            "A reasoned verdict from the assigned reviewer on the exact revision",
+          reviewRequest: request,
+        }),
+        completedAt: now,
+        criterionResultsJson: jsonValue([
+          {
+            criterion:
+              "Assigned reviewer submitted a reasoned exact-revision verdict",
+            evidence: {
+              artifactContentHash: artifact.contentHash,
+              artifactId: artifact.id,
+              commentContentHash: commentHash,
+              commentId: comment.id,
+            },
+            passed: true,
+          },
+        ]),
+        evidenceJson: jsonValue({
+          artifactContentHash: artifact.contentHash,
+          artifactId: artifact.id,
+          commentContentHash: commentHash,
+          commentId: comment.id,
+        }),
+        method: TaskVerificationMethod.DETERMINISTIC,
+        result: TaskVerificationResult.ACCEPTED,
+        reviewerUserId: actor.id,
+        ruleKey: REVIEW_DELIVERY_RULE_KEY,
+        ruleVersion: "1",
+        selfReviewed: true,
+        taskExecutionAttemptId: attempt.id,
+      },
+      select: { id: true, result: true },
+    });
+    const completed = await tx.task.updateMany({
+      where: {
+        deletedAt: null,
+        id: task.id,
+        status: TaskStatus.ACTIVE,
+      },
+      data: {
+        completedAt: now,
+        status: TaskStatus.VERIFIED,
+        verifiedAt: now,
+        verifiedByUserId: null,
+      },
+    });
+    if (completed.count !== 1) {
+      conflict("The review task changed before submission");
+    }
+    return {
+      artifact,
+      comment: { id: comment.id },
+      response,
+      verification,
+    };
+  });
+}
+
+export async function decideDocumentRevision(
+  authorityTaskId: string,
+  rawInput: unknown,
+  actorUserId: string,
+  options: {
+    clientAccessBoundary?: TaskClientAccessBoundary;
+    idempotencyKey: string;
+    now?: Date;
+  },
+) {
+  const input = DecideDocumentRevisionInputSchema.parse(rawInput);
+  const idempotencyKey = requireIdempotencyKey(options.idempotencyKey);
+  const now = options.now ?? new Date();
+  const requestHash = await sha256CanonicalJson({
+    actorUserId,
+    authorityTaskId,
+    input,
+  });
+
+  return prisma.$transaction(async (tx) => {
+    const initial = await getManagedAuthorityTask(
+      tx,
+      authorityTaskId,
+      actorUserId,
+      options.clientAccessBoundary,
+    );
+    await lockTaskRow(tx, initial.task.id);
+    const { actor, task: authorityTask } = await getManagedAuthorityTask(
+      tx,
+      authorityTaskId,
+      actorUserId,
+      options.clientAccessBoundary,
+    );
+    const existingArtifactId = await findIdempotentArtifactId(tx, {
+      idempotencyKey,
+      kind: INTERNAL_DECISION_ARTIFACT_KIND,
+      requestHash,
+      taskId: authorityTask.id,
+    });
+    if (existingArtifactId) {
+      const artifact = await loadArtifactWithAttempt(tx, existingArtifactId);
+      const decision = await readAuthenticDecisionArtifact(
+        artifact,
+        authorityTask.id,
+      );
+      if (!decision) conflict("The prior internal decision is invalid");
+      return {
+        artifact: { contentHash: artifact.contentHash, id: artifact.id },
+        decision,
+      };
+    }
+
+    const targetRevision = await loadRevisionById(tx, input.documentRevisionId);
+    if (targetRevision.document.taskId !== authorityTask.id) notFound();
+    await lockContentResources(tx, [
+      { id: targetRevision.documentId, type: "document" },
+    ]);
+    await assertDocumentPermission(
+      tx,
+      targetRevision.documentId,
+      actor.id,
+      ContentAccessLevel.FULL_ACCESS,
+    );
+    const target = revisionPin(targetRevision);
+    const lockedTarget = await loadExactRevision(tx, target);
+    if (
+      lockedTarget.document.currentRevisionId !== lockedTarget.id ||
+      lockedTarget.document.version !== lockedTarget.version
+    ) {
+      conflict("Only the current document revision can be decided");
+    }
+
+    const reviewed = await loadAuthenticReviewArtifact(
+      tx,
+      input.reviewArtifactId,
+    );
+    if (
+      reviewed.request.authorityTaskId !== authorityTask.id ||
+      reviewed.task.status !== TaskStatus.VERIFIED ||
+      !sameDocumentRevisionPin(reviewed.response.target, target)
+    ) {
+      notFound();
+    }
+    if (
+      actor.personId === reviewed.response.reviewerPersonId ||
+      lockedTarget.createdByUser.personId === reviewed.response.reviewerPersonId
+    ) {
+      invalid("The decision requires an independent review");
+    }
+    if (input.action === "ADOPT" && reviewed.response.verdict !== "APPROVE") {
+      conflict("Adoption requires an APPROVE verdict");
+    }
+
+    const priorArtifacts = await tx.taskExecutionArtifact.findMany({
+      where: {
+        deletedAt: null,
+        taskExecutionAttempt: {
+          deletedAt: null,
+          metadata: {
+            equals: INTERNAL_DECISION_ARTIFACT_KIND,
+            path: ["kind"],
+          },
+          taskId: authorityTask.id,
+        },
+      },
+      select: artifactWithAttemptSelect,
+    });
+    for (const priorArtifact of priorArtifacts) {
+      const prior = await readAuthenticDecisionArtifact(
+        priorArtifact,
+        authorityTask.id,
+      );
+      if (prior && sameDocumentRevisionPin(prior.target, target)) {
+        conflict("This revision already has an internal decision");
+      }
+    }
+
+    const decision = InternalDocumentDecisionV1Schema.parse({
+      action: input.action,
+      authorityTaskId: authorityTask.id,
+      decidedAt: now.toISOString(),
+      decidedByPersonId: actor.personId,
+      decidedByUserId: actor.id,
+      reason: input.action === "ADOPT" ? (input.reason ?? null) : input.reason,
+      review: {
+        artifactId: reviewed.artifact.id,
+        contentHash: reviewed.artifact.contentHash,
+        reviewerPersonId: reviewed.response.reviewerPersonId,
+        verdict: reviewed.response.verdict,
+      },
+      schema: "optimitron.internal-document-decision.v1",
+      scope: "INTERNAL",
+      target,
+    });
+    const artifact = await createCompletedArtifact({
+      actor,
+      idempotencyKey,
+      kind: INTERNAL_DECISION_ARTIFACT_KIND,
+      label:
+        decision.action === "ADOPT"
+          ? "Internal document adoption"
+          : "Internal document rejection",
+      now,
+      requestHash,
+      task: authorityTask,
+      tx,
+      value: decision,
+    });
+    return { artifact, decision };
+  });
+}
+
+async function buildPanelReview(
+  tx: Prisma.TransactionClient,
+  task: ReviewTask,
+): Promise<DocumentReviewPanelReview | null> {
+  const request = readReviewRequest(task.contextJson);
+  if (
+    !request ||
+    !task.assigneePerson ||
+    !(await hasValidReviewTaskProvenance(tx, task, request))
+  ) {
+    return null;
+  }
+  const revision = await loadExactRevisionOrNull(tx, request.target);
+  if (!revision) return null;
+  const result = await findAuthenticReviewResponse(task, request);
+  const stale =
+    task.status === TaskStatus.STALE ||
+    revision.document.currentRevisionId !== revision.id ||
+    revision.document.version !== revision.version;
+  const state: DocumentReviewState = stale
+    ? "STALE"
+    : !result
+      ? "AWAITING_RESPONSE"
+      : result.response.verdict === "APPROVE"
+        ? "APPROVED"
+        : result.response.verdict === "CHANGES_REQUESTED"
+          ? "CHANGES_REQUESTED"
+          : result.response.verdict === "REJECT"
+            ? "REJECTED"
+            : "ABSTAINED";
+  return {
+    request,
+    response: result
+      ? { ...result.response, artifactId: result.artifact.id }
+      : null,
+    reviewTaskId: task.id,
+    reviewer: task.assigneePerson,
+    state,
+    target: {
+      ...request.target,
+      body: revision.body,
+      stale,
+      title: revision.title,
+    },
+  };
+}
+
+export async function getDocumentReviewPanelData(
+  taskId: string,
+  actorUserId: string,
+  options: { clientAccessBoundary?: TaskClientAccessBoundary } = {},
+): Promise<DocumentReviewPanelData | null> {
+  return prisma.$transaction(async (tx) => {
+    const actor = await tx.user.findFirst({
+      where: { deletedAt: null, id: actorUserId },
+      select: { id: true, personId: true },
+    });
+    const requestedTaskProbe = await tx.task.findFirst({
+      where: taskBoundaryWhere(taskId, options.clientAccessBoundary),
+      select: requestedTaskProbeSelect,
+    });
+    if (!actor?.personId || !requestedTaskProbe) return null;
+    const directRequest = readReviewRequest(requestedTaskProbe.contextJson);
+    if (
+      directRequest &&
+      requestedTaskProbe.assigneePersonId === actor.personId
+    ) {
+      const requestedReviewTask = await tx.task.findFirst({
+        where: taskBoundaryWhere(taskId, options.clientAccessBoundary),
+        select: reviewTaskSelect,
+      });
+      if (!requestedReviewTask) return null;
+      const review = await buildPanelReview(tx, requestedReviewTask);
+      if (!review) return null;
+      return {
+        authorityTaskId: review.request.authorityTaskId,
+        canSubmit:
+          review.state === "AWAITING_RESPONSE" &&
+          requestedReviewTask.status === TaskStatus.ACTIVE &&
+          requestedReviewTask.createdByUserId !== actor.id,
+        mode: "REVIEWER",
+        review,
+      };
+    }
+
+    const authorityTaskId =
+      directRequest?.authorityTaskId ?? requestedTaskProbe.id;
+    const managed = await tx.task.findFirst({
+      where: {
+        AND: [
+          taskBoundaryWhere(authorityTaskId, options.clientAccessBoundary),
+          getTaskAccessWhere({
+            action: "MANAGE",
+            personId: actor.personId,
+            userId: actor.id,
+          }),
+        ],
+      },
+      select: { id: true },
+    });
+    if (!managed) return null;
+    const reviewTasks = await tx.task.findMany({
+      where: {
+        AND: [
+          genuineReviewChildWhere(authorityTaskId),
+          ...(options.clientAccessBoundary
+            ? [getTaskClientAccessWhere(options.clientAccessBoundary)]
+            : []),
+        ],
+      },
+      orderBy: { createdAt: "asc" },
+      select: reviewTaskSelect,
+    });
+    const reviews = (
+      await Promise.all(reviewTasks.map((task) => buildPanelReview(tx, task)))
+    ).filter((review): review is DocumentReviewPanelReview => review != null);
+
+    const operationArtifacts = (kind: string) =>
+      tx.taskExecutionArtifact.findMany({
+        where: {
+          deletedAt: null,
+          taskExecutionAttempt: {
+            deletedAt: null,
+            metadata: { equals: kind, path: ["kind"] },
+            taskId: authorityTaskId,
+          },
+        },
+        orderBy: { createdAt: "desc" as const },
+        select: artifactWithAttemptSelect,
+      });
+    const [decisionArtifacts, proposalArtifacts, applicationArtifacts] =
+      await Promise.all([
+        operationArtifacts(INTERNAL_DECISION_ARTIFACT_KIND),
+        operationArtifacts(PROPOSAL_ARTIFACT_KIND),
+        operationArtifacts(PROPOSAL_APPLICATION_ARTIFACT_KIND),
+      ]);
+    const decisions: Array<{
+      artifactId: string;
+      decision: InternalDocumentDecisionV1;
+    }> = [];
+    for (const artifact of decisionArtifacts) {
+      const decision = await readAuthenticDecisionArtifact(
+        artifact,
+        authorityTaskId,
+      );
+      if (decision) decisions.push({ artifactId: artifact.id, decision });
+    }
+    const appliedProposalArtifactIds = new Set<string>();
+    for (const artifact of applicationArtifacts) {
+      const application = await readAuthenticApplicationArtifact(
+        artifact,
+        authorityTaskId,
+      );
+      if (application) {
+        appliedProposalArtifactIds.add(application.proposalArtifact.artifactId);
+      }
+    }
+    const proposals: DocumentProposalPreview[] = [];
+    for (const artifact of proposalArtifacts) {
+      if (appliedProposalArtifactIds.has(artifact.id)) continue;
+      const preview = await buildProposalPreview(tx, artifact, authorityTaskId);
+      if (preview) proposals.push(preview);
+    }
+    return {
+      authorityTaskId,
+      decisions,
+      mode: "MANAGER",
+      proposals,
+      reviews,
+    };
+  });
+}

--- a/packages/web/src/lib/tasks/document-review.server.ts
+++ b/packages/web/src/lib/tasks/document-review.server.ts
@@ -1624,6 +1624,7 @@ export async function submitDocumentReview(
       authorUserId: actor.id,
       message: input.explanation,
       taskId: task.id,
+      visibility: TaskCommentVisibility.INTERNAL,
     });
     const commentHash = await sha256CanonicalJson({
       authorNameSnapshot: comment.authorNameSnapshot,

--- a/packages/web/src/lib/tasks/document-review.server.ts
+++ b/packages/web/src/lib/tasks/document-review.server.ts
@@ -1415,10 +1415,18 @@ export async function requestDocumentReview(
       loadRevisionById(tx, input.documentRevisionId),
       tx.person.findFirst({
         where: { deletedAt: null, id: input.reviewerPersonId },
-        select: { displayName: true, id: true },
+        select: {
+          displayName: true,
+          email: true,
+          id: true,
+          user: { select: { id: true } },
+        },
       }),
     ]);
     if (!reviewer || revision.document.taskId !== authorityTask.id) notFound();
+    if (!reviewer.email && !reviewer.user) {
+      invalid("Reviewer needs an email address or linked account to sign in");
+    }
     await lockContentResources(tx, [
       { id: revision.documentId, type: "document" },
     ]);

--- a/packages/web/src/lib/tasks/task-comments.server.ts
+++ b/packages/web/src/lib/tasks/task-comments.server.ts
@@ -3,7 +3,11 @@
  * counters (voteScore, upvoteCount, downvoteCount, replyCount) never drift.
  */
 
-import { Prisma } from "@optimitron/db";
+import {
+  Prisma,
+  TaskCommentSource,
+  TaskCommentVisibility,
+} from "@optimitron/db";
 import { prisma } from "@/lib/prisma";
 import {
   TaskCommentAttachmentInputError,
@@ -90,6 +94,81 @@ async function resolveMentionedUserIds(handles: string[]): Promise<string[]> {
     select: { user: { select: { id: true } } },
   });
   return persons.flatMap((p) => (p.user ? [p.user.id] : []));
+}
+
+/**
+ * Inserts a top-level comment using an existing transaction. Callers own task
+ * authorization and the surrounding state transition.
+ */
+export async function createTopLevelTaskCommentInTransaction(
+  tx: Prisma.TransactionClient,
+  input: {
+    authorUserId: string;
+    citationsJson?: Prisma.InputJsonValue | null;
+    message: string;
+    source?: TaskCommentSource;
+    taskId: string;
+    visibility?: TaskCommentVisibility;
+  },
+) {
+  const message = input.message.trim();
+  if (message.length < MIN_MESSAGE_LENGTH) {
+    throw new Error("Comment message is required");
+  }
+  if (message.length > MAX_MESSAGE_LENGTH) {
+    throw new Error(`Comment exceeds ${MAX_MESSAGE_LENGTH} character limit`);
+  }
+  const handles = parseMentions(message);
+  const mentionedPeople =
+    handles.length === 0
+      ? []
+      : await tx.person.findMany({
+          where: { handle: { in: handles, mode: "insensitive" } },
+          select: { user: { select: { id: true } } },
+        });
+  const mentionedUserIds = mentionedPeople.flatMap((person) =>
+    person.user ? [person.user.id] : [],
+  );
+  const comment = await tx.taskComment.create({
+    data: {
+      authorUserId: input.authorUserId,
+      citationsJson: input.citationsJson ?? Prisma.JsonNull,
+      mentionedUserIds,
+      message,
+      path: "",
+      source: input.source ?? TaskCommentSource.WEB,
+      taskId: input.taskId,
+      visibility: input.visibility ?? TaskCommentVisibility.PUBLIC,
+    },
+    select: {
+      authorNameSnapshot: true,
+      authorOrganizationId: true,
+      authorPersonId: true,
+      authorUserId: true,
+      createdAt: true,
+      editedAt: true,
+      id: true,
+      message: true,
+      taskId: true,
+      version: true,
+    },
+  });
+  return tx.taskComment.update({
+    where: { id: comment.id },
+    data: { path: `/${comment.id}` },
+    select: {
+      authorNameSnapshot: true,
+      authorOrganizationId: true,
+      authorPersonId: true,
+      authorUserId: true,
+      createdAt: true,
+      editedAt: true,
+      id: true,
+      message: true,
+      taskId: true,
+      version: true,
+    },
+  });
 }
 
 /**

--- a/packages/web/src/lib/tasks/task-merge.server.test.ts
+++ b/packages/web/src/lib/tasks/task-merge.server.test.ts
@@ -177,6 +177,63 @@ describe("mergeTask", () => {
     expectNoWrites();
   });
 
+  it("refuses to merge away a document-review authority with historical review children", async () => {
+    seedTasks({ can: {}, dup: {} });
+    h.state.tx.task.count.mockImplementation(
+      async (args: {
+        where: {
+          deletedAt?: unknown;
+          parentTaskId?: string;
+          taskKey?: unknown;
+        };
+      }) =>
+        args.where.parentTaskId === "dup" &&
+        !("deletedAt" in args.where) &&
+        args.where.taskKey != null
+          ? 1
+          : 0,
+    );
+
+    const report = await mergeTask({
+      canonicalTaskId: "can",
+      duplicateTaskId: "dup",
+    });
+
+    expect(report.refused).toContain("document-review authority");
+    expect(h.state.tx.task.count).toHaveBeenCalledWith({
+      where: {
+        parentTaskId: "dup",
+        taskKey: { startsWith: "document-review:dup:" },
+      },
+    });
+    expect(h.state.tx.$queryRaw).toHaveBeenCalledTimes(1);
+    expectNoWrites();
+  });
+
+  it("refuses to merge away an authority with historical governance artifacts", async () => {
+    seedTasks({ can: {}, dup: {} });
+    h.state.tx.taskExecutionAttempt.count.mockImplementation(
+      async (args: { where: { deletedAt?: unknown; taskId?: string } }) =>
+        args.where.taskId === "dup" && !("deletedAt" in args.where) ? 1 : 0,
+    );
+
+    const report = await mergeTask({
+      canonicalTaskId: "can",
+      duplicateTaskId: "dup",
+    });
+
+    expect(report.refused).toContain(
+      "proposal, application, or decision history",
+    );
+    expect(h.state.tx.taskExecutionAttempt.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ taskId: "dup" }),
+      }),
+    );
+    expect(h.state.tx.$queryRaw).toHaveBeenCalledTimes(1);
+    expectNoWrites();
+  });
+
   it("refuses when both tasks have a funding target, before any re-point", async () => {
     seedTasks({ can: {}, dup: {} });
     h.state.tx.taskFundingTarget.findUnique.mockImplementation(

--- a/packages/web/src/lib/tasks/task-merge.server.ts
+++ b/packages/web/src/lib/tasks/task-merge.server.ts
@@ -1,6 +1,16 @@
-import { TaskStatus, type Prisma } from "@optimitron/db";
+import {
+  TaskExecutionAttemptStatus,
+  TaskStatus,
+  type Prisma,
+} from "@optimitron/db";
 import { isReservedPlanningRootTask } from "@optimitron/db/task-keys";
 import { prisma } from "@/lib/prisma";
+import {
+  DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND,
+  DOCUMENT_PROPOSAL_ARTIFACT_KIND,
+  DOCUMENT_REVIEW_TASK_KEY_PREFIX,
+  INTERNAL_DOCUMENT_DECISION_ARTIFACT_KIND,
+} from "./document-review-contracts";
 
 /**
  * Admin-only duplicate-task merge.
@@ -22,6 +32,11 @@ type DbClient = Prisma.TransactionClient | typeof prisma;
 type TxClient = Prisma.TransactionClient;
 
 const MAX_ANCESTOR_DEPTH = 200;
+const DOCUMENT_GOVERNANCE_ARTIFACT_KINDS = [
+  DOCUMENT_PROPOSAL_ARTIFACT_KIND,
+  DOCUMENT_PROPOSAL_APPLICATION_ARTIFACT_KIND,
+  INTERNAL_DOCUMENT_DECISION_ARTIFACT_KIND,
+] as const;
 
 export interface MergeTaskInput {
   canonicalTaskId: string;
@@ -189,6 +204,49 @@ async function mergeTaskInClient(
   if (locked.length !== 2) {
     return refuse(
       "One of the tasks was deleted or merged by a concurrent operation; retry.",
+    );
+  }
+
+  // A review authority task's id is part of every immutable review request,
+  // proposal application, and decision. Re-parenting its review children or
+  // moving its governance artifacts would leave those records pointing at an
+  // authority task that this merge then soft-deletes. Historical rows count:
+  // soft deletion does not make governance provenance disposable. Check after
+  // locking the authority so a concurrent governance write cannot race this
+  // decision.
+  const [documentReviewChildCount, documentGovernanceAttemptCount] =
+    await Promise.all([
+      tx.task.count({
+        where: {
+          parentTaskId: duplicate.id,
+          taskKey: {
+            startsWith: `${DOCUMENT_REVIEW_TASK_KEY_PREFIX}${duplicate.id}:`,
+          },
+        },
+      }),
+      tx.taskExecutionAttempt.count({
+        where: {
+          OR: [
+            ...DOCUMENT_GOVERNANCE_ARTIFACT_KINDS.map((kind) => ({
+              artifacts: {
+                some: { metadataJson: { equals: kind, path: ["kind"] } },
+              },
+              metadata: { equals: kind, path: ["kind"] },
+              status: TaskExecutionAttemptStatus.COMPLETED,
+            })),
+          ],
+          taskId: duplicate.id,
+        },
+      }),
+    ]);
+  if (documentReviewChildCount > 0) {
+    return refuse(
+      `Duplicate task ${duplicate.id} is a document-review authority with review history and cannot be merged away.`,
+    );
+  }
+  if (documentGovernanceAttemptCount > 0) {
+    return refuse(
+      `Duplicate task ${duplicate.id} has document proposal, application, or decision history and cannot be merged away.`,
     );
   }
 

--- a/packages/web/src/lib/tasks/task-visibility.server.ts
+++ b/packages/web/src/lib/tasks/task-visibility.server.ts
@@ -9,10 +9,14 @@
 import {
   ActivityType,
   OrganizationMemberRole,
-  type Prisma,
+  Prisma,
   type TaskStatus,
 } from "@optimitron/db";
 import { prisma } from "@/lib/prisma";
+import {
+  DOCUMENT_REVIEW_CONTEXT_KEY,
+  DOCUMENT_REVIEW_TASK_KEY_PREFIX,
+} from "@/lib/tasks/document-review-contracts";
 
 /** Error message API routes map to HTTP 404. Private tasks throw the same
  * message as missing ones so they stay indistinguishable. */
@@ -73,6 +77,49 @@ const MANAGER_ORGANIZATION_ROLES = [
   OrganizationMemberRole.ADMIN,
 ] as const;
 
+const DOCUMENT_REVIEW_SCHEMA_WHERE: Prisma.TaskWhereInput = {
+  contextJson: {
+    equals: "optimitron.review-request.v1",
+    path: [DOCUMENT_REVIEW_CONTEXT_KEY, "schema"],
+  },
+};
+
+const NON_DOCUMENT_REVIEW_CONTEXT_WHERE: Prisma.TaskWhereInput = {
+  OR: [
+    { contextJson: { equals: Prisma.DbNull } },
+    {
+      contextJson: {
+        equals: Prisma.AnyNull,
+        path: [DOCUMENT_REVIEW_CONTEXT_KEY, "schema"],
+      },
+    },
+    { NOT: DOCUMENT_REVIEW_SCHEMA_WHERE },
+  ],
+};
+
+const NON_DOCUMENT_REVIEW_TASK_WHERE: Prisma.TaskWhereInput = {
+  OR: [
+    { taskKey: null },
+    {
+      taskKey: {
+        not: { startsWith: DOCUMENT_REVIEW_TASK_KEY_PREFIX },
+      },
+    },
+    {
+      AND: [
+        { taskKey: { startsWith: DOCUMENT_REVIEW_TASK_KEY_PREFIX } },
+        NON_DOCUMENT_REVIEW_CONTEXT_WHERE,
+      ],
+    },
+  ],
+};
+
+function excludeDocumentReviewTasks(
+  where: Prisma.TaskWhereInput,
+): Prisma.TaskWhereInput {
+  return { AND: [where, NON_DOCUMENT_REVIEW_TASK_WHERE] };
+}
+
 function organizationAccessWhere(
   userId: string,
   roles?: readonly OrganizationMemberRole[],
@@ -115,7 +162,10 @@ export function getTaskAccessWhere(input: {
   }
 
   if (input.action === "READ" || input.action === "READ_INTERNAL") {
-    principalWhere.push(...organizationAccessWhere(userId));
+    principalWhere.push(
+      ...organizationAccessWhere(userId).map(excludeDocumentReviewTasks),
+      ...organizationAccessWhere(userId, MANAGER_ORGANIZATION_ROLES),
+    );
     return input.action === "READ"
       ? { OR: [{ isPublic: true }, ...principalWhere] }
       : { OR: principalWhere };
@@ -123,22 +173,38 @@ export function getTaskAccessWhere(input: {
 
   if (input.action === "COMMENT" || input.action === "EXECUTE") {
     principalWhere.push(
-      ...organizationAccessWhere(userId, CONTRIBUTOR_ORGANIZATION_ROLES),
+      ...organizationAccessWhere(userId, CONTRIBUTOR_ORGANIZATION_ROLES).map(
+        excludeDocumentReviewTasks,
+      ),
     );
-    return input.action === "COMMENT"
-      ? { OR: [{ isPublic: true }, ...principalWhere] }
-      : { OR: principalWhere };
+    if (input.action === "EXECUTE") {
+      return {
+        AND: [{ OR: principalWhere }, NON_DOCUMENT_REVIEW_TASK_WHERE],
+      };
+    }
+    return {
+      OR: [
+        { isPublic: true },
+        ...principalWhere,
+        ...organizationAccessWhere(userId, MANAGER_ORGANIZATION_ROLES),
+      ],
+    };
   }
 
   return {
-    OR: [
-      { createdByUserId: userId },
+    AND: [
       {
-        managers: {
-          some: { deletedAt: null, userId },
-        },
+        OR: [
+          { createdByUserId: userId },
+          {
+            managers: {
+              some: { deletedAt: null, userId },
+            },
+          },
+          ...organizationAccessWhere(userId, MANAGER_ORGANIZATION_ROLES),
+        ],
       },
-      ...organizationAccessWhere(userId, MANAGER_ORGANIZATION_ROLES),
+      NON_DOCUMENT_REVIEW_TASK_WHERE,
     ],
   };
 }


### PR DESCRIPTION
## Purpose

Give people a simple, reusable way to improve and approve important text without creating a legal-only subsystem or forcing humans to edit documents directly.

Core user stories:

- A manager attaches authoritative text to a task and gathers feedback in ordinary comments.
- A human or AI agent selects useful comments and proposes revised text.
- The manager previews that proposal and creates a new immutable document version.
- A specific reviewer receives a private task pinned to one exact version, comments, and submits a formal verdict.
- If the text changes, the old review becomes visibly stale while its pinned copy and audit trail remain intact.
- The authorized manager records which version is the working text; that decision does not itself sign, file, enact, publish, fund, or otherwise execute anything externally.

The same flow can support founding documents, proposed laws, scientific protocols, policies, contracts, research reports, and other consequential text.

## What changed

- Adds generic document-review contracts and six shared operations: read an assigned exact-version review, create a proposal, apply a proposal, request a review, submit a verdict, and record a document decision.
- Exposes the workflow through REST and MCP using existing Task, Document/Revision, comment, execution-artifact, and verification records.
- Adds manager and reviewer panels to task pages, including proposal previews, confirmation before creating/adopting versions, stale-review states, and source-comment links.
- Keeps integrity hashes available in collapsed details instead of making them part of the normal reading flow.
- Improves nested comment/reply rendering and exact-comment navigation.
- Preserves private-assignee visibility while serving only the pinned revision through the review-task authorization path.

## Safety boundaries

- No Prisma schema or exported `@optimitron/db` type changes.
- Review tasks are private, exact-revision-bound, independent-reviewer assignments.
- Creating a newer revision atomically marks reviews of the prior revision stale.
- Delivery verification means the requested review was completed; it never turns `REJECT` into approval.
- Comment votes rank discussion only and cannot adopt text or determine truth.
- Reserved review-task metadata cannot be forged through generic task/document operations.
- Proposals are private unattached documents until a manager deliberately applies them.
- Task management alone never grants document access; managers see only review artifacts for documents they can separately read.
- Personal-scope MCP clients can read and submit only their authenticated assignee's exact review; organization-scoped managers can act only inside the canonical document boundary.
- Authority tasks and documents with governance history cannot be merged or relinked away from their immutable provenance.

## Deliberately deferred

This does not add lawyer research or outreach, invitation batches, reminders, contribution receipts, funding, referendum publication, Court-model rewrites, or a new wiki/review/board schema. Those can be added only after this smaller workflow proves the need.

This replaces #167 with a narrower kernel: 42 files and 7,816 additions here versus 145 files and 23,389 additions there.

## Verification

- `pnpm --filter @optimitron/web typecheck:app`
- `pnpm --filter @optimitron/web typecheck:tests`
- Focused Vitest suites: 289 passing in the final split (217 MCP-server, 6 MCP catalog/transport, and 66 workflow, authorization, API, merge, and UI tests).
- Fresh read-only security re-audit confirmed the OAuth, assignee, manager ACL, merge, relink, and independent-review findings are closed.
- `git diff --check`
- Captured and inspected manager, reviewer, and stale-review states on desktop and mobile.
- Verified proposal/adoption confirmations, cancellation without writes, exact source-comment navigation, and a clean manager console.
- Human approved the six-state local screenshot review and user-facing copy before this commit.

Supersedes #167.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Document Review workflows with manager and reviewer panels for proposals, version selection, feedback, and decisions.
  * Added API and MCP support for requesting, viewing, submitting, and deciding document reviews.
* **Bug Fixes**
  * Strengthened document access controls and governance safeguards.
  * Improved threaded comment display, headings, and navigation anchors.
* **Tests**
  * Expanded coverage for review workflows, authorization, idempotency, validation, and concurrency.
* **Chores**
  * Enhanced visual review reporting, coverage checks, fixtures, and Playwright cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->