### PR TITLE
Size the build heap for the build actually being run

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,7 +12,7 @@
     "dev": "pnpm run kill-port && pnpm run ensure-env && pnpm run guard:local-dev-db && pnpm run build:workspace-deps && cross-env NODE_OPTIONS=--max-old-space-size=6144 pnpm exec next dev --port 3001 --turbopack",
     "dev:fast": "pnpm run ensure-env && pnpm run guard:local-dev-db && cross-env NODE_OPTIONS=--max-old-space-size=6144 pnpm exec next dev --port 3001 --turbopack",
     "dev:watch": "node scripts/dev-watcher.mjs",
-    "build": "pnpm run ensure-env && pnpm run validate:content && pnpm run build:workspace-deps && cross-env NODE_OPTIONS=--max-old-space-size=3584 next build",
+    "build": "pnpm run ensure-env && pnpm run validate:content && pnpm run build:workspace-deps && node scripts/next-build.mjs",
     "build:vercel": "node scripts/run-with-timeout.mjs 420 pnpm run build",
     "build:fast": "pnpm run ensure-env && pnpm run validate:content && next build",
     "start": "pnpm run ensure-env && next start",

--- a/packages/web/scripts/next-build.mjs
+++ b/packages/web/scripts/next-build.mjs
@@ -35,7 +35,16 @@ const heapMb = generatesSourceMaps
   ? SOURCEMAP_BUILD_HEAP_MB
   : PLAIN_BUILD_HEAP_MB;
 
-const nodeOptions = [process.env.NODE_OPTIONS, `--max-old-space-size=${heapMb}`]
+// Drop any inherited ceiling so this script deterministically sets it. Node
+// takes the last occurrence, so appending would usually win anyway, but "our
+// value is applied because it happens to be last" is not a property worth
+// relying on when the whole point of this file is to control that number.
+const inheritedNodeOptions = (process.env.NODE_OPTIONS ?? "")
+  .split(/\s+/)
+  .filter((flag) => flag && !flag.startsWith("--max-old-space-size"))
+  .join(" ");
+
+const nodeOptions = [inheritedNodeOptions, `--max-old-space-size=${heapMb}`]
   .filter(Boolean)
   .join(" ");
 
@@ -49,13 +58,27 @@ const child = spawn("next", ["build", ...process.argv.slice(2)], {
   env: { ...process.env, NODE_OPTIONS: nodeOptions },
 });
 
