### PR TITLE
Fix MCP task search and page previews

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -115,6 +115,10 @@ Example `listTasks` request:
 ```
 
 `searchTasks` uses the same pagination fields plus its required `query`.
+It fuzzy-ranks title, description, impact statement, task key, assignee, and
+organization matches. For signed-in callers, `visibility: "all"` includes
+private tasks they created, manage, are assigned, claimed, or can access through
+an organization; it never means every user's private work.
 
 Paginated response from either tool:
 
@@ -408,6 +412,11 @@ disagree, those sources win.
 - Health tracking (`earthdata:write`, companion-loop stage 1): `recordMeasurement`, `upsertTrackingReminder`, `listTrackingReminders`, `listDueTrackingReminders`, `respondToTrackingReminder`, `recordInterventionExperience`.
 - Task templates: `getTaskTemplate`, `listTaskTemplates`, `previewTaskTemplate`.
 - Knowledge: `searchManual`, `askWishonia`, `searchRepo`, `getFileContent`, `listRepoFiles`, `listSitePages`, `getPageContent`.
+
+`getPageContent` is a public, logged-out page reader. It prefers the repository's
+rendered `page.logged-out.md` snapshot so client-side loading shells are not
+returned as page text. It does not expose authenticated page copy.
+
 - Completion: `completeTask` for a private owner-created `Self` task; `startTaskExecution` → `submitTaskArtifact` → `submitTaskForVerification` for formal work.
 - Claims: `claimTask`, `completeTaskClaim` (claim submission only).
 - Task triggers (data-driven blueprints): `createTaskTrigger`, `updateTaskTrigger`, `disableTaskTrigger`, `listTaskTriggers`, `getTaskTrigger`, `fireTaskTrigger`. See "Task Trigger Framework" below.

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -8,6 +8,7 @@ const { REDIRECTS } = require("./src/lib/redirects");
 /** @type {import('next').NextConfig} */
 const isStaticExport = process.env.NEXT_OUTPUT_EXPORT === "true";
 const legislationContentTraceFiles = ["../../content/legislation/**/*.md"];
+const loggedOutPageSnapshotTraceFiles = ["./src/app/**/page.logged-out.md"];
 
 const nextConfig = {
   experimental: {
@@ -48,6 +49,7 @@ const nextConfig = {
   basePath: isStaticExport ? "/optimitron" : "",
   outputFileTracingRoot: path.resolve(__dirname, "../.."),
   outputFileTracingIncludes: {
+    "/api/mcp": loggedOutPageSnapshotTraceFiles,
     "/legislation": legislationContentTraceFiles,
     "/legislation/*": legislationContentTraceFiles,
     "/api/og/route": [

--- a/packages/web/src/__tests__/next-config-legislation.test.ts
+++ b/packages/web/src/__tests__/next-config-legislation.test.ts
@@ -18,4 +18,16 @@ describe("next.config legislation tracing", () => {
     expect(includes["/legislation"] ?? []).toContain(expectedContentGlob);
     expect(includes["/legislation/*"] ?? []).toContain(expectedContentGlob);
   });
+
+  it("includes rendered logged-out page snapshots in the MCP server trace", () => {
+    const configPath = fileURLToPath(
+      new URL("../../next.config.js", import.meta.url),
+    );
+    const config = require(configPath) as NextConfigWithTracing;
+    const includes = config.outputFileTracingIncludes ?? {};
+
+    expect(includes["/api/mcp"] ?? []).toContain(
+      "./src/app/**/page.logged-out.md",
+    );
+  });
 });

--- a/packages/web/src/lib/__tests__/site-inventory.server.test.ts
+++ b/packages/web/src/lib/__tests__/site-inventory.server.test.ts
@@ -93,7 +93,7 @@ describe("site inventory", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await getPageContent({
-      url: "https://optimitron.com/invest",
+      url: "https://warondisease.org/invest",
     });
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -102,6 +102,41 @@ describe("site inventory", () => {
       "YOUR PLANET MAY BE ELIGIBLE FOR OPTIMIZATION",
     );
     expect(result.content).not.toContain("Booting Earth Optimization System");
+  });
+
+  it("does not serve the War on Disease home snapshot for another site variant", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          "<html><head><title>Optimitron</title></head><body><main><h1>Optimize Earth</h1><p>Every job required to optimize it.</p></main></body></html>",
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getPageContent({ url: "https://optimitron.com/" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.title).toBe("Optimitron");
+    expect(result.content).toContain("Optimize Earth");
+    expect(result.content).not.toContain("TAKE 30 SECONDS");
+  });
+
+  it("does not serve a non-root snapshot captured for another site variant", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          "<html><head><title>Compute</title></head><body><main><h1>Optimitron compute</h1></main></body></html>",
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getPageContent({
+      url: "https://optimitron.com/invest",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.content).toContain("Optimitron compute");
+    expect(result.content).not.toContain("QUANTIFY ANYTHING");
   });
 
   it("rejects a loading shell when no rendered snapshot exists", async () => {
@@ -129,11 +164,12 @@ describe("site inventory", () => {
   });
 
   it("does not let an encoded '..' segment traverse to another route's snapshot", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(
-        "<html><head><title>Fallback</title></head><body><main><h1>Fallback</h1></main></body></html>",
-        { headers: { "content-type": "text/html" } },
-      ),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          "<html><head><title>Fallback</title></head><body><main><h1>Fallback</h1></main></body></html>",
+          { headers: { "content-type": "text/html" } },
+        ),
     );
     vi.stubGlobal("fetch", fetchMock);
 

--- a/packages/web/src/lib/__tests__/site-inventory.server.test.ts
+++ b/packages/web/src/lib/__tests__/site-inventory.server.test.ts
@@ -56,7 +56,7 @@ describe("site inventory", () => {
     ).toBe(true);
   });
 
-  it("extracts clean markdown from an allowed Optimitron property URL", async () => {
+  it("extracts clean markdown from an allowed manual URL", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
@@ -74,18 +74,52 @@ describe("site inventory", () => {
     );
 
     const result = await getPageContent({
-      url: "https://warondisease.org/vote",
+      url: "https://manual.warondisease.org/knowledge/test-page",
     });
 
     expect(result).toMatchObject({
       lastModified: "Wed, 29 Apr 2026 12:00:00 GMT",
       sections: ["Vote"],
       title: "Vote",
-      url: "https://warondisease.org/vote",
+      url: "https://manual.warondisease.org/knowledge/test-page",
     });
     expect(result.content).toContain("# Vote");
     expect(result.content).toContain("- One task");
     expect(result.content).not.toContain("<main");
+  });
+
+  it("serves the rendered logged-out snapshot instead of fetching a loader", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getPageContent({
+      url: "https://optimitron.com/invest",
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.title).toContain("Invest");
+    expect(result.content).toContain(
+      "YOUR PLANET MAY BE ELIGIBLE FOR OPTIMIZATION",
+    );
+    expect(result.content).not.toContain("Booting Earth Optimization System");
+  });
+
+  it("rejects a loading shell when no rendered snapshot exists", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            "<html><body><main>Booting Earth Optimization System. Thank you for your patience. Your civilization is very important to us.</main></body></html>",
+          ),
+      ),
+    );
+
+    await expect(
+      getPageContent({
+        url: "https://manual.warondisease.org/knowledge/no-snapshot",
+      }),
+    ).rejects.toThrow("Page returned only its loading shell");
   });
 
   it("rejects URLs outside configured Optimitron properties", async () => {

--- a/packages/web/src/lib/__tests__/site-inventory.server.test.ts
+++ b/packages/web/src/lib/__tests__/site-inventory.server.test.ts
@@ -127,4 +127,25 @@ describe("site inventory", () => {
       getPageContent({ url: "https://example.com/vote" }),
     ).rejects.toThrow("URL is not an allowed Optimitron property route");
   });
+
+  it("does not let an encoded '..' segment traverse to another route's snapshot", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        "<html><head><title>Fallback</title></head><body><main><h1>Fallback</h1></main></body></html>",
+        { headers: { "content-type": "text/html" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    // "%2e%2e%2Fvote" decodes to "../vote", which (pre-fix) escaped the
+    // "invest" segment and resolved to the unrelated vote snapshot instead
+    // of being rejected. The fix must reject the whole snapshot lookup and
+    // fall through to a live fetch instead of serving the wrong page.
+    const result = await getPageContent({
+      url: "https://optimitron.com/invest/%2e%2e%2Fvote",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.title).toBe("Fallback");
+  });
 });

--- a/packages/web/src/lib/__tests__/task-visibility.server.test.ts
+++ b/packages/web/src/lib/__tests__/task-visibility.server.test.ts
@@ -91,7 +91,7 @@ describe("getTaskVisibilityWhere", () => {
     expect(where.isPublic).toBeUndefined();
   });
 
-  it("lets signed-in viewers reach public, own, and assigned tasks", () => {
+  it("lets signed-in viewers reach public, own, assigned, and claimed tasks", () => {
     const where = getTaskVisibilityWhere({
       taskId: "task_1",
       userId: "user_1",
@@ -107,6 +107,17 @@ describe("getTaskVisibilityWhere", () => {
         {
           managers: {
             some: { deletedAt: null, userId: "user_1" },
+          },
+        },
+        {
+          claims: {
+            some: {
+              deletedAt: null,
+              status: {
+                in: ["CLAIMED", "IN_PROGRESS", "COMPLETED", "VERIFIED"],
+              },
+              userId: "user_1",
+            },
           },
         },
       ]),

--- a/packages/web/src/lib/__tests__/task-visibility.server.test.ts
+++ b/packages/web/src/lib/__tests__/task-visibility.server.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Prisma } from "@optimitron/db";
+import { Prisma, TaskClaimStatus } from "@optimitron/db";
 import {
   DOCUMENT_REVIEW_CONTEXT_KEY,
   DOCUMENT_REVIEW_TASK_KEY_PREFIX,
@@ -273,6 +273,22 @@ describe("getTaskVisibilityWhere", () => {
         },
       ],
     });
+  });
+
+  it("keeps completed claims readable without making them executable", () => {
+    const readable = JSON.stringify(
+      getTaskAccessWhere({ action: "READ", userId: "reviewer_user" }),
+    );
+    const executable = JSON.stringify(
+      getTaskAccessWhere({ action: "EXECUTE", userId: "reviewer_user" }),
+    );
+
+    expect(readable).toContain(TaskClaimStatus.COMPLETED);
+    expect(readable).toContain(TaskClaimStatus.VERIFIED);
+    expect(executable).toContain(TaskClaimStatus.CLAIMED);
+    expect(executable).toContain(TaskClaimStatus.IN_PROGRESS);
+    expect(executable).not.toContain(TaskClaimStatus.COMPLETED);
+    expect(executable).not.toContain(TaskClaimStatus.VERIFIED);
   });
 
   it.each(["EXECUTE", "MANAGE", "VERIFY"] as const)(

--- a/packages/web/src/lib/__tests__/tasks.server.test.ts
+++ b/packages/web/src/lib/__tests__/tasks.server.test.ts
@@ -141,6 +141,13 @@ function lastTaskFindManyArgs() {
   return calls.at(-1)?.[0] ?? {};
 }
 
+function firstTaskFindManyArgs() {
+  const calls = mocks.prisma.taskFindMany.mock.calls as Array<
+    [Record<string, unknown>]
+  >;
+  return calls[0]?.[0] ?? {};
+}
+
 function mockTask(overrides: Record<string, unknown> = {}) {
   return {
     _count: { childTasks: 0, executionAttempts: 0 },
@@ -162,6 +169,7 @@ function mockTask(overrides: Record<string, unknown> = {}) {
     dueAt: null,
     estimatedEffortHours: null,
     id: "task_1",
+    impactStatement: null,
     incomingEdges: [],
     interestTags: [],
     isPublic: true,
@@ -755,27 +763,60 @@ describe("tasks server", () => {
     ]);
   });
 
-  it("searchTasks ignores request-framing words but requires every distinctive term", async () => {
+  it("searchTasks ignores request-framing words and accepts any distinctive term", async () => {
     await searchTasks("find secret grant memo task", { userId: null });
 
-    const args = lastTaskFindManyArgs();
+    const args = firstTaskFindManyArgs();
     const filters = (args.where as { AND: unknown[] }).AND;
     expect(filters[0]).toEqual(
       expect.objectContaining({ deletedAt: null, isPublic: true }),
     );
-    expect(filters.slice(1)).toHaveLength(3);
+    expect(filters.slice(1)).toHaveLength(1);
+    const termFilter = filters[1] as { OR: unknown[] };
     for (const term of ["secret", "grant", "memo"]) {
-      expect(filters.slice(1)).toContainEqual(
-        expect.objectContaining({
-          OR: expect.arrayContaining([
-            { title: { contains: term, mode: "insensitive" } },
-          ]),
-        }),
+      expect(termFilter.OR).toEqual(
+        expect.arrayContaining([
+          { title: { contains: term, mode: "insensitive" } },
+        ]),
       );
     }
-    expect(JSON.stringify(filters.slice(1))).not.toContain('"find"');
-    expect(JSON.stringify(filters.slice(1))).not.toContain('"task"');
+    expect(JSON.stringify(termFilter)).not.toContain('"find"');
+    expect(JSON.stringify(termFilter)).not.toContain('"task"');
     expect(args.take).toBe(64);
+  });
+
+  it("finds the reported securities-counsel task from a longer natural query", async () => {
+    mocks.prisma.taskFindMany.mockResolvedValue([
+      mockTask({
+        description: "Have independent counsel review the offering documents.",
+        id: "cms0wpz59001b04jwyofp05lw",
+        impactStatement: "Verify the EOS equity structure before financing.",
+        title: "Get securities counsel to review the EOS equity structure",
+      }),
+    ]);
+
+    const results = await searchTasks(
+      "EOS securities counsel stock purchase agreement lawyer review offering",
+      { userId: "user-a" },
+    );
+
+    expect(results[0]?.id).toBe("cms0wpz59001b04jwyofp05lw");
+  });
+
+  it("uses the bounded fallback to find a misspelled title", async () => {
+    mocks.prisma.taskFindMany.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      mockTask({
+        id: "securities-counsel",
+        title: "Get securities counsel to review the equity structure",
+      }),
+    ]);
+
+    const results = await searchTasks("securites counsl", {
+      userId: "user-a",
+    });
+
+    expect(results[0]?.id).toBe("securities-counsel");
+    expect(mocks.prisma.taskFindMany).toHaveBeenCalledTimes(2);
   });
 
   it.each([
@@ -848,10 +889,10 @@ describe("tasks server", () => {
     );
   });
 
-  it("searchTasks with a user searches public tasks plus that user's created private tasks", async () => {
+  it("searchTasks includes every private task the authenticated person can access", async () => {
     await searchTasks("secret grant memo", { userId: "user-a" });
 
-    const args = lastTaskFindManyArgs();
+    const args = firstTaskFindManyArgs();
     const [visibility] = (args.where as { AND: unknown[] }).AND as Array<{
       OR?: unknown[];
       deletedAt?: unknown;
@@ -861,8 +902,24 @@ describe("tasks server", () => {
       expect.arrayContaining([
         { isPublic: true },
         { createdByUserId: "user-a" },
+        { assigneePersonId: "person_admin" },
+        {
+          claims: {
+            some: {
+              deletedAt: null,
+              status: {
+                in: ["CLAIMED", "IN_PROGRESS", "COMPLETED", "VERIFIED"],
+              },
+              userId: "user-a",
+            },
+          },
+        },
       ]),
     );
+    expect(mocks.prisma.userFindUnique).toHaveBeenCalledWith({
+      select: { personId: true },
+      where: { id: "user-a" },
+    });
   });
 
   it("records the creator on private tasks created by the creator", async () => {

--- a/packages/web/src/lib/__tests__/tasks.server.test.ts
+++ b/packages/web/src/lib/__tests__/tasks.server.test.ts
@@ -766,23 +766,25 @@ describe("tasks server", () => {
   it("searchTasks ignores request-framing words and accepts any distinctive term", async () => {
     await searchTasks("find secret grant memo task", { userId: null });
 
-    const args = firstTaskFindManyArgs();
-    const filters = (args.where as { AND: unknown[] }).AND;
-    expect(filters[0]).toEqual(
-      expect.objectContaining({ deletedAt: null, isPublic: true }),
+    const args = mocks.prisma.taskFindMany.mock.calls.map(
+      (call) => call[0] as { take: number; where: { AND: unknown[] } },
     );
-    expect(filters.slice(1)).toHaveLength(1);
-    const termFilter = filters[1] as { OR: unknown[] };
-    for (const term of ["secret", "grant", "memo"]) {
-      expect(termFilter.OR).toEqual(
-        expect.arrayContaining([
-          { title: { contains: term, mode: "insensitive" } },
-        ]),
+    expect(args).toHaveLength(4);
+    for (const [index, term] of ["secret", "grant", "memo"].entries()) {
+      expect(args[index]?.where.AND[0]).toEqual(
+        expect.objectContaining({ deletedAt: null, isPublic: true }),
       );
+      expect(args[index]?.where.AND[1]).toEqual(
+        expect.objectContaining({
+          OR: expect.arrayContaining([
+            { title: { contains: term, mode: "insensitive" } },
+          ]),
+        }),
+      );
+      expect(args[index]?.take).toBe(21);
     }
-    expect(JSON.stringify(termFilter)).not.toContain('"find"');
-    expect(JSON.stringify(termFilter)).not.toContain('"task"');
-    expect(args.take).toBe(64);
+    expect(JSON.stringify(args.slice(0, 3))).not.toContain('"find"');
+    expect(JSON.stringify(args.slice(0, 3))).not.toContain('"task"');
   });
 
   it("finds the reported securities-counsel task from a longer natural query", async () => {
@@ -804,19 +806,22 @@ describe("tasks server", () => {
   });
 
   it("uses the bounded fallback to find a misspelled title", async () => {
-    mocks.prisma.taskFindMany.mockResolvedValueOnce([]).mockResolvedValueOnce([
-      mockTask({
-        id: "securities-counsel",
-        title: "Get securities counsel to review the equity structure",
-      }),
-    ]);
+    mocks.prisma.taskFindMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        mockTask({
+          id: "securities-counsel",
+          title: "Get securities counsel to review the equity structure",
+        }),
+      ]);
 
     const results = await searchTasks("securites counsl", {
       userId: "user-a",
     });
 
     expect(results[0]?.id).toBe("securities-counsel");
-    expect(mocks.prisma.taskFindMany).toHaveBeenCalledTimes(2);
+    expect(mocks.prisma.taskFindMany).toHaveBeenCalledTimes(3);
   });
 
   it.each([

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -8085,7 +8085,7 @@ const TASK_TOOL_DEFINITIONS = [
   {
     name: "getPageContent",
     description:
-      "Fetch an Optimitron-owned page URL and return clean markdown, title, section headings, and last-modified metadata.",
+      "Return the fully rendered logged-out text for an Optimitron-owned page as clean markdown, with its title, section headings, and last-modified metadata. Checked-in rendered snapshots are preferred so client-side loading shells are never mistaken for page content; this public reader does not expose authenticated page text.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -8130,7 +8130,7 @@ const TASK_TOOL_DEFINITIONS = [
   {
     name: "searchTasks",
     description:
-      "Search your accessible tasks by title, description, task key, assignee, or organization. " +
+      "Fuzzy-search your accessible tasks by title, description, impact statement, task key, assignee, or organization. Signed-in results may include public tasks and private tasks you created, manage, are assigned, claimed, or can access through an organization; other users' private work remains excluded. " +
       "Use this before createTask/updateTask to find parents, duplicates, blockerTaskIds, or blockedTaskIds. " +
       "For Optimitron code or documentation work, query the stable key 'optimitron:dev', select that exact result, and call createTask with parentTaskKey='optimitron:dev'. Returns the legacy result array unless paginated=true or cursor is supplied. Paginated inventory uses immutable task-ID order, not relevance order.",
     inputSchema: {

--- a/packages/web/src/lib/site-inventory.server.ts
+++ b/packages/web/src/lib/site-inventory.server.ts
@@ -314,12 +314,27 @@ function sectionsFromMarkdown(markdown: string) {
 }
 
 function snapshotPaths(pathname: string) {
-  const segments = pathname
-    .split("/")
-    .filter(Boolean)
-    .map((segment) => decodeURIComponent(segment));
-  if (segments.some((segment) => segment === "." || segment === "..")) {
-    return [];
+  const rawSegments = pathname.split("/").filter(Boolean);
+  const segments: string[] = [];
+  for (const rawSegment of rawSegments) {
+    let segment: string;
+    try {
+      segment = decodeURIComponent(rawSegment);
+    } catch {
+      return [];
+    }
+    // Reject segments that are (or, once decoded, resolve to) "." / ".." or
+    // that contain a path separator — otherwise a value like "%2e%2e%2fsecret"
+    // decodes to "../secret" and can traverse outside src/app when joined.
+    if (
+      segment === "." ||
+      segment === ".." ||
+      segment.includes("/") ||
+      segment.includes("\\")
+    ) {
+      return [];
+    }
+    segments.push(segment);
   }
 
   const relativePath = path.join(...segments, "page.logged-out.md");

--- a/packages/web/src/lib/site-inventory.server.ts
+++ b/packages/web/src/lib/site-inventory.server.ts
@@ -354,6 +354,7 @@ function visibleCopyFromSnapshot(snapshot: string) {
 
 async function readLoggedOutPageSnapshot(url: URL) {
   if (url.hostname.toLowerCase() === MANUAL_HOST) return null;
+  const requestedSite = getKnownSite(url.hostname.toLowerCase());
 
   for (const snapshotPath of snapshotPaths(url.pathname)) {
     try {
@@ -367,6 +368,26 @@ async function readLoggedOutPageSnapshot(url: URL) {
       const metadataTitle = snapshot
         .match(/^- Page title:\s*(.+)$/m)?.[1]
         ?.trim();
+      const canonicalUrl = snapshot
+        .match(/^- Canonical:\s*(.+)$/m)?.[1]
+        ?.trim();
+      let snapshotSite: ReturnType<typeof getKnownSite> = null;
+      if (canonicalUrl && canonicalUrl !== "[missing]") {
+        try {
+          snapshotSite = getKnownSite(
+            new URL(canonicalUrl).hostname.toLowerCase(),
+          );
+        } catch {
+          snapshotSite = null;
+        }
+      }
+      if (
+        requestedSite &&
+        snapshotSite &&
+        requestedSite.key !== snapshotSite.key
+      ) {
+        continue;
+      }
       return {
         content,
         lastModified: fileStats.mtime.toUTCString(),

--- a/packages/web/src/lib/site-inventory.server.ts
+++ b/packages/web/src/lib/site-inventory.server.ts
@@ -1,3 +1,5 @@
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
 import { allNavLinks, type NavItem } from "@/lib/routes";
 import { isRedirectOnlyRoutePath } from "@/lib/redirect-review";
 import {
@@ -27,6 +29,10 @@ interface SitePageInventoryEntry {
 const MANUAL_HOST = "manual.warondisease.org";
 const MANUAL_SITEMAP_URL = `https://${MANUAL_HOST}/sitemap.xml`;
 const SITE_INVENTORY_FETCH_TIMEOUT_MS = 10_000;
