### PR TITLE
Add one-call completion for personal tasks

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -31,9 +31,9 @@ verified against `feature/private-execution-system` (2026-07-17).
 
 - **Layer:** personal / org
 - **Status:** implemented
-- **Summary:** Full task lifecycle over MCP (~110 tools) and REST: create/update/delete, claim → complete → verify, threaded comments, applications and candidate matching, org ownership.
+- **Summary:** Full task lifecycle over MCP (~110 tools) and REST: create/update/delete, one-call completion for private owner-created `Self` tasks, claim → complete → verify for contributed work, threaded comments, applications and candidate matching, org ownership.
 - **Evidence:** packages/web/src/lib/mcp-server.ts; packages/web/src/lib/tasks.server.ts (`createTask`); packages/web/src/lib/tasks/task-comments.server.ts; tests: packages/web/src/lib/**tests**/mcp-server.test.ts, **tests**/tasks.server.test.ts, **tests**/task-comments.server.test.ts
-- **Acceptance:** An MCP client can create a task under an explicit parent, claim it, complete the claim, and read the comment thread — all persisted.
+- **Acceptance:** An MCP client can create a task under an explicit parent, mark its own simple private `Self` task done in one call, or claim and submit contributed work for verification — all persisted.
 - **Roadmap:** shipped — maintain
 
 ### OPT-TASK-02 — Dependency graph (TaskEdge) with blocker gating

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -35,11 +35,14 @@ For personal and organization planning, the MCP server is an expected-value task
 2. Create individual tasks or call `reviewPrivateTaskBundle` for an explicitly selected source batch.
 3. Inspect every normalized action, duplicate, dependency, estimate, source anchor, and error. Apply the unchanged review with `applyPrivateTaskBundle`; private candidates become `ACTIVE`, never public proposals.
 4. Audit with `getQueueAudit`, then ask `getNextAction` or `getExecutionPlan`.
-5. Call `startTaskExecution`, coordinate through comments, and submit outputs with `submitTaskArtifact` and `submitTaskForVerification`.
-6. An authorized human calls `verifyTaskExecution`. Acceptance alone sets the task to `VERIFIED`; rejection preserves history and requeues the task.
-7. Repeat; dependents become available only after accepted verification.
+5. For a private, uncompensated `Self` task you own, call `completeTask` once with factual completion evidence. It self-verifies the task and removes it from the active queue.
+6. For delegated, shared, paid, public, organization, or agent work, call `startTaskExecution`, coordinate through comments, and submit outputs with `submitTaskArtifact` and `submitTaskForVerification`.
+7. An authorized human calls `verifyTaskExecution`. Acceptance alone sets the task to `VERIFIED`; rejection preserves history and requeues the task.
+8. Repeat; dependents become available only after accepted verification.
 
 `updateTask(status="VERIFIED")` is invalid. Claim and completion operations derive the actor from OAuth and never accept authority from a caller-supplied user ID.
+
+`completeTaskClaim` is a contribution-coordination operation, not task completion. It auto-claims open work when needed and marks that claim `COMPLETED`. An authorized reviewer may later verify the claim; `OPEN_SINGLE` then resolves the task, while `OPEN_MANY` remains active for more contributions.
 
 The canonical score is `priority`:
 
@@ -203,7 +206,8 @@ disagree, those sources win.
 - Health tracking (`earthdata:write`, companion-loop stage 1): `recordMeasurement`, `upsertTrackingReminder`, `listTrackingReminders`, `listDueTrackingReminders`, `respondToTrackingReminder`, `recordInterventionExperience`.
 - Task templates: `getTaskTemplate`, `listTaskTemplates`, `previewTaskTemplate`.
 - Knowledge: `searchManual`, `askWishonia`, `searchRepo`, `getFileContent`, `listRepoFiles`, `listSitePages`, `getPageContent`.
-- Claims: `claimTask`, `completeTaskClaim`.
+- Completion: `completeTask` for a private owner-created `Self` task; `startTaskExecution` → `submitTaskArtifact` → `submitTaskForVerification` for formal work.
+- Claims: `claimTask`, `completeTaskClaim` (claim submission only).
 - Task triggers (data-driven blueprints): `createTaskTrigger`, `updateTaskTrigger`, `disableTaskTrigger`, `listTaskTriggers`, `getTaskTrigger`, `fireTaskTrigger`. See "Task Trigger Framework" below.
 
 ## Task Trigger Framework