+// `shell: true` means the shell is our direct child, so when something kills
+// `next` underneath it we are handed the shell's 128+N exit code with a null
+// signal -- including the OOM case this diagnostic exists for. Map those back.
+const SIGNAL_EXIT_CODES = new Map([
+  [130, "SIGINT"],
+  [137, "SIGKILL"],
+  [143, "SIGTERM"],
+]);
+
 child.on("exit", (code, signal) => {
-  // A signal here is the kernel OOM killer, not a build error. Surface it as a
-  // failure but make the distinction visible, because the fix is the opposite
-  // of the one for a heap error.
-  if (signal) {
+  const terminatingSignal = signal ?? SIGNAL_EXIT_CODES.get(code ?? -1) ?? null;
+  if (terminatingSignal) {
+    // Deliberately does not assert OOM. Several things here send signals --
+    // scripts/run-with-timeout.mjs sends SIGTERM then SIGKILL when a build
+    // exceeds its budget, and CI cancels jobs the same way. Saying "out of
+    // memory" would send someone to tune the heap for a timeout.
     console.error(
-      `[next-build] terminated by ${signal} — this is the container running out of memory, not the heap. Lower the ceiling or reduce parallelism.`,
+      `[next-build] terminated by ${terminatingSignal}, not a heap error -- raising --max-old-space-size will not help.`,
+    );
+    console.error(
+      "[next-build] check, in order: the platform build log for an OOM report (then lower the ceiling or reduce parallelism), scripts/run-with-timeout.mjs firing on the build budget, or a cancelled CI job.",
     );
     process.exit(1);
   }

--- a/packages/web/scripts/next-build.mjs
+++ b/packages/web/scripts/next-build.mjs
@@ -1,0 +1,68 @@
+/**
+ * Runs `next build` with a heap ceiling sized for the build actually being run.
+ *
+ * One number cannot serve both environments, because they do different amounts
+ * of work:
+ *
+ *   Preview / CI / local — no SENTRY_AUTH_TOKEN, so `sourcemaps.disable` is
+ *   true (next.config.js) and the Sentry plugin skips source-map generation.
+ *   A full build completes in about 2 GB here, measured. Previews also build
+ *   several PRs concurrently on one machine, so a high ceiling is actively
+ *   harmful: V8 does not collect aggressively while it believes it has
+ *   headroom, and the container OOM-kills the whole build. 3584 MB was chosen
+ *   from that measurement and holds.
+ *
+ *   Production — SENTRY_AUTH_TOKEN is set, so source maps are generated and
+ *   debug IDs are injected across the server, edge, and client compilations.
+ *   That is substantially more memory, and 3584 MB is not enough: it failed
+ *   with "FATAL ERROR: Ineffective mark-compacts near heap limit". Production
+ *   builds are serialized (one commit to main at a time), so the container
+ *   pressure that forces previews low does not apply. 5120 MB is the value
+ *   production deployed on successfully before it was lowered.
+ *
+ * Read the failure signature before changing these:
+ *   - Node "JavaScript heap out of memory"  -> this process needs MORE. Raise.
+ *   - Kernel SIGKILL / Vercel "OOM event detected" -> the sum of processes is
+ *     too high. Lower, or reduce build parallelism.
+ */
+import { spawn } from "node:child_process";
+
+const SOURCEMAP_BUILD_HEAP_MB = 5120;
+const PLAIN_BUILD_HEAP_MB = 3584;
+
+const generatesSourceMaps = Boolean(process.env.SENTRY_AUTH_TOKEN);
+const heapMb = generatesSourceMaps
+  ? SOURCEMAP_BUILD_HEAP_MB
+  : PLAIN_BUILD_HEAP_MB;
+
+const nodeOptions = [process.env.NODE_OPTIONS, `--max-old-space-size=${heapMb}`]
+  .filter(Boolean)
+  .join(" ");
+
+console.log(
+  `[next-build] heap ${heapMb} MB (sentry source maps: ${generatesSourceMaps ? "on" : "off"})`,
+);
+
+const child = spawn("next", ["build", ...process.argv.slice(2)], {
+  stdio: "inherit",
+  shell: true,
+  env: { ...process.env, NODE_OPTIONS: nodeOptions },
+});
+
+child.on("exit", (code, signal) => {
+  // A signal here is the kernel OOM killer, not a build error. Surface it as a
+  // failure but make the distinction visible, because the fix is the opposite
+  // of the one for a heap error.
+  if (signal) {
+    console.error(
+      `[next-build] terminated by ${signal} — this is the container running out of memory, not the heap. Lower the ceiling or reduce parallelism.`,
+    );
+    process.exit(1);
+  }
+  process.exit(code ?? 1);
+});
+
+child.on("error", (error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Production has not deployed since #193 merged. `deploy-production` fails at step 10, "Build Vercel production artifact":

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

## What happened

This is my regression. I lowered `--max-old-space-size` from 5120 to 3584 after measuring a build that completed comfortably in 2 GB — but every environment I measured, local and preview, has no `SENTRY_AUTH_TOKEN`, so `sourcemaps.disable` is true and the Sentry plugin skips source-map generation entirely. Production has the token and generates and injects source maps across the server, edge, and client compilations. I sized the ceiling for the cheap path and shipped it to the expensive one.

## Why one number can't serve both

The two environments do different amounts of work and fail in **opposite directions**:

- **Preview / CI / local** — no source maps; a full build fits in ~2 GB. Previews also build several PRs concurrently on one machine, so a high ceiling is actively harmful: V8 doesn't collect aggressively while it thinks it has headroom and the container OOM-kills the build. That is what 5120 → 3584 fixed, and it holds.
- **Production** — source maps on, and builds are serialized (one commit to main at a time), so the container pressure that forces previews low doesn't apply. 5120 is the value production last deployed on successfully.

So the ceiling is now chosen from whether source maps are actually running, in `packages/web/scripts/next-build.mjs`, with both measurements and the diagnostic rule recorded next to the constants:

- Node **"JavaScript heap out of memory"** → this process needs more. Raise it.
- Kernel **SIGKILL** / Vercel "OOM event detected" → the sum of processes is too high. Lower it.

The script also names a signal-kill explicitly on exit, because the two failures look alike in CI and call for opposite fixes.

## Scope

Deliberately minimal — this is a hotfix for a dead deploy pipeline. Worth knowing: everything after step 10 was **skipped**, including "Apply production database migrations" and "Sync canonical production data". So production never ran the managed-data sync either — the five-mission layer is missing from the live database as well as the site, and both land once a build succeeds.

## Verification

Full local build passes through the new script and logs `heap 3584 MB (sentry source maps: off)`; 308 static pages generated, exit 0. Both branches confirmed: 5120 with a token present, 3584 without.

After merge: watch `deploy-production` go green, then confirm https://optimitron.com/tasks/optimize-earth lists all five missions instead of "End War and Disease".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPEjHa1c79JKSFLVYkfSkz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability for large production builds by automatically allocating additional memory when source maps are enabled.
  * Preserved existing environment settings and build arguments while providing clearer failure reporting for memory-related build interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->