### PR TITLE
Harden personal task completion

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -35,7 +35,7 @@ For personal and organization planning, the MCP server is an expected-value task
 2. Create individual tasks or call `reviewPrivateTaskBundle` for an explicitly selected source batch.
 3. Inspect every normalized action, duplicate, dependency, estimate, source anchor, and error. Apply the unchanged review with `applyPrivateTaskBundle`; private candidates become `ACTIVE`, never public proposals.
 4. Audit with `getQueueAudit`, then ask `getNextAction` or `getExecutionPlan`.
-5. For a private, uncompensated `Self` task you own, call `completeTask` once with factual completion evidence. It self-verifies the task and removes it from the active queue.
+5. For a private, uncompensated `Self` task you own, call `completeTask` once with factual completion evidence. It self-verifies the task and removes it from the active queue. `OPEN_MANY` work remains contribution-oriented and cannot use this shortcut; correct an incorrectly classified one-person task to `OPEN_SINGLE` first.
 6. For delegated, shared, paid, public, organization, or agent work, call `startTaskExecution`, coordinate through comments, and submit outputs with `submitTaskArtifact` and `submitTaskForVerification`.
 7. An authorized human calls `verifyTaskExecution`. Acceptance alone sets the task to `VERIFIED`; rejection preserves history and requeues the task.
 8. Repeat; dependents become available only after accepted verification.

--- a/docs/TASK_MODEL.md
+++ b/docs/TASK_MODEL.md
@@ -50,7 +50,7 @@ Reviewed private source actions are created directly as private `ACTIVE` tasks. 
 
 ### Personal Self-Completion
 
