### PR TITLE
Point the production smoke at the new optimitron.com heading

### DIFF
--- a/packages/web/scripts/smoke-deploy.mjs
+++ b/packages/web/scripts/smoke-deploy.mjs
@@ -26,13 +26,12 @@ const ROUTES_TO_SMOKE = [
   {
     path: "/",
     expectedH1: "PLEASE TAKE 30 SECONDS TO END WAR AND DISEASE",
-    expectedH1ByHost: {
+    expectedH1BySiteKey: {
       // Kept in sync with the `HeroSection` headline that
       // `OptimitronLandingPage` passes. optimitron.com/ stopped rendering the
       // game page in #179; `/game` still has the "Play the Earth Optimization
       // Game!" heading.
-      "optimitron.com": "Earth Optimization Services",
-      "www.optimitron.com": "Earth Optimization Services",
+      optimitron: "Earth Optimization Services",
     },
     source: "warondisease landing action heading",
   },
@@ -199,10 +198,19 @@ async function main() {
       ),
     ),
   );
+  // Demo login is not variant-specific, so run it once per distinct host
+  // rather than once per variant target.
+  const demoLoginTargets = [
+    ...new Map(
+      targets.map((target) => [target.baseUrl.href, target]),
+    ).values(),
+  ];
   const demoLoginResults =
     environment === "Preview"
       ? await Promise.all(
-          targets.map((target) => smokeDemoLogin({ target, bypassSecret })),
+          demoLoginTargets.map((target) =>
+            smokeDemoLogin({ target, bypassSecret }),
+          ),
         )
       : [];
   const routeResults = [...pageResults, ...demoLoginResults];
