### PR TITLE
Make reveal animations settle instantly under automation

### DIFF
--- a/packages/web/e2e/utils/audit-helpers.ts
+++ b/packages/web/e2e/utils/audit-helpers.ts
@@ -63,19 +63,29 @@ export async function forceAnimationsComplete(page: Page): Promise<void> {
   // Framer Motion sets opacity via inline styles while animating, which CSS
   // overrides can't reliably normalize. Force any inline opacity below 1 up to
   // 1 so audits measure the settled UI state rather than a transient frame.
+  // Elements can hydrate and start a fade after a scan completes, so rescan
+  // until a pass finds nothing new (bounded — a scan that races hydration was
+  // the main source of blank sections in visual-review diffs).
   await retryAfterNavigation(page, async () => {
-    await page.evaluate(() => {
-      const all = document.querySelectorAll("*");
-      for (const el of all) {
-        const htmlEl = el as HTMLElement;
-        const inlineOpacity = Number.parseFloat(htmlEl.style.opacity);
-        if (Number.isFinite(inlineOpacity) && inlineOpacity < 1) {
-          htmlEl.dataset.visualForceVisible = "";
-          htmlEl.style.opacity = "1";
-          htmlEl.style.transform = "none";
+    for (let pass = 0; pass < 5; pass++) {
+      const forced = await page.evaluate(() => {
+        let count = 0;
+        const all = document.querySelectorAll("*");
+        for (const el of all) {
+          const htmlEl = el as HTMLElement;
+          const inlineOpacity = Number.parseFloat(htmlEl.style.opacity);
+          if (Number.isFinite(inlineOpacity) && inlineOpacity < 1) {
+            htmlEl.dataset.visualForceVisible = "";
+            htmlEl.style.opacity = "1";
+            htmlEl.style.transform = "none";
+            count++;
+          }
         }
-      }
-    });
+        return count;
+      });
+      if (forced === 0) break;
+      await page.waitForTimeout(100);
+    }
   });
 
   await waitForPaint(page);

--- a/packages/web/e2e/utils/audit-helpers.ts
+++ b/packages/web/e2e/utils/audit-helpers.ts
@@ -83,8 +83,10 @@ export async function forceAnimationsComplete(page: Page): Promise<void> {
         }
         return count;
       });
-      if (forced === 0) break;
-      await page.waitForTimeout(100);
+      if (forced === 0 && pass > 0) break;
+      if (pass < 4) {
+        await page.waitForTimeout(100);
+      }
     }
   });
 

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -137,6 +137,23 @@ const OPTIMITRON_GAME_LANDING_FILES = [
   ...SHARED_LANDING_SECTION_FILES,
 ];
 
