### PR TITLE
Leave headroom for Vercel web builds

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,7 +12,7 @@
     "dev": "pnpm run kill-port && pnpm run ensure-env && pnpm run guard:local-dev-db && pnpm run build:workspace-deps && cross-env NODE_OPTIONS=--max-old-space-size=6144 pnpm exec next dev --port 3001 --turbopack",
     "dev:fast": "pnpm run ensure-env && pnpm run guard:local-dev-db && cross-env NODE_OPTIONS=--max-old-space-size=6144 pnpm exec next dev --port 3001 --turbopack",
     "dev:watch": "node scripts/dev-watcher.mjs",
-    "build": "pnpm run ensure-env && pnpm run validate:content && pnpm run build:workspace-deps && cross-env NODE_OPTIONS=--max-old-space-size=6144 next build",
+    "build": "pnpm run ensure-env && pnpm run validate:content && pnpm run build:workspace-deps && cross-env NODE_OPTIONS=--max-old-space-size=5120 next build",
     "build:vercel": "node scripts/run-with-timeout.mjs 420 pnpm run build",
     "build:fast": "pnpm run ensure-env && pnpm run validate:content && next build",
     "start": "pnpm run ensure-env && next start",


### PR DESCRIPTION
## Summary

- reduce the web production-build Node heap from 6144 MB to 5120 MB
- leave roughly 3 GB of the Vercel 8 GB builder for webpack/native processes and container overhead
- keep more heap than the prior 4096 MB setting that hit Node's heap limit

## Why

Unrelated preview branches repeatedly completed dependency and workspace builds, reached Next.js compilation, and were then killed by Vercel's container-level OOM detector. The failure had no application stack trace and reproduced across both the homepage and visual-review branches, so this is a shared build configuration issue rather than either feature's code.

## Validation

- all workspace prerequisite builds passed locally
- the production Next.js webpack compilation completed with the 5120 MB heap
- the isolated worktree then stopped during page-data collection only because it intentionally lacked NEXTAUTH_SECRET and DATABASE_URL
- git diff --check passed

The Vercel preview for this PR is the final container-level verification.