### PR TITLE
Link bare task IDs in descriptions

### DIFF
--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -86,6 +86,10 @@ const TASK_DELETE_BUTTON_FILE =
   "packages/web/src/components/tasks/TaskDeleteButton.tsx";
 const TASK_MANAGEMENT_CONTROLS_FILE =
   "packages/web/src/components/tasks/TaskManagementControls.tsx";
+const TASK_DESCRIPTION_FILE =
+  "packages/web/src/components/tasks/task-description.tsx";
+const RICH_MARKDOWN_FILE =
+  "packages/web/src/components/markdown/rich-markdown.tsx";
 const CREATE_TASK_DIALOG_FILE =
   "packages/web/src/components/tasks/CreateTaskDialog.tsx";
 const TASK_DEPENDENCIES_SECTION_FILE =
@@ -519,12 +523,15 @@ function loadDocumentReviewRoutes(): VisualRoute[] {
         TASK_MANAGEMENT_CONTROLS_FILE,
         TASK_COMPLETE_FORM_FILE,
         TASK_DELETE_BUTTON_FILE,
+        TASK_DESCRIPTION_FILE,
+        RICH_MARKDOWN_FILE,
       ],
       name: "task-management-owner",
       openTaskManagement: true,
       path: `/tasks/${manifest.managementOwnerTaskId}`,
       required: true,
       requiredSelector: "[data-task-management][open]",