+// /invest renders EosInvestLandingPage, the only page with the scroll-driven
+// investor sections. StepReveal ships nowhere else, so without this list a
+// change to it has no registered visual state.
+const INVEST_LANDING_FILES = [
+  "packages/web/src/app/invest/page.tsx",
+  "packages/web/src/components/animations/ScrollReveal.tsx",
+  "packages/web/src/components/animations/StepReveal.tsx",
+  "packages/web/src/components/invest/EosInvestLandingPage.tsx",
+  "packages/web/src/components/invest/GiantNumber.tsx",
+  "packages/web/src/components/invest/OptimitronLoop.tsx",
+  "packages/web/src/components/invest/ProgressSpine.tsx",
+  "packages/web/src/components/invest/ShareClassCards.tsx",
+  "packages/web/src/components/invest/StickyRiskSteps.tsx",
+  "packages/web/src/components/invest/WarheadGrid.tsx",
+  "packages/web/src/components/landing/TreatyVoteFlow.tsx",
+];
+
 const VISUAL_COVERS_BY_PATH = new Map<string, string[]>([
   [
     ROUTES.eos,
@@ -150,6 +167,7 @@ const VISUAL_COVERS_BY_PATH = new Map<string, string[]>([
     ],
   ],
   [ROUTES.game, OPTIMITRON_GAME_LANDING_FILES],
+  [ROUTES.invest, INVEST_LANDING_FILES],
   [ROUTES.profile, ["packages/web/src/components/Providers.tsx"]],
   [ROUTES.scoreboard, [POLITICIAN_SCORECARD_TABLE_FILE]],
   [ROUTES.services, ["packages/web/src/app/services/page.tsx"]],
@@ -162,6 +180,9 @@ const REQUIRED_SELECTOR_BY_PATH = new Map<string, string>([
   [ROUTES.employees, PRESIDENT_TASK_LIST_SELECTOR],
   [ROUTES.eos, "h1"],
   [ROUTES.game, "#vote"],
+  // Last section of the page: proves the capture rendered the whole pitch,
+  // not just the hero.
+  [ROUTES.invest, "#claim"],
   [ROUTES.profile, '[data-visual-auth-state="authenticated"]'],
   [ROUTES.scoreboard, 'input[placeholder="Search name or state..."]'],
   [ROUTES.services, "h1"],

--- a/packages/web/src/components/animations/LiveDeathTicker.tsx
+++ b/packages/web/src/components/animations/LiveDeathTicker.tsx
@@ -110,12 +110,14 @@ export function LiveDeathTicker({
   // Automation (screenshots, copy previews, e2e) must capture a deterministic
   // frame: the live count's digit width varies with capture timing, shifting
   // this centered row between runs. Serve the static fallback there, same as
-  // reduced motion. Effect-set state (not a render-time check) so the server
-  // and hydration renders match.
-  const [isAutomation, setIsAutomation] = useState(false);
-  useEffect(() => {
-    if (navigator.webdriver) setIsAutomation(true);
-  }, []);
+  // reduced motion. Lazy-initialized (not effect-set) so it's already correct
+  // on the first client render the ticker-starting effect below observes —
+  // an effect-set value lags a render, letting the interval start briefly
+  // under automation before tearing back down. hasHydrated still gates the
+  // rendered output, so server and first-client-render HTML still match.
+  const [isAutomation] = useState(
+    () => typeof navigator !== "undefined" && navigator.webdriver === true,
+  );
 
   useEffect(() => {
     if (prefersReducedMotion || isAutomation) return;

--- a/packages/web/src/components/animations/LiveDeathTicker.tsx
+++ b/packages/web/src/components/animations/LiveDeathTicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, type RefObject } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import { useReducedMotion } from "framer-motion";
 import {
   DEATHS_PER_SECOND,
@@ -107,9 +107,18 @@ export function LiveDeathTicker({
   ];
   const prefersReducedMotion = useReducedMotion();
   const hasHydrated = useHydrated();
+  // Automation (screenshots, copy previews, e2e) must capture a deterministic
+  // frame: the live count's digit width varies with capture timing, shifting
+  // this centered row between runs. Serve the static fallback there, same as
+  // reduced motion. Effect-set state (not a render-time check) so the server
+  // and hydration renders match.
+  const [isAutomation, setIsAutomation] = useState(false);
+  useEffect(() => {
+    if (navigator.webdriver) setIsAutomation(true);
+  }, []);
 
   useEffect(() => {
-    if (prefersReducedMotion) return;
+    if (prefersReducedMotion || isAutomation) return;
 
     activeTickerRefs.add(refs);
     startTickerLoop();
@@ -122,9 +131,9 @@ export function LiveDeathTicker({
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [prefersReducedMotion]);
+  }, [prefersReducedMotion, isAutomation]);
 
-  if (!hasHydrated || prefersReducedMotion) {
+  if (!hasHydrated || prefersReducedMotion || isAutomation) {
     return (
       <div className={`grid grid-cols-1 md:grid-cols-3 gap-6 text-center ${className}`}>
         {counters.map((c) => (

--- a/packages/web/src/components/animations/ScrollReveal.tsx
+++ b/packages/web/src/components/animations/ScrollReveal.tsx
@@ -34,7 +34,12 @@ export function ScrollReveal({
   const prefersReducedMotion = useReducedMotion();
   const hasHydrated = useHydrated();
   const { x, y } = offsets[direction];
-  const shouldAnimate = hasHydrated && !prefersReducedMotion;
+  // Automation (screenshots, copy previews, e2e) must capture the settled
+  // content, never a scroll-position-dependent fade frame. Render-time check
+  // so below-fold content is never faded out in the first place; markup is
+  // identical either way, only motion props change.
+  const isAutomation = typeof navigator !== "undefined" && navigator.webdriver;
+  const shouldAnimate = hasHydrated && !prefersReducedMotion && !isAutomation;
 
   return (
     <motion.div

--- a/packages/web/src/components/animations/StepReveal.tsx
+++ b/packages/web/src/components/animations/StepReveal.tsx
@@ -15,6 +15,10 @@ export function StepReveal({
   const ref = useRef<HTMLDivElement>(null);
   const isInView = useInView(ref, { once: true, margin: "-60px" });
   const prefersReducedMotion = useReducedMotion();
+  // Automation (screenshots, copy previews, e2e) must capture every step
+  // settled, never a stagger frame. Keep the motion.div wrappers so the DOM
+  // shape matches the server render; only the motion props change.
+  const isAutomation = typeof navigator !== "undefined" && navigator.webdriver;
 
   if (prefersReducedMotion) {
     return <div className={className}>{children}</div>;
@@ -27,17 +31,17 @@ export function StepReveal({
       {items.map((child, i) => (
         <motion.div
           key={i}
-          initial={{ opacity: 0, y: 20, scale: 0.95 }}
+          initial={isAutomation ? false : { opacity: 0, y: 20, scale: 0.95 }}
           animate={
-            isInView
+            isInView || isAutomation
               ? { opacity: 1, y: 0, scale: 1 }
               : { opacity: 0, y: 20, scale: 0.95 }
           }
-          transition={{
-            duration: 0.4,
-            delay: i * staggerDelay,
-            ease: "easeOut",
-          }}
+          transition={
+            isAutomation
+              ? { duration: 0 }
+              : { duration: 0.4, delay: i * staggerDelay, ease: "easeOut" }
+          }
         >
           {child}
         </motion.div>


### PR DESCRIPTION
## Why

PR #191 changes only a smoke script, yet its visual review flagged "changed screenshots" on /game, /invest, and the optimitron.com home. Inspection of the published before/after PNGs showed every diff is animation state, not content: whole scroll-reveal sections (the allocation slider + donut charts, the /invest headlines, the giant-number captions) blank or mid-fade in one capture and settled in the other, plus 1–2px centered-row jitter around the live tickers. Any PR touching nothing will keep rolling these dice.

## Root causes

- `ScrollReveal` / `StepReveal` fade below-fold content after hydration and were the only animated components without the `navigator.webdriver` escape that `CountUp`, `WarheadGrid`, `TreatyVoteFlow`, and `ProgressSpine` already use.
- `forceAnimationsComplete`'s framer-motion rescue scan ran once; elements hydrating after the scan were captured at opacity 0.
- `LiveDeathTicker`'s live count keeps ticking during capture (the frozen Playwright clock still advances in real time), so the transparent-masked number's digit width shifts the centered row between runs; pre- vs post-hydration markup differs too.

## Fix

- `ScrollReveal` / `StepReveal`: settle instantly under automation; DOM shape unchanged, only motion props.
- `LiveDeathTicker`: serve the static fallback under automation, same as reduced motion.
- `forceAnimationsComplete`: rescan until a pass finds nothing new (bounded at 5 passes).

No behavior change for real users; the escapes fire only under `navigator.webdriver`.

## Verification

- `pnpm --filter @optimitron/web typecheck:fast` passes.
- This PR's own visual review may still flag these routes once (its baseline from main predates the fix); after merge, baselines become deterministic and UI-untouched PRs should come up clean. Screenshots were inspected locally from the PR #191 review artifacts; no repo screenshots added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animation reliability so content settles consistently during loading and navigation.
  * Prevented visibility issues for newly loaded elements.
  * Disabled live, scroll-based, and step animations in automated browsing environments for stable results.
  * Preserved normal animation behavior for standard browsing and reduced-motion preferences.
  * Expanded visual coverage for the investment landing page to help catch display issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->