### PR TITLE
Fix production build heap limit

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,7 +12,7 @@
     "dev": "pnpm run kill-port && pnpm run ensure-env && pnpm run guard:local-dev-db && pnpm run build:workspace-deps && cross-env NODE_OPTIONS=--max-old-space-size=6144 pnpm exec next dev --port 3001 --turbopack",
     "dev:fast": "pnpm run ensure-env && pnpm run guard:local-dev-db && cross-env NODE_OPTIONS=--max-old-space-size=6144 pnpm exec next dev --port 3001 --turbopack",
     "dev:watch": "node scripts/dev-watcher.mjs",
-    "build": "pnpm run ensure-env && pnpm run validate:content && pnpm run build:workspace-deps && cross-env NODE_OPTIONS=--max-old-space-size=4096 next build",
+    "build": "pnpm run ensure-env && pnpm run validate:content && pnpm run build:workspace-deps && cross-env NODE_OPTIONS=--max-old-space-size=6144 next build",
     "build:vercel": "node scripts/run-with-timeout.mjs 420 pnpm run build",
     "build:fast": "pnpm run ensure-env && pnpm run validate:content && next build",
     "start": "pnpm run ensure-env && next start",


### PR DESCRIPTION
## What changed

- Raise the web production-build heap ceiling from 4096 MB to 6144 MB.
- Match the limit already configured on the GitHub Actions production deployment job.

## Why

Every production deployment since July 26 has failed while compiling Next.js at the hard-coded 4096 MB ceiling (`Reached heap limit`). The job-level 6144 MB setting could not help because the package script overwrote it.

This has left production pinned to an older deployment, including the old `warondisease.org` MCP OAuth issuer even though PR #168 changed the canonical production issuer to `optimitron.com`.

## Impact

The production build can use the memory CI already reserves, allowing the normal deploy pipeline to publish the merged application and unblock the Optimitron plugin OAuth flow.

## Validation

- `git diff --check`
- Parsed `packages/web/package.json` and asserted the build script contains `--max-old-space-size=6144`
- The production GitHub Actions lane is the end-to-end validation for the failing Linux build path

Local dependency linking was attempted twice but exceeded a bounded five-minute window on Windows before a build could start; no test or build failure occurred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the memory available during production builds to improve build reliability for larger applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->