--- a/docs/TASK_MODEL.md
+++ b/docs/TASK_MODEL.md
@@ -48,6 +48,12 @@ Task status is intentionally narrow:
 
 Reviewed private source actions are created directly as private `ACTIVE` tasks. There is no separate long-lived `COMPLETED` task state. Only accepted verification may move a task to `VERIFIED`; generic update paths may not set it.
 
+### Personal Self-Completion
+
+The authenticated creator may self-attest a private, uncompensated `Self` task with `completeTask`. The shortcut is limited to a childless, unblocked personal task that is unassigned or assigned only to the creator, has no claim, application, payout, manager, or execution history, and has no active agent lease. It records evidence and moves the task directly to `VERIFIED`, which is the resolved task state.
+
+Delegated, shared, paid, public, organization, and agent work stays on the artifact-and-verification lifecycle. `completeTaskClaim` completes only one worker's claim; it does not resolve the task.
+
 ## Deadlines
 
 - `Task.dueAt` is the first-class accountability deadline / target date field.
@@ -65,7 +71,7 @@ Claim status is more expressive than task status because claims represent user w
 - `REJECTED`
 - `ABANDONED`
 
-Claims coordinate public or multi-claimant work. `TaskExecutionAttempt` is the canonical record for each real execution. The execution workflow is:
+Claims coordinate public or multi-claimant work. `TaskExecutionAttempt` is the canonical record for formal execution; the narrow personal `completeTask` shortcut records evidence directly on the task. The formal execution workflow is:
 
 - `ACTIVE task -> RUNNING attempt -> submitted attempt -> accepted or rejected verification`
 

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   listTasks: vi.fn(),
   getTaskDetailData: vi.fn(),
   claimTask: vi.fn(),
+  completeSelfTask: vi.fn(),
   completeTaskClaim: vi.fn(),
   computeTaskPriority: vi.fn(),
   rankTasksForUser: vi.fn(),