-The authenticated creator may self-attest a private, uncompensated `Self` task with `completeTask`. The shortcut is limited to a childless, unblocked personal task that is unassigned or assigned only to the creator, has no claim, application, payout, manager, or execution history, and has no active agent lease. It records evidence and moves the task directly to `VERIFIED`, which is the resolved task state.
+The authenticated creator may self-attest a private, uncompensated `Self` task with `completeTask`. The shortcut is limited to a childless, unblocked personal task that is unassigned or assigned only to the creator, has no claim, application, payout, manager, or execution history, and has no active agent lease. It records evidence and moves the task directly to `VERIFIED`, which is the resolved task state. `OPEN_MANY` work remains open for independent contributions and cannot use this shortcut.
 
 Delegated, shared, paid, public, organization, and agent work stays on the artifact-and-verification lifecycle. `completeTaskClaim` completes only one worker's claim; it does not resolve the task.
 

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -4782,7 +4782,6 @@ describe("MCP server tool dispatch", () => {
       );
       expect(parseToolBody(result)).toMatchObject({
         alreadyCompleted: false,
-        completionMode: "OWNER_SELF_ATTESTATION",
         status: TaskStatus.VERIFIED,
         taskId: "task-1",
         writeReceipt: {
@@ -4791,29 +4790,6 @@ describe("MCP server tool dispatch", () => {
           requestId: expect.any(String),
           taskId: "task-1",
         },
-      });
-    });
-
-    it("reports an already verified task without relabeling its provenance", async () => {
-      mocks.completeSelfTask.mockResolvedValue({
-        alreadyCompleted: true,
-        task: { id: "task-1", status: TaskStatus.VERIFIED },
-      });
-      const client = await setup("user-1", ALL_SCOPES);
-
-      const result = await client.callTool({
-        name: "completeTask",
-        arguments: {
-          completionEvidence: "Retry after the task left the queue.",
-          taskId: "task-1",
-        },
-      });
-
-      expect(parseToolBody(result)).toMatchObject({
-        alreadyCompleted: true,
-        completionMode: "ALREADY_VERIFIED",
-        status: TaskStatus.VERIFIED,
-        writeReceipt: { outcome: "already_completed" },
       });
     });
 
@@ -4840,8 +4816,6 @@ describe("MCP server tool dispatch", () => {
         alreadyCompleted: false,
         awaitingVerification: true,
         claimId: "claim-1",
-        claimStatus: TaskClaimStatus.COMPLETED,
-        nextAction: "await_claim_verification",
         status: TaskClaimStatus.COMPLETED,
         writeReceipt: {
           operation: "completeTaskClaim",

--- a/packages/web/src/lib/__tests__/mcp-tool-catalog.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-tool-catalog.test.ts
@@ -38,7 +38,7 @@ describe("MCP tool catalog", () => {
     }
   });
 
-  it("makes task completion and claim submission unambiguous", () => {
+  it("requires evidence for both task completion writes", () => {
     const definitions = getToolDefinitions();
     const completeTask = definitions.find(
       (tool) => tool.name === "completeTask",
@@ -57,9 +57,6 @@ describe("MCP tool catalog", () => {
         ? completeClaim.inputSchema.required
         : undefined,
     ).toEqual(["taskId", "completionEvidence"]);
-    expect(completeClaim?.description).toContain(
-      "does not itself complete the task",
-    );
   });
 
   it("only references real tools in the server instructions", () => {

--- a/packages/web/src/lib/__tests__/tasks.server.test.ts
+++ b/packages/web/src/lib/__tests__/tasks.server.test.ts
@@ -252,19 +252,16 @@ describe("tasks server", () => {
 
   it.each([
     ["unassigned", {}],
-    ["unassigned OPEN_MANY", { claimPolicy: TaskClaimPolicy.OPEN_MANY }],
+    ["unassigned task without executor metadata", { contextJson: null }],
+    [
+      "legacy unassigned ASSIGNED_ONLY",
+      { claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY },
+    ],
     [
       "self-assigned",
       {
         assigneePersonId: "person_1",
         claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
-      },
-    ],
-    [
-      "self-assigned OPEN_MANY",
-      {
-        assigneePersonId: "person_1",
-        claimPolicy: TaskClaimPolicy.OPEN_MANY,
       },
     ],
     ["volunteer", { compensationKind: TaskCompensationKind.VOLUNTEER }],
@@ -312,8 +309,8 @@ describe("tasks server", () => {
   it.each([
     ["assigned", { assigneePersonId: "person_2" }, "completeTask only works"],
     [
-      "unassigned ASSIGNED_ONLY",
-      { claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY },
+      "OPEN_MANY",
+      { claimPolicy: TaskClaimPolicy.OPEN_MANY },
       "completeTask only works",
     ],
     [
@@ -329,6 +326,16 @@ describe("tasks server", () => {
     [
       "agent",
       { contextJson: { executor_type: "AI Agent" } },
+      "completeTask only works",
+    ],
+    [
+      "unknown executor",
+      { contextJson: { executor_type: "Unknown" } },
+      "completeTask only works",
+    ],
+    [
+      "AGENT_ONLY",
+      { executionMode: TaskExecutionMode.AGENT_ONLY },
       "completeTask only works",
     ],
     ["actively leased", { agentLeases: [{ id: "lease_1" }] }, "formal work"],
@@ -361,20 +368,49 @@ describe("tasks server", () => {
     },
   );
 
-  it("does not verify a task when a child appears before the guarded update", async () => {
-    mocks.prisma.userFindUnique.mockResolvedValue({ personId: "person_1" });
-    mocks.tx.taskFindFirst.mockResolvedValue(eligibleSelfTask());
-    mocks.tx.taskUpdateMany.mockResolvedValue({ count: 0 });
+  it("does not match an assigned task to an actor without a Person", async () => {
+    mocks.prisma.userFindUnique.mockResolvedValue({ personId: null });
+    mocks.tx.taskFindFirst.mockResolvedValue(
+      eligibleSelfTask({
+        assigneePersonId: "person_1",
+        claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
+      }),
+    );
 
     await expect(
       completeSelfTask("task_1", "user_1", "I say this is done."),
-    ).rejects.toThrow("Task is no longer active");
+    ).rejects.toThrow("completeTask only works");
+    expect(mocks.tx.taskUpdateMany).not.toHaveBeenCalled();
+  });
 
-    expect(mocks.tx.taskUpdateMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({ childTasks: { none: {} } }),
+  it("preserves completion provenance when a completed task is retried", async () => {
+    const completedAt = new Date("2026-07-30T18:00:00.000Z");
+    mocks.prisma.userFindUnique.mockResolvedValue({ personId: "person_1" });
+    mocks.tx.taskFindFirst.mockResolvedValue(
+      eligibleSelfTask({
+        completedAt,
+        completionEvidence: "Original evidence.",
+        status: TaskStatus.VERIFIED,
+        verifiedAt: completedAt,
+        verifiedByUserId: "user_original",
       }),
     );
+
+    await expect(
+      completeSelfTask("task_1", "user_1", "Replacement evidence."),
+    ).resolves.toEqual({
+      alreadyCompleted: true,
+      task: {
+        completedAt,
+        completionEvidence: "Original evidence.",
+        id: "task_1",
+        status: TaskStatus.VERIFIED,
+        verifiedAt: completedAt,
+        verifiedByUserId: "user_original",
+      },
+    });
+
+    expect(mocks.tx.taskUpdateMany).not.toHaveBeenCalled();
     expect(mocks.tx.taskFindUniqueOrThrow).not.toHaveBeenCalled();
   });
 
@@ -883,12 +919,12 @@ describe("tasks server", () => {
 
   // OPT-TASK-06 regression: a parentless PRIVATE task lands in the creator's
   // private planning branch, never the root.
-  it("defaults a parentless private task into the creator's planning branch", async () => {
+  it("defaults a parentless private task to OPEN_SINGLE in the creator's planning branch", async () => {
     mocks.ensureExecutionPlanningBranch.mockResolvedValue({
       id: "planner-branch-1",
     });
     mocks.prisma.taskCreate.mockResolvedValue({
-      claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
+      claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
       createdByUserId: "user_creator",
       id: "task_4",
       isPublic: false,
@@ -906,7 +942,9 @@ describe("tasks server", () => {
     expect(mocks.prisma.taskCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
+          claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
           isPublic: false,
+          maxClaims: null,
           parentTaskId: "planner-branch-1",
         }),
       }),

--- a/packages/web/src/lib/mcp-instructions.ts
+++ b/packages/web/src/lib/mcp-instructions.ts
@@ -13,7 +13,7 @@ START HERE (in order):
 
 CREATING WORK: always searchTasks first (visibility defaults to 'all' — public plus your private work — when signed in; pass 'public' or 'private' to narrow). createTask requires an explicit parentTaskId — choose the closest existing objective; never attach directly to Optimize Earth. Estimate value/p_success/hours honestly; a calibrated guess beats omission. Use proposeTaskBundle for multi-task drafts (it runs duplicate review).
 
-COMPLETING WORK: for a private uncompensated Self task you own, call completeTask once with factual completion evidence; it self-verifies the task and removes it from your active queue. For delegated, shared, paid, public, organization, or agent work, use startTaskExecution → submitTaskArtifact → submitTaskForVerification, then wait for authorized verification. completeTaskClaim only submits one claim for review and never completes the task itself.
+COMPLETING WORK: for a private uncompensated Self task you own, call completeTask once with factual completion evidence; it self-verifies the task and removes it from your active queue. Use startTaskExecution → submitTaskArtifact → submitTaskForVerification for OPEN_MANY, delegated, shared, paid, public, organization, or agent work, then wait for authorized verification. If a one-person task was incorrectly stored as OPEN_MANY and has no formal work history, change it to OPEN_SINGLE before completing it. completeTaskClaim only submits one claim for review and never completes the task itself.
 
 COORDINATING: postTaskComment for threaded discussion (markdown, math, mermaid); use claimTask to reserve open work before starting; updateTask to fix estimates, parents, or dependencies as scope changes.
 

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -7546,7 +7546,7 @@ const TASK_TOOL_DEFINITIONS = [
   {
     name: "completeTask",
     description:
-      "Mark one private Self task you own VERIFIED in a single call so it leaves your active queue. This owner-attestation shortcut is only for uncompensated, childless personal tasks that are unassigned or assigned only to you and have no formal work history. For delegated, shared, paid, public, organization, or agent work, use startTaskExecution, submitTaskArtifact, and submitTaskForVerification instead.",
+      "Mark one private Self task you own VERIFIED in a single call so it leaves your active queue. This owner-attestation shortcut is only for uncompensated, childless personal tasks that are unassigned or assigned only to you and have no formal work history. Use the submission-and-verification workflow for OPEN_MANY, delegated, shared, paid, public, organization, or agent work. If a one-person task was incorrectly stored as OPEN_MANY and has no formal history, update its claimPolicy to OPEN_SINGLE first.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -14061,9 +14061,6 @@ export function createMcpServer(
             );
             return ok({
               alreadyCompleted: completion.alreadyCompleted,
-              completionMode: completion.alreadyCompleted
-                ? "ALREADY_VERIFIED"
-                : "OWNER_SELF_ATTESTATION",
               status: completion.task.status,
               taskId: completion.task.id,
               writeReceipt: {
@@ -14121,11 +14118,6 @@ export function createMcpServer(
                 existingClaim.status === TaskClaimStatus.VERIFIED,
               awaitingVerification: claim.status !== TaskClaimStatus.VERIFIED,
               claimId: claim.id,
-              claimStatus: claim.status,
-              nextAction:
-                claim.status === TaskClaimStatus.VERIFIED
-                  ? "none"
-                  : "await_claim_verification",
               status: claim.status,
               writeReceipt: {
                 operation: "completeTaskClaim",

--- a/packages/web/src/lib/tasks.server.ts
+++ b/packages/web/src/lib/tasks.server.ts
@@ -1935,10 +1935,7 @@ export async function createTask(
   const claimSettings = resolveTaskClaimSettings({
     assigneeOrganizationId,
     assigneePersonId,
-    requestedClaimPolicy:
-      input.isPublic === false && input.claimPolicy == null
-        ? TaskClaimPolicy.ASSIGNED_ONLY
-        : input.claimPolicy,
+    requestedClaimPolicy: input.claimPolicy,
     requestedMaxClaims: input.maxClaims,
   });
   const resolvedClaimPolicy = claimSettings.claimPolicy;
@@ -2201,21 +2198,19 @@ export async function deleteTaskCreatedByUser(
 }
 
 const SIMPLE_SELF_COMPLETION_ERROR =
-  "completeTask only works for a private, owner-created, uncompensated Self task that is unassigned or assigned only to you. Use startTaskExecution, submitTaskArtifact, and submitTaskForVerification for delegated, shared, paid, public, organization, or agent work.";
+  "completeTask only works for a private, owner-created, uncompensated Self task that is unassigned or assigned only to you. If a one-person task was incorrectly stored as OPEN_MANY and has no formal history, update its claimPolicy to OPEN_SINGLE first. Use startTaskExecution, submitTaskArtifact, and submitTaskForVerification for genuine OPEN_MANY, delegated, shared, paid, public, organization, or agent work.";
 
 function isSelfExecutorContext(contextJson: unknown) {
-  if (
-    !contextJson ||
-    typeof contextJson !== "object" ||
-    Array.isArray(contextJson)
-  ) {
+  if (contextJson == null) return true;
+  if (typeof contextJson !== "object" || Array.isArray(contextJson)) {
     return false;
   }
   const context = contextJson as Record<string, unknown>;
   const executorType = context.executor_type ?? context.executorType;
+  if (executorType == null) return true;
   return (
     typeof executorType === "string" &&
-    executorType.trim().toLowerCase() === "self"
+    ["", "self"].includes(executorType.trim().toLowerCase())
   );
 }
 
@@ -2297,6 +2292,8 @@ export async function completeSelfTask(
         compensationMaxAmountMinorUnits: true,
         compensationMinAmountMinorUnits: true,
         compensationPaymentRails: true,
+        completedAt: true,
+        completionEvidence: true,
         contextJson: true,
         createdByUserId: true,
         executionAttempts: {
@@ -2329,6 +2326,7 @@ export async function completeSelfTask(
         },
         status: true,
         taskKey: true,
+        verifiedAt: true,
         verifiedByUserId: true,
       },
     });
@@ -2339,10 +2337,11 @@ export async function completeSelfTask(
       task.ownerOrganizationId === null &&
       task.createdByUserId === userId &&
       task.assigneeOrganizationId === null &&
-      ((task.assigneePersonId === null &&
-        (task.claimPolicy === TaskClaimPolicy.OPEN_SINGLE ||
-          task.claimPolicy === TaskClaimPolicy.OPEN_MANY)) ||
-        task.assigneePersonId === actor.personId) &&
+      (task.claimPolicy === TaskClaimPolicy.OPEN_SINGLE ||
+        task.claimPolicy === TaskClaimPolicy.ASSIGNED_ONLY) &&
+      (task.assigneePersonId === null ||
+        (actor.personId !== null &&
+          task.assigneePersonId === actor.personId)) &&
       task.applicationPolicy === TaskApplicationPolicy.CLOSED &&
       (task.compensationKind === TaskCompensationKind.UNSPECIFIED ||
         task.compensationKind === TaskCompensationKind.VOLUNTEER) &&
@@ -2359,8 +2358,11 @@ export async function completeSelfTask(
       return {
         alreadyCompleted: true,
         task: {
+          completedAt: task.completedAt,
+          completionEvidence: task.completionEvidence,
           id: task.id,
           status: task.status,
+          verifiedAt: task.verifiedAt,
           verifiedByUserId: task.verifiedByUserId,
         },
       };

--- a/packages/web/src/lib/tasks/agent-lease.server.test.ts
+++ b/packages/web/src/lib/tasks/agent-lease.server.test.ts
@@ -1,0 +1,157 @@
+import { TaskClaimPolicy, TaskStatus } from "@optimitron/db";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { prisma } from "@/lib/prisma";
+import { completeSelfTask } from "../tasks.server";
+import { acquireLease, heartbeatLease } from "./agent-lease.server";
+
+const TEST_PREFIX = "agent_lease_integrity_";
+
+async function cleanup() {
+  await prisma.agentTaskLease.deleteMany({
+    where: { taskId: { startsWith: TEST_PREFIX } },
+  });
+  await prisma.task.deleteMany({
+    where: { id: { startsWith: TEST_PREFIX } },
+  });
+  await prisma.user.deleteMany({
+    where: { id: { startsWith: TEST_PREFIX } },
+  });
+}
+
+async function createTask(
+  suffix: string,
+  status: TaskStatus = TaskStatus.ACTIVE,
+) {
+  const user = await prisma.user.create({
+    data: {
+      email: `${TEST_PREFIX}${suffix}@example.test`,
+      id: `${TEST_PREFIX}user_${suffix}`,
+    },
+  });
+  const task = await prisma.task.create({
+    data: {
+      claimPolicy: TaskClaimPolicy.OPEN_SINGLE,
+      contextJson: { executorType: "self" },
+      createdByUserId: user.id,
+      description: "Agent lease lifecycle regression fixture.",
+      id: `${TEST_PREFIX}task_${suffix}`,
+      isPublic: false,
+      status,
+      title: `Lease ${suffix}`,
+    },
+  });
+  return { task, user };
+}
+
+describe.sequential("agent task lease lifecycle integrity", () => {
+  beforeEach(cleanup);
+  afterAll(cleanup);
+
+  it("rejects missing and soft-deleted tasks without creating leases", async () => {
+    const missingTaskId = `${TEST_PREFIX}task_missing`;
+    await expect(acquireLease(missingTaskId, "agent-a")).rejects.toThrow(
+      "Task not found.",
+    );
+
+    const { task } = await createTask("deleted");
+    await prisma.task.update({
+      where: { id: task.id },
+      data: { deletedAt: new Date("2025-01-01T00:00:00.000Z") },
+    });
+    await expect(acquireLease(task.id, "agent-a")).rejects.toThrow(
+      "Task not found.",
+    );
+
+    await expect(
+      prisma.agentTaskLease.count({
+        where: { taskId: { in: [missingTaskId, task.id] } },
+      }),
+    ).resolves.toBe(0);
+  });
+
+  it.each([TaskStatus.DRAFT, TaskStatus.VERIFIED, TaskStatus.STALE])(
+    "rejects a %s task without creating a lease",
+    async (status) => {
+      const { task } = await createTask(status.toLowerCase(), status);
+
+      await expect(acquireLease(task.id, "agent-a")).rejects.toThrow(
+        "Task is not active.",
+      );
+      await expect(
+        prisma.agentTaskLease.count({ where: { taskId: task.id } }),
+      ).resolves.toBe(0);
+    },
+  );
+
+  it("serializes competing acquisitions so only one agent gets the task", async () => {
+    const { task } = await createTask("competing_agents");
+
+    const results = await Promise.allSettled([
+      acquireLease(task.id, "agent-a", 3_600),
+      acquireLease(task.id, "agent-b", 3_600),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === "rejected"),
+    ).toHaveLength(1);
+    await expect(
+      prisma.agentTaskLease.count({
+        where: { released: false, taskId: task.id },
+      }),
+    ).resolves.toBe(1);
+  });
+
+  it("does not renew a lease after its task stops being active", async () => {
+    const { task } = await createTask("heartbeat_completed");
+    const lease = await acquireLease(task.id, "agent-a", 3_600);
+    await prisma.task.update({
+      where: { id: task.id },
+      data: { status: TaskStatus.VERIFIED },
+    });
+
+    await expect(heartbeatLease(task.id, "agent-a", 7_200)).rejects.toThrow(
+      "Task is not active.",
+    );
+    await expect(
+      prisma.agentTaskLease.findUniqueOrThrow({
+        where: { id: lease.id },
+        select: { expiresAt: true },
+      }),
+    ).resolves.toEqual({ expiresAt: lease.expiresAt });
+  });
+
+  it("never leaves a completed task with an active lease when completion races acquisition", async () => {
+    const { task, user } = await createTask("completion_race");
+
+    const results = await Promise.allSettled([
+      acquireLease(task.id, "agent-a", 3_600),
+      completeSelfTask(task.id, user.id, "Finished the personal task."),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === "rejected"),
+    ).toHaveLength(1);
+
+    const [persistedTask, activeLeaseCount] = await Promise.all([
+      prisma.task.findUniqueOrThrow({
+        where: { id: task.id },
+        select: { status: true },
+      }),
+      prisma.agentTaskLease.count({
+        where: { released: false, taskId: task.id },
+      }),
+    ]);
+    if (persistedTask.status === TaskStatus.VERIFIED) {
+      expect(activeLeaseCount).toBe(0);
+    } else {
+      expect(persistedTask.status).toBe(TaskStatus.ACTIVE);
+      expect(activeLeaseCount).toBe(1);
+    }
+  });
+});

--- a/packages/web/src/lib/tasks/agent-lease.server.ts
+++ b/packages/web/src/lib/tasks/agent-lease.server.ts
@@ -1,7 +1,21 @@
+import { TaskStatus, type Prisma } from "@optimitron/db";
 import { prisma } from "@/lib/prisma";
 
 /** Default lease duration: 10 minutes. */
 const DEFAULT_LEASE_SECONDS = 600;
+
+async function lockActiveTask(tx: Prisma.TransactionClient, taskId: string) {
+  const [task] = await tx.$queryRaw<Array<{ status: TaskStatus }>>`
+    SELECT "status"
+    FROM "Task"
+    WHERE "id" = ${taskId} AND "deletedAt" IS NULL
+    FOR UPDATE
+  `;
+  if (!task) throw new Error("Task not found.");
+  if (task.status !== TaskStatus.ACTIVE) {
+    throw new Error("Task is not active.");
+  }
+}
 
 /**
  * Acquire a short-lived lease on a task. Prevents multiple agents from
@@ -15,10 +29,13 @@ export async function acquireLease(
   agentId: string,
   leaseSeconds = DEFAULT_LEASE_SECONDS,
 ) {
-  const now = new Date();
-  const expiresAt = new Date(now.getTime() + leaseSeconds * 1000);
-
   return prisma.$transaction(async (tx) => {
+    // Serialize with task completion and competing acquisitions; the locked
+    // row carries the current lifecycle state.
+    await lockActiveTask(tx, taskId);
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + leaseSeconds * 1000);
+
     // Release any expired leases on this task
     await tx.agentTaskLease.updateMany({
       where: {
@@ -76,26 +93,28 @@ export async function heartbeatLease(
   agentId: string,
   leaseSeconds = DEFAULT_LEASE_SECONDS,
 ) {
-  const now = new Date();
+  return prisma.$transaction(async (tx) => {
+    await lockActiveTask(tx, taskId);
+    const now = new Date();
+    const lease = await tx.agentTaskLease.findUnique({
+      where: { taskId_agentId: { taskId, agentId } },
+      select: { id: true, expiresAt: true, released: true },
+    });
 
-  const lease = await prisma.agentTaskLease.findUnique({
-    where: { taskId_agentId: { taskId, agentId } },
-    select: { id: true, expiresAt: true, released: true },
-  });
+    if (!lease || lease.released) {
+      throw new Error("No active lease found. Acquire a new lease.");
+    }
+    if (lease.expiresAt < now) {
+      throw new Error("Lease has expired. Acquire a new lease.");
+    }
 
-  if (!lease || lease.released) {
-    throw new Error("No active lease found. Acquire a new lease.");
-  }
-  if (lease.expiresAt < now) {
-    throw new Error("Lease has expired. Acquire a new lease.");
-  }
-
-  return prisma.agentTaskLease.update({
-    where: { id: lease.id },
-    data: {
-      expiresAt: new Date(now.getTime() + leaseSeconds * 1000),
-      lastHeartbeatAt: now,
-    },
+    return tx.agentTaskLease.update({
+      where: { id: lease.id },
+      data: {
+        expiresAt: new Date(now.getTime() + leaseSeconds * 1000),
+        lastHeartbeatAt: now,
+      },
+    });
   });
 }
 
@@ -139,6 +158,10 @@ export async function isTaskLeased(taskId: string) {
   });
 
   return activeLease
-    ? { leased: true as const, agentId: activeLease.agentId, expiresAt: activeLease.expiresAt }
+    ? {
+        leased: true as const,
+        agentId: activeLease.agentId,
+        expiresAt: activeLease.expiresAt,
+      }
     : { leased: false as const };
 }


### PR DESCRIPTION
## User story

A person should be able to finish a private, uncompensated one-person task with one evidence-bearing `completeTask` call and have it leave the active queue. Multi-contributor, delegated, paid, public, organization, and agent work must still use formal submission and independent verification.

## What changed

- default private unassigned tasks to `OPEN_SINGLE`, while retaining safe support for legacy `ASSIGNED_ONLY` personal tasks
- treat absent executor metadata as personal work, but reject explicit unknown or agent execution
- keep `OPEN_MANY` on the contribution workflow instead of allowing self-verification
- preserve original completion evidence and timestamps on idempotent retries
- serialize agent lease acquisition and heartbeats against task completion
- remove redundant MCP response fields and mock-only coverage
- document the one-call completion boundary and the correction path for misclassified one-person tasks

## Verification

- `pnpm --filter @optimitron/web test`
- `pnpm --filter @optimitron/web run typecheck:fast`
- focused task, lease, MCP, and catalog suites: 275 tests passed
- Prettier and `git diff --check`

No Prisma schema, exported database type, or UI changes.