### PR TITLE
Add compact bulk tracking reminder responses

### DIFF
--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -9879,6 +9879,208 @@ describe("MCP server tool dispatch", () => {
       ).toHaveLength(1);
     });
 
+    it("lists compact notifications and preserves the deprecated alias response key", async () => {
+      const now = vi
+        .spyOn(Date, "now")
+        .mockReturnValue(new Date("2026-08-03T10:00:00.000Z").getTime());
+      try {
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+        mocks.trackingReminderFindMany.mockResolvedValue([
+          EXISTING_TRACKING_REMINDER,
+        ]);
+        mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const canonical = await client.callTool({
+          name: "listTrackingReminderNotifications",
+          arguments: { compact: true, dateKey: "2026-08-03" },
+        });
+        const deprecatedAlias = await client.callTool({
+          name: "listDueTrackingReminders",
+          arguments: { compact: true, dateKey: "2026-08-03" },
+        });
+
+        expect(canonical.isError).toBeFalsy();
+        expect(parseToolBody(canonical)).toEqual({
+          dateKey: "2026-08-03",
+          notifications: [
+            {
+              due: "2026-08-03T08:00:00.000Z",
+              id: "reminder-1",
+              name: "Vitamin D",
+              status: "OVERDUE",
+            },
+          ],
+        });
+        expect(parseToolBody(deprecatedAlias)).toEqual({
+          dateKey: "2026-08-03",
+          reminders: [
+            {
+              due: "2026-08-03T08:00:00.000Z",
+              id: "reminder-1",
+              name: "Vitamin D",
+              status: "OVERDUE",
+            },
+          ],
+        });
+      } finally {
+        now.mockRestore();
+      }
+    });
+
+    it("restores a snoozed notification after its deferred time", async () => {
+      const now = vi
+        .spyOn(Date, "now")
+        .mockReturnValue(new Date("2026-08-03T10:00:00.000Z").getTime());
+      try {
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+        mocks.trackingReminderFindMany.mockResolvedValue([
+          EXISTING_TRACKING_REMINDER,
+        ]);
+        mocks.trackingReminderNotificationFindMany.mockResolvedValue([
+          {
+            deletedAt: null,
+            id: "notification-1",
+            notifyAt: new Date("2026-08-03T10:30:00.000Z"),
+            status: NotificationStatus.SNOOZED,
+            trackedValue: null,
+            trackingReminderId: "reminder-1",
+            userId: "user-1",
+          },
+        ]);
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const before = await client.callTool({
+          name: "listTrackingReminderNotifications",
+          arguments: { dateKey: "2026-08-03" },
+        });
+        expect(parseToolBody(before)).toMatchObject({ notifications: [] });
+
+        now.mockReturnValue(new Date("2026-08-03T10:31:00.000Z").getTime());
+        const after = await client.callTool({
+          name: "listTrackingReminderNotifications",
+          arguments: { dateKey: "2026-08-03" },
+        });
+        expect(parseToolBody(after)).toMatchObject({
+          notifications: [
+            {
+              derivedStatus: "OVERDUE",
+              notifyAt: "2026-08-03T10:30:00.000Z",
+              reminderId: "reminder-1",
+              status: NotificationStatus.SNOOZED,
+            },
+          ],
+        });
+      } finally {
+        now.mockRestore();
+      }
+    });
+
+    it("rejects unknown bulk exception IDs before any response write", async () => {
+      mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+      mocks.trackingReminderFindMany.mockResolvedValue([
+        EXISTING_TRACKING_REMINDER,
+      ]);
+      mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "respondToTrackingReminderNotifications",
+        arguments: {
+          dateKey: "2026-08-03",
+          defaultStatus: "TRACKED",
+          except: [
+            {
+              status: "SKIPPED",
+              trackingReminderId: "misheard-reminder",
+            },
+          ],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolBody(result)).toEqual({
+        answeredCount: 0,
+        dateKey: "2026-08-03",
+        failed: [],
+        results: [],
+        unknownExceptionIds: ["misheard-reminder"],
+      });
+      expect(mocks.transaction).not.toHaveBeenCalled();
+      expect(mocks.trackingReminderNotificationCreate).not.toHaveBeenCalled();
+      expect(mocks.trackingReminderNotificationUpdate).not.toHaveBeenCalled();
+      expect(mocks.measurementUpsert).not.toHaveBeenCalled();
+    });
+
+    it("bulk responses apply the default and exception statuses", async () => {
+      const secondReminder = {
+        ...EXISTING_TRACKING_REMINDER,
+        globalVariable: {
+          ...TRACKING_VARIABLE,
+          id: "gv-magnesium",
+          name: "Magnesium",
+        },
+        globalVariableId: "gv-magnesium",
+        id: "reminder-2",
+      };
+      const reminders = [EXISTING_TRACKING_REMINDER, secondReminder];
+      mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+      mocks.trackingReminderFindMany.mockResolvedValue(reminders);
+      mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
+      mocks.trackingReminderFindFirst.mockImplementation(
+        async ({ where }: { where: { id: string } }) =>
+          reminders.find((reminder) => reminder.id === where.id) ?? null,
+      );
+      mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
+      mocks.trackingReminderNotificationCreate.mockImplementation(
+        async ({ data }: { data: Record<string, unknown> }) => ({
+          ...data,
+          id: `notification-${String(data.trackingReminderId)}`,
+        }),
+      );
+      mocks.measurementUpsert.mockResolvedValue({
+        globalVariableId: "gv-vitd",
+        id: "measurement-1",
+        subjectId: "subject-1",
+        unitId: "unit-iu",
+        value: 1,
+      });
+      mocks.trackingReminderUpdate.mockResolvedValue({ id: "reminder-1" });
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "respondToTrackingReminderNotifications",
+        arguments: {
+          dateKey: "2026-08-03",
+          defaultStatus: "TRACKED",
+          except: [
+            {
+              status: "SKIPPED",
+              trackingReminderId: "reminder-2",
+            },
+          ],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolBody(result)).toMatchObject({
+        answeredCount: 2,
+        failed: [],
+        results: [
+          { reminderId: "reminder-1", status: NotificationStatus.TRACKED },
+          { reminderId: "reminder-2", status: NotificationStatus.SKIPPED },
+        ],
+        unknownExceptionIds: [],
+      });
+      expect(mocks.trackingReminderNotificationCreate).toHaveBeenCalledTimes(2);
+      expect(
+        mocks.trackingReminderNotificationCreate.mock.calls.map(
+          ([call]) => call.data.status,
+        ),
+      ).toEqual([NotificationStatus.TRACKED, NotificationStatus.SKIPPED]);
+      expect(mocks.measurementUpsert).toHaveBeenCalledTimes(1);
+    });
+
     it("listDueTrackingReminders marks unanswered past reminders overdue", async () => {
       const now = vi
         .spyOn(Date, "now")
@@ -10035,6 +10237,48 @@ describe("MCP server tool dispatch", () => {
       };
       expect(body.result.measurement).not.toBeNull();
       expect(body.result.measurement?.value).toBe(3);
+    });
+
+    it("respondToTrackingReminder stores the deferred time for a first snooze", async () => {
+      const now = vi
+        .spyOn(Date, "now")
+        .mockReturnValue(new Date("2026-08-03T10:00:00.000Z").getTime());
+      try {
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+        mocks.trackingReminderFindFirst.mockResolvedValue(
+          EXISTING_TRACKING_REMINDER,
+        );
+        mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
+        mocks.trackingReminderNotificationCreate.mockImplementation(
+          async ({ data }: { data: Record<string, unknown> }) => ({
+            ...data,
+            id: "notification-1",
+          }),
+        );
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "respondToTrackingReminder",
+          arguments: {
+            dateKey: "2026-08-03",
+            snoozeMinutes: 45,
+            status: "SNOOZED",
+            trackingReminderId: "reminder-1",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(mocks.trackingReminderNotificationCreate).toHaveBeenCalledWith({
+          data: expect.objectContaining({
+            notifyAt: new Date("2026-08-03T10:45:00.000Z"),
+            status: NotificationStatus.SNOOZED,
+            trackingReminderId: "reminder-1",
+          }),
+        });
+        expect(mocks.measurementUpsert).not.toHaveBeenCalled();
+      } finally {
+        now.mockRestore();
+      }
     });
 
     it("respondToTrackingReminder updates the same local-date response after the reminder time changes", async () => {

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -9956,6 +9956,23 @@ describe("MCP server tool dispatch", () => {
         });
         expect(parseToolBody(before)).toMatchObject({ notifications: [] });
 
+        now.mockReturnValue(new Date("2026-08-03T10:30:00.000Z").getTime());
+        const atDeferredTime = await client.callTool({
+          name: "listTrackingReminderNotifications",
+          arguments: { dateKey: "2026-08-03" },
+        });
+        expect(parseToolBody(atDeferredTime)).toMatchObject({
+          notifications: [
+            {
+              derivedStatus: NotificationStatus.PENDING,
+              isOverdue: false,
+              notifyAt: "2026-08-03T10:30:00.000Z",
+              reminderId: "reminder-1",
+              status: NotificationStatus.SNOOZED,
+            },
+          ],
+        });
+
         now.mockReturnValue(new Date("2026-08-03T10:31:00.000Z").getTime());
         const after = await client.callTool({
           name: "listTrackingReminderNotifications",
@@ -9974,6 +9991,28 @@ describe("MCP server tool dispatch", () => {
       } finally {
         now.mockRestore();
       }
+    });
+
+    it("rejects a non-array bulk exception value before any read or write", async () => {
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "respondToTrackingReminderNotifications",
+        arguments: {
+          dateKey: "2026-08-03",
+          defaultStatus: "SKIPPED",
+          except: { trackingReminderId: "reminder-1" },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).message).toContain(
+        "except must be an array of exception entries",
+      );
+      expect(mocks.trackingReminderFindMany).not.toHaveBeenCalled();
+      expect(mocks.transaction).not.toHaveBeenCalled();
+      expect(mocks.trackingReminderNotificationCreate).not.toHaveBeenCalled();
+      expect(mocks.trackingReminderNotificationUpdate).not.toHaveBeenCalled();
+      expect(mocks.measurementUpsert).not.toHaveBeenCalled();
     });
 
     it("rejects unknown bulk exception IDs before any response write", async () => {
@@ -10079,6 +10118,71 @@ describe("MCP server tool dispatch", () => {
         ),
       ).toEqual([NotificationStatus.TRACKED, NotificationStatus.SKIPPED]);
       expect(mocks.measurementUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it("bulk responses leave later notifications untouched", async () => {
+      const now = vi
+        .spyOn(Date, "now")
+        .mockReturnValue(new Date("2026-08-03T10:00:00.000Z").getTime());
+      try {
+        const laterReminder = {
+          ...EXISTING_TRACKING_REMINDER,
+          globalVariable: {
+            ...TRACKING_VARIABLE,
+            id: "gv-magnesium",
+            name: "Magnesium",
+          },
+          globalVariableId: "gv-magnesium",
+          id: "reminder-2",
+          reminderStartTime: "18:00",
+        };
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+        mocks.trackingReminderFindMany.mockResolvedValue([
+          EXISTING_TRACKING_REMINDER,
+          laterReminder,
+        ]);
+        mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
+        mocks.trackingReminderFindFirst.mockResolvedValue(
+          EXISTING_TRACKING_REMINDER,
+        );
+        mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
+        mocks.trackingReminderNotificationCreate.mockImplementation(
+          async ({ data }: { data: Record<string, unknown> }) => ({
+            ...data,
+            id: "notification-1",
+          }),
+        );
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "respondToTrackingReminderNotifications",
+          arguments: {
+            dateKey: "2026-08-03",
+            defaultStatus: "SKIPPED",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(parseToolBody(result)).toMatchObject({
+          answeredCount: 1,
+          failed: [],
+          results: [
+            { reminderId: "reminder-1", status: NotificationStatus.SKIPPED },
+          ],
+        });
+        expect(mocks.trackingReminderNotificationCreate).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(
+          mocks.trackingReminderNotificationCreate.mock.calls[0]?.[0],
+        ).toMatchObject({
+          data: expect.objectContaining({
+            trackingReminderId: "reminder-1",
+          }),
+        });
+      } finally {
+        now.mockRestore();
+      }
     });
 
     it("listDueTrackingReminders marks unanswered past reminders overdue", async () => {
@@ -10276,6 +10380,47 @@ describe("MCP server tool dispatch", () => {
           }),
         });
         expect(mocks.measurementUpsert).not.toHaveBeenCalled();
+      } finally {
+        now.mockRestore();
+      }
+    });
+
+    it("caps a snooze at the end of its local day", async () => {
+      const now = vi
+        .spyOn(Date, "now")
+        .mockReturnValue(new Date("2026-08-03T23:50:00.000Z").getTime());
+      try {
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+        mocks.trackingReminderFindFirst.mockResolvedValue(
+          EXISTING_TRACKING_REMINDER,
+        );
+        mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
+        mocks.trackingReminderNotificationCreate.mockImplementation(
+          async ({ data }: { data: Record<string, unknown> }) => ({
+            ...data,
+            id: "notification-1",
+          }),
+        );
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "respondToTrackingReminder",
+          arguments: {
+            dateKey: "2026-08-03",
+            snoozeMinutes: 45,
+            status: "SNOOZED",
+            trackingReminderId: "reminder-1",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(mocks.trackingReminderNotificationCreate).toHaveBeenCalledWith({
+          data: expect.objectContaining({
+            notifyAt: new Date("2026-08-03T23:59:59.999Z"),
+            status: NotificationStatus.SNOOZED,
+            trackingReminderId: "reminder-1",
+          }),
+        });
       } finally {
         now.mockRestore();
       }

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -326,7 +326,9 @@ const TOOL_SCOPES: Record<string, McpScope[]> = {
   upsertTrackingReminder: [McpScope.TASKS_PERSONAL],
   listTrackingReminders: [McpScope.TASKS_PERSONAL],
   listDueTrackingReminders: [McpScope.TASKS_PERSONAL],
+  listTrackingReminderNotifications: [McpScope.TASKS_PERSONAL],
   respondToTrackingReminder: [McpScope.TASKS_PERSONAL],
+  respondToTrackingReminderNotifications: [McpScope.TASKS_PERSONAL],
   getMe: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ORGANIZATION],
   inspectToolAccess: [],
   updateMyProfile: [McpScope.TASKS_PERSONAL],
@@ -3587,6 +3589,9 @@ async function listTrackingRemindersForUser(
   });
 }
 
+/** Default snooze length when a caller does not name one. */
+const DEFAULT_SNOOZE_MINUTES = 30;
+
 async function listDueTrackingRemindersForUser(
   input: Record<string, unknown>,
   userId: string,
@@ -3637,7 +3642,7 @@ async function listDueTrackingRemindersForUser(
     occurrenceByReminderId.set(reminder.id, occurrence);
     return true;
   });
-  if (dueReminders.length === 0) return { dateKey, reminders: [] };
+  if (dueReminders.length === 0) return { dateKey, notifications: [] };
 
   const notifications = await prisma.trackingReminderNotification.findMany({
     orderBy: [{ notifyAt: "asc" }],
@@ -3670,9 +3675,13 @@ async function listDueTrackingRemindersForUser(
         );
       }
       const status = notification?.status ?? NotificationStatus.PENDING;
+      const snoozeElapsed =
+        status === NotificationStatus.SNOOZED &&
+        notifyAt.getTime() <= Date.now();
       const isOverdue =
         (status === NotificationStatus.PENDING ||
-          status === NotificationStatus.SENT) &&
+          status === NotificationStatus.SENT ||
+          snoozeElapsed) &&
         notifyAt.getTime() < Date.now();
       return {
         dateKey,
@@ -3695,17 +3704,38 @@ async function listDueTrackingRemindersForUser(
     })
     .filter((reminder) => {
       if (input.includeCompleted === true) return true;
+      if (
+        reminder.status === NotificationStatus.SNOOZED &&
+        reminder.notifyAt.getTime() <= Date.now()
+      ) {
+        return true;
+      }
       return (
         reminder.status === NotificationStatus.PENDING ||
         reminder.status === NotificationStatus.SENT
       );
     });
-  return { dateKey, reminders: remindersWithStatus };
+  return { dateKey, notifications: remindersWithStatus };
+}
+
+function toCompactTrackingNotifications(
+  result: Awaited<ReturnType<typeof listDueTrackingRemindersForUser>>,
+) {
+  return {
+    dateKey: result.dateKey,
+    notifications: result.notifications.map((notification) => ({
+      due: notification.notifyAt,
+      id: notification.reminderId,
+      name: notification.globalVariable.name,
+      status: notification.derivedStatus,
+    })),
+  };
 }
 
 async function findOrCreateTrackingNotification(
   tx: Prisma.TransactionClient,
   input: {
+    deferUntil?: Date | null;
     localDayEnd: Date;
     localDayStart: Date;
     notifyAt: Date;
@@ -3727,6 +3757,7 @@ async function findOrCreateTrackingNotification(
     receivedAt: new Date(),
     status: input.status,
     trackedValue: input.trackedValue,
+    ...(input.deferUntil ? { notifyAt: input.deferUntil } : {}),
   };
   if (existing) {
     return tx.trackingReminderNotification.update({
@@ -3737,11 +3768,142 @@ async function findOrCreateTrackingNotification(
   return tx.trackingReminderNotification.create({
     data: {
       ...data,
-      notifyAt: input.notifyAt,
+      notifyAt: input.deferUntil ?? input.notifyAt,
       trackingReminderId: input.trackingReminderId,
       userId: input.userId,
     },
   });
+}
+
+function parseSnoozeMinutes(input: Record<string, unknown>) {
+  const snoozeMinutes =
+    parseOptionalFiniteNumberInput(input, "snoozeMinutes") ??
+    DEFAULT_SNOOZE_MINUTES;
+  if (snoozeMinutes <= 0) {
+    throw new Error("snoozeMinutes must be greater than 0.");
+  }
+  return snoozeMinutes;
+}
+
+function assertTrackingReminderResponseStatus(
+  status: NotificationStatus | undefined,
+  fieldName: string,
+): asserts status is NotificationStatus {
+  if (
+    status !== NotificationStatus.TRACKED &&
+    status !== NotificationStatus.SKIPPED &&
+    status !== NotificationStatus.SNOOZED
+  ) {
+    throw new Error(`${fieldName} must be TRACKED, SKIPPED, or SNOOZED.`);
+  }
+}
+
+async function respondToTrackingReminderNotificationsForUser(
+  input: Record<string, unknown>,
+  userId: string,
+) {
+  const defaultStatus = parseEnumInput(
+    NotificationStatus,
+    input.defaultStatus,
+    "defaultStatus",
+  );
+  assertTrackingReminderResponseStatus(defaultStatus, "defaultStatus");
+
+  const globalSnoozeMinutes =
+    input.snoozeMinutes === undefined ? undefined : parseSnoozeMinutes(input);
+  const exceptions = Array.isArray(input.except) ? input.except : [];
+  const overrideById = new Map<
+    string,
+    {
+      note: unknown;
+      snoozeMinutes: number | undefined;
+      status: NotificationStatus;
+      value: number | null | undefined;
+    }
+  >();
+
+  for (const raw of exceptions) {
+    if (raw === null || typeof raw !== "object") {
+      throw new Error("Each except entry must be an object.");
+    }
+    const entry = raw as Record<string, unknown>;
+    const trackingReminderId = optionalString(
+      entry.trackingReminderId ?? entry.id,
+    );
+    if (!trackingReminderId) {
+      throw new Error("Each except entry needs a trackingReminderId.");
+    }
+    const status =
+      parseEnumInput(NotificationStatus, entry.status, "status") ??
+      defaultStatus;
+    assertTrackingReminderResponseStatus(status, "status");
+    overrideById.set(trackingReminderId, {
+      note: entry.note,
+      snoozeMinutes:
+        entry.snoozeMinutes === undefined
+          ? undefined
+          : parseSnoozeMinutes(entry),
+      status,
+      value: parseOptionalFiniteNumberInput(entry, "value"),
+    });
+  }
+
+  const due = await listDueTrackingRemindersForUser(
+    { dateKey: input.dateKey },
+    userId,
+  );
+  const dueIds = new Set(due.notifications.map((item) => item.reminderId));
+  const unknownExceptionIds = [...overrideById.keys()].filter(
+    (id) => !dueIds.has(id),
+  );
+
+  if (unknownExceptionIds.length > 0) {
+    return {
+      answeredCount: 0,
+      dateKey: due.dateKey,
+      failed: [],
+      results: [],
+      unknownExceptionIds,
+    };
+  }
+
+  const results: Array<{
+    reminderId: string;
+    status: NotificationStatus;
+  }> = [];
+  const failed: Array<{ reminderId: string; error: string }> = [];
+
+  for (const item of due.notifications) {
+    const override = overrideById.get(item.reminderId);
+    const status = override?.status ?? defaultStatus;
+    try {
+      await respondToTrackingReminderForUser(
+        {
+          dateKey: due.dateKey,
+          note: override?.note ?? input.note,
+          snoozeMinutes: override?.snoozeMinutes ?? globalSnoozeMinutes,
+          status,
+          trackingReminderId: item.reminderId,
+          value: override?.value,
+        },
+        userId,
+      );
+      results.push({ reminderId: item.reminderId, status });
+    } catch (error) {
+      failed.push({
+        error: error instanceof Error ? error.message : String(error),
+        reminderId: item.reminderId,
+      });
+    }
+  }
+
+  return {
+    answeredCount: results.length,
+    dateKey: due.dateKey,
+    failed,
+    results,
+    unknownExceptionIds,
+  };
 }
 
 async function respondToTrackingReminderForUser(
@@ -3751,15 +3913,11 @@ async function respondToTrackingReminderForUser(
   const status =
     parseEnumInput(NotificationStatus, input.status, "status") ??
     NotificationStatus.TRACKED;
-  if (
-    status !== NotificationStatus.TRACKED &&
-    status !== NotificationStatus.SKIPPED &&
-    status !== NotificationStatus.SNOOZED
-  ) {
-    throw new Error("status must be TRACKED, SKIPPED, or SNOOZED.");
-  }
+  assertTrackingReminderResponseStatus(status, "status");
   const trackingReminderId = optionalString(input.trackingReminderId);
   if (!trackingReminderId) throw new Error("trackingReminderId is required.");
+  const snoozeMinutes =
+    status === NotificationStatus.SNOOZED ? parseSnoozeMinutes(input) : null;
   const trackedAt = parseOptionalDateValue(input.trackedAt, "trackedAt");
   const prisma = await getPrisma();
   const user = await prisma.user.findUnique({
@@ -3802,7 +3960,17 @@ async function respondToTrackingReminderForUser(
       dateKey,
       timeZone,
     );
+    const deferUntil =
+      snoozeMinutes === null
+        ? null
+        : new Date(
+            Math.min(
+              Date.now() + snoozeMinutes * 60_000,
+              localDayEnd.getTime() - 1,
+            ),
+          );
     const notification = await findOrCreateTrackingNotification(tx, {
+      deferUntil,
       localDayEnd,
       localDayStart,
       notifyAt,
@@ -5175,9 +5343,9 @@ const TRACKING_TOOL_DEFINITIONS = [
     },
   },
   {
-    name: "listDueTrackingReminders",
+    name: "listTrackingReminderNotifications",
     description:
-      "List medication, food, symptom, and other tracking reminders due for a date. Each result includes derivedStatus, isOverdue, and overdueSince so callers never need to compare notifyAt with the current time themselves. Use this to answer what the user is supposed to take or track today.",
+      "List due tracking reminder notifications. A reminder defines a schedule. A notification is one occurrence that you answer. Most pending notifications have no stored row. Use compact mode for voice or chat clients.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -5185,12 +5353,86 @@ const TRACKING_TOOL_DEFINITIONS = [
           type: "string",
           description: "Local date in YYYY-MM-DD. Defaults to today.",
         },
+        compact: {
+          type: "boolean",
+          description:
+            "Return only id, name, due, and status for each notification.",
+        },
+        includeCompleted: {
+          type: "boolean",
+          description:
+            "Include completed notifications and snoozes that have not elapsed.",
+        },
+      },
+    },
+  },
+  {
+    name: "listDueTrackingReminders",
+    description:
+      "Deprecated alias for listTrackingReminderNotifications. It keeps the reminders response key for existing callers.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        dateKey: {
+          type: "string",
+          description: "Local date in YYYY-MM-DD. Defaults to today.",
+        },
+        compact: {
+          type: "boolean",
+          description:
+            "Return only id, name, due, and status for each notification.",
+        },
         includeCompleted: {
           type: "boolean",
           description:
             "When true, include reminders already TRACKED, SKIPPED, or SNOOZED for the date.",
         },
       },
+    },
+  },
+  {
+    name: "respondToTrackingReminderNotifications",
+    description:
+      "Answer all due notifications with one default status and optional exceptions. If any exception ID is not due, this tool writes nothing. Valid reminders continue when one response fails.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        dateKey: {
+          type: "string",
+          description: "Local date in YYYY-MM-DD. Defaults to today.",
+        },
+        defaultStatus: {
+          type: "string",
+          enum: ["TRACKED", "SKIPPED", "SNOOZED"],
+          description:
+            "Apply this status to each notification without an exception.",
+        },
+        except: {
+          type: "array",
+          description:
+            "Override individual notifications by trackingReminderId.",
+          items: {
+            type: "object",
+            properties: {
+              trackingReminderId: { type: "string" },
+              status: {
+                type: "string",
+                enum: ["TRACKED", "SKIPPED", "SNOOZED"],
+              },
+              value: { type: "number" },
+              snoozeMinutes: { type: "number" },
+              note: { type: "string" },
+            },
+            required: ["trackingReminderId"],
+          },
+        },
+        note: { type: "string" },
+        snoozeMinutes: {
+          type: "number",
+          description: "Set the snooze duration. The default is 30 minutes.",
+        },
+      },
+      required: ["defaultStatus"],
     },
   },
   {
@@ -5205,7 +5447,11 @@ const TRACKING_TOOL_DEFINITIONS = [
           type: "string",
           enum: ["TRACKED", "SKIPPED", "SNOOZED"],
           description:
-            "TRACKED records a measurement (including value 0); SKIPPED records no measurement and leaves a gap; SNOOZED defers.",
+            "TRACKED records a measurement. SKIPPED records no measurement. SNOOZED defers the notification.",
+        },
+        snoozeMinutes: {
+          type: "number",
+          description: "Set the snooze duration. The default is 30 minutes.",
         },
         value: {
           type: "number",
@@ -9474,13 +9720,35 @@ export function createMcpServer(
             });
           }
 
+          case "listTrackingReminderNotifications":
           case "listDueTrackingReminders": {
             if (!userId)
               return authRequired(
                 name,
-                "This tool lists your due personal tracking reminders.",
+                "This tool lists your due personal tracking reminder notifications.",
               );
-            return ok(await listDueTrackingRemindersForUser(a, userId));
+            const result =
+              a.compact === true
+                ? toCompactTrackingNotifications(
+                    await listDueTrackingRemindersForUser(a, userId),
+                  )
+                : await listDueTrackingRemindersForUser(a, userId);
+            if (name === "listDueTrackingReminders") {
+              const { notifications, ...rest } = result;
+              return ok({ ...rest, reminders: notifications });
+            }
+            return ok(result);
+          }
+
+          case "respondToTrackingReminderNotifications": {
+            if (!userId)
+              return authRequired(
+                name,
+                "This tool records responses to your tracking reminder notifications.",
+              );
+            return ok(
+              await respondToTrackingReminderNotificationsForUser(a, userId),
+            );
           }
 
           case "respondToTrackingReminder": {

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -3675,20 +3675,22 @@ async function listDueTrackingRemindersForUser(
         );
       }
       const status = notification?.status ?? NotificationStatus.PENDING;
+      const now = Date.now();
       const snoozeElapsed =
-        status === NotificationStatus.SNOOZED &&
-        notifyAt.getTime() <= Date.now();
+        status === NotificationStatus.SNOOZED && notifyAt.getTime() <= now;
       const isOverdue =
         (status === NotificationStatus.PENDING ||
           status === NotificationStatus.SENT ||
           snoozeElapsed) &&
-        notifyAt.getTime() < Date.now();
+        notifyAt.getTime() < now;
       return {
         dateKey,
         defaultValue: cleanNumber(reminder.defaultValue),
         derivedStatus: isOverdue
           ? TrackingReminderDerivedStatus.OVERDUE
-          : status,
+          : snoozeElapsed
+            ? NotificationStatus.PENDING
+            : status,
         globalVariable: reminder.globalVariable,
         instructions: reminder.instructions,
         isOverdue,
@@ -3811,6 +3813,9 @@ async function respondToTrackingReminderNotificationsForUser(
 
   const globalSnoozeMinutes =
     input.snoozeMinutes === undefined ? undefined : parseSnoozeMinutes(input);
+  if (input.except !== undefined && !Array.isArray(input.except)) {
+    throw new Error("except must be an array of exception entries.");
+  }
   const exceptions = Array.isArray(input.except) ? input.except : [];
   const overrideById = new Map<
     string,
@@ -3827,9 +3832,7 @@ async function respondToTrackingReminderNotificationsForUser(
       throw new Error("Each except entry must be an object.");
     }
     const entry = raw as Record<string, unknown>;
-    const trackingReminderId = optionalString(
-      entry.trackingReminderId ?? entry.id,
-    );
+    const trackingReminderId = optionalString(entry.trackingReminderId);
     if (!trackingReminderId) {
       throw new Error("Each except entry needs a trackingReminderId.");
     }
@@ -3852,7 +3855,11 @@ async function respondToTrackingReminderNotificationsForUser(
     { dateKey: input.dateKey },
     userId,
   );
-  const dueIds = new Set(due.notifications.map((item) => item.reminderId));
+  const now = Date.now();
+  const dueNotifications = due.notifications.filter(
+    (item) => item.notifyAt.getTime() <= now,
+  );
+  const dueIds = new Set(dueNotifications.map((item) => item.reminderId));
   const unknownExceptionIds = [...overrideById.keys()].filter(
     (id) => !dueIds.has(id),
   );
@@ -3873,7 +3880,7 @@ async function respondToTrackingReminderNotificationsForUser(
   }> = [];
   const failed: Array<{ reminderId: string; error: string }> = [];
 
-  for (const item of due.notifications) {
+  for (const item of dueNotifications) {
     const override = overrideById.get(item.reminderId);
     const status = override?.status ?? defaultStatus;
     try {
@@ -5356,7 +5363,7 @@ const TRACKING_TOOL_DEFINITIONS = [
         compact: {
           type: "boolean",
           description:
-            "Return only id, name, due, and status for each notification.",
+            "Return trackingReminderId as id, plus name, due, and status.",
         },
         includeCompleted: {
           type: "boolean",
@@ -5380,7 +5387,7 @@ const TRACKING_TOOL_DEFINITIONS = [
         compact: {
           type: "boolean",
           description:
-            "Return only id, name, due, and status for each notification.",
+            "Return trackingReminderId as id, plus name, due, and status.",
         },
         includeCompleted: {
           type: "boolean",
@@ -5393,7 +5400,7 @@ const TRACKING_TOOL_DEFINITIONS = [
   {
     name: "respondToTrackingReminderNotifications",
     description:
-      "Answer all due notifications with one default status and optional exceptions. If any exception ID is not due, this tool writes nothing. Valid reminders continue when one response fails.",
+      "Answer notifications whose due time has arrived. Apply one default status and optional exceptions. If any exception ID is not due, this tool writes nothing. Valid reminders continue when one response fails.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -5429,7 +5436,8 @@ const TRACKING_TOOL_DEFINITIONS = [
         note: { type: "string" },
         snoozeMinutes: {
           type: "number",
-          description: "Set the snooze duration. The default is 30 minutes.",
+          description:
+            "Set the snooze duration. The default is 30 minutes. The server caps the deferred time at the local day's end.",
         },
       },
       required: ["defaultStatus"],
@@ -5451,7 +5459,8 @@ const TRACKING_TOOL_DEFINITIONS = [
         },
         snoozeMinutes: {
           type: "number",
-          description: "Set the snooze duration. The default is 30 minutes.",
+          description:
+            "Set the snooze duration. The default is 30 minutes. The server caps the deferred time at the local day's end.",
         },
         value: {
           type: "number",


### PR DESCRIPTION
## What changed

- Add `listTrackingReminderNotifications` with a compact response for voice and chat clients.
- Keep `listDueTrackingReminders` as a deprecated response-compatible alias.
- Add one bulk response tool with a default status and per-reminder exceptions.
- Make `SNOOZED` defer the occurrence and surface it again after the deferred time.

## Why

Tracking reminders are recurring rules, while notifications are the occurrences a person answers. The previous API conflated those concepts and required one tool call per response. Snooze also recorded a status without moving the occurrence.

## Safety

- The bulk tool validates every exception ID before any write.
- An unknown or misheard exception ID produces zero writes.
- A first-time snooze stores the deferred time rather than the original schedule.
- The dispatcher and due-list behavior are covered through the MCP client boundary.

## Validation

- Focused reminder regressions: 5/5 passed
- Full MCP suite: 282/282 passed in the initial complete run
- Web app typecheck: passed
- Web test typecheck: passed
- ESLint on both changed files: passed
- `git diff --check`: passed

A later full-suite repeat under heavy concurrent machine load timed out in ten unrelated task-read tests; all reminder tests remained green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for listing tracking-reminder notifications.
  * Added bulk responses for all due reminders, with default or per-reminder statuses.
  * Added configurable snoozing, including a 30-minute default and same-day deferral options.
  * Snoozed reminders now reappear as overdue when the snooze period expires.
  * Added compact notification results for quicker review.

* **Bug Fixes**
  * Improved validation and partial-failure reporting for invalid reminder responses.
  * Snoozing a reminder now correctly defers its next notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->