### PR TITLE
Guard anonymous MCP task discovery

### DIFF
--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -3431,6 +3431,44 @@ describe("MCP server tool dispatch", () => {
     });
   });
 
+  describe("getNextTask public front door", () => {
+    it("returns open public work to an anonymous caller with no capability tags", async () => {
+      mocks.listTasks.mockResolvedValue([
+        makeCreatedTask({
+          createdByUserId: "another-user",
+          id: "public-open-task",
+          title: "Open public work",
+        }),
+      ]);
+      mocks.isTaskBlocked.mockReturnValue(false);
+      mocks.computeTaskPriority.mockReturnValue(
+        makePriority({ priority: 250 }),
+      );
+      mocks.isTaskLeased.mockResolvedValue({ leased: false });
+
+      const client = await setup(undefined, []);
+      const result = await client.callTool({
+        name: "getNextTask",
+        arguments: {},
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolBody(result)).toMatchObject({
+        score: 250,
+        task: {
+          id: "public-open-task",
+          title: "Open public work",
+        },
+      });
+      expect(mocks.listTasks).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: TaskStatus.ACTIVE,
+          visibility: "public",
+        }),
+      );
+    });
+  });
+
   describe("getExecutionPlan", () => {
     it("simulates dependencies and excludes container tasks", async () => {
       mocks.listTasks.mockResolvedValue([

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -3433,16 +3433,50 @@ describe("MCP server tool dispatch", () => {
 
   describe("getNextTask public front door", () => {
     it("returns open public work to an anonymous caller with no capability tags", async () => {
-      mocks.listTasks.mockResolvedValue([
+      const candidates = [
         makeCreatedTask({
           createdByUserId: "another-user",
           id: "public-open-task",
           title: "Open public work",
         }),
+        makeCreatedTask({
+          createdByUserId: "another-user",
+          id: "private-active-task",
+          title: "Private work",
+        }),
+        makeCreatedTask({
+          createdByUserId: "another-user",
+          id: "public-verified-task",
+          status: TaskStatus.VERIFIED,
+          title: "Finished public work",
+        }),
+      ];
+      const publicTaskIds = new Set([
+        "public-open-task",
+        "public-verified-task",
       ]);
+      mocks.listTasks.mockImplementation(
+        async ({
+          status,
+          visibility,
+        }: {
+          status?: TaskStatus;
+          visibility?: string;
+        }) => {
+          const filtered = candidates.filter(
+            (task) =>
+              (visibility !== "public" || publicTaskIds.has(task.id)) &&
+              (!status || task.status === status),
+          );
+          return filtered;
+        },
+      );
       mocks.isTaskBlocked.mockReturnValue(false);
-      mocks.computeTaskPriority.mockReturnValue(
-        makePriority({ priority: 250 }),
+      mocks.computeTaskPriority.mockImplementation(
+        (task: { id: string }) =>
+          makePriority({
+            priority: task.id === "public-open-task" ? 250 : 1_000,
+          }),
       );
       mocks.isTaskLeased.mockResolvedValue({ leased: false });
 
@@ -3460,12 +3494,6 @@ describe("MCP server tool dispatch", () => {
           title: "Open public work",
         },
       });
-      expect(mocks.listTasks).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: TaskStatus.ACTIVE,
-          visibility: "public",
-        }),
-      );
     });
   });
 


### PR DESCRIPTION
## Summary

- add regression coverage proving a tagless anonymous MCP caller receives eligible open public work
- pin public visibility and ACTIVE status filtering at the MCP front door

## Validation

- pnpm --filter @optimitron/web run typecheck:tests
- pnpm --filter @optimitron/web exec vitest run src/lib/__tests__/mcp-server.test.ts (268 tests)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that anonymous requests receive an eligible public task.
  * Verified that the response includes the task’s computed score and applies active-status and public-visibility filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->