+const GLOBAL_LOADING_TEXT = [
+  "Booting Earth Optimization System",
+  "Your civilization is very important to us.",
+] as const;
 
 function hostnameFromOrigin(origin: string) {
   return new URL(origin).hostname.toLowerCase();
@@ -307,6 +313,68 @@ function sectionsFromMarkdown(markdown: string) {
     .filter((section): section is string => Boolean(section));
 }
 
+function snapshotPaths(pathname: string) {
+  const segments = pathname
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => decodeURIComponent(segment));
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    return [];
+  }
+
+  const relativePath = path.join(...segments, "page.logged-out.md");
+  return [
+    path.resolve(process.cwd(), "src", "app", relativePath),
+    path.resolve(process.cwd(), "packages", "web", "src", "app", relativePath),
+  ];
+}
+
+function visibleCopyFromSnapshot(snapshot: string) {
+  const marker = "## Visible Page Copy";
+  const markerIndex = snapshot.indexOf(marker);
+  return markerIndex >= 0
+    ? snapshot.slice(markerIndex + marker.length).trim()
+    : snapshot.trim();
+}
+
+async function readLoggedOutPageSnapshot(url: URL) {
+  if (url.hostname.toLowerCase() === MANUAL_HOST) return null;
+
+  for (const snapshotPath of snapshotPaths(url.pathname)) {
+    try {
+      const [snapshot, fileStats] = await Promise.all([
+        readFile(snapshotPath, "utf8"),
+        stat(snapshotPath),
+      ]);
+      const content = visibleCopyFromSnapshot(snapshot);
+      if (!content) continue;
+
+      const metadataTitle = snapshot
+        .match(/^- Page title:\s*(.+)$/m)?.[1]
+        ?.trim();
+      return {
+        content,
+        lastModified: fileStats.mtime.toUTCString(),
+        sections: sectionsFromMarkdown(content),
+        title: metadataTitle || titleFromPath(url.pathname),
+        url: url.toString(),
+      };
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") throw error;
+    }
+  }
+
+  return null;
+}
+
+function isLoadingShell(content: string) {
+  const normalized = content.toLowerCase();
+  return GLOBAL_LOADING_TEXT.some((text) =>
+    normalized.includes(text.toLowerCase()),
+  );
+}
+
 export async function getPageContent(input: GetPageContentInput) {
   if (!input.url?.trim()) {
     throw new Error("url is required");
@@ -316,6 +384,9 @@ export async function getPageContent(input: GetPageContentInput) {
   if (!isAllowedPropertyUrl(url)) {
     throw new Error(`URL is not an allowed Optimitron property route: ${input.url}`);
   }
+
+  const snapshot = await readLoggedOutPageSnapshot(url);
+  if (snapshot) return snapshot;
 
   const response = await fetch(url.toString(), {
     headers: { accept: "text/html,application/xhtml+xml" },
@@ -327,6 +398,11 @@ export async function getPageContent(input: GetPageContentInput) {
 
   const html = await response.text();
   const content = htmlToMarkdown(html);
+  if (isLoadingShell(content)) {
+    throw new Error(
+      `Page returned only its loading shell and no rendered logged-out snapshot exists for ${url.pathname}`,
+    );
+  }
   return {
     content,
     lastModified: response.headers.get("last-modified"),

--- a/packages/web/src/lib/tasks.server.ts
+++ b/packages/web/src/lib/tasks.server.ts
@@ -555,6 +555,7 @@ const taskSearchSelect = {
   category: true,
   description: true,
   id: true,
+  impactStatement: true,
   interestTags: true,
   roleTitle: true,
   skillTags: true,
@@ -871,6 +872,7 @@ function mapTaskSearchResult(
   const href = getTaskPath(task.id);
   const snippet = [
     task.description,
+    task.impactStatement,
     task.roleTitle,
     assigneeParts.length > 0
       ? `Assigned to ${assigneeParts.join(" / ")}`
@@ -899,12 +901,111 @@ function mapTaskSearchResult(
           ...assigneeParts,
         ],
         section: "Tasks",
-      }),
+      }) +
+      fuzzyTaskSearchScore(task, searchTerms),
     snippet: snippet || null,
     status: task.status,
     taskKey: task.taskKey,
     title: task.title,
   };
+}
+
+function editDistance(left: string, right: string) {
+  const previous = Array.from(
+    { length: right.length + 1 },
+    (_, index) => index,
+  );
+
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    const current = [leftIndex];
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      current[rightIndex] = Math.min(
+        (current[rightIndex - 1] ?? 0) + 1,
+        (previous[rightIndex] ?? 0) + 1,
+        (previous[rightIndex - 1] ?? 0) +
+          (left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1),
+      );
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+
+  return previous[right.length] ?? Math.max(left.length, right.length);
+}
+
+function fuzzyTokenSimilarity(queryTerm: string, candidate: string) {
+  if (queryTerm === candidate) return 1;
+  if (
+    queryTerm.length >= 3 &&
+    (candidate.includes(queryTerm) || queryTerm.includes(candidate))
+  ) {
+    return (
+      Math.min(queryTerm.length, candidate.length) /
+      Math.max(queryTerm.length, candidate.length)
+    );
+  }
+
+  const maximumDistance =
+    Math.max(queryTerm.length, candidate.length) >= 7 ? 2 : 1;
+  const distance = editDistance(queryTerm, candidate);
+  return distance <= maximumDistance
+    ? 1 - distance / Math.max(queryTerm.length, candidate.length)
+    : 0;
+}
+
+function searchTokens(value: string | null | undefined) {
+  return (value ?? "")
+    .toLowerCase()
+    .split(/[^a-z0-9%]+/i)
+    .filter((token) => token.length >= 2);
+}
+
+function fuzzyTaskSearchScore(
+  task: TaskSearchItem,
+  searchTerms: ReturnType<typeof getSearchTerms>,
+) {
+  const assigneeParts = [
+    task.assigneePerson?.displayName,
+    task.assigneePerson?.currentAffiliation,
+    task.assigneeOrganization?.name,
+  ];
+  const weightedFields = [
+    { tokens: searchTokens(task.title), weight: 5 },
+    {
+      tokens: searchTokens(
+        [task.taskKey, task.roleTitle, ...task.interestTags, ...task.skillTags]
+          .filter(Boolean)
+          .join(" "),
+      ),
+      weight: 3,
+    },
+    {
+      tokens: searchTokens(
+        [task.description, task.impactStatement, ...assigneeParts]
+          .filter(Boolean)
+          .join(" "),
+      ),
+      weight: 2,
+    },
+  ];
+
+  let score = 0;
+  for (const queryTerm of searchTerms.terms) {
+    let bestWeightedSimilarity = 0;
+    for (const field of weightedFields) {
+      for (const token of field.tokens) {
+        const similarity = fuzzyTokenSimilarity(queryTerm, token);
+        if (similarity >= 0.7) {
+          bestWeightedSimilarity = Math.max(
+            bestWeightedSimilarity,
+            similarity * field.weight,
+          );
+        }
+      }
+    }
+    score += bestWeightedSimilarity;
+  }
+
+  return Number(score.toFixed(3));
 }
 
 function buildParentInheritedImpactFrame(
@@ -1716,16 +1817,16 @@ export async function searchTasks(
   const candidateTerms =
     distinctiveTerms.length > 0 ? distinctiveTerms : queryTerms;
 
-  // Prisma cannot order substring matches by relevance. Require every
-  // distinctive term at the database boundary, then rank the bounded matches
-  // in memory. Ignoring request-framing words keeps natural agent queries such
-  // as "find Optimize Optimitron parent" from failing on the word "parent"
-  // without letting a single common term flood the candidate window.
+  // Prisma cannot order substring matches by relevance. Pull any literal
+  // match into a bounded candidate set, then rank it in memory. Requiring
+  // every word here made natural-language agent queries fail whenever they
+  // included one reasonable synonym that was not copied into the task.
   const candidateLimit = Math.min(Math.max(limit * 4, 64), 500);
-  const requiredTermMatches = candidateTerms.map((term) => ({
-    OR: [
+  const anyTermMatches: Prisma.TaskWhereInput = {
+    OR: candidateTerms.flatMap((term) => [
       { title: { contains: term, mode: "insensitive" as const } },
       { description: { contains: term, mode: "insensitive" as const } },
+      { impactStatement: { contains: term, mode: "insensitive" as const } },
       { taskKey: { contains: term, mode: "insensitive" as const } },
       { roleTitle: { contains: term, mode: "insensitive" as const } },
       {
@@ -1755,11 +1856,19 @@ export async function searchTasks(
           },
         },
       },
-    ],
-  }));
+    ]),
+  };
+
+  const viewer = options?.userId
+    ? await prisma.user.findUnique({
+        where: { id: options.userId },
+        select: { personId: true },
+      })
+    : null;
 
   const accessFilters: Prisma.TaskWhereInput[] = [
     getTaskVisibilityWhere({
+      personId: viewer?.personId,
       userId: options?.userId,
       visibility:
         options?.visibility ?? (options?.userId ? "accessible" : "public"),
@@ -1781,19 +1890,36 @@ export async function searchTasks(
     exactTaskKeyPromise,
     prisma.task.findMany({
       where: {
-        AND: [...accessFilters, ...requiredTermMatches],
+        AND: [...accessFilters, anyTermMatches],
       },
       orderBy: [{ verifiedAt: "desc" }, { createdAt: "desc" }],
       select: taskSearchSelect,
       take: candidateLimit,
     }),
   ]);
-  const tasks = exactTaskKeyMatch
+  let tasks = exactTaskKeyMatch
     ? [
         exactTaskKeyMatch,
         ...candidates.filter((task) => task.id !== exactTaskKeyMatch.id),
       ]
     : candidates;
+
+  // A bounded accessible fallback makes misspellings discoverable even when
+  // no token can pass Prisma's literal `contains` filter. It is only used
+  // when literal matching did not fill the requested result window.
+  if (tasks.length < limit) {
+    const fuzzyCandidates = await prisma.task.findMany({
+      where: { AND: accessFilters },
+      orderBy: [{ verifiedAt: "desc" }, { createdAt: "desc" }],
+      select: taskSearchSelect,
+      take: 500,
+    });
+    const taskIds = new Set(tasks.map((task) => task.id));
+    tasks = [
+      ...tasks,
+      ...fuzzyCandidates.filter((task) => !taskIds.has(task.id)),
+    ];
+  }
 
   return tasks
     .map((task) => mapTaskSearchResult(task, searchTerms))

--- a/packages/web/src/lib/tasks.server.ts
+++ b/packages/web/src/lib/tasks.server.ts
@@ -1814,16 +1814,21 @@ export async function searchTasks(
   const distinctiveTerms = queryTerms.filter(
     (term) => !taskSearchIntentTerms.has(term),
   );
-  const candidateTerms =
-    distinctiveTerms.length > 0 ? distinctiveTerms : queryTerms;
+  const candidateTerms = (
+    distinctiveTerms.length > 0 ? distinctiveTerms : queryTerms
+  ).slice(0, 8);
 
   // Prisma cannot order substring matches by relevance. Pull any literal
   // match into a bounded candidate set, then rank it in memory. Requiring
   // every word here made natural-language agent queries fail whenever they
   // included one reasonable synonym that was not copied into the task.
   const candidateLimit = Math.min(Math.max(limit * 4, 64), 500);
-  const anyTermMatches: Prisma.TaskWhereInput = {
-    OR: candidateTerms.flatMap((term) => [
+  const perTermLimit = Math.max(
+    limit,
+    Math.floor(candidateLimit / candidateTerms.length),
+  );
+  const matchesTerm = (term: string): Prisma.TaskWhereInput => ({
+    OR: [
       { title: { contains: term, mode: "insensitive" as const } },
       { description: { contains: term, mode: "insensitive" as const } },
       { impactStatement: { contains: term, mode: "insensitive" as const } },
@@ -1856,8 +1861,8 @@ export async function searchTasks(
           },
         },
       },
-    ]),
-  };
+    ],
+  });
 
   const viewer = options?.userId
     ? await prisma.user.findUnique({
@@ -1886,17 +1891,24 @@ export async function searchTasks(
         select: taskSearchSelect,
       })
     : Promise.resolve(null);
-  const [exactTaskKeyMatch, candidates] = await Promise.all([
+  const [exactTaskKeyMatch, candidateGroups] = await Promise.all([
     exactTaskKeyPromise,
-    prisma.task.findMany({
-      where: {
-        AND: [...accessFilters, anyTermMatches],
-      },
-      orderBy: [{ verifiedAt: "desc" }, { createdAt: "desc" }],
-      select: taskSearchSelect,
-      take: candidateLimit,
-    }),
+    Promise.all(
+      candidateTerms.map((term) =>
+        prisma.task.findMany({
+          where: {
+            AND: [...accessFilters, matchesTerm(term)],
+          },
+          orderBy: [{ verifiedAt: "desc" }, { createdAt: "desc" }],
+          select: taskSearchSelect,
+          take: perTermLimit,
+        }),
+      ),
+    ),
   ]);
+  const candidates = Array.from(
+    new Map(candidateGroups.flat().map((task) => [task.id, task])).values(),
+  );
   let tasks = exactTaskKeyMatch
     ? [
         exactTaskKeyMatch,

--- a/packages/web/src/lib/tasks/task-visibility.server.ts
+++ b/packages/web/src/lib/tasks/task-visibility.server.ts
@@ -85,6 +85,11 @@ const VIEWABLE_CLAIM_STATUSES = [
   TaskClaimStatus.VERIFIED,
 ] as const;
 
+const EXECUTABLE_CLAIM_STATUSES = [
+  TaskClaimStatus.CLAIMED,
+  TaskClaimStatus.IN_PROGRESS,
+] as const;
+
 const DOCUMENT_REVIEW_SCHEMA_WHERE: Prisma.TaskWhereInput = {
   contextJson: {
     equals: "optimitron.review-request.v1",
@@ -168,7 +173,13 @@ export function getTaskAccessWhere(input: {
       claims: {
         some: {
           deletedAt: null,
-          status: { in: [...VIEWABLE_CLAIM_STATUSES] },
+          status: {
+            in: [
+              ...(input.action === "EXECUTE"
+                ? EXECUTABLE_CLAIM_STATUSES
+                : VIEWABLE_CLAIM_STATUSES),
+            ],
+          },
           userId,
         },
       },

--- a/packages/web/src/lib/tasks/task-visibility.server.ts
+++ b/packages/web/src/lib/tasks/task-visibility.server.ts
@@ -10,6 +10,7 @@ import {
   ActivityType,
   OrganizationMemberRole,
   Prisma,
+  TaskClaimStatus,
   type TaskStatus,
 } from "@optimitron/db";
 import { prisma } from "@/lib/prisma";
@@ -75,6 +76,13 @@ const CONTRIBUTOR_ORGANIZATION_ROLES = [
 const MANAGER_ORGANIZATION_ROLES = [
   OrganizationMemberRole.OWNER,
   OrganizationMemberRole.ADMIN,
+] as const;
+
+const VIEWABLE_CLAIM_STATUSES = [
+  TaskClaimStatus.CLAIMED,
+  TaskClaimStatus.IN_PROGRESS,
+  TaskClaimStatus.COMPLETED,
+  TaskClaimStatus.VERIFIED,
 ] as const;
 
 const DOCUMENT_REVIEW_SCHEMA_WHERE: Prisma.TaskWhereInput = {
@@ -154,6 +162,15 @@ export function getTaskAccessWhere(input: {
     {
       managers: {
         some: { deletedAt: null, userId },
+      },
+    },
+    {
+      claims: {
+        some: {
+          deletedAt: null,
+          status: { in: [...VIEWABLE_CLAIM_STATUSES] },
+          userId,
+        },
       },
     },
   ];
@@ -286,7 +303,8 @@ export function getTaskVisibilityWhere(input?: {
     input?.userId
   ) {
     // Accessible tasks include public work and private work connected to the
-    // viewer by creation, assignment, management, or organization membership.
+    // viewer by creation, assignment, an active/completed claim, management,
+    // or organization membership.
     // from /tasks "Your Tasks" → /tasks/[id]. "private" narrows the same
     // access predicate to non-public rows only.
     const accessWhere = getTaskAccessWhere({


### PR DESCRIPTION
## What this achieves

- Natural-language and misspelled MCP task searches find relevant work instead of requiring every query word to appear.
- Signed-in task search includes only private work the caller can legitimately access: created, assigned, claimed, managed, or organization-authorized tasks.
- `getPageContent` returns rendered logged-out page text from the existing checked-in copy snapshots instead of the client loading shell.
- MCP documentation now states the search and public-page privacy boundaries explicitly.

No Prisma schema changes and no new search service.

## Verification

- 82 focused Vitest tests passed
- `typecheck:app` passed
- `typecheck:tests` passed
- `git diff --check` passed