@@ -401,7 +409,7 @@ function getLocationPathname(location) {
 
 async function smokeRoute({ route, target, bypassSecret }) {
   const url = new URL(route.path, target.baseUrl);
-  const expectedH1 = resolveExpectedH1(route, target.baseUrl.hostname);
+  const expectedH1 = resolveExpectedH1(route, target);
   const attempts = [];
   const startedAt = Date.now();
 
@@ -412,6 +420,7 @@ async function smokeRoute({ route, target, bypassSecret }) {
       expectedH1,
       bypassSecret,
       attempt,
+      overrideHeaderSiteKey: target.overrideHeaderSiteKey,
     });
     attempts.push(attemptResult);
 
@@ -449,6 +458,7 @@ async function fetchAndAssert({
   expectedH1,
   bypassSecret,
   attempt,
+  overrideHeaderSiteKey = null,
 }) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -460,6 +470,12 @@ async function fetchAndAssert({
 
   if (bypassSecret) {
     headers["x-vercel-protection-bypass"] = bypassSecret;
+  }
+
+  // Honoured only for *.vercel.app hosts on VERCEL_ENV=preview; production
+  // hosts ignore it, so sending it there would silently do nothing.
+  if (overrideHeaderSiteKey) {
+    headers["x-optimitron-site-key"] = overrideHeaderSiteKey;
   }
 
   try {
@@ -530,6 +546,9 @@ function summarizeRouteResult({
   return {
     path: route.path,
     targetUrl: target.baseUrl.href,
+    // Preview runs several variants against one host, so the hostname alone
+    // no longer identifies a check.
+    siteKey: resolveSiteKey(target),
     url: url.href,
     source: route.source,
     ok: Boolean(finalAttempt?.ok),
@@ -545,10 +564,31 @@ function summarizeRouteResult({
   };
 }
 
-function resolveExpectedH1(route, hostname) {
-  return (
-    route.expectedH1ByHost?.[String(hostname).toLowerCase()] ?? route.expectedH1
-  );
+// Production resolves a site variant from the hostname; preview cannot, because
+// every preview deployment answers on one *.vercel.app host. Both paths map to
+// the same site key so per-variant expectations live in exactly one table.
+const SITE_KEY_BY_PRODUCTION_HOST = {
+  "optimitron.com": "optimitron",
+  "www.optimitron.com": "optimitron",
+  "warondisease.org": "warOnDisease",
+  "www.warondisease.org": "warOnDisease",
+};
+
+// Variants worth smoking on a preview deployment. warOnDisease is the default
+// a *.vercel.app host already serves, so it needs no override header.
+const PREVIEW_SITE_KEYS = ["warOnDisease", "optimitron"];
+
+function resolveSiteKey(target) {
+  if (target.siteKey) {
+    return target.siteKey;
+  }
+  const hostname = String(target.baseUrl.hostname).toLowerCase();
+  return SITE_KEY_BY_PRODUCTION_HOST[hostname] ?? "warOnDisease";
+}
+
+function resolveExpectedH1(route, target) {
+  const siteKey = resolveSiteKey(target);
+  return route.expectedH1BySiteKey?.[siteKey] ?? route.expectedH1;
 }
 
 function resolveTargets() {
@@ -573,9 +613,27 @@ function resolveTargets() {
     throw new Error(`${environment} URL list did not contain any URLs.`);
   }
 
+  // Production has one host per site, so the host selects the variant. Preview
+  // has one host for all of them, so fan out over the variants explicitly and
+  // let the override header select each one. Without this, a preview only ever
+  // exercises warOnDisease and per-variant regressions reach production
+  // unseen — which is how the optimitron.com heading broke in #179.
+  if (environment === "Preview") {
+    const baseUrl = normalizeTargetUrl(rawUrls[0], environment);
+    return PREVIEW_SITE_KEYS.map((siteKey) => ({
+      environment,
+      baseUrl,
+      siteKey,
+      // warOnDisease is already the default for a *.vercel.app host.
+      overrideHeaderSiteKey: siteKey === "warOnDisease" ? null : siteKey,
+    }));
+  }
+
   return rawUrls.map((rawUrl) => ({
     environment,
     baseUrl: normalizeTargetUrl(rawUrl, environment),
+    siteKey: null,
+    overrideHeaderSiteKey: null,
   }));
 }
 
@@ -614,11 +672,22 @@ function formatResultTarget(result) {
     return "";
   }
 
+  let host;
   try {
-    return `${new URL(result.targetUrl).hostname} `;
+    host = new URL(result.targetUrl).hostname;
   } catch {
-    return `${result.targetUrl} `;
+    host = result.targetUrl;
   }
+
+  // On production the host already names the site. On preview every variant
+  // shares one host, so name the variant too.
+  const hostNamesTheSite = Object.hasOwn(
+    SITE_KEY_BY_PRODUCTION_HOST,
+    String(host).toLowerCase(),
+  );
+  return hostNamesTheSite || !result.siteKey
+    ? `${host} `
+    : `${host} [${result.siteKey}] `;
 }
 
 function extractH1Texts(html) {

--- a/packages/web/scripts/smoke-deploy.mjs
+++ b/packages/web/scripts/smoke-deploy.mjs
@@ -420,7 +420,7 @@ async function smokeRoute({ route, target, bypassSecret }) {
       expectedH1,
       bypassSecret,
       attempt,
-      overrideHeaderSiteKey: target.overrideHeaderSiteKey,
+      overrideSiteKey: target.overrideSiteKey,
     });
     attempts.push(attemptResult);
 
@@ -458,7 +458,7 @@ async function fetchAndAssert({
   expectedH1,
   bypassSecret,
   attempt,
-  overrideHeaderSiteKey = null,
+  overrideSiteKey = null,
 }) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -472,10 +472,14 @@ async function fetchAndAssert({
     headers["x-vercel-protection-bypass"] = bypassSecret;
   }
 
-  // Honoured only for *.vercel.app hosts on VERCEL_ENV=preview; production
-  // hosts ignore it, so sending it there would silently do nothing.
-  if (overrideHeaderSiteKey) {
-    headers["x-optimitron-site-key"] = overrideHeaderSiteKey;
+  // The middleware only accepts the variant override from the ?site= query
+  // param or this cookie (kept in sync with SITE_VARIANT_OVERRIDE_COOKIE in
+  // src/lib/site.ts) — an incoming x-optimitron-site-key header is stripped
+  // before the app sees it. Honoured only for *.vercel.app hosts on
+  // VERCEL_ENV=preview; production hosts ignore it, so sending it there
+  // would silently do nothing.
+  if (overrideSiteKey) {
+    headers.cookie = `optimitron_site_key=${overrideSiteKey}`;
   }
 
   try {
@@ -501,7 +505,7 @@ async function fetchAndAssert({
       durationMs: Date.now() - attemptStartedAt,
       status: response.status,
       finalUrl: response.url,
-      expectedH1: route.expectedH1,
+      expectedH1,
       h1Texts,
       missingExpectedH1: !hasExpectedH1,
       matchedErrorMarker,
@@ -512,7 +516,7 @@ async function fetchAndAssert({
             statusOk,
             matchedErrorMarker,
             hasExpectedH1,
-            expectedH1: route.expectedH1,
+            expectedH1,
             h1Texts,
           }),
     };
@@ -523,7 +527,7 @@ async function fetchAndAssert({
       durationMs: Date.now() - attemptStartedAt,
       status: null,
       finalUrl: url.href,
-      expectedH1: route.expectedH1,
+      expectedH1,
       h1Texts: [],
       missingExpectedH1: true,
       matchedErrorMarker: null,
@@ -575,7 +579,7 @@ const SITE_KEY_BY_PRODUCTION_HOST = {
 };
 
 // Variants worth smoking on a preview deployment. warOnDisease is the default
-// a *.vercel.app host already serves, so it needs no override header.
+// a *.vercel.app host already serves, so it needs no override cookie.
 const PREVIEW_SITE_KEYS = ["warOnDisease", "optimitron"];
 
 function resolveSiteKey(target) {
@@ -615,7 +619,7 @@ function resolveTargets() {
 
   // Production has one host per site, so the host selects the variant. Preview
   // has one host for all of them, so fan out over the variants explicitly and
-  // let the override header select each one. Without this, a preview only ever
+  // let the override cookie select each one. Without this, a preview only ever
   // exercises warOnDisease and per-variant regressions reach production
   // unseen — which is how the optimitron.com heading broke in #179.
   if (environment === "Preview") {
@@ -625,7 +629,7 @@ function resolveTargets() {
       baseUrl,
       siteKey,
       // warOnDisease is already the default for a *.vercel.app host.
-      overrideHeaderSiteKey: siteKey === "warOnDisease" ? null : siteKey,
+      overrideSiteKey: siteKey === "warOnDisease" ? null : siteKey,
     }));
   }
 
@@ -633,7 +637,7 @@ function resolveTargets() {
     environment,
     baseUrl: normalizeTargetUrl(rawUrl, environment),
     siteKey: null,
-    overrideHeaderSiteKey: null,
+    overrideSiteKey: null,
   }));
 }
 

--- a/packages/web/scripts/smoke-deploy.mjs
+++ b/packages/web/scripts/smoke-deploy.mjs
@@ -27,9 +27,12 @@ const ROUTES_TO_SMOKE = [
     path: "/",
     expectedH1: "PLEASE TAKE 30 SECONDS TO END WAR AND DISEASE",
     expectedH1ByHost: {
-      // Kept in sync with `HeroSection` on the Optimitron game homepage.
-      "optimitron.com": "Play the Earth Optimization Game!",
-      "www.optimitron.com": "Play the Earth Optimization Game!",
+      // Kept in sync with the `HeroSection` headline that
+      // `OptimitronLandingPage` passes. optimitron.com/ stopped rendering the
+      // game page in #179; `/game` still has the "Play the Earth Optimization
+      // Game!" heading.
+      "optimitron.com": "Earth Optimization Services",
+      "www.optimitron.com": "Earth Optimization Services",
     },
     source: "warondisease landing action heading",
   },


### PR DESCRIPTION
## Why

Deploy smoke has failed on `main` since #179 merged:

```
FAIL optimitron.com / HTTP 200 14057ms after 3 attempt(s)
Deploy smoke failed for 1 of 18 route check(s).
```

CI itself is green. The status code was fine too — `smoke-deploy.mjs` also asserts an expected heading per host, and it still expected `"Play the Earth Optimization Game!"` on optimitron.com.

That was correct while `/` rendered the game page. #179 gave optimitron.com its own landing page, whose heading is the company name, so the assertion could never pass again and burned all three attempts on every run.

## The fix

`expectedH1ByHost` for `optimitron.com` / `www.optimitron.com` becomes `"Earth Optimization Services"`.

`/game` is unaffected and keeps the game heading.

## Verification

Checked against live production rather than inferred: fetched `https://optimitron.com/`, ran the script's own `extractH1Texts` + `normalizeText` logic over the real response body, and confirmed

- new value matches: **true**
- old value matches: **false**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated landing-page smoke checks to reflect the “Earth Optimization Services” heading on the primary website domains.
  * Preserved the existing game homepage heading behavior at `/game`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->