### PR TITLE
Add listMeasurements MCP tool for reading logged measurements

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -176,9 +176,9 @@ verified against `feature/private-execution-system` (2026-07-17).
 
 - **Layer:** personal
 - **Status:** implemented
-- **Summary:** Personal health-variable reminders can be created, edited in place, listed, queried by due date, and answered as tracked, skipped, or snoozed through MCP. Answering a tracked reminder writes a `Measurement`; reminders are queried on demand rather than delivered by a scheduler or UI.
-- **Evidence:** `upsertTrackingReminder`, `listTrackingReminders`, `listDueTrackingReminders`, and `respondToTrackingReminder` in packages/web/src/lib/mcp-server.ts
-- **Acceptance:** An authenticated caller can preserve a reminder's ID and response history while changing its schedule, and a tracked response writes a measurement.
+- **Summary:** Personal health-variable reminders can be created, edited in place, listed, queried by due date, and answered as tracked, skipped, or snoozed through MCP. Answering a tracked reminder writes a `Measurement`; `listMeasurements` reads those measurements back for one variable or all of them. Reminders are queried on demand rather than delivered by a scheduler or UI.
+- **Evidence:** `upsertTrackingReminder`, `listTrackingReminders`, `listDueTrackingReminders`, `respondToTrackingReminder`, and `listMeasurements` in packages/web/src/lib/mcp-server.ts
+- **Acceptance:** An authenticated caller can preserve a reminder's ID and response history while changing its schedule, a tracked response writes a measurement, and `listMeasurements` returns that measurement scoped to the caller's own subject.
 - **Roadmap:** shipped MCP workflow — task-queue or push delivery remains in OPT-HEALTH-06.
 
 ### OPT-HEALTH-05 — Wearable/app health importers

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -410,6 +410,23 @@ Record it later:
 }
 ```
 
+Read back what has been logged with `listMeasurements`. Omit the variable
+filter to see every variable, or pass `variableName` / `globalVariableId` for
+one. Results are newest first and cover both direct `recordMeasurement` calls
+and measurements written by answering a tracking reminder:
+
+```json
+{
+  "variableName": "Greek yogurt",
+  "startTimeAfter": "2026-07-01T00:00:00Z",
+  "limit": 50
+}
+```
+
+An unknown variable name is an error rather than an empty page, so a typo does
+not read as "nothing logged". Pages return `nextCursor`; repeat the same call
+with `cursor` set until it is null.
+
 `serving`, `servings`, and the UCUM code `{serving}` resolve to the seeded
 `servings` unit. Use servings for simple behavior or adherence tracking. Use a
 specific mass, volume, energy, or nutrient unit such as `g`, `mL`, or `kcal`
@@ -460,7 +477,7 @@ disagree, those sources win.
 - Collections (structured records): `createCollection`, `updateCollection`, `getCollection`, `listCollections`, `createCollectionRecord`, `updateCollectionRecord`, `queryCollectionRecords`, `upsertCollectionRecordsBatch`, `saveCollectionView`.
 - Reviewed form responses: `findReviewedAnswers`, `prepareFormResponses`, `proposeFormSubmission`. Applications, surveys, RFPs, intake forms, and questionnaires can reuse person- or organization-owned text and narrative answers. Accepted answers are immutable document-revision artifacts; unresolved questions become private atomic tasks; the prepared text-response payload remains a pending external action until human approval. The normalized data model preserves typed free-form surveys; these MCP tools currently handle narrative fields only, not signatures, file uploads, or one-time typed controls.
 - Content: `searchContent`, `exportContent`, `manageContentAccess`, `manageContentFiles`, `reportContent`.
-- Health tracking (companion-loop stage 1): `recordMeasurement` and the reminder tools use `tasks:personal`; `recordInterventionExperience` uses `earthdata:write`. To reschedule or disable a reminder without replacing it, call `listTrackingReminders`, then pass its `trackingReminderId` and only the changed fields to `upsertTrackingReminder`.
+- Health tracking (companion-loop stage 1): `recordMeasurement`, `listMeasurements`, and the reminder tools use `tasks:personal`; `recordInterventionExperience` uses `earthdata:write`. `listMeasurements` reads back the caller's own measurements for any variable (or all variables), newest first, with cursor pagination. To reschedule or disable a reminder without replacing it, call `listTrackingReminders`, then pass its `trackingReminderId` and only the changed fields to `upsertTrackingReminder`.
 - Task templates: `getTaskTemplate`, `listTaskTemplates`, `previewTaskTemplate`.
 - Knowledge: `searchManual`, `askWishonia`, `searchRepo`, `getFileContent`, `listRepoFiles`, `listSitePages`, `getPageContent`.
 

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -3206,13 +3206,17 @@ describe("MCP server tool dispatch", () => {
       });
     });
 
-    it("rejects anonymous calls to getMyQueue / getAIQueue / getQueueAudit with the same structured error", async () => {
+    it("rejects anonymous calls to getMyQueue / getAIQueue / getQueueAudit / listMeasurements with the same structured error", async () => {
       const client = await setup(undefined, ALL_SCOPES);
 
       for (const tool of [
         "getMyQueue",
         "getAIQueue",
         "getQueueAudit",
+        // Without the dispatch guard, listMeasurementsForUser would run with
+        // userId undefined, and Prisma would drop the `subject.userId` filter
+        // and return every user's measurements.
+        "listMeasurements",
       ] as const) {
         const result = await client.callTool({ name: tool, arguments: {} });
         expect(result.isError, `${tool} should error`).toBe(true);

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -149,6 +149,7 @@ const mocks = vi.hoisted(() => ({
   unitFindFirst: vi.fn(),
   nOf1VariableUpsert: vi.fn(),
   measurementUpsert: vi.fn(),
+  measurementFindMany: vi.fn(),
   trackingReminderUpsert: vi.fn(),
   trackingReminderFindMany: vi.fn(),
   trackingReminderFindFirst: vi.fn(),
@@ -451,6 +452,7 @@ vi.mock("../prisma", () => ({
       upsert: mocks.nOf1VariableUpsert,
     },
     measurement: {
+      findMany: mocks.measurementFindMany,
       upsert: mocks.measurementUpsert,
     },
     trackingReminder: {
@@ -3472,11 +3474,10 @@ describe("MCP server tool dispatch", () => {
         },
       );
       mocks.isTaskBlocked.mockReturnValue(false);
-      mocks.computeTaskPriority.mockImplementation(
-        (task: { id: string }) =>
-          makePriority({
-            priority: task.id === "public-open-task" ? 250 : 1_000,
-          }),
+      mocks.computeTaskPriority.mockImplementation((task: { id: string }) =>
+        makePriority({
+          priority: task.id === "public-open-task" ? 250 : 1_000,
+        }),
       );
       mocks.isTaskLeased.mockResolvedValue({ leased: false });
 
@@ -9131,6 +9132,193 @@ describe("MCP server tool dispatch", () => {
       expect(mocks.variableCategoryFindFirst).not.toHaveBeenCalled();
       expect(mocks.globalVariableUpsert).not.toHaveBeenCalled();
       expect(mocks.measurementUpsert).not.toHaveBeenCalled();
+    });
+
+    const measurementRow = (id: string, startTime: string) => ({
+      createdAt: new Date(startTime),
+      duration: null,
+      globalVariable: TRACKING_VARIABLE,
+      globalVariableId: "gv-vitd",
+      id,
+      latitude: null,
+      longitude: null,
+      nOf1VariableId: "nof1-1",
+      note: null,
+      originalUnit: TRACKING_UNIT,
+      originalValue: 5000,
+      sourceName: "mcp",
+      startTime: new Date(startTime),
+      subjectId: "subject-1",
+      unit: TRACKING_UNIT,
+      updatedAt: new Date(startTime),
+      value: 5000,
+    });
+
+    it("listMeasurements scopes the query to the caller's own subject and applies the time window", async () => {
+      mocks.measurementFindMany.mockResolvedValue([
+        measurementRow("measurement-2", "2026-07-02T08:00:00.000Z"),
+        measurementRow("measurement-1", "2026-07-01T08:00:00.000Z"),
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listMeasurements",
+        arguments: {
+          startTimeAfter: "2026-07-01T00:00:00.000Z",
+          startTimeBefore: "2026-07-03T00:00:00.000Z",
+          variableName: "vitamin d",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.globalVariableFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            deletedAt: null,
+            name: { equals: "vitamin d", mode: "insensitive" },
+          },
+        }),
+      );
+      const call = mocks.measurementFindMany.mock.calls[0]![0] as {
+        orderBy: unknown;
+        take: number;
+        where: Record<string, unknown>;
+      };
+      expect(call.where).toEqual({
+        deletedAt: null,
+        globalVariableId: "gv-vitd",
+        startTime: {
+          gte: new Date("2026-07-01T00:00:00.000Z"),
+          lte: new Date("2026-07-03T00:00:00.000Z"),
+        },
+        subject: { userId: "user-1" },
+      });
+      expect(call.orderBy).toEqual([{ startTime: "desc" }, { id: "desc" }]);
+      expect(call.take).toBe(101);
+
+      const body = parseToolBody(result) as {
+        measurements: { id: string }[];
+        nextCursor: string | null;
+      };
+      expect(body.measurements.map((m) => m.id)).toEqual([
+        "measurement-2",
+        "measurement-1",
+      ]);
+      expect(body.nextCursor).toBeNull();
+    });
+
+    it("listMeasurements returns every variable when no variable filter is given", async () => {
+      mocks.measurementFindMany.mockResolvedValue([]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listMeasurements",
+        arguments: {},
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.globalVariableFindFirst).not.toHaveBeenCalled();
+      const call = mocks.measurementFindMany.mock.calls[0]![0] as {
+        where: Record<string, unknown>;
+      };
+      expect(call.where).toEqual({
+        deletedAt: null,
+        subject: { userId: "user-1" },
+      });
+    });
+
+    it("listMeasurements trims an overfetched page and returns the last kept row as nextCursor", async () => {
+      mocks.measurementFindMany.mockResolvedValue([
+        measurementRow("measurement-3", "2026-07-03T08:00:00.000Z"),
+        measurementRow("measurement-2", "2026-07-02T08:00:00.000Z"),
+        measurementRow("measurement-1", "2026-07-01T08:00:00.000Z"),
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listMeasurements",
+        arguments: { cursor: "measurement-4", limit: 2 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const call = mocks.measurementFindMany.mock.calls[0]![0] as {
+        cursor: { id: string };
+        skip: number;
+        take: number;
+      };
+      expect(call.take).toBe(3);
+      expect(call.cursor).toEqual({ id: "measurement-4" });
+      expect(call.skip).toBe(1);
+
+      const body = parseToolBody(result) as {
+        measurements: { id: string }[];
+        nextCursor: string | null;
+      };
+      expect(body.measurements.map((m) => m.id)).toEqual([
+        "measurement-3",
+        "measurement-2",
+      ]);
+      expect(body.nextCursor).toBe("measurement-2");
+    });
+
+    it("listMeasurements rejects an unknown variable instead of returning an empty page", async () => {
+      mocks.globalVariableFindFirst.mockResolvedValue(null);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listMeasurements",
+        arguments: { variableName: "Nonexistent" },
+      });
+
+      expect(result.isError).toBe(true);
+      const body = parseToolBody(result);
+      expect(body.message).toContain("GlobalVariable not found: Nonexistent");
+      expect(mocks.measurementFindMany).not.toHaveBeenCalled();
+    });
+
+    it("listMeasurements rejects a limit above the maximum page size with no query", async () => {
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listMeasurements",
+        arguments: { limit: 501 },
+      });
+
+      expect(result.isError).toBe(true);
+      const body = parseToolBody(result);
+      expect(body.message).toContain("limit must be 500 or less");
+      expect(mocks.measurementFindMany).not.toHaveBeenCalled();
+    });
+
+    it("listMeasurements rejects an inverted time window with no query", async () => {
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listMeasurements",
+        arguments: {
+          startTimeAfter: "2026-07-03T00:00:00.000Z",
+          startTimeBefore: "2026-07-01T00:00:00.000Z",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const body = parseToolBody(result);
+      expect(body.message).toContain(
+        "startTimeAfter must be at or before startTimeBefore",
+      );
+      expect(mocks.measurementFindMany).not.toHaveBeenCalled();
+    });
+
+    it("listMeasurements rejects a caller lacking TASKS_PERSONAL scope", async () => {
+      const client = await setup("user-1", []);
+
+      const result = await client.callTool({
+        name: "listMeasurements",
+        arguments: {},
+      });
+
+      expect(result.isError).toBe(true);
+      const body = parseToolBody(result);
+      expect(body.message).toContain("Insufficient scope");
+      expect(mocks.measurementFindMany).not.toHaveBeenCalled();
     });
 
     it("upsertTrackingReminder keeps no-ID creation idempotent and defaults reminderFrequency to 86400", async () => {

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -144,6 +144,7 @@ const mocks = vi.hoisted(() => ({
   ensureSubjectForUser: vi.fn(),
   userFindUniqueOrThrow: vi.fn(),
   globalVariableFindFirst: vi.fn(),
+  globalVariableFindMany: vi.fn(),
   globalVariableUpsert: vi.fn(),
   variableCategoryFindFirst: vi.fn(),
   unitFindFirst: vi.fn(),
@@ -440,6 +441,7 @@ vi.mock("../prisma", () => ({
     },
     globalVariable: {
       findFirst: mocks.globalVariableFindFirst,
+      findMany: mocks.globalVariableFindMany,
       upsert: mocks.globalVariableUpsert,
     },
     variableCategory: {
@@ -753,6 +755,7 @@ beforeEach(() => {
     },
     globalVariable: {
       findFirst: mocks.globalVariableFindFirst,
+      findMany: mocks.globalVariableFindMany,
       upsert: mocks.globalVariableUpsert,
     },
     variableCategory: {
@@ -9155,6 +9158,7 @@ describe("MCP server tool dispatch", () => {
     });
 
     it("listMeasurements scopes the query to the caller's own subject and applies the time window", async () => {
+      mocks.globalVariableFindMany.mockResolvedValue([TRACKING_VARIABLE]);
       mocks.measurementFindMany.mockResolvedValue([
         measurementRow("measurement-2", "2026-07-02T08:00:00.000Z"),
         measurementRow("measurement-1", "2026-07-01T08:00:00.000Z"),
@@ -9171,8 +9175,9 @@ describe("MCP server tool dispatch", () => {
       });
 
       expect(result.isError).toBeFalsy();
-      expect(mocks.globalVariableFindFirst).toHaveBeenCalledWith(
+      expect(mocks.globalVariableFindMany).toHaveBeenCalledWith(
         expect.objectContaining({
+          take: 2,
           where: {
             deletedAt: null,
             name: { equals: "vitamin d", mode: "insensitive" },
@@ -9218,6 +9223,7 @@ describe("MCP server tool dispatch", () => {
 
       expect(result.isError).toBeFalsy();
       expect(mocks.globalVariableFindFirst).not.toHaveBeenCalled();
+      expect(mocks.globalVariableFindMany).not.toHaveBeenCalled();
       const call = mocks.measurementFindMany.mock.calls[0]![0] as {
         where: Record<string, unknown>;
       };
@@ -9262,7 +9268,7 @@ describe("MCP server tool dispatch", () => {
     });
 
     it("listMeasurements rejects an unknown variable instead of returning an empty page", async () => {
-      mocks.globalVariableFindFirst.mockResolvedValue(null);
+      mocks.globalVariableFindMany.mockResolvedValue([]);
 
       const client = await setup("user-1", ALL_SCOPES);
       const result = await client.callTool({
@@ -9274,6 +9280,53 @@ describe("MCP server tool dispatch", () => {
       const body = parseToolBody(result);
       expect(body.message).toContain("GlobalVariable not found: Nonexistent");
       expect(mocks.measurementFindMany).not.toHaveBeenCalled();
+    });
+
+    it("listMeasurements rejects a case-insensitive variable name collision instead of picking arbitrarily", async () => {
+      mocks.globalVariableFindMany.mockResolvedValue([
+        TRACKING_VARIABLE,
+        { ...TRACKING_VARIABLE, id: "gv-vitd-lower", name: "vitamin d" },
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listMeasurements",
+        arguments: { variableName: "vitamin d" },
+      });
+
+      expect(result.isError).toBe(true);
+      const body = parseToolBody(result);
+      expect(body.message).toContain(
+        'Multiple variables match "vitamin d" case-insensitively',
+      );
+      expect(mocks.measurementFindMany).not.toHaveBeenCalled();
+    });
+
+    it("listMeasurements selects a variable by globalVariableId without the case-insensitive name lookup", async () => {
+      mocks.globalVariableFindFirst.mockResolvedValue(TRACKING_VARIABLE);
+      mocks.measurementFindMany.mockResolvedValue([]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listMeasurements",
+        arguments: { globalVariableId: "gv-vitd" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.globalVariableFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { deletedAt: null, id: "gv-vitd" },
+        }),
+      );
+      expect(mocks.globalVariableFindMany).not.toHaveBeenCalled();
+      const call = mocks.measurementFindMany.mock.calls[0]![0] as {
+        where: Record<string, unknown>;
+      };
+      expect(call.where).toEqual({
+        deletedAt: null,
+        globalVariableId: "gv-vitd",
+        subject: { userId: "user-1" },
+      });
     });
 
     it("listMeasurements rejects a limit above the maximum page size with no query", async () => {

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -3501,24 +3501,38 @@ async function listMeasurementsForUser(
   const prisma = await getPrisma();
   // Read-only variable lookup: unlike recordMeasurement this must never create
   // a GlobalVariable, and an unknown name is an error rather than an empty page.
-  const variableWhere = globalVariableId
-    ? { deletedAt: null, id: globalVariableId }
-    : variableName
-      ? {
-          deletedAt: null,
-          name: { equals: variableName, mode: "insensitive" as const },
-        }
-      : null;
-  const variable = variableWhere
-    ? await prisma.globalVariable.findFirst({
-        select: TRACKING_VARIABLE_SELECT,
-        where: variableWhere,
-      })
-    : null;
-  if (variableWhere && !variable) {
-    throw new Error(
-      `GlobalVariable not found: ${globalVariableId ?? variableName}`,
-    );
+  let variable: Prisma.GlobalVariableGetPayload<{
+    select: typeof TRACKING_VARIABLE_SELECT;
+  }> | null = null;
+  if (globalVariableId) {
+    variable = await prisma.globalVariable.findFirst({
+      select: TRACKING_VARIABLE_SELECT,
+      where: { deletedAt: null, id: globalVariableId },
+    });
+    if (!variable) {
+      throw new Error(`GlobalVariable not found: ${globalVariableId}`);
+    }
+  } else if (variableName) {
+    // Case-insensitive matches can be ambiguous: recordMeasurement looks up
+    // and creates variables by exact-case name, so "Vitamin D" and "vitamin d"
+    // can both exist despite the DB unique constraint being case-sensitive.
+    const matches = await prisma.globalVariable.findMany({
+      select: TRACKING_VARIABLE_SELECT,
+      where: {
+        deletedAt: null,
+        name: { equals: variableName, mode: "insensitive" as const },
+      },
+      take: 2,
+    });
+    if (matches.length === 0) {
+      throw new Error(`GlobalVariable not found: ${variableName}`);
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `Multiple variables match "${variableName}" case-insensitively. Use globalVariableId to disambiguate.`,
+      );
+    }
+    variable = matches[0] ?? null;
   }
 
   const rows = await prisma.measurement.findMany({

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -321,6 +321,7 @@ const TOOL_SCOPES: Record<string, McpScope[]> = {
   getQueueAudit: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ORGANIZATION],
   getTaskTreeAudit: [McpScope.TASKS_ADMIN],
   [RECORD_MEASUREMENT_TOOL_NAME]: [McpScope.TASKS_PERSONAL],
+  listMeasurements: [McpScope.TASKS_PERSONAL],
   upsertTrackingReminder: [McpScope.TASKS_PERSONAL],
   listTrackingReminders: [McpScope.TASKS_PERSONAL],
   listDueTrackingReminders: [McpScope.TASKS_PERSONAL],
@@ -2763,6 +2764,29 @@ const TRACKING_REMINDER_INCLUDE = {
   },
 } satisfies Prisma.TrackingReminderInclude;
 
+const TRACKING_MEASUREMENT_SELECT = {
+  createdAt: true,
+  duration: true,
+  globalVariable: { select: TRACKING_VARIABLE_SELECT },
+  globalVariableId: true,
+  id: true,
+  latitude: true,
+  longitude: true,
+  nOf1VariableId: true,
+  note: true,
+  originalUnit: { select: TRACKING_UNIT_SELECT },
+  originalValue: true,
+  sourceName: true,
+  startTime: true,
+  subjectId: true,
+  unit: { select: TRACKING_UNIT_SELECT },
+  updatedAt: true,
+  value: true,
+} satisfies Prisma.MeasurementSelect;
+
+const DEFAULT_MEASUREMENT_PAGE_SIZE = 100;
+const MAX_MEASUREMENT_PAGE_SIZE = 500;
+
 interface TrackingVariableArgs {
   categoryName?: string | null;
   combinationOperation?: CombinationOperation;
@@ -3441,6 +3465,91 @@ async function upsertTrackingReminderForUser(
     });
     return { reminder, subjectId: subject.id };
   });
+}
+
+async function listMeasurementsForUser(
+  input: Record<string, unknown>,
+  userId: string,
+) {
+  const limit = parsePositiveInteger(
+    input.limit,
+    "limit",
+    DEFAULT_MEASUREMENT_PAGE_SIZE,
+  );
+  if (limit > MAX_MEASUREMENT_PAGE_SIZE) {
+    throw new Error(`limit must be ${MAX_MEASUREMENT_PAGE_SIZE} or less.`);
+  }
+  const cursor = optionalString(input.cursor);
+  const startTimeAfter = parseOptionalDateValue(
+    input.startTimeAfter,
+    "startTimeAfter",
+  );
+  const startTimeBefore = parseOptionalDateValue(
+    input.startTimeBefore,
+    "startTimeBefore",
+  );
+  if (
+    startTimeAfter &&
+    startTimeBefore &&
+    startTimeAfter.getTime() > startTimeBefore.getTime()
+  ) {
+    throw new Error("startTimeAfter must be at or before startTimeBefore.");
+  }
+  const globalVariableId = optionalString(input.globalVariableId);
+  const variableName = optionalString(input.variableName);
+
+  const prisma = await getPrisma();
+  // Read-only variable lookup: unlike recordMeasurement this must never create
+  // a GlobalVariable, and an unknown name is an error rather than an empty page.
+  const variableWhere = globalVariableId
+    ? { deletedAt: null, id: globalVariableId }
+    : variableName
+      ? {
+          deletedAt: null,
+          name: { equals: variableName, mode: "insensitive" as const },
+        }
+      : null;
+  const variable = variableWhere
+    ? await prisma.globalVariable.findFirst({
+        select: TRACKING_VARIABLE_SELECT,
+        where: variableWhere,
+      })
+    : null;
+  if (variableWhere && !variable) {
+    throw new Error(
+      `GlobalVariable not found: ${globalVariableId ?? variableName}`,
+    );
+  }
+
+  const rows = await prisma.measurement.findMany({
+    orderBy: [{ startTime: "desc" }, { id: "desc" }],
+    select: TRACKING_MEASUREMENT_SELECT,
+    take: limit + 1,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    where: {
+      deletedAt: null,
+      subject: { userId },
+      ...(variable ? { globalVariableId: variable.id } : {}),
+      ...(startTimeAfter || startTimeBefore
+        ? {
+            startTime: {
+              ...(startTimeAfter ? { gte: startTimeAfter } : {}),
+              ...(startTimeBefore ? { lte: startTimeBefore } : {}),
+            },
+          }
+        : {}),
+    },
+  });
+
+  const measurements = rows.slice(0, limit);
+  return {
+    measurements,
+    nextCursor:
+      rows.length > limit
+        ? (measurements[measurements.length - 1]?.id ?? null)
+        : null,
+    variable,
+  };
 }
 
 async function listTrackingRemindersForUser(
@@ -4929,6 +5038,41 @@ const TRACKING_TOOL_DEFINITIONS = [
         longitude: { type: "number" },
       },
       required: ["value"],
+    },
+  },
+  {
+    name: "listMeasurements",
+    description:
+      "List the authenticated user's own recorded measurements, newest first. Covers everything logged through recordMeasurement or a tracking-reminder response. Filter by globalVariableId or variableName for one variable, or omit both to see every variable. Use this to review logged doses, foods, symptoms, moods, sleep, activity, labs, and vitals, or to check whether a reminder was actually answered.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        globalVariableId: { type: "string" },
+        variableName: {
+          type: "string",
+          description:
+            "Variable name, matched case-insensitively. An unknown variable is an error, not an empty result.",
+        },
+        startTimeAfter: {
+          type: "string",
+          description:
+            "ISO date/time. Only measurements at or after this time.",
+        },
+        startTimeBefore: {
+          type: "string",
+          description:
+            "ISO date/time. Only measurements at or before this time.",
+        },
+        limit: {
+          type: "number",
+          description: `Page size. Default ${DEFAULT_MEASUREMENT_PAGE_SIZE}, maximum ${MAX_MEASUREMENT_PAGE_SIZE}.`,
+        },
+        cursor: {
+          type: "string",
+          description:
+            "nextCursor from the previous page. Repeat the same filters until nextCursor is null.",
+        },
+      },
     },
   },
   {
@@ -9278,6 +9422,15 @@ export function createMcpServer(
             return ok({
               result: await recordTrackingMeasurement(a, userId),
             });
+          }
+
+          case "listMeasurements": {
+            if (!userId)
+              return authRequired(
+                name,
+                "This tool lists your personal tracking measurements.",
+              );
+            return ok(await listMeasurementsForUser(a, userId));
           }
 
           case "upsertTrackingReminder": {


### PR DESCRIPTION
recordMeasurement and respondToTrackingReminder could write measurements, but nothing could read them back. listMeasurements returns the caller's own measurements newest first, for one variable (by id or case-insensitive name) or across every variable, with an optional startTime window and cursor pagination.

Scoped to tasks:personal and filtered by subject.userId, so a caller only ever sees their own measurements. The variable lookup is read-only: unlike recordMeasurement it never creates a GlobalVariable, and an unknown name is an error rather than an empty page.


Claude-Session: https://claude.ai/code/session_01Y9eGXKCWK79b2KRVGDQExR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a personal measurement lookup tool for retrieving health measurements by variable or across all variables.
  * Supports date-range filtering, newest-first sorting, and cursor-based pagination.
  * Added validation for unknown variables, invalid page sizes, and invalid date ranges.
  * Measurement access is limited to the authenticated caller’s authorized personal data.

* **Documentation**
  * Documented measurement retrieval, filtering, pagination, and access behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->