### PR TITLE
Make flyer outreach the poster page action

### DIFF
--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -180,6 +180,13 @@ const VISUAL_COVERS_BY_PATH = new Map<string, string[]>([
   ],
   [ROUTES.game, OPTIMITRON_GAME_LANDING_FILES],
   [ROUTES.methodology, ["packages/web/src/app/methodology/page.tsx"]],
+  [
+    ROUTES.poster,
+    [
+      "packages/web/src/app/poster/page.tsx",
+      "packages/web/src/app/poster/poster-client.tsx",
+    ],
+  ],
   [ROUTES.invest, INVEST_LANDING_FILES],
   [ROUTES.profile, ["packages/web/src/components/Providers.tsx"]],
   [ROUTES.scoreboard, [POLITICIAN_SCORECARD_TABLE_FILE]],
@@ -194,6 +201,10 @@ const REQUIRED_SELECTOR_BY_PATH = new Map<string, string>([
   [ROUTES.eos, "h1"],
   [ROUTES.game, "#vote"],
   [ROUTES.methodology, "#methodology"],
+  [
+    ROUTES.poster,
+    'button[aria-label="Copy the flyer route prompt for your AI"]',
+  ],
   // Last section of the page: proves the capture rendered the whole pitch,
   // not just the hero.
   [ROUTES.invest, "#claim"],
@@ -361,10 +372,7 @@ const SEEDED_DYNAMIC_ROUTES: VisualRoute[] = [
     requiredText: /^Estimate$/,
   },
   {
-    covers: [
-      TASK_TREE_VIEW_FILE,
-      "packages/web/src/app/tasks/tree/page.tsx",
-    ],
+    covers: [TASK_TREE_VIEW_FILE, "packages/web/src/app/tasks/tree/page.tsx"],
     name: "tasks-tree",
     path: "/tasks/tree",
     required: true,

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -201,10 +201,7 @@ const REQUIRED_SELECTOR_BY_PATH = new Map<string, string>([
   [ROUTES.eos, "h1"],
   [ROUTES.game, "#vote"],
   [ROUTES.methodology, "#methodology"],
-  [
-    ROUTES.poster,
-    'button[aria-label="Copy the flyer route prompt for your AI"]',
-  ],
+  [ROUTES.poster, '[data-visual-action="copy-flyer-route-prompt"]'],
   // Last section of the page: proves the capture rendered the whole pitch,
   // not just the hero.
   [ROUTES.invest, "#claim"],

--- a/packages/web/src/app/poster/page.logged-out.md
+++ b/packages/web/src/app/poster/page.logged-out.md
@@ -2,26 +2,29 @@
 
 ## Metadata
 
-- Page title: International Campaign to End War and Disease
-- Meta description: Let's trade one apocalypse out of humanity's 122-apocalypse mass-murder capacity for disease eradication in 36 years instead of 443.
-- Canonical: [missing]
-- Open Graph title: International Campaign to End War and Disease
-- Open Graph description: Let's trade one apocalypse out of humanity's 122-apocalypse mass-murder capacity for disease eradication in 36 years instead of 443.
-- Open Graph image: https://warondisease.org/site-assets/warondisease/war-on-disease-og-1200x630.png
-- Twitter title: International Campaign to End War and Disease
-- Twitter description: Let's trade one apocalypse out of humanity's 122-apocalypse mass-murder capacity for disease eradication in 36 years instead of 443.
+- Page title: Hang Up Flyers | International Campaign to End War and Disease
+- Meta description: Every human on earth would be vastly richer and significantly less dead if we agreed to sacrifice one of our 122 apocalypse capacity for disease eradication. Hang referral flyers where humans will see them and let nearby foot traffic recruit voters while you do something else.
+- Canonical: https://warondisease.org/poster
+- Open Graph title: Hang Up Flyers
+- Open Graph description: Every human on earth would be vastly richer and significantly less dead if we agreed to sacrifice one of our 122 apocalypse capacity for disease eradication. Hang referral flyers where humans will see them and let nearby foot traffic recruit voters while you do something else.
+- Open Graph image: https://warondisease.org/api/og/route?path=%2Fposter
+- Twitter title: Hang Up Flyers
+- Twitter description: Every human on earth would be vastly richer and significantly less dead if we agreed to sacrifice one of our 122 apocalypse capacity for disease eradication. Hang referral flyers where humans will see them and let nearby foot traffic recruit voters while you do something else.
 
 ## Visible Page Copy
 
-## PRINT YOUR REFERRAL POSTER
-- Print it, tape it up, and share it. Every human who votes through your link earns you optimization points and moves humanity one click closer to ending war and disease.
+## HANG UP FLYERS
+- Print these flyers and put them where humans will see them. Every human who votes through your link earns you optimization points and moves humanity one click closer to ending war and disease.
 - Going door to door? [Print the YES signature sheet](/door-to-door) instead.
 - This prints the generic campaign URL. [Sign in](/auth/signin) to personalize the URL and QR code.
-- PRINT
+- PRINT FLYERS
 - COPY LINK
 - [LETTER](/poster)
 - [A4](/poster?paper=a4)
-- [CARD](/poster?paper=card)
+### MAKE YOUR AI PLAN THE ROUTE
+- Your AI can make the list. You can operate tape. Copy this prompt and let it put nearby places in a useful order.
+- Plan a one-hour flyer route for me. Use my current location if you have it. Otherwise, ask for my neighborhood or ZIP code. Find nearby places likely to permit community flyers, such as libraries, coffee shops, community centers, campuses, laundromats, grocery stores, clinics, and public bulletin boards. Rank them by likely permission, foot traffic, opening hours, and travel time. Put them in the best order to visit. Include each address and tell me whom to ask before posting. Do not recommend posting anywhere without permission.
+- COPY AI PROMPT
 ### PLEASE TAKE 30 SECONDS TO END WAR AND DISEASE
 - SCAN OR TYPE
 - WARONDISEASE.ORG

--- a/packages/web/src/app/poster/page.tsx
+++ b/packages/web/src/app/poster/page.tsx
@@ -4,17 +4,25 @@ import type { CSSProperties } from "react";
 import { CampaignQrCode } from "@/components/sharing/campaign-qr-code";
 import { authOptions } from "@/lib/auth";
 import { CAMPAIGN_PRINT_COPY } from "@/lib/messaging";
-import { ROUTES } from "@/lib/routes";
+import { getRouteMetadata } from "@/lib/metadata";
+import { posterLink, ROUTES } from "@/lib/routes";
 import { buildUserReferralUrl } from "@/lib/url";
-import { PosterCopyLinkButton, PosterPrintButton } from "./poster-client";
+import {
+  FlyerRoutePromptCopyButton,
+  PosterCopyLinkButton,
+  PosterPrintButton,
+} from "./poster-client";
 
 const CAMPAIGN_ORIGIN = "https://warondisease.org";
 const POSTER_FAVICON_SRC = "/site-assets/warondisease/warondisease-favicon.png";
+const FLYER_ROUTE_PROMPT =
+  "Plan a one-hour flyer route for me. Use my current location if you have it. Otherwise, ask for my neighborhood or ZIP code. Find nearby places likely to permit community flyers, such as libraries, coffee shops, community centers, campuses, laundromats, grocery stores, clinics, and public bulletin boards. Rank them by likely permission, foot traffic, opening hours, and travel time. Put them in the best order to visit. Include each address and tell me whom to ask before posting. Do not recommend posting anywhere without permission.";
 
-type PaperSize = "letter" | "a4" | "card";
+export const metadata = getRouteMetadata(posterLink);
+
+type PaperSize = "letter" | "a4";
 
 function normalizePaperSize(value: string | string[] | undefined): PaperSize {
-  if (value === "card") return "card";
   return value === "a4" ? "a4" : "letter";
 }
 
@@ -25,11 +33,9 @@ function getVisibleTargetUrl(qrTarget: string) {
 function getPosterUrlStyle(visibleTargetUrl: string): CSSProperties {
   const normalizedLength = Math.max(visibleTargetUrl.length, 1);
   const fontCqw = Math.min(7.9, Math.max(3, 130 / normalizedLength));
-  const cardFontCqw = Math.min(5.8, Math.max(3, 126 / normalizedLength));
 
   return {
     "--poster-url-font-size": `${fontCqw.toFixed(2)}cqw`,
-    "--poster-card-url-font-size": `${cardFontCqw.toFixed(2)}cqw`,
     whiteSpace: normalizedLength <= 42 ? "nowrap" : undefined,
   } as CSSProperties;
 }
@@ -137,52 +143,6 @@ export default async function PosterPage({
           font-size: clamp(1.05rem, 3.8cqw, 0.3in);
         }
 
-        .poster-sheet[data-paper-size="card"] {
-          width: min(100%, 3.5in);
-          min-height: 2in;
-        }
-
-        .poster-card-line {
-          display: block;
-          font-weight: 900;
-          line-height: 0.98;
-          text-transform: uppercase;
-          white-space: nowrap;
-        }
-
-        .poster-card-line-0 {
-          font-size: clamp(0.86rem, 7.8cqw, 0.22in);
-        }
-
-        .poster-card-line-1 {
-          font-size: clamp(1rem, 9.4cqw, 0.265in);
-        }
-
-        .poster-card-line-2 {
-          font-size: clamp(0.8rem, 7.2cqw, 0.2in);
-        }
-
-        .poster-card-line-3 {
-          font-size: clamp(0.86rem, 7.8cqw, 0.22in);
-        }
-
-        .poster-card-url {
-          display: block;
-          font-family: "Courier New", monospace;
-          font-size: clamp(0.55rem, var(--poster-card-url-font-size), 0.19in);
-          font-weight: 900;
-          line-height: 1;
-          overflow-wrap: anywhere;
-          text-transform: uppercase;
-          word-break: break-word;
-        }
-
-        .poster-card-qr svg {
-          display: block;
-          width: min(30cqw, 1in);
-          height: auto;
-        }
-
         @media print {
           @page {
             size: letter;
@@ -196,11 +156,6 @@ export default async function PosterPage({
 
           @page poster-a4 {
             size: A4;
-            margin: 0;
-          }
-
-          @page poster-card {
-            size: 3.5in 2in;
             margin: 0;
           }
 
@@ -325,39 +280,6 @@ export default async function PosterPage({
             width: 1.25in !important;
           }
 
-          .poster-sheet[data-paper-size="card"] {
-            page: poster-card;
-            width: 3.5in !important;
-            height: 2in !important;
-            min-height: 2in !important;
-            max-height: 2in !important;
-            padding: 0.12in !important;
-          }
-
-          .poster-card-line-0 {
-            font-size: 0.22in !important;
-          }
-
-          .poster-card-line-1 {
-            font-size: 0.265in !important;
-          }
-
-          .poster-card-line-2 {
-            font-size: 0.2in !important;
-          }
-
-          .poster-card-line-3 {
-            font-size: 0.22in !important;
-          }
-
-          .poster-card-url {
-            font-size: clamp(0.1in, var(--poster-card-url-font-size), 0.18in) !important;
-          }
-
-          .poster-card-qr svg {
-            width: 1in !important;
-            height: 1in !important;
-          }
         }
       `}</style>
 
@@ -367,12 +289,12 @@ export default async function PosterPage({
       >
         <div className="max-w-3xl">
           <h1 className="text-4xl font-black uppercase leading-none text-foreground sm:text-5xl md:text-6xl">
-            Print your referral poster
+            Hang up flyers
           </h1>
           <p className="mt-3 max-w-2xl text-base font-bold leading-relaxed text-foreground sm:text-lg">
-            Print it, tape it up, and share it. Every human who votes through
-            your link earns you optimization points and moves humanity one
-            click closer to ending war and disease.
+            Print these flyers and put them where humans will see them. Every
+            human who votes through your link earns you optimization points and
+            moves humanity one click closer to ending war and disease.
           </p>
           <p className="mt-3 text-sm font-bold text-foreground">
             Going door to door?{" "}
@@ -386,12 +308,15 @@ export default async function PosterPage({
           </p>
           {hasPersonalReferralUrl ? (
             <p className="mt-2 break-all text-sm font-bold text-muted-foreground">
-              This poster uses your referral link: {visibleTargetUrl}
+              These flyers use your referral link: {visibleTargetUrl}
             </p>
           ) : (
             <p className="mt-2 text-sm font-bold text-muted-foreground">
               This prints the generic campaign URL.{" "}
-              <Link className="underline underline-offset-4" href={ROUTES.signIn}>
+              <Link
+                className="underline underline-offset-4"
+                href={ROUTES.signIn}
+              >
                 Sign in
               </Link>{" "}
               to personalize the URL and QR code.
@@ -400,7 +325,7 @@ export default async function PosterPage({
         </div>
 
         <div className="flex flex-wrap items-center gap-2 text-sm font-bold uppercase text-foreground">
-          <PosterPrintButton />
+          <PosterPrintButton label="Print flyers" />
           <PosterCopyLinkButton value={qrTarget} />
           <div className="flex items-center gap-2">
             <Link
@@ -425,103 +350,76 @@ export default async function PosterPage({
             >
               A4
             </Link>
-            <Link
-              aria-current={paperSize === "card" ? "page" : undefined}
-              className={`border-2 border-foreground px-3 py-2 ${
-                paperSize === "card"
-                  ? "bg-foreground text-background"
-                  : "bg-background text-foreground hover:bg-muted"
-              }`}
-              href={`${ROUTES.poster}?paper=card`}
-            >
-              Card
-            </Link>
           </div>
+        </div>
+
+        <div className="mt-2 max-w-3xl border-t border-foreground pt-5">
+          <h2 className="text-2xl font-black uppercase leading-tight text-foreground sm:text-3xl">
+            Make your AI plan the route
+          </h2>
+          <p className="mt-2 max-w-2xl font-bold leading-relaxed text-foreground">
+            Your AI can make the list. You can operate tape. Copy this prompt
+            and let it put nearby places in a useful order.
+          </p>
+          <blockquote className="my-4 border-l-2 border-foreground pl-4 text-sm font-bold leading-relaxed text-foreground sm:text-base">
+            {FLYER_ROUTE_PROMPT}
+          </blockquote>
+          <FlyerRoutePromptCopyButton value={FLYER_ROUTE_PROMPT} />
         </div>
       </div>
 
       <article
-        aria-label={`Printable War on Disease referral poster for ${visibleTargetUrl}`}
-        className={`poster-sheet mx-auto border-2 border-foreground bg-background text-foreground ${
-          paperSize === "card"
-            ? "grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[minmax(0,1fr)_auto] items-center gap-x-[clamp(0.3rem,2vw,0.08in)] gap-y-[clamp(0.16rem,1.5vw,0.06in)] p-[clamp(0.45rem,4vw,0.12in)]"
-            : "flex flex-col justify-center gap-[clamp(1.35rem,6vw,0.82in)] p-[clamp(1rem,5vw,0.62in)]"
-        }`}
+        aria-label={`Printable War on Disease referral flyer for ${visibleTargetUrl}`}
+        className="poster-sheet mx-auto flex flex-col justify-center gap-[clamp(1.35rem,6vw,0.82in)] border-2 border-foreground bg-background p-[clamp(1rem,5vw,0.62in)] text-foreground"
         data-paper-size={paperSize}
       >
-        {paperSize === "card" ? (
-          <>
-            <div className="min-w-0 text-left">
-              {CAMPAIGN_PRINT_COPY.businessCardLines.slice(0, -1).map((line, index) => (
-                <span
-                  className={`poster-card-line poster-card-line-${index}`}
-                  key={line}
-                >
-                  {line}
-                </span>
-              ))}
-            </div>
-            <div className="poster-card-qr w-fit border-2 border-foreground bg-background p-[clamp(0.16rem,1.4vw,0.06in)]">
+        <div className="flex min-h-0 items-center justify-center text-center">
+          <h2 className="poster-headline w-full max-w-full uppercase tracking-normal text-foreground">
+            {CAMPAIGN_PRINT_COPY.flyerHeadlineLines.map((line, index) => (
+              <span
+                className={`poster-headline-line poster-headline-line-${index}`}
+                key={line}
+              >
+                {line}
+              </span>
+            ))}
+          </h2>
+        </div>
+
+        <footer className="poster-footer">
+          <div className="poster-qr-row">
+            <img
+              alt=""
+              aria-hidden="true"
+              className="poster-favicon"
+              height={512}
+              src={POSTER_FAVICON_SRC}
+              width={512}
+            />
+            <div className="poster-qr w-fit border-2 border-foreground bg-background p-[clamp(0.45rem,2vw,0.15in)]">
               <CampaignQrCode value={qrTarget} />
             </div>
+            <img
+              alt=""
+              aria-hidden="true"
+              className="poster-favicon"
+              height={512}
+              src={POSTER_FAVICON_SRC}
+              width={512}
+            />
+          </div>
+          <div className="min-w-0">
+            <p className="poster-url-label font-bold uppercase leading-none text-muted-foreground">
+              Scan or type
+            </p>
             <p
-              className="poster-card-url col-span-2 min-w-0 text-center"
+              className="poster-visible-url mt-2 font-bold uppercase leading-none text-foreground"
               style={visibleTargetUrlStyle}
             >
               {visibleTargetUrl}
             </p>
-          </>
-        ) : (
-          <>
-            <div className="flex min-h-0 items-center justify-center text-center">
-              <h2 className="poster-headline w-full max-w-full uppercase tracking-normal text-foreground">
-                {CAMPAIGN_PRINT_COPY.flyerHeadlineLines.map((line, index) => (
-                  <span
-                    className={`poster-headline-line poster-headline-line-${index}`}
-                    key={line}
-                  >
-                    {line}
-                  </span>
-                ))}
-              </h2>
-            </div>
-
-            <footer className="poster-footer">
-              <div className="poster-qr-row">
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  className="poster-favicon"
-                  height={512}
-                  src={POSTER_FAVICON_SRC}
-                  width={512}
-                />
-                <div className="poster-qr w-fit border-2 border-foreground bg-background p-[clamp(0.45rem,2vw,0.15in)]">
-                  <CampaignQrCode value={qrTarget} />
-                </div>
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  className="poster-favicon"
-                  height={512}
-                  src={POSTER_FAVICON_SRC}
-                  width={512}
-                />
-              </div>
-              <div className="min-w-0">
-                <p className="poster-url-label font-bold uppercase leading-none text-muted-foreground">
-                  Scan or type
-                </p>
-                <p
-                  className="poster-visible-url mt-2 font-bold uppercase leading-none text-foreground"
-                  style={visibleTargetUrlStyle}
-                >
-                  {visibleTargetUrl}
-                </p>
-              </div>
-            </footer>
-          </>
-        )}
+          </div>
+        </footer>
       </article>
     </section>
   );

--- a/packages/web/src/app/poster/poster-client.tsx
+++ b/packages/web/src/app/poster/poster-client.tsx
@@ -4,19 +4,27 @@ import { useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { copyTextToClipboard } from "@/lib/clipboard";
 
-export function PosterPrintButton() {
+export function PosterPrintButton({ label = "Print" }: { label?: string }) {
   return (
     <button
       type="button"
       className="border-2 border-foreground bg-foreground px-4 py-2 text-sm font-black uppercase text-background transition-colors hover:bg-background hover:text-foreground"
       onClick={() => window.print()}
     >
-      Print
+      {label}
     </button>
   );
 }
 
-export function PosterCopyLinkButton({ value }: { value: string }) {
+function CopyTextButton({
+  ariaLabel,
+  idleLabel,
+  value,
+}: {
+  ariaLabel: string;
+  idleLabel: string;
+  value: string;
+}) {
   const [copyState, setCopyState] = useState<"copied" | "error" | "idle">(
     "idle",
   );
@@ -36,7 +44,7 @@ export function PosterCopyLinkButton({ value }: { value: string }) {
   return (
     <button
       type="button"
-      aria-label="Copy poster referral link"
+      aria-label={ariaLabel}
       className="inline-flex items-center gap-2 border-2 border-foreground bg-background px-4 py-2 text-sm font-black uppercase text-foreground transition-colors hover:bg-foreground hover:text-background"
       onClick={handleCopy}
     >
@@ -49,7 +57,27 @@ export function PosterCopyLinkButton({ value }: { value: string }) {
         ? "Copied"
         : copyState === "error"
           ? "Copy failed"
-          : "Copy link"}
+          : idleLabel}
     </button>
+  );
+}
+
+export function PosterCopyLinkButton({ value }: { value: string }) {
+  return (
+    <CopyTextButton
+      ariaLabel="Copy referral link"
+      idleLabel="Copy link"
+      value={value}
+    />
+  );
+}
+
+export function FlyerRoutePromptCopyButton({ value }: { value: string }) {
+  return (
+    <CopyTextButton
+      ariaLabel="Copy the flyer route prompt for your AI"
+      idleLabel="Copy AI prompt"
+      value={value}
+    />
   );
 }

--- a/packages/web/src/app/poster/poster-client.tsx
+++ b/packages/web/src/app/poster/poster-client.tsx
@@ -20,10 +20,12 @@ function CopyTextButton({
   ariaLabel,
   idleLabel,
   value,
+  visualAction,
 }: {
   ariaLabel: string;
   idleLabel: string;
   value: string;
+  visualAction?: string;
 }) {
   const [copyState, setCopyState] = useState<"copied" | "error" | "idle">(
     "idle",
@@ -46,6 +48,7 @@ function CopyTextButton({
       type="button"
       aria-label={ariaLabel}
       className="inline-flex items-center gap-2 border-2 border-foreground bg-background px-4 py-2 text-sm font-black uppercase text-foreground transition-colors hover:bg-foreground hover:text-background"
+      data-visual-action={visualAction}
       onClick={handleCopy}
     >
       {copyState === "copied" ? (
@@ -78,6 +81,7 @@ export function FlyerRoutePromptCopyButton({ value }: { value: string }) {
       ariaLabel="Copy the flyer route prompt for your AI"
       idleLabel="Copy AI prompt"
       value={value}
+      visualAction="copy-flyer-route-prompt"
     />
   );
 }

--- a/packages/web/src/lib/messaging.ts
+++ b/packages/web/src/lib/messaging.ts
@@ -37,13 +37,6 @@ export {
 };
 
 export const CAMPAIGN_PRINT_COPY = {
-  businessCardLines: [
-    "Please take",
-    "30 seconds",
-    "to end war",
-    "and disease",
-    "warondisease.org",
-  ],
   flyerHeadlineLines: [
     "Please take",
     "30 seconds",

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -1261,13 +1261,13 @@ export const messagesLink: NavItem = {
 
 export const posterLink: NavItem = {
   href: ROUTES.poster,
-  label: "Print a Poster",
+  label: "Hang Up Flyers",
   emoji: "📄",
-  description: `Every human on earth would be vastly richer and significantly less dead if we agreed to sacrifice one of our ${apocalypseCount} apocalypse capacity for disease eradication. A poster taped to a wall recruits voters who agree to this arrangement around the clock, without needing you in the room.`,
-  tagline: "Print your campaign QR code.",
+  description: `Every human on earth would be vastly richer and significantly less dead if we agreed to sacrifice one of our ${apocalypseCount} apocalypse capacity for disease eradication. Hang referral flyers where humans will see them and let nearby foot traffic recruit voters while you do something else.`,
+  tagline: "Print flyers. Ask your AI for a route. Hang them up.",
   copyPreview: true,
   screenshot: true,
-  cta: "Print",
+  cta: "Hang Flyers",
 };
 
 export const computeLink: NavItem = {


### PR DESCRIPTION
## User story and mission payoff

A human willing to do local outreach should see the real job: hang referral flyers where people will notice them. The page now carries that action through printing, local route planning, permission, and placement so more nearby humans can reach the 1% Treaty vote.

## What changed

- Renamed the navigation item and page from **Print a Poster** to **Hang Up Flyers**.
- Added the missing route metadata export, so the browser tab now reads **Hang Up Flyers | International Campaign to End War and Disease** instead of only the site name.
- Added a copyable AI prompt that requests nearby permitted locations in an efficient order, ranked by foot traffic, opening hours, permission likelihood, and travel time.
- Kept Letter and A4 flyer formats. Removed the unrelated business-card option and its dead layout code.
- Added explicit visual-review coverage for the page and its client-side copy controls.

## Copy review

- **Before:** Print a Poster
  **After:** Hang Up Flyers
- **Before:** Print your referral poster
  **After:** Hang up flyers
- **Before:** Printing was the final action.
  **After:** Print flyers, ask an AI for a route, get permission, and hang them up.
- **New:** Copyable, permission-aware local flyer-route prompt.

## Verification

- Captured and inspected desktop and mobile before/after screenshots for `/poster?logout=1`.
- Captured and inspected desktop and mobile before/after screenshots for the logged-out side menu.
- Confirmed the Letter and A4 layouts render without visible overflow.
- Confirmed legacy `?paper=card` links fall back to the Letter flyer.
- Confirmed the page title and canonical metadata in the rendered copy snapshot.
- Confirmed the AI-prompt copy control is present and interactive.
- Local review coverage: 2/2 changed UI files, no missing screenshot pairs.
- The side-menu text change was smaller than the normal visual threshold, so the local review used a tighter threshold to surface it. No dynamic screenshot noise was masked.

## Checks

- [ ] Human copy review
- [ ] Human visual review
- [ ] Human merge approval

## Review pages

- [Hang Up Flyers](https://optimitron-web-git-feature-hang-up-flyers-mike-p-sinns-projects.vercel.app/poster?logout=1)