+      requiredText: /^Review the filing evidence$/,
     },
     {
       authenticated: true,

--- a/packages/web/scripts/seed-visual-review-fixtures.ts
+++ b/packages/web/scripts/seed-visual-review-fixtures.ts
@@ -49,6 +49,7 @@ const ids = {
   managerTask: `${FIXTURE_PREFIX}manager_task`,
   managementClaimTask: `${FIXTURE_PREFIX}management_claim_task`,
   managementOwnerTask: `${FIXTURE_PREFIX}management_owner_task`,
+  referenceTargetTask: "cvisualtasklink0000000000",
   staleTask: `${FIXTURE_PREFIX}stale_task`,
 };
 
@@ -243,6 +244,25 @@ async function seedTaskManagementStates(input: {
   demo: Awaited<ReturnType<typeof loadDemoActor>>;
   fixtureManager: Awaited<ReturnType<typeof ensureFixtureManager>>;
 }) {
+  await prisma.task.upsert({
+    where: { id: ids.referenceTargetTask },
+    update: {
+      createdByUserId: input.demo.user.id,
+      deletedAt: null,
+      description: "Review the source documents for the filing checklist.",
+      isPublic: false,
+      taskKey: `${FIXTURE_PREFIX}reference_target`,
+      title: "Review the filing evidence",
+    },
+    create: {
+      createdByUserId: input.demo.user.id,
+      description: "Review the source documents for the filing checklist.",
+      id: ids.referenceTargetTask,
+      isPublic: false,
+      taskKey: `${FIXTURE_PREFIX}reference_target`,
+      title: "Review the filing evidence",
+    },
+  });
   const ownerTask = await prisma.task.upsert({
     where: { id: ids.managementOwnerTask },
     update: {
@@ -250,8 +270,7 @@ async function seedTaskManagementStates(input: {
       claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
       createdByUserId: input.demo.user.id,
       deletedAt: null,
-      description:
-        "Confirm the filing checklist, add any missing steps, and archive this task when the checklist is no longer current.",
+      description: `Confirm the filing checklist against ${ids.referenceTargetTask}, add any missing steps, and archive this task when the checklist is no longer current.`,
       dueAt: MANAGEMENT_DUE_AT,
       estimatedEffortHours: 2,
       isPublic: false,
@@ -262,8 +281,7 @@ async function seedTaskManagementStates(input: {
       assigneePersonId: input.demo.person.id,
       claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
       createdByUserId: input.demo.user.id,
-      description:
-        "Confirm the filing checklist, add any missing steps, and archive this task when the checklist is no longer current.",
+      description: `Confirm the filing checklist against ${ids.referenceTargetTask}, add any missing steps, and archive this task when the checklist is no longer current.`,
       dueAt: MANAGEMENT_DUE_AT,
       estimatedEffortHours: 2,
       id: ids.managementOwnerTask,

--- a/packages/web/src/app/tasks/[id]/page.tsx
+++ b/packages/web/src/app/tasks/[id]/page.tsx
@@ -60,6 +60,7 @@ import { normalizeTaskCommunicationEndpointUrl } from "@/lib/tasks/task-communic
 import { OUTBOUND_MESSAGE_OPERATION } from "@/lib/email/outbound-message-approval.server";
 import { listExternalActionRequestsForHuman } from "@/lib/tasks/external-action.server";
 import { TREATY_PARENT_TASK_ID } from "@/lib/tasks/task-keys";
+import { resolveTaskReferenceLinks } from "@/lib/tasks/task-reference-links.server";
 import {
   canUserManageTask,
   TASK_NOT_FOUND_MESSAGE,
@@ -453,6 +454,11 @@ export default async function TaskDetailPage({
   }
 
   const { task, viewer, viewerClaim } = data;
+  const taskReferenceLinks = await resolveTaskReferenceLinks({
+    markdown: task.description,
+    personId: viewer?.personId,
+    userId,
+  });
   const isAssignedDocumentReviewer =
     documentReviewPageData?.panel.mode === "REVIEWER";
   const showDocumentReviewManager =
@@ -809,7 +815,10 @@ export default async function TaskDetailPage({
           <>
             <section className="border-b border-foreground py-6">
               <article className="min-w-0">
-                <TaskDescription markdown={task.description} />
+                <TaskDescription
+                  markdown={task.description}
+                  taskReferences={taskReferenceLinks}
+                />
               </article>
             </section>
 

--- a/packages/web/src/components/markdown/rich-markdown.tsx
+++ b/packages/web/src/components/markdown/rich-markdown.tsx
@@ -7,10 +7,15 @@ import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 import { MermaidBlock } from "./mermaid-block";
 import { ChartBlock, parseChartConfig } from "./chart-block";
+import {
+  createTaskReferenceLinksPlugin,
+  type TaskReferenceLink,
+} from "@/lib/tasks/task-reference-links";
 
 interface RichMarkdownProps {
   markdown: string;
   className?: string;
+  taskReferences?: readonly TaskReferenceLink[];
 }
 
 /**
@@ -28,15 +33,22 @@ interface RichMarkdownProps {
  * comment actually contains one of those fence types. Zero bundle cost
  * for text-only content.
  */
-export function RichMarkdown({ markdown, className }: RichMarkdownProps) {
+export function RichMarkdown({
+  markdown,
+  className,
+  taskReferences = [],
+}: RichMarkdownProps) {
   return (
-    <div className={`task-markdown space-y-3 text-[15px] leading-[1.6] text-foreground ${className ?? ""}`}>
+    <div
+      className={`task-markdown space-y-3 text-[15px] leading-[1.6] text-foreground ${className ?? ""}`}
+    >
       <ReactMarkdown
         remarkPlugins={[
           remarkGfm,
           // Disable single-`$` inline math so currency like "$27.2B" isn't
           // misparsed as a math delimiter. Block math with `$$...$$` still works.
           [remarkMath, { singleDollarTextMath: false }],
+          createTaskReferenceLinksPlugin(taskReferences),
         ]}
         rehypePlugins={[rehypeKatex]}
         components={getRichMarkdownComponents()}

--- a/packages/web/src/components/tasks/task-description.test.ts
+++ b/packages/web/src/components/tasks/task-description.test.ts
@@ -4,10 +4,7 @@
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  getTaskDescriptionSummary,
-  TaskDescription,
-} from "./task-description";
+import { getTaskDescriptionSummary, TaskDescription } from "./task-description";
 
 describe("getTaskDescriptionSummary", () => {
   it("treats escaped line breaks as markdown paragraph boundaries", () => {
@@ -57,5 +54,47 @@ describe("TaskDescription", () => {
         item.textContent?.trim(),
       ),
     ).toEqual(["First item"]);
+  });
+
+  it("links accessible bare task IDs without changing protected markdown", async () => {
+    const accessibleId = "cautolinkpublic0000000000";
+    const inaccessibleId = "cautolinkprivate000000000";
+
+    await act(async () => {
+      root.render(
+        React.createElement(TaskDescription, {
+          markdown: [
+            `Read ${accessibleId} and keep ${inaccessibleId} private.`,
+            `Inline code: \`${accessibleId}\`.`,
+            `[Existing link](/tasks/${accessibleId}).`,
+          ].join("\n\n"),
+          taskReferences: [
+            {
+              href: `/tasks/${accessibleId}`,
+              id: accessibleId,
+              title: "Accessible task title",
+            },
+          ],
+        }),
+      );
+    });
+
+    expect(
+      Array.from(container.querySelectorAll("a")).map((link) => ({
+        href: link.getAttribute("href"),
+        text: link.textContent,
+      })),
+    ).toEqual([
+      {
+        href: `/tasks/${accessibleId}`,
+        text: "Accessible task title",
+      },
+      {
+        href: `/tasks/${accessibleId}`,
+        text: "Existing link",
+      },
+    ]);
+    expect(container.querySelector("code")?.textContent).toBe(accessibleId);
+    expect(container.textContent).toContain(inaccessibleId);
   });
 });

--- a/packages/web/src/components/tasks/task-description.tsx
+++ b/packages/web/src/components/tasks/task-description.tsx
@@ -1,5 +1,6 @@
 import { RichMarkdown } from "@/components/markdown/rich-markdown";
 import { normalizeTaskTextLineBreaks } from "@/lib/task-text";
+import type { TaskReferenceLink } from "@/lib/tasks/task-reference-links";
 
 /**
  * Render a task description as markdown with the neobrutalist typography system.
@@ -8,11 +9,18 @@ import { normalizeTaskTextLineBreaks } from "@/lib/task-text";
  * also handles inline math, mermaid diagrams, chart fences, and everything else
  * across the app. This keeps existing call sites working without changes.
  */
-export function TaskDescription({ markdown }: { markdown: string }) {
+export function TaskDescription({
+  markdown,
+  taskReferences = [],
+}: {
+  markdown: string;
+  taskReferences?: readonly TaskReferenceLink[];
+}) {
   return (
     <RichMarkdown
       markdown={normalizeTaskTextLineBreaks(markdown)}
       className="task-description"
+      taskReferences={taskReferences}
     />
   );
 }
@@ -22,7 +30,10 @@ export function TaskDescription({ markdown }: { markdown: string }) {
  * OG images, and share text. Strips markdown syntax and returns the first
  * paragraph, truncated to maxLength chars.
  */
-export function getTaskDescriptionSummary(markdown: string, maxLength = 220): string {
+export function getTaskDescriptionSummary(
+  markdown: string,
+  maxLength = 220,
+): string {
   const normalizedMarkdown = normalizeTaskTextLineBreaks(markdown);
   const firstParagraph =
     normalizedMarkdown

--- a/packages/web/src/lib/tasks/task-reference-links.server.test.ts
+++ b/packages/web/src/lib/tasks/task-reference-links.server.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { prisma } from "@/lib/prisma";
+import { resolveTaskReferenceLinks } from "@/lib/tasks/task-reference-links.server";
+
+const TEST_PREFIX = "task_reference_links_";
+const PUBLIC_TASK_ID = "cautolinkpublic0000000000";
+const PRIVATE_TASK_ID = "cautolinkprivate000000000";
+const OWN_TASK_ID = "cautolinkowned00000000000";
+
+async function cleanup() {
+  await prisma.task.deleteMany({
+    where: { createdByUserId: { startsWith: TEST_PREFIX } },
+  });
+  await prisma.user.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+  await prisma.person.deleteMany({
+    where: { id: { startsWith: TEST_PREFIX } },
+  });
+}
+
+async function createUser(suffix: string) {
+  const person = await prisma.person.create({
+    data: {
+      displayName: `Task reference ${suffix}`,
+      id: `${TEST_PREFIX}person_${suffix}`,
+    },
+  });
+  const user = await prisma.user.create({
+    data: {
+      email: `${TEST_PREFIX}${suffix}@example.test`,
+      id: `${TEST_PREFIX}user_${suffix}`,
+      personId: person.id,
+    },
+  });
+  return { person, user };
+}
+
+describe.sequential("resolveTaskReferenceLinks", () => {
+  beforeEach(cleanup);
+  afterAll(cleanup);
+
+  it("returns titles only for tasks the viewer can access", async () => {
+    const viewer = await createUser("viewer");
+    const other = await createUser("other");
+    await prisma.task.createMany({
+      data: [
+        {
+          createdByUserId: other.user.id,
+          description: "Public task.",
+          id: PUBLIC_TASK_ID,
+          isPublic: true,
+          title: "Public task title",
+        },
+        {
+          createdByUserId: other.user.id,
+          description: "Private task.",
+          id: PRIVATE_TASK_ID,
+          isPublic: false,
+          title: "Private task title",
+        },
+        {
+          createdByUserId: viewer.user.id,
+          description: "Viewer-owned task.",
+          id: OWN_TASK_ID,
+          isPublic: false,
+          title: "Viewer task title",
+        },
+      ],
+    });
+    const markdown = `${PRIVATE_TASK_ID} ${PUBLIC_TASK_ID} ${OWN_TASK_ID}`;
+
+    await expect(
+      resolveTaskReferenceLinks({
+        markdown,
+        personId: viewer.person.id,
+        userId: viewer.user.id,
+      }),
+    ).resolves.toEqual([
+      {
+        href: `/tasks/${PUBLIC_TASK_ID}`,
+        id: PUBLIC_TASK_ID,
+        title: "Public task title",
+      },
+      {
+        href: `/tasks/${OWN_TASK_ID}`,
+        id: OWN_TASK_ID,
+        title: "Viewer task title",
+      },
+    ]);
+
+    await expect(
+      resolveTaskReferenceLinks({ markdown, userId: null }),
+    ).resolves.toEqual([
+      {
+        href: `/tasks/${PUBLIC_TASK_ID}`,
+        id: PUBLIC_TASK_ID,
+        title: "Public task title",
+      },
+    ]);
+  });
+});

--- a/packages/web/src/lib/tasks/task-reference-links.server.ts
+++ b/packages/web/src/lib/tasks/task-reference-links.server.ts
@@ -1,0 +1,37 @@
+import { prisma } from "@/lib/prisma";
+import { getTaskVisibilityWhere } from "@/lib/tasks/task-visibility.server";
+import {
+  extractTaskReferenceIds,
+  type TaskReferenceLink,
+} from "@/lib/tasks/task-reference-links";
+
+export async function resolveTaskReferenceLinks(input: {
+  markdown: string;
+  personId?: string | null;
+  userId?: string | null;
+}): Promise<TaskReferenceLink[]> {
+  const taskIds = extractTaskReferenceIds(input.markdown);
+  if (taskIds.length === 0) return [];
+
+  const tasks = await prisma.task.findMany({
+    where: {
+      AND: [
+        getTaskVisibilityWhere({
+          personId: input.personId,
+          userId: input.userId,
+          visibility: "accessible",
+        }),
+        { id: { in: taskIds } },
+      ],
+    },
+    select: { id: true, title: true },
+  });
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+
+  return taskIds.flatMap((id) => {
+    const task = taskById.get(id);
+    return task
+      ? [{ href: `/tasks/${task.id}`, id: task.id, title: task.title }]
+      : [];
+  });
+}

--- a/packages/web/src/lib/tasks/task-reference-links.ts
+++ b/packages/web/src/lib/tasks/task-reference-links.ts
@@ -1,0 +1,95 @@
+export interface TaskReferenceLink {
+  href: string;
+  id: string;
+  title: string;
+}
+
+interface MarkdownNode {
+  children?: MarkdownNode[];
+  type: string;
+  url?: string;
+  value?: string;
+}
+
+const TASK_ID_SOURCE = String.raw`\bc[a-z0-9]{24}\b`;
+const PROTECTED_MARKDOWN_NODE_TYPES = new Set([
+  "code",
+  "definition",
+  "image",
+  "imageReference",
+  "inlineCode",
+  "link",
+  "linkReference",
+]);
+
+function taskIdPattern() {
+  return new RegExp(TASK_ID_SOURCE, "g");
+}
+
+export function extractTaskReferenceIds(markdown: string): string[] {
+  return [...new Set(markdown.match(taskIdPattern()) ?? [])];
+}
+
+function linkTextNode(
+  node: MarkdownNode,
+  referenceById: ReadonlyMap<string, TaskReferenceLink>,
+): MarkdownNode[] {
+  const value = node.value ?? "";
+  const replacements: MarkdownNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of value.matchAll(taskIdPattern())) {
+    const id = match[0];
+    const index = match.index;
+    const reference = referenceById.get(id);
+    if (!reference) continue;
+
+    if (index > lastIndex) {
+      replacements.push({ type: "text", value: value.slice(lastIndex, index) });
+    }
+    replacements.push({
+      type: "link",
+      url: reference.href,
+      children: [{ type: "text", value: reference.title }],
+    });
+    lastIndex = index + id.length;
+  }
+
+  if (lastIndex === 0) return [node];
+  if (lastIndex < value.length) {
+    replacements.push({ type: "text", value: value.slice(lastIndex) });
+  }
+  return replacements;
+}
+
+function linkTaskReferences(
+  node: MarkdownNode,
+  referenceById: ReadonlyMap<string, TaskReferenceLink>,
+) {
+  if (!node.children || PROTECTED_MARKDOWN_NODE_TYPES.has(node.type)) return;
+
+  const children: MarkdownNode[] = [];
+  for (const child of node.children) {
+    if (child.type === "text") {
+      children.push(...linkTextNode(child, referenceById));
+      continue;
+    }
+    linkTaskReferences(child, referenceById);
+    children.push(child);
+  }
+  node.children = children;
+}
+
+export function createTaskReferenceLinksPlugin(
+  references: readonly TaskReferenceLink[],
+) {
+  const referenceById = new Map(
+    references.map((reference) => [reference.id, reference]),
+  );
+
+  return function remarkTaskReferenceLinks() {
+    return function transformTaskReferenceLinks(tree: MarkdownNode) {
+      linkTaskReferences(tree, referenceById);
+    };
+  };
+}


### PR DESCRIPTION
## Why

Task descriptions can contain bare CUID task IDs. They are not useful to readers because they cannot be clicked and reveal no task title. MCP task creation and update instructions already tell agents to write titled Markdown links, but existing descriptions still need a render-time repair.

## What changed

- Resolve CUID references through the same viewer-specific task visibility predicate used by task pages.
- Render accessible bare IDs as internal links labeled with the referenced task title.
- Leave inaccessible IDs as plain text so private titles cannot leak.
- Preserve inline code, code blocks, images, and existing Markdown links.
- Seed a deterministic task-page fixture and require the resolved title in visual review.

## Verification

- 4 focused resolver and DOM tests pass.
- Web app and test TypeScript checks pass.
- 12 task-detail Playwright captures pass across desktop and mobile.
- Visual review covers all 3 changed UI files with no blocking issues.
- `git diff --check` passes.

## Visual review

Captured and inspected locally. The management form keeps the raw editable ID, while the rendered task body shows the underlined title `Review the filing evidence`. No clipping, overlap, or responsive breakage appeared. Screenshot artifacts were not uploaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task references in descriptions now appear as clickable links when the referenced task is accessible.
  * Links display the referenced task’s title and respect privacy and viewer permissions.
  * Public task references remain available to anonymous viewers.
* **Bug Fixes**
  * Task IDs in code, images, definitions, and existing links are preserved without unintended conversion.
  * Unavailable or invalid task references remain plain text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->