@@ -168,6 +169,7 @@ vi.mock("../triggers", () => ({
 
 vi.mock("../tasks.server", () => ({
   claimTask: mocks.claimTask,
+  completeSelfTask: mocks.completeSelfTask,
   completeTaskClaim: mocks.completeTaskClaim,
   listTasks: mocks.listTasks,
   getTaskDetailData: mocks.getTaskDetailData,
@@ -716,6 +718,10 @@ beforeEach(() => {
   mocks.claimTask.mockResolvedValue({
     id: "claim-1",
     status: TaskClaimStatus.CLAIMED,
+  });
+  mocks.completeSelfTask.mockResolvedValue({
+    alreadyCompleted: false,
+    task: { id: "task-1", status: TaskStatus.VERIFIED },
   });
   mocks.completeTaskClaim.mockResolvedValue({
     id: "claim-1",
@@ -4757,6 +4763,60 @@ describe("MCP server tool dispatch", () => {
       });
     });
 
+    it("completeTask self-verifies an eligible personal task in one call", async () => {
+      const client = await setup("user-1", ALL_SCOPES);
+
+      const result = await client.callTool({
+        name: "completeTask",
+        arguments: {
+          completionEvidence: "Text sent and reply received.",
+          taskId: "task-1",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.completeSelfTask).toHaveBeenCalledWith(
+        "task-1",
+        "user-1",
+        "Text sent and reply received.",
+      );
+      expect(parseToolBody(result)).toMatchObject({
+        alreadyCompleted: false,
+        completionMode: "OWNER_SELF_ATTESTATION",
+        status: TaskStatus.VERIFIED,
+        taskId: "task-1",
+        writeReceipt: {
+          operation: "completeTask",
+          outcome: "verified",
+          requestId: expect.any(String),
+          taskId: "task-1",
+        },
+      });
+    });
+
+    it("reports an already verified task without relabeling its provenance", async () => {
+      mocks.completeSelfTask.mockResolvedValue({
+        alreadyCompleted: true,
+        task: { id: "task-1", status: TaskStatus.VERIFIED },
+      });
+      const client = await setup("user-1", ALL_SCOPES);
+
+      const result = await client.callTool({
+        name: "completeTask",
+        arguments: {
+          completionEvidence: "Retry after the task left the queue.",
+          taskId: "task-1",
+        },
+      });
+
+      expect(parseToolBody(result)).toMatchObject({
+        alreadyCompleted: true,
+        completionMode: "ALREADY_VERIFIED",
+        status: TaskStatus.VERIFIED,
+        writeReceipt: { outcome: "already_completed" },
+      });
+    });
+
     it("completeTaskClaim claims the task before completing it", async () => {
       mocks.taskFindFirst.mockResolvedValue({ id: "task-1" });
       const client = await setup("user-1", ALL_SCOPES);
@@ -4778,7 +4838,10 @@ describe("MCP server tool dispatch", () => {
       );
       expect(parseToolBody(result)).toMatchObject({
         alreadyCompleted: false,
+        awaitingVerification: true,
         claimId: "claim-1",
+        claimStatus: TaskClaimStatus.COMPLETED,
+        nextAction: "await_claim_verification",
         status: TaskClaimStatus.COMPLETED,
         writeReceipt: {
           operation: "completeTaskClaim",

--- a/packages/web/src/lib/__tests__/mcp-tool-catalog.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-tool-catalog.test.ts
@@ -38,6 +38,30 @@ describe("MCP tool catalog", () => {
     }
   });
 
+  it("makes task completion and claim submission unambiguous", () => {
+    const definitions = getToolDefinitions();
+    const completeTask = definitions.find(
+      (tool) => tool.name === "completeTask",
+    );
+    const completeClaim = definitions.find(
+      (tool) => tool.name === "completeTaskClaim",
+    );
+
+    expect(
+      completeTask && "required" in completeTask.inputSchema
+        ? completeTask.inputSchema.required
+        : undefined,
+    ).toEqual(["taskId", "completionEvidence"]);
+    expect(
+      completeClaim && "required" in completeClaim.inputSchema
+        ? completeClaim.inputSchema.required
+        : undefined,
+    ).toEqual(["taskId", "completionEvidence"]);
+    expect(completeClaim?.description).toContain(
+      "does not itself complete the task",
+    );
+  });
+
   it("only references real tools in the server instructions", () => {
     // The docs-drift class this prevents: MCP_SERVER.md once documented a
     // phantom updateMilestone tool. Instructions ship to every client on

--- a/packages/web/src/lib/__tests__/tasks.server.test.ts
+++ b/packages/web/src/lib/__tests__/tasks.server.test.ts
@@ -1,7 +1,10 @@
 import {
+  TaskApplicationPolicy,
   TaskCategory,
   TaskClaimPolicy,
   TaskClaimStatus,
+  TaskCompensationKind,
+  TaskExecutionMode,
   TaskStatus,
 } from "@optimitron/db";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -26,11 +29,13 @@ const mocks = vi.hoisted(() => ({
     userFindUniqueOrThrow: vi.fn(),
   },
   tx: {
+    queryRaw: vi.fn(),
     taskClaimFindUniqueOrThrow: vi.fn(),
     taskClaimUpdate: vi.fn(),
     taskFindUniqueOrThrow: vi.fn(),
     taskFindFirst: vi.fn(),
     taskUpdate: vi.fn(),
+    taskUpdateMany: vi.fn(),
     userFindUnique: vi.fn(),
   },
 }));
@@ -87,6 +92,7 @@ vi.mock("@/lib/tasks/planning-branch.server", async (importActual) => ({
 }));
 
 import {
+  completeSelfTask,
   completeTaskClaim,
   createTask,
   getTaskDetailData,
@@ -99,10 +105,12 @@ import {
 
 function createTransactionClient() {
   return {
+    $queryRaw: mocks.tx.queryRaw,
     task: {
       findFirst: mocks.tx.taskFindFirst,
       findUniqueOrThrow: mocks.tx.taskFindUniqueOrThrow,
       update: mocks.tx.taskUpdate,
+      updateMany: mocks.tx.taskUpdateMany,
     },
     user: { findUnique: mocks.tx.userFindUnique },
     taskClaim: {
@@ -191,6 +199,7 @@ describe("tasks server", () => {
     mocks.ensureExecutionPlanningBranch.mockResolvedValue({
       id: "planner-branch-1",
     });
+    mocks.tx.queryRaw.mockResolvedValue([{ id: "task_1" }]);
     mocks.prisma.taskFindMany.mockResolvedValue([]);
     mocks.prisma.userFindUnique.mockResolvedValue({
       isAdmin: true,
@@ -206,6 +215,167 @@ describe("tasks server", () => {
         callback: (tx: ReturnType<typeof createTransactionClient>) => unknown,
       ) => callback(createTransactionClient()),
     );
+  });
+
+  function eligibleSelfTask(overrides: Record<string, unknown> = {}) {
+    return {
+      agentLeases: [],
+      applicationPolicy: TaskApplicationPolicy.CLOSED,
+      applications: [],
+      assigneeOrganizationId: null,
+      assigneePersonId: null,
+      childTasks: [],
+      claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
+      claims: [],
+      compensationKind: TaskCompensationKind.UNSPECIFIED,
+      compensationCadence: null,
+      compensationCurrency: null,
+      compensationMaxAmountMinorUnits: null,
+      compensationMinAmountMinorUnits: null,
+      compensationPaymentRails: [],
+      contextJson: { executor_type: "Self" },
+      createdByUserId: "user_1",
+      executionAttempts: [],
+      executionMode: TaskExecutionMode.HUMAN_OR_AGENT,
+      id: "task_1",
+      incomingEdges: [],
+      isPublic: false,
+      managers: [],
+      ownerOrganizationId: null,
+      payouts: [],
+      status: TaskStatus.ACTIVE,
+      taskKey: null,
+      verifiedByUserId: null,
+      ...overrides,
+    };
+  }
+
+  it.each([
+    ["unassigned", {}],
+    ["unassigned OPEN_MANY", { claimPolicy: TaskClaimPolicy.OPEN_MANY }],
+    [
+      "self-assigned",
+      {
+        assigneePersonId: "person_1",
+        claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
+      },
+    ],
+    [
+      "self-assigned OPEN_MANY",
+      {
+        assigneePersonId: "person_1",
+        claimPolicy: TaskClaimPolicy.OPEN_MANY,
+      },
+    ],
+    ["volunteer", { compensationKind: TaskCompensationKind.VOLUNTEER }],
+  ])(
+    "completes an owner-created %s Self task in one call",
+    async (_kind, overrides) => {
+      mocks.prisma.userFindUnique.mockResolvedValue({ personId: "person_1" });
+      mocks.tx.taskFindFirst.mockResolvedValue(eligibleSelfTask(overrides));
+      mocks.tx.taskUpdateMany.mockResolvedValue({ count: 1 });
+      mocks.tx.taskFindUniqueOrThrow.mockResolvedValue({
+        completionEvidence: "Text sent and reply received.",
+        id: "task_1",
+        status: TaskStatus.VERIFIED,
+        verifiedByUserId: "user_1",
+      });
+
+      const result = await completeSelfTask(
+        "task_1",
+        "user_1",
+        "Text sent and reply received.",
+      );
+
+      expect(mocks.tx.queryRaw).toHaveBeenCalledOnce();
+      expect(mocks.tx.taskUpdateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            completionEvidence: "Text sent and reply received.",
+            status: TaskStatus.VERIFIED,
+            verifiedByUserId: "user_1",
+          }),
+          where: {
+            childTasks: { none: {} },
+            id: "task_1",
+            status: TaskStatus.ACTIVE,
+          },
+        }),
+      );
+      expect(result).toMatchObject({
+        alreadyCompleted: false,
+        task: { id: "task_1", status: TaskStatus.VERIFIED },
+      });
+    },
+  );
+
+  it.each([
+    ["assigned", { assigneePersonId: "person_2" }, "completeTask only works"],
+    [
+      "unassigned ASSIGNED_ONLY",
+      { claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY },
+      "completeTask only works",
+    ],
+    [
+      "paid",
+      { compensationKind: TaskCompensationKind.BOUNTY },
+      "completeTask only works",
+    ],
+    [
+      "compensation metadata",
+      { compensationMinAmountMinorUnits: BigInt(1000) },
+      "completeTask only works",
+    ],
+    [
+      "agent",
+      { contextJson: { executor_type: "AI Agent" } },
+      "completeTask only works",
+    ],
+    ["actively leased", { agentLeases: [{ id: "lease_1" }] }, "formal work"],
+    ["claimed", { claims: [{ id: "claim_1" }] }, "formal work"],
+    [
+      "previously executed",
+      { executionAttempts: [{ id: "attempt_1" }] },
+      "formal work",
+    ],
+    [
+      "container with resolved child history",
+      { childTasks: [{ id: "child_1" }] },
+      "Task is a container",
+    ],
+    [
+      "reserved planning root",
+      { taskKey: "planner:person:person_1" },
+      "Task is a container",
+    ],
+  ])(
+    "keeps %s work on formal verification",
+    async (_kind, overrides, error) => {
+      mocks.prisma.userFindUnique.mockResolvedValue({ personId: "person_1" });
+      mocks.tx.taskFindFirst.mockResolvedValue(eligibleSelfTask(overrides));
+
+      await expect(
+        completeSelfTask("task_1", "user_1", "I say this is done."),
+      ).rejects.toThrow(error);
+      expect(mocks.tx.taskUpdateMany).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not verify a task when a child appears before the guarded update", async () => {
+    mocks.prisma.userFindUnique.mockResolvedValue({ personId: "person_1" });
+    mocks.tx.taskFindFirst.mockResolvedValue(eligibleSelfTask());
+    mocks.tx.taskUpdateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      completeSelfTask("task_1", "user_1", "I say this is done."),
+    ).rejects.toThrow("Task is no longer active");
+
+    expect(mocks.tx.taskUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ childTasks: { none: {} } }),
+      }),
+    );
+    expect(mocks.tx.taskFindUniqueOrThrow).not.toHaveBeenCalled();
   });
 
   it("completes active claims without overwriting their original start time", async () => {

--- a/packages/web/src/lib/mcp-instructions.ts
+++ b/packages/web/src/lib/mcp-instructions.ts
@@ -13,7 +13,9 @@ START HERE (in order):
 
 CREATING WORK: always searchTasks first (visibility defaults to 'all' — public plus your private work — when signed in; pass 'public' or 'private' to narrow). createTask requires an explicit parentTaskId — choose the closest existing objective; never attach directly to Optimize Earth. Estimate value/p_success/hours honestly; a calibrated guess beats omission. Use proposeTaskBundle for multi-task drafts (it runs duplicate review).
 
-COORDINATING: postTaskComment for threaded discussion (markdown, math, mermaid); use claimTask to reserve work before starting, or call completeTaskClaim directly when the work is done (it claims first if needed); updateTask to fix estimates, parents, or dependencies as scope changes.
+COMPLETING WORK: for a private uncompensated Self task you own, call completeTask once with factual completion evidence; it self-verifies the task and removes it from your active queue. For delegated, shared, paid, public, organization, or agent work, use startTaskExecution → submitTaskArtifact → submitTaskForVerification, then wait for authorized verification. completeTaskClaim only submits one claim for review and never completes the task itself.
+
+COORDINATING: postTaskComment for threaded discussion (markdown, math, mermaid); use claimTask to reserve open work before starting; updateTask to fix estimates, parents, or dependencies as scope changes.
 
 CLIENT RECOVERY: if the MCP host says a tool "has not been loaded yet," retry the exact same call once. That message comes from the host's lazy tool catalog, not Optimitron's argument validation; do not rewrite correct parameters in response.
 

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -286,6 +286,7 @@ const TOOL_SCOPES: Record<string, McpScope[]> = {
   // tasks:personal
   claimTask: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ORGANIZATION],
   claimSignerReminder: [McpScope.TASKS_PERSONAL],
+  completeTask: [McpScope.TASKS_PERSONAL],
   completeTaskClaim: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ORGANIZATION],
   logAgentRun: [McpScope.AGENT_RUN],
   acquireLease: [McpScope.AGENT_RUN],
@@ -7543,9 +7544,25 @@ const TASK_TOOL_DEFINITIONS = [
     },
   },
   {
+    name: "completeTask",
+    description:
+      "Mark one private Self task you own VERIFIED in a single call so it leaves your active queue. This owner-attestation shortcut is only for uncompensated, childless personal tasks that are unassigned or assigned only to you and have no formal work history. For delegated, shared, paid, public, organization, or agent work, use startTaskExecution, submitTaskArtifact, and submitTaskForVerification instead.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        taskId: { type: "string", description: "Private Self task ID" },
+        completionEvidence: {
+          type: "string",
+          description: "A short factual description of what was completed",
+        },
+      },
+      required: ["taskId", "completionEvidence"],
+    },
+  },
+  {
     name: "completeTaskClaim",
     description:
-      "Claim an open task if needed, then mark the authenticated user's claim completed. Safe to retry after completion. Requires completionEvidence describing what was done.",
+      "Claim an open task if needed, then mark only the authenticated user's claim completed. This does not itself complete the task. An authorized reviewer may later verify the claim; OPEN_SINGLE then resolves the task, while OPEN_MANY remains active for more contributions. Safe to retry after claim completion.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -7555,7 +7572,7 @@ const TASK_TOOL_DEFINITIONS = [
           description: "What was done and proof it worked",
         },
       },
-      // Handler validation keeps errors concise for remote clients.
+      required: ["taskId", "completionEvidence"],
     },
   },
   {
@@ -13879,7 +13896,7 @@ export function createMcpServer(
 
           // ── claimTask ──────────────────────────────────────────
           case "claimTask": {
-            const { tasks } = await getTaskFunctions();
+            const tasks = await import("./tasks.server");
             if (!userId) return authRequired(name, "Claiming requires OAuth.");
             if (!(await canAccessTaskResource(a.taskId as string, "COMMENT"))) {
               return err("Task not found");
@@ -14016,9 +14033,53 @@ export function createMcpServer(
             });
           }
 
+          // ── completeTask ───────────────────────────────────────
+          case "completeTask": {
+            const tasks = await import("./tasks.server");
+            if (!userId)
+              return authRequired(name, "Completing a task requires OAuth.");
+            const taskId = optionalString(a.taskId);
+            const completionEvidence = optionalString(a.completionEvidence);
+            const missingFields = [
+              ...(taskId ? [] : ["taskId"]),
+              ...(completionEvidence ? [] : ["completionEvidence"]),
+            ];
+            if (missingFields.length > 0) {
+              return err(
+                `Missing required fields: ${missingFields.join(", ")}.`,
+                {
+                  code: "INVALID_ARGUMENT",
+                  details: { missingFields },
+                },
+              );
+            }
+
+            const completion = await tasks.completeSelfTask(
+              taskId!,
+              userId,
+              completionEvidence!,
+            );
+            return ok({
+              alreadyCompleted: completion.alreadyCompleted,
+              completionMode: completion.alreadyCompleted
+                ? "ALREADY_VERIFIED"
+                : "OWNER_SELF_ATTESTATION",
+              status: completion.task.status,
+              taskId: completion.task.id,
+              writeReceipt: {
+                operation: "completeTask",
+                outcome: completion.alreadyCompleted
+                  ? "already_completed"
+                  : "verified",
+                requestId,
+                taskId: completion.task.id,
+              },
+            });
+          }
+
           // ── completeTaskClaim ──────────────────────────────────
           case "completeTaskClaim": {
-            const { tasks } = await getTaskFunctions();
+            const tasks = await import("./tasks.server");
             if (!userId)
               return authRequired(name, "Completing a claim requires OAuth.");
             const taskId = optionalString(a.taskId);
@@ -14058,7 +14119,13 @@ export function createMcpServer(
               alreadyCompleted:
                 existingClaim.status === TaskClaimStatus.COMPLETED ||
                 existingClaim.status === TaskClaimStatus.VERIFIED,
+              awaitingVerification: claim.status !== TaskClaimStatus.VERIFIED,
               claimId: claim.id,
+              claimStatus: claim.status,
+              nextAction:
+                claim.status === TaskClaimStatus.VERIFIED
+                  ? "none"
+                  : "await_claim_verification",
               status: claim.status,
               writeReceipt: {
                 operation: "completeTaskClaim",

--- a/packages/web/src/lib/tasks.server.ts
+++ b/packages/web/src/lib/tasks.server.ts
@@ -2,16 +2,21 @@ import {
   CourtCasePartyRole,
   OrgType,
   ReferendumVoteSource,
+  TaskApplicationPolicy,
   TaskCategory,
   TaskClaimPolicy,
   TaskClaimStatus,
+  TaskCompensationKind,
+  TaskEdgeType,
   TaskExecutionAttemptStatus,
+  TaskExecutionMode,
   TaskImpactFrameKey,
   TaskStatus,
   TaskVerificationResult,
   VotePosition,
   type Prisma,
 } from "@optimitron/db";
+import { isReservedPlanningRootTask } from "@optimitron/db/task-keys";
 import {
   assertOrganizationCanBePubliclyReferenced,
   upsertTrustedOrganization,
@@ -2195,6 +2200,233 @@ export async function deleteTaskCreatedByUser(
   return { id: taskId, deleted: true };
 }
 
+const SIMPLE_SELF_COMPLETION_ERROR =
+  "completeTask only works for a private, owner-created, uncompensated Self task that is unassigned or assigned only to you. Use startTaskExecution, submitTaskArtifact, and submitTaskForVerification for delegated, shared, paid, public, organization, or agent work.";
+
+function isSelfExecutorContext(contextJson: unknown) {
+  if (
+    !contextJson ||
+    typeof contextJson !== "object" ||
+    Array.isArray(contextJson)
+  ) {
+    return false;
+  }
+  const context = contextJson as Record<string, unknown>;
+  const executorType = context.executor_type ?? context.executorType;
+  return (
+    typeof executorType === "string" &&
+    executorType.trim().toLowerCase() === "self"
+  );
+}
+
+async function lockTaskForUpdate(tx: Prisma.TransactionClient, taskId: string) {
+  await tx.$queryRaw<Array<{ id: string }>>`
+    SELECT "id"
+    FROM "Task"
+    WHERE "id" = ${taskId}
+    FOR UPDATE
+  `;
+}
+
+/**
+ * Self-attest one small personal task in a single call. This deliberately does
+ * not replace the artifact + independent-verification path for consequential
+ * work. The narrow eligibility checks keep this equivalent to the owner
+ * clicking "done" on a private personal reminder.
+ */
+export async function completeSelfTask(
+  taskId: string,
+  userId: string,
+  completionEvidence: string,
+) {
+  const evidence = completionEvidence.trim();
+  if (!evidence) throw new Error("Completion evidence is required.");
+
+  const actor = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { personId: true },
+  });
+  if (!actor) throw new Error("Task not found");
+
+  return prisma.$transaction(async (tx) => {
+    const taskAccess = getTaskAccessWhere({
+      action: "VERIFY",
+      personId: actor.personId,
+      userId,
+    });
+    const accessibleTask = await tx.task.findFirst({
+      where: { deletedAt: null, id: taskId, ...taskAccess },
+      select: { id: true },
+    });
+    if (!accessibleTask) throw new Error("Task not found");
+
+    await lockTaskForUpdate(tx, taskId);
+    const checkedAt = new Date();
+
+    const task = await tx.task.findFirst({
+      where: {
+        deletedAt: null,
+        id: taskId,
+        ...taskAccess,
+      },
+      select: {
+        agentLeases: {
+          where: { expiresAt: { gte: checkedAt }, released: false },
+          select: { id: true },
+          take: 1,
+        },
+        applicationPolicy: true,
+        applications: {
+          select: { id: true },
+          take: 1,
+        },
+        assigneeOrganizationId: true,
+        assigneePersonId: true,
+        childTasks: {
+          select: { id: true },
+          take: 1,
+        },
+        claimPolicy: true,
+        claims: {
+          select: { id: true },
+          take: 1,
+        },
+        compensationCadence: true,
+        compensationCurrency: true,
+        compensationKind: true,
+        compensationMaxAmountMinorUnits: true,
+        compensationMinAmountMinorUnits: true,
+        compensationPaymentRails: true,
+        contextJson: true,
+        createdByUserId: true,
+        executionAttempts: {
+          select: { id: true },
+          take: 1,
+        },
+        executionMode: true,
+        id: true,
+        incomingEdges: {
+          where: {
+            deletedAt: null,
+            edgeType: { in: [TaskEdgeType.BLOCKS, TaskEdgeType.DEPENDS_ON] },
+            fromTask: {
+              deletedAt: null,
+              status: { not: TaskStatus.VERIFIED },
+            },
+          },
+          select: { id: true },
+          take: 1,
+        },
+        isPublic: true,
+        managers: {
+          select: { id: true },
+          take: 1,
+        },
+        ownerOrganizationId: true,
+        payouts: {
+          select: { id: true },
+          take: 1,
+        },
+        status: true,
+        taskKey: true,
+        verifiedByUserId: true,
+      },
+    });
+    if (!task) throw new Error("Task not found");
+
+    const eligible =
+      !task.isPublic &&
+      task.ownerOrganizationId === null &&
+      task.createdByUserId === userId &&
+      task.assigneeOrganizationId === null &&
+      ((task.assigneePersonId === null &&
+        (task.claimPolicy === TaskClaimPolicy.OPEN_SINGLE ||
+          task.claimPolicy === TaskClaimPolicy.OPEN_MANY)) ||
+        task.assigneePersonId === actor.personId) &&
+      task.applicationPolicy === TaskApplicationPolicy.CLOSED &&
+      (task.compensationKind === TaskCompensationKind.UNSPECIFIED ||
+        task.compensationKind === TaskCompensationKind.VOLUNTEER) &&
+      task.compensationCadence === null &&
+      task.compensationCurrency === null &&
+      task.compensationMinAmountMinorUnits === null &&
+      task.compensationMaxAmountMinorUnits === null &&
+      task.compensationPaymentRails.length === 0 &&
+      task.executionMode !== TaskExecutionMode.AGENT_ONLY &&
+      isSelfExecutorContext(task.contextJson);
+    if (!eligible) throw new Error(SIMPLE_SELF_COMPLETION_ERROR);
+
+    if (task.status === TaskStatus.VERIFIED) {
+      return {
+        alreadyCompleted: true,
+        task: {
+          id: task.id,
+          status: task.status,
+          verifiedByUserId: task.verifiedByUserId,
+        },
+      };
+    }
+    if (task.status !== TaskStatus.ACTIVE) {
+      throw new Error("Only active Self tasks can be completed.");
+    }
+    if (isReservedPlanningRootTask(task) || task.childTasks.length > 0) {
+      throw new Error(
+        "Task is a container. Use the formal execution and verification workflow.",
+      );
+    }
+    if (task.incomingEdges.length > 0) {
+      throw new Error("Task is blocked by an unverified dependency.");
+    }
+    if (
+      task.agentLeases.length > 0 ||
+      task.applications.length > 0 ||
+      task.claims.length > 0 ||
+      task.executionAttempts.length > 0 ||
+      task.managers.length > 0 ||
+      task.payouts.length > 0
+    ) {
+      throw new Error(
+        "Task already has shared or formal work state or history. Finish that workflow instead.",
+      );
+    }
+
+    const completedAt = checkedAt;
+    const updated = await tx.task.updateMany({
+      where: {
+        childTasks: { none: {} },
+        id: task.id,
+        status: TaskStatus.ACTIVE,
+      },
+      data: {
+        completedAt,
+        completionEvidence: evidence,
+        status: TaskStatus.VERIFIED,
+        verifiedAt: completedAt,
+        verifiedByUserId: userId,
+      },
+    });
+    if (updated.count !== 1) {
+      throw new Error("Task is no longer active.");
+    }
+
+    const completedTask = await tx.task.findUniqueOrThrow({
+      where: { id: task.id },
+      select: {
+        completedAt: true,
+        completionEvidence: true,
+        id: true,
+        status: true,
+        verifiedAt: true,
+        verifiedByUserId: true,
+      },
+    });
+
+    return {
+      alreadyCompleted: false,
+      task: completedTask,
+    };
+  });
+}
+
 export async function claimTask(taskId: string, userId: string) {
   return prisma.$transaction(async (tx) => {
     const actor = await tx.user.findUnique({
@@ -2202,15 +2434,23 @@ export async function claimTask(taskId: string, userId: string) {
       select: { personId: true },
     });
     if (!actor) throw new Error("Task not found");
+    const taskAccess = getTaskAccessWhere({
+      action: "COMMENT",
+      personId: actor.personId,
+      userId,
+    });
+    const accessibleTask = await tx.task.findFirst({
+      where: { deletedAt: null, id: taskId, ...taskAccess },
+      select: { id: true },
+    });
+    if (!accessibleTask) throw new Error("Task not found");
+
+    await lockTaskForUpdate(tx, taskId);
     const task = await tx.task.findFirst({
       where: {
         deletedAt: null,
         id: taskId,
-        ...getTaskAccessWhere({
-          action: "COMMENT",
-          personId: actor.personId,
-          userId,
-        }),
+        ...taskAccess,
       },
       select: {
         claimPolicy: true,


### PR DESCRIPTION
## User story

A person should be able to mark a small private personal reminder done in one MCP call. An agent acting through that person's MCP connection should also understand the difference between completing a task and merely submitting a claim for review.

## What changed

- adds `completeTask({ taskId, completionEvidence })` for narrowly eligible private, owner-created Self tasks
- records completion evidence and moves the task to `VERIFIED`, removing it from active queues
- supports unassigned or self-assigned personal tasks using `OPEN_SINGLE`, legacy `OPEN_MANY`, or normal `ASSIGNED_ONLY` semantics when there is no collaboration history
- keeps delegated, shared, paid, public, organization, agent, and container work on the artifact-and-verification lifecycle
- makes `completeTaskClaim` required arguments and claim-only result state explicit
- locks and rechecks task state before completion or claiming, including reserved-root, blocker, compensation, history, payout, and active-lease guards
- makes the final task transition conditional on the task still being active and childless
- narrows lazy imports for claim/completion handlers to avoid the cold-start timeout exposed by the MCP integration test
- documents the two completion paths in the MCP and task-model references

## Verification

- `pnpm --filter @optimitron/web run typecheck:fast`
- 266 focused Vitest tests: MCP dispatch, task service, and tool catalog
- `git diff --check`

No UI, Prisma schema, or exported database-type changes.