### PR TITLE
Bound MCP task search descriptions

### DIFF
--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -2539,6 +2539,45 @@ describe("MCP server tool dispatch", () => {
       ]);
     });
 
+    it("bounds long search snippets and points agents to getTask", async () => {
+      const taskId = "task-with-long-description";
+      mocks.searchTasks.mockResolvedValue([
+        {
+          id: taskId,
+          snippet: "a".repeat(250),
+          title: "Task with a long description",
+        },
+        {
+          id: "task-with-short-description",
+          snippet: "Short description",
+          title: "Task with a short description",
+        },
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "searchTasks",
+        arguments: { query: "description" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const body = parseToolBody(result) as unknown as Array<
+        Record<string, unknown>
+      >;
+      expect(body[0]).toMatchObject({
+        fullDescriptionHint: `Call getTask with {"taskId":"${taskId}"} to read the full description.`,
+        id: taskId,
+        snippet: `${"a".repeat(199)}…`,
+        snippetTruncated: true,
+      });
+      expect(body[1]).toMatchObject({
+        id: "task-with-short-description",
+        snippet: "Short description",
+      });
+      expect(body[1]).not.toHaveProperty("fullDescriptionHint");
+      expect(body[1]).not.toHaveProperty("snippetTruncated");
+    });
+
     it("does not invent private visibility when listTasks omits isPublic", async () => {
       mocks.listTasks.mockResolvedValue([
         makeCreatedTask({

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -931,6 +931,25 @@ function dedupeStrings(values: Array<string | null | undefined>) {
 }
 
 const TASK_PAGE_CURSOR_VERSION = 2;
+const TASK_SEARCH_SNIPPET_MAX_LENGTH = 200;
+
+function boundTaskSearchSnippet<T extends { id: string; snippet?: unknown }>(
+  task: T,
+) {
+  if (
+    typeof task.snippet !== "string" ||
+    task.snippet.length <= TASK_SEARCH_SNIPPET_MAX_LENGTH
+  ) {
+    return task;
+  }
+
+  return {
+    ...task,
+    snippet: `${task.snippet.slice(0, TASK_SEARCH_SNIPPET_MAX_LENGTH - 1).trimEnd()}…`,
+    snippetTruncated: true,
+    fullDescriptionHint: `Call getTask with {"taskId":"${task.id}"} to read the full description.`,
+  };
+}
 
 function getTaskPageSignature(
   tool: "listTasks" | "searchTasks",
@@ -8797,6 +8816,7 @@ const TASK_TOOL_DEFINITIONS = [
     description:
       "Fuzzy-search your accessible tasks by title, description, impact statement, task key, assignee, or organization. Signed-in results may include public tasks and private tasks you created, manage, are assigned, claimed, or can access through an organization; other users' private work remains excluded. " +
       "Use this before createTask/updateTask to find parents, duplicates, blockerTaskIds, or blockedTaskIds. " +
+      "Long snippets are capped at 200 characters and include a getTask instruction for reading the full description. " +
       "For Optimitron code or documentation work, query the stable key 'optimitron:dev', select that exact result, and call createTask with parentTaskKey='optimitron:dev'. Returns the legacy result array unless paginated=true or cursor is supplied. Paginated inventory uses immutable task-ID order, not relevance order.",
     inputSchema: {
       type: "object" as const,
@@ -10808,7 +10828,8 @@ export function createMcpServer(
               status,
               visibility: scope,
             });
-            if (!wantsPagination) return ok(results.slice(0, limit));
+            const boundedResults = results.map(boundTaskSearchSnippet);
+            if (!wantsPagination) return ok(boundedResults.slice(0, limit));
             if (results.length >= 500) {
               return err(
                 "This search matched the server's 500-candidate ranking window. Narrow the query or filters before paginating so no matches are silently omitted.",
@@ -10825,7 +10846,7 @@ export function createMcpServer(
                   scope,
                   status: status ?? null,
                 }),
-                tasks: results,
+                tasks: boundedResults,
                 tool: "searchTasks",
               });
               return ok(page);


### PR DESCRIPTION
## What changed

- Cap every `searchTasks` snippet at 200 characters.
- Mark truncated snippets with `snippetTruncated: true`.
- Add a `fullDescriptionHint` that shows the exact `getTask` call with the returned task ID.
- Leave short snippets unchanged.
- Document the bounded response in the `searchTasks` tool description.

## Why

`searchTasks` previously returned complete multi-paragraph task descriptions. A page of long results could consume an agent's context window and interrupt the conversation. The response is now bounded while keeping the full description one explicit tool call away.

## Validation

- `pnpm --filter @optimitron/web exec vitest run src/lib/__tests__/mcp-server.test.ts -t "bounds long search snippets and points agents to getTask"`
- `pnpm --filter @optimitron/web run typecheck:app`
- `pnpm --filter @optimitron/web run typecheck:tests`
- `pnpm exec eslint --no-warn-ignored packages/web/src/lib/mcp-server.ts packages/web/src/lib/__tests__/mcp-server.test.ts`
- `git diff --check`

The full MCP test file reached 285/287 with two unrelated authorization tests exceeding the local 5-second timeout. Both assertions passed when rerun in isolation with a diagnostic 20-second timeout; no repository timeout was changed.

Task: [Truncate task descriptions in searchTasks response by default](https://optimitron.com/tasks/cmsm03hcl002z04lg76t99847)