### PR TITLE
Add flyer hang nearby tasks and fix poster print blank page

### DIFF
--- a/packages/db/src/__tests__/flyer-hang-task-keys.test.ts
+++ b/packages/db/src/__tests__/flyer-hang-task-keys.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFlyerHangPlaceTaskKey,
+  getUserHangFlyersTaskKey,
+  isFlyerHangPlaceTaskKey,
+} from "../task-keys.js";
+
+describe("flyer hang task keys", () => {
+  it("builds stable place keys including negative longitudes", () => {
+    expect(
+      buildFlyerHangPlaceTaskKey({
+        placeId: "30.27:-97.74:library",
+        source: "grid",
+      }),
+    ).toBe("flyer-hang:place:grid:30.27:-97.74:library");
+  });
+
+  it("builds personal hangFlyers subtask keys", () => {
+    expect(getUserHangFlyersTaskKey("abc")).toBe(
+      "program:one-percent-treaty:user:abc:hangFlyers",
+    );
+    expect(isFlyerHangPlaceTaskKey(getUserHangFlyersTaskKey("abc"))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/db/src/managed-data/managed-task-triggers.ts
+++ b/packages/db/src/managed-data/managed-task-triggers.ts
@@ -251,6 +251,23 @@ const userOnboardingTreaty: ManagedTaskTriggerInput = {
       contributesToGate: true,
     },
     {
+      kind: "hangFlyers",
+      sortOrder: 35,
+      titleTemplate: "Print and hang referral flyers near you",
+      descriptionTemplate:
+        "Print your referral poster. Open nearby hang spots. Claim a board, ask before you tape, photograph the hung flyer, and mark the hang done. Rehang when a spot goes stale.",
+      category: "OUTREACH",
+      estimatedEffortHours: 0.5,
+      dueDays: 0,
+      creatorResolver: "actor",
+      assigneePersonResolver: "actor",
+      parentResolver: "trigger.parentSpec",
+      actionLinkUrlTemplate: "/poster",
+      actionLinkLabelTemplate: "Open poster and hang list",
+      // Optional outreach — does not block Humanity Manager promotion.
+      contributesToGate: false,
+    },
+    {
       kind: "phoneScript",
       sortOrder: 40,
       titleTemplate: HUMANITY_MANAGEMENT.callOneHumanTaskTitle,

--- a/packages/db/src/task-keys.ts
+++ b/packages/db/src/task-keys.ts
@@ -238,6 +238,42 @@ export function getUserTreatySubtaskKey(userId: string, kind: string) {
   return `${getUserTreatyTaskKey(userId)}:${kind}`;
 }
 
+// Flyer hang coordination (shared place tasks + personal plan subtask)
+
+/** Shared parent under the 1% Treaty for public flyer-hang place tasks. */
+export const FLYER_HANG_PROGRAM_TASK_KEY =
+  "program:one-percent-treaty:flyer-hang";
+
+/** Prefix for durable place / grid-slot hang tasks. */
+export const FLYER_HANG_PLACE_TASK_KEY_PREFIX = "flyer-hang:place";
+
+/** Personal onboarding subtask kind: print and hang nearby. */
+export const USER_TREATY_HANG_FLYERS_SUBTASK_KIND = "hangFlyers";
+
+export function buildFlyerHangPlaceTaskKey(input: {
+  placeId: string;
+  source: string;
+}) {
+  const source = input.source.trim().toLowerCase();
+  const placeId = input.placeId.trim().toLowerCase();
+  if (!/^[a-z0-9_-]+$/.test(source) || !/^[a-z0-9._+:-]+$/i.test(placeId)) {
+    throw new Error(
+      `Invalid flyer hang place key parts: ${input.source}/${input.placeId}`,
+    );
+  }
+  return `${FLYER_HANG_PLACE_TASK_KEY_PREFIX}:${source}:${placeId}`;
+}
+
+export function isFlyerHangPlaceTaskKey(taskKey: string | null | undefined) {
+  return (
+    taskKey != null && taskKey.startsWith(`${FLYER_HANG_PLACE_TASK_KEY_PREFIX}:`)
+  );
+}
+
+export function getUserHangFlyersTaskKey(userId: string) {
+  return getUserTreatySubtaskKey(userId, USER_TREATY_HANG_FLYERS_SUBTASK_KIND);
+}
+
 // Signer reminder subtask
 
 export const SIGNER_REMINDER_TASK_KEY_PREFIX =

--- a/packages/web/src/app/api/auth/post-signin/route.test.ts
+++ b/packages/web/src/app/api/auth/post-signin/route.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  after: vi.fn(),
   applyPostSigninSync: vi.fn(),
   requireAuth: vi.fn(),
+  seedNearbyFlyerHangTasksAfterSignin: vi.fn(),
 }));
 
 vi.mock("@/lib/auth-utils", () => ({
@@ -11,14 +13,29 @@ vi.mock("@/lib/auth-utils", () => ({
 
 vi.mock("@/lib/post-signin-sync.server", () => ({
   applyPostSigninSync: mocks.applyPostSigninSync,
+  seedNearbyFlyerHangTasksAfterSignin: mocks.seedNearbyFlyerHangTasksAfterSignin,
 }));
+
+// after() only works inside a real Next.js request lifecycle; calling POST()
+// directly (like every other route unit test in this repo) doesn't set that
+// up, so after() itself is stubbed here. What matters for this test is that
+// the flyer-hang seed is deferred via after() with the right args, not that
+// after()'s own scheduling machinery runs.
+vi.mock("next/server", async () => {
+  const actual = await vi.importActual<typeof import("next/server")>(
+    "next/server",
+  );
+  return { ...actual, after: mocks.after };
+});
 
 import { POST } from "./route";
 
 describe("post-signin auth route", () => {
   beforeEach(() => {
+    mocks.after.mockReset();
     mocks.applyPostSigninSync.mockReset();
     mocks.requireAuth.mockReset();
+    mocks.seedNearbyFlyerHangTasksAfterSignin.mockReset();
   });
 
   it("returns 401 when authentication fails", async () => {
@@ -38,6 +55,7 @@ describe("post-signin auth route", () => {
   it("syncs referral and profile data for authenticated users", async () => {
     mocks.requireAuth.mockResolvedValue({ userId: "user_1" });
     mocks.applyPostSigninSync.mockResolvedValue({
+      personId: "person_1",
       referralRecorded: true,
       userUpdated: true,
     });
@@ -65,14 +83,24 @@ describe("post-signin auth route", () => {
     });
     await expect(response.json()).resolves.toEqual({
       success: true,
+      personId: "person_1",
       referralRecorded: true,
       userUpdated: true,
     });
+    // Flyer-hang seeding is deferred via after(), not awaited inline —
+    // it must not add Overpass's up-to-20s latency to every signin.
+    expect(mocks.after).toHaveBeenCalledTimes(1);
+    await mocks.after.mock.calls[0]?.[0]?.();
+    expect(mocks.seedNearbyFlyerHangTasksAfterSignin).toHaveBeenCalledWith(
+      "user_1",
+      "person_1",
+    );
   });
 
   it("treats an authenticated empty request body as no post-sign-in context", async () => {
     mocks.requireAuth.mockResolvedValue({ userId: "user_1" });
     mocks.applyPostSigninSync.mockResolvedValue({
+      personId: "person_1",
       referralRecorded: false,
       userUpdated: false,
     });
@@ -94,6 +122,7 @@ describe("post-signin auth route", () => {
     });
     await expect(response.json()).resolves.toEqual({
       success: true,
+      personId: "person_1",
       referralRecorded: false,
       userUpdated: false,
     });

--- a/packages/web/src/app/api/auth/post-signin/route.ts
+++ b/packages/web/src/app/api/auth/post-signin/route.ts
@@ -1,6 +1,9 @@
-import { NextResponse } from "next/server";
+import { after, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth-utils";
-import { applyPostSigninSync } from "@/lib/post-signin-sync.server";
+import {
+  applyPostSigninSync,
+  seedNearbyFlyerHangTasksAfterSignin,
+} from "@/lib/post-signin-sync.server";
 
 export const runtime = "nodejs";
 
@@ -75,6 +78,11 @@ export async function POST(request: Request) {
           ? sanitizeLandingUrl(body.signupLandingUrl)
           : null,
     });
+
+    // Deferred until after the response is sent — seeding flyer-hang tasks
+    // can wait up to 20s on Overpass and shouldn't add that latency to
+    // every signin. See seedNearbyFlyerHangTasksAfterSignin for details.
+    after(() => seedNearbyFlyerHangTasksAfterSignin(userId, result.personId));
 
     return NextResponse.json({ success: true, ...result });
   } catch (error) {

--- a/packages/web/src/app/api/flyer-hang/nearby/route.ts
+++ b/packages/web/src/app/api/flyer-hang/nearby/route.ts
@@ -1,0 +1,102 @@
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
+import { authOptions } from "@/lib/auth";
+import { ensureNearbyFlyerHangTasks } from "@/lib/flyer-hang/server";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+type NearbyBody = {
+  city?: string | null;
+  countryCode?: string | null;
+  latitude?: number;
+  longitude?: number;
+  regionCode?: string | null;
+};
+
+function readFiniteNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  let body: NearbyBody = {};
+  try {
+    body = (await request.json()) as NearbyBody;
+  } catch {
+    body = {};
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      city: true,
+      countryCode: true,
+      latitude: true,
+      longitude: true,
+      personId: true,
+      regionCode: true,
+    },
+  });
+  if (!user) {
+    return NextResponse.json({ error: "User not found." }, { status: 404 });
+  }
+
+  const latitude = readFiniteNumber(body.latitude) ?? user.latitude;
+  const longitude = readFiniteNumber(body.longitude) ?? user.longitude;
+  if (latitude == null || longitude == null) {
+    return NextResponse.json(
+      {
+        error: "Location required.",
+        places: [],
+        needsLocation: true,
+      },
+      { status: 400 },
+    );
+  }
+
+  // Persist browser geolocation when the profile still lacks coordinates.
+  if (
+    readFiniteNumber(body.latitude) != null &&
+    readFiniteNumber(body.longitude) != null &&
+    (user.latitude == null || user.longitude == null)
+  ) {
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        latitude,
+        longitude,
+        ...(body.city && !user.city ? { city: body.city } : {}),
+        ...(body.countryCode && !user.countryCode
+          ? { countryCode: body.countryCode }
+          : {}),
+        ...(body.regionCode && !user.regionCode
+          ? { regionCode: body.regionCode }
+          : {}),
+      },
+    });
+  }
+
+  const result = await ensureNearbyFlyerHangTasks({
+    city: body.city ?? user.city,
+    countryCode: body.countryCode ?? user.countryCode,
+    createdByUserId: userId,
+    latitude,
+    longitude,
+    personId: user.personId,
+    regionCode: body.regionCode ?? user.regionCode,
+    userId,
+  });
+
+  return NextResponse.json({
+    needsLocation: false,
+    personalTaskId: result.personalTaskId,
+    places: result.places,
+    usedOverpass: result.usedOverpass,
+  });
+}

--- a/packages/web/src/app/api/flyer-hang/nearby/route.ts
+++ b/packages/web/src/app/api/flyer-hang/nearby/route.ts
@@ -14,8 +14,21 @@ type NearbyBody = {
   regionCode?: string | null;
 };
 
-function readFiniteNumber(value: unknown) {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
+function readFiniteNumber(value: unknown, min: number, max: number) {
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    value >= min &&
+    value <= max
+    ? value
+    : null;
+}
+
+function readLatitude(value: unknown) {
+  return readFiniteNumber(value, -90, 90);
+}
+
+function readLongitude(value: unknown) {
+  return readFiniteNumber(value, -180, 180);
 }
 
 export async function POST(request: Request) {
@@ -47,8 +60,8 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "User not found." }, { status: 404 });
   }
 
-  const latitude = readFiniteNumber(body.latitude) ?? user.latitude;
-  const longitude = readFiniteNumber(body.longitude) ?? user.longitude;
+  const latitude = readLatitude(body.latitude) ?? user.latitude;
+  const longitude = readLongitude(body.longitude) ?? user.longitude;
   if (latitude == null || longitude == null) {
     return NextResponse.json(
       {
@@ -62,8 +75,8 @@ export async function POST(request: Request) {
 
   // Persist browser geolocation when the profile still lacks coordinates.
   if (
-    readFiniteNumber(body.latitude) != null &&
-    readFiniteNumber(body.longitude) != null &&
+    readLatitude(body.latitude) != null &&
+    readLongitude(body.longitude) != null &&
     (user.latitude == null || user.longitude == null)
   ) {
     await prisma.user.update({
@@ -82,21 +95,29 @@ export async function POST(request: Request) {
     });
   }
 
-  const result = await ensureNearbyFlyerHangTasks({
-    city: body.city ?? user.city,
-    countryCode: body.countryCode ?? user.countryCode,
-    createdByUserId: userId,
-    latitude,
-    longitude,
-    personId: user.personId,
-    regionCode: body.regionCode ?? user.regionCode,
-    userId,
-  });
+  try {
+    const result = await ensureNearbyFlyerHangTasks({
+      city: body.city ?? user.city,
+      countryCode: body.countryCode ?? user.countryCode,
+      createdByUserId: userId,
+      latitude,
+      longitude,
+      personId: user.personId,
+      regionCode: body.regionCode ?? user.regionCode,
+      userId,
+    });
 
-  return NextResponse.json({
-    needsLocation: false,
-    personalTaskId: result.personalTaskId,
-    places: result.places,
-    usedOverpass: result.usedOverpass,
-  });
+    return NextResponse.json({
+      needsLocation: false,
+      personalTaskId: result.personalTaskId,
+      places: result.places,
+      usedOverpass: result.usedOverpass,
+    });
+  } catch (error) {
+    console.error("[FLYER HANG] Failed to load nearby tasks", userId, error);
+    return NextResponse.json(
+      { error: "Could not load hang spots.", needsLocation: false, places: [] },
+      { status: 500 },
+    );
+  }
 }

--- a/packages/web/src/app/poster/page.tsx
+++ b/packages/web/src/app/poster/page.tsx
@@ -10,6 +10,7 @@ import { buildUserReferralUrl } from "@/lib/url";
 import {
   FlyerRoutePromptCopyButton,
   PosterCopyLinkButton,
+  PosterHangNearbyPanel,
   PosterPrintButton,
 } from "./poster-client";
 
@@ -51,6 +52,7 @@ export default async function PosterPage({
     paramsPromise,
     getServerSession(authOptions),
   ]);
+  const sessionUserId = session?.user?.id ?? null;
   const hasPersonalReferralUrl = Boolean(
     session?.user?.handle?.trim() || session?.user?.referralCode?.trim(),
   );
@@ -144,18 +146,15 @@ export default async function PosterPage({
         }
 
         @media print {
+          /*
+           * One unnamed @page only. Named CSS pages (page: poster-letter)
+           * plus an exact 11in/297mm sheet make Chrome print preview emit a
+           * blank trailing page when margins or pixel rounding disagree with
+           * the box. Keep sheet boxes a hair under the page size — same
+           * approach as the existing A4 296mm clamp.
+           */
           @page {
-            size: letter;
-            margin: 0;
-          }
-
-          @page poster-letter {
-            size: letter;
-            margin: 0;
-          }
-
-          @page poster-a4 {
-            size: A4;
+            size: ${paperSize === "a4" ? "A4" : "letter"};
             margin: 0;
           }
 
@@ -171,26 +170,31 @@ export default async function PosterPage({
            */
           html,
           body {
-            width: 100%;
-            min-height: 100%;
+            width: 100% !important;
+            height: auto !important;
+            min-height: 0 !important;
+            margin: 0 !important;
+            padding: 0 !important;
             background: #ffffff !important;
             color: #000000 !important;
-            overflow: visible !important;
+            overflow: hidden !important;
           }
 
           nav,
-          body > footer,
+          footer:not(.poster-footer),
           [data-print-hidden="true"] {
             display: none !important;
           }
 
-          main {
-            min-height: 0 !important;
-          }
-
+          main,
           .poster-root {
+            display: block !important;
+            width: auto !important;
+            height: auto !important;
             min-height: 0 !important;
+            margin: 0 !important;
             padding: 0 !important;
+            overflow: hidden !important;
             background: #ffffff !important;
             color: #000000 !important;
           }
@@ -200,14 +204,15 @@ export default async function PosterPage({
             break-before: avoid;
             break-inside: avoid;
             box-sizing: border-box;
-            margin: 0 auto !important;
-            overflow: hidden;
-            page: poster-letter;
+            margin: 0 !important;
+            overflow: hidden !important;
             width: 8.5in !important;
-            height: 11in !important;
-            min-height: 11in !important;
-            max-height: 11in !important;
-            border-color: transparent !important;
+            /* 10.95in (not 11in): Chrome pixel rounding on exact-letter
+               sheets spills a blank trailing page. */
+            height: 10.95in !important;
+            min-height: 10.95in !important;
+            max-height: 10.95in !important;
+            border: 0 !important;
             background: #ffffff !important;
             color: #000000 !important;
           }
@@ -240,7 +245,6 @@ export default async function PosterPage({
           /* 296mm (not 297mm): Chrome pixel rounding on exact-A4 sheets
              spills a blank trailing page. */
           .poster-sheet[data-paper-size="a4"] {
-            page: poster-a4;
             width: 210mm !important;
             height: 296mm !important;
             min-height: 296mm !important;
@@ -352,6 +356,8 @@ export default async function PosterPage({
             </Link>
           </div>
         </div>
+
+        <PosterHangNearbyPanel signedIn={Boolean(sessionUserId)} />
 
         <div className="mt-2 max-w-3xl border-t border-foreground pt-5">
           <h2 className="text-2xl font-black uppercase leading-tight text-foreground sm:text-3xl">

--- a/packages/web/src/app/poster/poster-client.tsx
+++ b/packages/web/src/app/poster/poster-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { copyTextToClipboard } from "@/lib/clipboard";
 import type { FlyerHangNearbyTask } from "@/lib/flyer-hang";
@@ -107,9 +107,16 @@ export function PosterHangNearbyPanel({ signedIn }: { signedIn: boolean }) {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [needsLocation, setNeedsLocation] = useState(false);
+  // The initial saved-location load and an explicit "Use my location" click
+  // can both be in flight at once (geolocation permission prompts add
+  // unpredictable latency). Only the response to the most recently
+  // *started* request should be allowed to update state, so a slow saved-
+  // location reply can't clobber a faster, more-precise browser-location one.
+  const requestIdRef = useRef(0);
 
   async function loadNearby(coords?: { latitude: number; longitude: number }) {
     if (!signedIn) return;
+    const requestId = ++requestIdRef.current;
     setLoading(true);
     setError(null);
     try {
@@ -123,6 +130,7 @@ export function PosterHangNearbyPanel({ signedIn }: { signedIn: boolean }) {
         needsLocation?: boolean;
         places?: FlyerHangNearbyTask[];
       };
+      if (requestId !== requestIdRef.current) return;
       if (!response.ok) {
         setNeedsLocation(Boolean(payload.needsLocation));
         setPlaces([]);
@@ -132,10 +140,11 @@ export function PosterHangNearbyPanel({ signedIn }: { signedIn: boolean }) {
       setNeedsLocation(false);
       setPlaces(payload.places ?? []);
     } catch {
+      if (requestId !== requestIdRef.current) return;
       setError("Could not load hang spots.");
       setPlaces([]);
     } finally {
-      setLoading(false);
+      if (requestId === requestIdRef.current) setLoading(false);
     }
   }
 
@@ -172,7 +181,7 @@ export function PosterHangNearbyPanel({ signedIn }: { signedIn: boolean }) {
 
   if (!signedIn) {
     return (
-      <div className="border-2 border-foreground bg-background p-4">
+      <div className="border border-foreground bg-background p-4">
         <h2 className="text-xl font-black uppercase">Hang near you</h2>
         <p className="mt-2 text-sm font-bold text-muted-foreground">
           Sign in to get nearby hang spots as claimable tasks and credit when
@@ -183,7 +192,7 @@ export function PosterHangNearbyPanel({ signedIn }: { signedIn: boolean }) {
   }
 
   return (
-    <div className="border-2 border-foreground bg-background p-4">
+    <div className="border border-foreground bg-background p-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h2 className="text-xl font-black uppercase">Hang near you</h2>
@@ -194,7 +203,7 @@ export function PosterHangNearbyPanel({ signedIn }: { signedIn: boolean }) {
         </div>
         <button
           type="button"
-          className="border-2 border-foreground bg-background px-3 py-2 text-xs font-black uppercase text-foreground hover:bg-foreground hover:text-background"
+          className="border border-foreground bg-background px-3 py-2 text-xs font-black uppercase text-foreground hover:bg-foreground hover:text-background"
           onClick={requestBrowserLocation}
         >
           Use my location
@@ -232,7 +241,7 @@ export function PosterHangNearbyPanel({ signedIn }: { signedIn: boolean }) {
                 </p>
               </div>
               <Link
-                className="shrink-0 border-2 border-foreground bg-foreground px-3 py-1.5 text-xs font-black uppercase text-background hover:bg-background hover:text-foreground"
+                className="shrink-0 border border-foreground bg-foreground px-3 py-1.5 text-xs font-black uppercase text-background hover:bg-background hover:text-foreground"
                 href={place.href}
               >
                 Open task

--- a/packages/web/src/app/poster/poster-client.tsx
+++ b/packages/web/src/app/poster/poster-client.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { copyTextToClipboard } from "@/lib/clipboard";
+import type { FlyerHangNearbyTask } from "@/lib/flyer-hang";
 
 export function PosterPrintButton({ label = "Print" }: { label?: string }) {
   return (
@@ -83,5 +85,162 @@ export function FlyerRoutePromptCopyButton({ value }: { value: string }) {
       value={value}
       visualAction="copy-flyer-route-prompt"
     />
+  );
+}
+
+function formatDistanceKm(distanceKm: number) {
+  if (distanceKm < 1) return `${Math.max(0.1, distanceKm).toFixed(1)} km`;
+  return `${distanceKm.toFixed(1)} km`;
+}
+
+function freshnessLabel(place: FlyerHangNearbyTask) {
+  if (place.freshness.status === "never_hung") return "Needs first hang";
+  if (place.freshness.status === "stale") {
+    const days = place.freshness.staleAgeDays;
+    return days == null ? "Needs rehang" : `Stale · ${Math.floor(days)}d ago`;
+  }
+  return "Recently hung";
+}
+
+export function PosterHangNearbyPanel({ signedIn }: { signedIn: boolean }) {
+  const [places, setPlaces] = useState<FlyerHangNearbyTask[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [needsLocation, setNeedsLocation] = useState(false);
+
+  async function loadNearby(coords?: { latitude: number; longitude: number }) {
+    if (!signedIn) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/flyer-hang/nearby", {
+        body: JSON.stringify(coords ?? {}),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      const payload = (await response.json()) as {
+        error?: string;
+        needsLocation?: boolean;
+        places?: FlyerHangNearbyTask[];
+      };
+      if (!response.ok) {
+        setNeedsLocation(Boolean(payload.needsLocation));
+        setPlaces([]);
+        setError(payload.error ?? "Could not load hang spots.");
+        return;
+      }
+      setNeedsLocation(false);
+      setPlaces(payload.places ?? []);
+    } catch {
+      setError("Could not load hang spots.");
+      setPlaces([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!signedIn) return;
+    void loadNearby();
+    // Initial load uses saved profile/IP location; browser geolocation is
+    // opt-in via the button below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signedIn]);
+
+  function requestBrowserLocation() {
+    if (!navigator.geolocation) {
+      setError("This browser cannot share location.");
+      return;
+    }
+    setLoading(true);
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        void loadNearby({
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+        });
+      },
+      () => {
+        setLoading(false);
+        setError(
+          "Location permission denied. Enable it, or use a saved profile location.",
+        );
+      },
+      { enableHighAccuracy: false, maximumAge: 60_000, timeout: 15_000 },
+    );
+  }
+
+  if (!signedIn) {
+    return (
+      <div className="border-2 border-foreground bg-background p-4">
+        <h2 className="text-xl font-black uppercase">Hang near you</h2>
+        <p className="mt-2 text-sm font-bold text-muted-foreground">
+          Sign in to get nearby hang spots as claimable tasks and credit when
+          someone votes through your poster QR.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-2 border-foreground bg-background p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-black uppercase">Hang near you</h2>
+          <p className="mt-2 max-w-2xl text-sm font-bold text-muted-foreground">
+            Shared hang spots. Claim one, ask before you tape, photograph it,
+            mark it done. Spots go stale after about 21 days and need a rehang.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="border-2 border-foreground bg-background px-3 py-2 text-xs font-black uppercase text-foreground hover:bg-foreground hover:text-background"
+          onClick={requestBrowserLocation}
+        >
+          Use my location
+        </button>
+      </div>
+
+      {loading ? (
+        <p className="mt-4 text-sm font-bold text-muted-foreground">
+          Finding hang spots…
+        </p>
+      ) : null}
+      {error ? (
+        <p className="mt-4 text-sm font-bold text-foreground">{error}</p>
+      ) : null}
+      {needsLocation ? (
+        <p className="mt-2 text-sm font-bold text-muted-foreground">
+          Share location once so we can seed boards near you.
+        </p>
+      ) : null}
+
+      {places.length > 0 ? (
+        <ul className="mt-4 grid gap-2">
+          {places.map((place) => (
+            <li
+              key={place.id}
+              className="flex flex-wrap items-center justify-between gap-2 border border-foreground px-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-black uppercase text-foreground">
+                  {place.title}
+                </p>
+                <p className="text-xs font-bold text-muted-foreground">
+                  {formatDistanceKm(place.distanceKm)} · {freshnessLabel(place)}
+                  {place.source === "osm" ? " · mapped place" : " · area target"}
+                </p>
+              </div>
+              <Link
+                className="shrink-0 border-2 border-foreground bg-foreground px-3 py-1.5 text-xs font-black uppercase text-background hover:bg-background hover:text-foreground"
+                href={place.href}
+              >
+                Open task
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
   );
 }

--- a/packages/web/src/lib/__tests__/post-signin-sync.server.test.ts
+++ b/packages/web/src/lib/__tests__/post-signin-sync.server.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  ensureNearbyFlyerHangTasks: vi.fn(),
   ensurePersonForUser: vi.fn(),
   ensureUserTreatyTask: vi.fn(),
   findUnique: vi.fn(),
@@ -47,11 +48,24 @@ vi.mock("@/lib/triggers", () => ({
   buildTriggerParams: () => ({}),
 }));
 
-import { applyPostSigninSync } from "../post-signin-sync.server";
+vi.mock("@/lib/flyer-hang/server", () => ({
+  ensureNearbyFlyerHangTasks: mocks.ensureNearbyFlyerHangTasks,
+}));
+
+import {
+  applyPostSigninSync,
+  seedNearbyFlyerHangTasksAfterSignin,
+} from "../post-signin-sync.server";
 
 describe("post-signin sync", () => {
   beforeEach(() => {
     mocks.findUnique.mockReset();
+    mocks.ensureNearbyFlyerHangTasks.mockReset();
+    mocks.ensureNearbyFlyerHangTasks.mockResolvedValue({
+      personalTaskId: "task_personal",
+      places: [],
+      usedOverpass: true,
+    });
     mocks.ensurePersonForUser.mockReset();
     mocks.ensurePersonForUser.mockResolvedValue({ id: "person_1" });
     mocks.ensureUserTreatyTask.mockReset();
@@ -81,6 +95,7 @@ describe("post-signin sync", () => {
         shareAttemptId: "sa_123",
       }),
     ).resolves.toEqual({
+      personId: "person_1",
       referralRecorded: true,
       userUpdated: true,
     });
@@ -138,6 +153,7 @@ describe("post-signin sync", () => {
         name: "New Name",
       }),
     ).resolves.toEqual({
+      personId: "person_1",
       referralRecorded: false,
       userUpdated: false,
     });
@@ -148,5 +164,71 @@ describe("post-signin sync", () => {
     expect(mocks.ensurePersonForUser).toHaveBeenCalledWith("user_1", {
       displayName: "New Name",
     });
+  });
+});
+
+describe("seedNearbyFlyerHangTasksAfterSignin", () => {
+  beforeEach(() => {
+    mocks.findUnique.mockReset();
+    mocks.ensureNearbyFlyerHangTasks.mockReset();
+    mocks.ensureNearbyFlyerHangTasks.mockResolvedValue({
+      personalTaskId: "task_personal",
+      places: [],
+      usedOverpass: true,
+    });
+  });
+
+  it("seeds nearby tasks when the user has finite saved coordinates", async () => {
+    mocks.findUnique.mockResolvedValue({
+      city: "Austin",
+      countryCode: "US",
+      latitude: 30.27,
+      longitude: -97.74,
+      regionCode: "TX",
+    });
+
+    await seedNearbyFlyerHangTasksAfterSignin("user_1", "person_1");
+
+    expect(mocks.ensureNearbyFlyerHangTasks).toHaveBeenCalledWith({
+      city: "Austin",
+      countryCode: "US",
+      createdByUserId: "user_1",
+      latitude: 30.27,
+      longitude: -97.74,
+      personId: "person_1",
+      regionCode: "TX",
+      userId: "user_1",
+    });
+  });
+
+  it("skips seeding when the user has no saved coordinates yet", async () => {
+    mocks.findUnique.mockResolvedValue({
+      city: null,
+      countryCode: null,
+      latitude: null,
+      longitude: null,
+      regionCode: null,
+    });
+
+    await seedNearbyFlyerHangTasksAfterSignin("user_1", "person_1");
+
+    expect(mocks.ensureNearbyFlyerHangTasks).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors from ensureNearbyFlyerHangTasks — signin must not fail on this", async () => {
+    mocks.findUnique.mockResolvedValue({
+      city: "Austin",
+      countryCode: "US",
+      latitude: 30.27,
+      longitude: -97.74,
+      regionCode: "TX",
+    });
+    mocks.ensureNearbyFlyerHangTasks.mockRejectedValue(
+      new Error("Overpass timed out"),
+    );
+
+    await expect(
+      seedNearbyFlyerHangTasksAfterSignin("user_1", "person_1"),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/web/src/lib/__tests__/tasks.server.test.ts
+++ b/packages/web/src/lib/__tests__/tasks.server.test.ts
@@ -5,6 +5,7 @@ import {
   TaskClaimStatus,
   TaskCompensationKind,
   TaskEdgeType,
+  TaskEngagementKind,
   TaskExecutionMode,
   TaskStatus,
 } from "@optimitron/db";
@@ -33,7 +34,10 @@ const mocks = vi.hoisted(() => ({
   },
   tx: {
     queryRaw: vi.fn(),
+    taskClaimCount: vi.fn(),
+    taskClaimCreate: vi.fn(),
     taskClaimFindFirst: vi.fn(),
+    taskClaimFindUnique: vi.fn(),
     taskClaimFindUniqueOrThrow: vi.fn(),
     taskClaimUpdate: vi.fn(),
     taskClaimUpdateMany: vi.fn(),
@@ -101,6 +105,7 @@ vi.mock("@/lib/tasks/planning-branch.server", async (importActual) => ({
 import {
   abandonTaskClaim,
   canCompleteSelfTask,
+  claimTask,
   completeSelfTask,
   completeTaskClaim,
   completeTaskForUser,
@@ -125,7 +130,10 @@ function createTransactionClient() {
     },
     user: { findUnique: mocks.tx.userFindUnique },
     taskClaim: {
+      count: mocks.tx.taskClaimCount,
+      create: mocks.tx.taskClaimCreate,
       findFirst: mocks.tx.taskClaimFindFirst,
+      findUnique: mocks.tx.taskClaimFindUnique,
       findUniqueOrThrow: mocks.tx.taskClaimFindUniqueOrThrow,
       update: mocks.tx.taskClaimUpdate,
       updateMany: mocks.tx.taskClaimUpdateMany,
@@ -615,6 +623,83 @@ describe("tasks server", () => {
       "Only active claims can be released.",
     );
     expect(mocks.tx.taskClaimUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("reopens a completed unpaid ongoing claim so the same volunteer can rehang", async () => {
+    mocks.tx.userFindUnique.mockResolvedValue({ personId: "person_1" });
+    mocks.tx.taskFindFirst
+      .mockResolvedValueOnce({ id: "task_1" })
+      .mockResolvedValueOnce({
+        claimPolicy: TaskClaimPolicy.OPEN_MANY,
+        compensationCadence: null,
+        compensationCurrency: null,
+        compensationKind: TaskCompensationKind.UNSPECIFIED,
+        compensationMaxAmountMinorUnits: null,
+        compensationPaymentRails: [],
+        engagementKind: TaskEngagementKind.ONGOING,
+        id: "task_1",
+        maxClaims: null,
+        status: TaskStatus.ACTIVE,
+      });
+    mocks.tx.taskClaimFindUnique.mockResolvedValue({
+      id: "claim_1",
+      status: TaskClaimStatus.COMPLETED,
+      taskId: "task_1",
+      userId: "user_1",
+    });
+    mocks.tx.taskClaimCount.mockResolvedValue(0);
+    mocks.tx.taskClaimUpdate.mockResolvedValue({
+      id: "claim_1",
+      status: TaskClaimStatus.CLAIMED,
+      taskId: "task_1",
+      userId: "user_1",
+    });
+
+    await expect(claimTask("task_1", "user_1")).resolves.toMatchObject({
+      id: "claim_1",
+      status: TaskClaimStatus.CLAIMED,
+    });
+    expect(mocks.tx.taskClaimUpdate).toHaveBeenCalledWith({
+      where: { id: "claim_1" },
+      data: expect.objectContaining({
+        completedAt: null,
+        status: TaskClaimStatus.CLAIMED,
+        verifiedAt: null,
+        verifiedByUserId: null,
+      }),
+    });
+    expect(mocks.tx.taskClaimCreate).not.toHaveBeenCalled();
+  });
+
+  it("does not reopen a verified paid claim", async () => {
+    const existingClaim = {
+      id: "claim_paid",
+      status: TaskClaimStatus.VERIFIED,
+      taskId: "task_paid",
+      userId: "user_1",
+    };
+    mocks.tx.userFindUnique.mockResolvedValue({ personId: "person_1" });
+    mocks.tx.taskFindFirst
+      .mockResolvedValueOnce({ id: "task_paid" })
+      .mockResolvedValueOnce({
+        claimPolicy: TaskClaimPolicy.OPEN_MANY,
+        compensationCadence: null,
+        compensationCurrency: "usd",
+        compensationKind: TaskCompensationKind.BOUNTY,
+        compensationMaxAmountMinorUnits: 5000n,
+        compensationPaymentRails: ["stripe"],
+        engagementKind: TaskEngagementKind.ONGOING,
+        id: "task_paid",
+        maxClaims: null,
+        status: TaskStatus.ACTIVE,
+      });
+    mocks.tx.taskClaimFindUnique.mockResolvedValue(existingClaim);
+
+    await expect(claimTask("task_paid", "user_1")).resolves.toEqual(
+      existingClaim,
+    );
+    expect(mocks.tx.taskClaimUpdate).not.toHaveBeenCalled();
+    expect(mocks.tx.taskClaimCreate).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/packages/web/src/lib/flyer-hang/__tests__/flyer-hang.test.ts
+++ b/packages/web/src/lib/flyer-hang/__tests__/flyer-hang.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFlyerHangPlaceTaskKey,
+  getUserHangFlyersTaskKey,
+  isFlyerHangPlaceTaskKey,
+} from "@optimitron/db/task-keys";
+import {
+  buildFlyerHangGridId,
+  buildGridSlotPlaceCandidates,
+  parseOverpassFlyerHangPlaces,
+  taskKeyForFlyerHangPlace,
+} from "@/lib/flyer-hang/places";
+import {
+  compareFlyerHangPriority,
+  getFlyerHangFreshness,
+} from "@/lib/flyer-hang/staleness";
+
+describe("flyer hang task keys", () => {
+  it("builds stable place keys for dedupe", () => {
+    expect(
+      buildFlyerHangPlaceTaskKey({ placeId: "node:123", source: "osm" }),
+    ).toBe("flyer-hang:place:osm:node:123");
+    expect(
+      buildFlyerHangPlaceTaskKey({
+        placeId: "30.27:-97.74:library",
+        source: "grid",
+      }),
+    ).toBe("flyer-hang:place:grid:30.27:-97.74:library");
+  });
+
+  it("recognizes place keys and personal hang plan keys", () => {
+    expect(isFlyerHangPlaceTaskKey("flyer-hang:place:osm:node:1")).toBe(true);
+    expect(isFlyerHangPlaceTaskKey("program:one-percent-treaty:user:u1")).toBe(
+      false,
+    );
+    expect(getUserHangFlyersTaskKey("user_1")).toBe(
+      "program:one-percent-treaty:user:user_1:hangFlyers",
+    );
+  });
+});
+
+describe("flyer hang places", () => {
+  it("builds the same grid slots for users in the same cell", () => {
+    const a = buildGridSlotPlaceCandidates({
+      city: "Austin",
+      latitude: 30.2711,
+      longitude: -97.7437,
+    });
+    const b = buildGridSlotPlaceCandidates({
+      city: "Austin",
+      latitude: 30.274,
+      longitude: -97.741,
+    });
+    expect(buildFlyerHangGridId(30.2711, -97.7437)).toBe(
+      buildFlyerHangGridId(30.274, -97.741),
+    );
+    expect(a.map((place) => taskKeyForFlyerHangPlace(place))).toEqual(
+      b.map((place) => taskKeyForFlyerHangPlace(place)),
+    );
+    expect(a).toHaveLength(5);
+  });
+
+  it("parses Overpass elements into nearby places", () => {
+    const places = parseOverpassFlyerHangPlaces(
+      {
+        elements: [
+          {
+            id: 9,
+            lat: 30.27,
+            lon: -97.74,
+            tags: { amenity: "library", name: "Central Library" },
+            type: "node",
+          },
+          {
+            id: 10,
+            center: { lat: 31.0, lon: -97.0 },
+            tags: { amenity: "cafe" },
+            type: "way",
+          },
+        ],
+      },
+      { latitude: 30.27, longitude: -97.74 },
+    );
+    expect(places).toHaveLength(1);
+    expect(places[0]?.name).toBe("Central Library");
+    expect(places[0]?.placeId).toBe("node:9");
+  });
+});
+
+describe("flyer hang staleness", () => {
+  const now = new Date("2026-08-10T12:00:00.000Z");
+
+  it("marks never-hung and old hangs as stale", () => {
+    expect(getFlyerHangFreshness({ lastHungAt: null, now }).status).toBe(
+      "never_hung",
+    );
+    expect(
+      getFlyerHangFreshness({
+        lastHungAt: "2026-07-01T12:00:00.000Z",
+        now,
+      }).status,
+    ).toBe("stale");
+    expect(
+      getFlyerHangFreshness({
+        lastHungAt: "2026-08-05T12:00:00.000Z",
+        now,
+      }).status,
+    ).toBe("fresh");
+  });
+
+  it("ranks stale and never-hung before fresh, then by distance", () => {
+    const ranked = [
+      {
+        distanceKm: 0.2,
+        isStale: false,
+        lastHungAt: new Date("2026-08-08T00:00:00.000Z"),
+      },
+      {
+        distanceKm: 1.5,
+        isStale: true,
+        lastHungAt: new Date("2026-06-01T00:00:00.000Z"),
+      },
+      { distanceKm: 0.8, isStale: true, lastHungAt: null },
+    ].sort(compareFlyerHangPriority);
+    expect(ranked.map((row) => row.distanceKm)).toEqual([0.8, 1.5, 0.2]);
+  });
+});

--- a/packages/web/src/lib/flyer-hang/constants.ts
+++ b/packages/web/src/lib/flyer-hang/constants.ts
@@ -1,0 +1,46 @@
+/** Days after a verified hang before the place ranks as needing a rehang. */
+export const FLYER_HANG_STALE_AFTER_DAYS = 21;
+
+/** Max place tasks returned / upserted per nearby ensure. */
+export const FLYER_HANG_NEARBY_LIMIT = 12;
+
+/** Search radius for Overpass POIs and listing distance filter (km). */
+export const FLYER_HANG_SEARCH_RADIUS_KM = 5;
+
+/** Grid cell size in degrees (~1.1 km at the equator). */
+export const FLYER_HANG_GRID_DEGREES = 0.01;
+
+export const FLYER_HANG_GRID_SLOTS = [
+  {
+    id: "library",
+    title: "Hang a flyer at a nearby library",
+    description:
+      "Print your referral poster. Ask the library front desk or community-board owner first. Tape it where humans already stop to read. Photograph the hung flyer, then mark this task done so others know the board is covered.",
+  },
+  {
+    id: "cafe",
+    title: "Hang a flyer at a cafe with a community board",
+    description:
+      "Print your referral poster. Ask before taping. Prefer corkboards and windows that already hold local notices. Photograph the hung flyer, then mark this task done.",
+  },
+  {
+    id: "campus",
+    title: "Hang a flyer on a campus or school notice board",
+    description:
+      "Print your referral poster. Use public notice boards only. Ask staff when the board is managed. Photograph the hung flyer, then mark this task done.",
+  },
+  {
+    id: "community",
+    title: "Hang a flyer at a community center",
+    description:
+      "Print your referral poster. Ask at the desk for the public board. Photograph the hung flyer, then mark this task done.",
+  },
+  {
+    id: "transit",
+    title: "Hang a flyer near a busy transit stop board",
+    description:
+      "Print your referral poster. Use only boards that already hold public notices. Do not tape private property. Photograph the hung flyer, then mark this task done.",
+  },
+] as const;
+
+export type FlyerHangGridSlotId = (typeof FLYER_HANG_GRID_SLOTS)[number]["id"];

--- a/packages/web/src/lib/flyer-hang/ensure-nearby.server.ts
+++ b/packages/web/src/lib/flyer-hang/ensure-nearby.server.ts
@@ -1,0 +1,365 @@
+import {
+  TaskCategory,
+  TaskClaimPolicy,
+  TaskClaimStatus,
+  TaskEngagementKind,
+  TaskRemotePolicy,
+  TaskStatus,
+} from "@optimitron/db";
+import type { Prisma } from "@optimitron/db";
+import {
+  FLYER_HANG_PLACE_TASK_KEY_PREFIX,
+  FLYER_HANG_PROGRAM_TASK_KEY,
+  TREATY_PARENT_TASK_ID,
+  USER_TREATY_HANG_FLYERS_SUBTASK_KIND,
+  getUserHangFlyersTaskKey,
+  getUserTreatyTaskKey,
+} from "@optimitron/db/task-keys";
+import { prisma } from "@/lib/prisma";
+import { ROUTES, getTaskPath } from "@/lib/routes";
+import {
+  FLYER_HANG_GRID_SLOTS,
+  FLYER_HANG_NEARBY_LIMIT,
+  FLYER_HANG_SEARCH_RADIUS_KM,
+  FLYER_HANG_STALE_AFTER_DAYS,
+} from "./constants";
+import {
+  buildGridSlotPlaceCandidates,
+  fetchOverpassFlyerHangPlaces,
+  haversineKm,
+  taskKeyForFlyerHangPlace,
+  type FlyerHangPlaceCandidate,
+} from "./places";
+import { compareFlyerHangPriority, getFlyerHangFreshness } from "./staleness";
+import type { FlyerHangNearbyTask } from "./types";
+
+export type { FlyerHangNearbyTask };
+
+type EnsureDb = Prisma.TransactionClient | typeof prisma;
+
+function parseFlyerHangSource(taskKey: string | null | undefined) {
+  if (!taskKey?.startsWith(`${FLYER_HANG_PLACE_TASK_KEY_PREFIX}:`)) {
+    return "unknown";
+  }
+  return taskKey.slice(`${FLYER_HANG_PLACE_TASK_KEY_PREFIX}:`.length).split(":")[0] ??
+    "unknown";
+}
+
+async function resolveFlyerHangProgramParentId(
+  db: EnsureDb,
+  createdByUserId: string,
+) {
+  const existing = await db.task.findFirst({
+    where: { deletedAt: null, taskKey: FLYER_HANG_PROGRAM_TASK_KEY },
+    select: { id: true },
+  });
+  if (existing) return existing.id;
+
+  const created = await db.task.create({
+    data: {
+      category: TaskCategory.OUTREACH,
+      claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
+      createdByUserId,
+      description:
+        "Shared inventory of places where humans hang 1% Treaty referral flyers. Child tasks are claimable hang spots. One hang does not close the place — flyers go stale and need rehangs.",
+      engagementKind: TaskEngagementKind.ONGOING,
+      isPublic: true,
+      parentTaskId: TREATY_PARENT_TASK_ID,
+      status: TaskStatus.ACTIVE,
+      taskKey: FLYER_HANG_PROGRAM_TASK_KEY,
+      title: "Hang referral flyers in public places",
+    },
+    select: { id: true },
+  });
+  return created.id;
+}
+
+function descriptionForPlace(place: FlyerHangPlaceCandidate) {
+  if (place.source === "grid" && place.slotId) {
+    const slot = FLYER_HANG_GRID_SLOTS.find((s) => s.id === place.slotId);
+    if (slot) return slot.description;
+  }
+  return [
+    `Print your referral poster from ${ROUTES.poster}.`,
+    `Ask before you tape anything at ${place.name}.`,
+    "Photograph the hung flyer.",
+    "Mark this hang done so nearby humans know the board is covered.",
+    `Rehang after about ${FLYER_HANG_STALE_AFTER_DAYS} days when the paper is gone or stale.`,
+  ].join(" ");
+}
+
+function contextJsonForPlace(place: FlyerHangPlaceCandidate) {
+  return {
+    kind: "flyer-hang-place",
+    placeId: place.placeId,
+    placeName: place.name,
+    slotId: place.slotId ?? null,
+    source: place.source,
+    staleAfterDays: FLYER_HANG_STALE_AFTER_DAYS,
+  } satisfies Prisma.InputJsonObject;
+}
+
+async function upsertPlaceTask(
+  db: EnsureDb,
+  input: {
+    createdByUserId: string;
+    parentTaskId: string;
+    place: FlyerHangPlaceCandidate;
+  },
+) {
+  const taskKey = taskKeyForFlyerHangPlace(input.place);
+  const title =
+    input.place.source === "grid" && input.place.slotId
+      ? (FLYER_HANG_GRID_SLOTS.find((s) => s.id === input.place.slotId)?.title ??
+        input.place.name)
+      : `Hang a flyer at ${input.place.name}`;
+  const locationText = [
+    input.place.name,
+    input.place.city,
+    input.place.regionCode,
+    input.place.countryCode,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  return db.task.upsert({
+    where: { taskKey },
+    create: {
+      category: TaskCategory.OUTREACH,
+      claimPolicy: TaskClaimPolicy.OPEN_MANY,
+      contextJson: contextJsonForPlace(input.place),
+      createdByUserId: input.createdByUserId,
+      description: descriptionForPlace(input.place),
+      engagementKind: TaskEngagementKind.ONGOING,
+      estimatedEffortHours: 0.25,
+      interestTags: ["flyer", "poster", "outreach", "1-percent-treaty"],
+      isPublic: true,
+      locationText,
+      parentTaskId: input.parentTaskId,
+      remotePolicy: TaskRemotePolicy.ONSITE,
+      skillTags: ["print", "local-outreach"],
+      status: TaskStatus.ACTIVE,
+      taskKey,
+      title,
+      workLocationCity: input.place.city,
+      workLocationCountryCode: input.place.countryCode,
+      workLocationLatitude: input.place.latitude,
+      workLocationLongitude: input.place.longitude,
+      workLocationRadiusKm: FLYER_HANG_SEARCH_RADIUS_KM,
+      workLocationRegionCode: input.place.regionCode,
+    },
+    update: {
+      description: descriptionForPlace(input.place),
+      locationText,
+      title,
+      workLocationCity: input.place.city,
+      workLocationCountryCode: input.place.countryCode,
+      workLocationLatitude: input.place.latitude,
+      workLocationLongitude: input.place.longitude,
+      workLocationRadiusKm: FLYER_HANG_SEARCH_RADIUS_KM,
+      workLocationRegionCode: input.place.regionCode,
+    },
+    select: {
+      id: true,
+      locationText: true,
+      taskKey: true,
+      title: true,
+      workLocationLatitude: true,
+      workLocationLongitude: true,
+    },
+  });
+}
+
+async function loadLastHungAtByTaskId(
+  db: EnsureDb,
+  taskIds: string[],
+): Promise<Map<string, Date>> {
+  if (taskIds.length === 0) return new Map();
+  const claims = await db.taskClaim.findMany({
+    where: {
+      deletedAt: null,
+      status: TaskClaimStatus.VERIFIED,
+      taskId: { in: taskIds },
+    },
+    select: {
+      completedAt: true,
+      taskId: true,
+      verifiedAt: true,
+    },
+    orderBy: { verifiedAt: "desc" },
+  });
+  const map = new Map<string, Date>();
+  for (const claim of claims) {
+    if (map.has(claim.taskId)) continue;
+    const at = claim.verifiedAt ?? claim.completedAt;
+    if (at) map.set(claim.taskId, at);
+  }
+  return map;
+}
+
+export async function ensurePersonalHangFlyersTask(
+  input: {
+    createdByUserId: string;
+    personId?: string | null;
+    userId: string;
+  },
+  db: EnsureDb = prisma,
+) {
+  const taskKey = getUserHangFlyersTaskKey(input.userId);
+  const parentKey = getUserTreatyTaskKey(input.userId);
+  const parent = await db.task.findFirst({
+    where: { deletedAt: null, taskKey: parentKey },
+    select: { id: true },
+  });
+
+  return db.task.upsert({
+    where: { taskKey },
+    create: {
+      assigneePersonId: input.personId ?? null,
+      category: TaskCategory.OUTREACH,
+      claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
+      contextJson: {
+        kind: "flyer-hang-plan",
+        subtaskKind: USER_TREATY_HANG_FLYERS_SUBTASK_KIND,
+      },
+      createdByUserId: input.createdByUserId,
+      description: [
+        "Print your personal referral poster.",
+        "Open the hang list for places near you.",
+        "Claim a spot, hang the flyer after you ask permission, photograph it, and mark the hang done.",
+        "Rehang when a spot goes stale (~21 days).",
+      ].join(" "),
+      estimatedEffortHours: 0.5,
+      interestTags: ["flyer", "poster", "outreach"],
+      isPublic: false,
+      parentTaskId: parent?.id ?? null,
+      status: TaskStatus.ACTIVE,
+      taskKey,
+      title: "Print and hang referral flyers near you",
+    },
+    update: {
+      assigneePersonId: input.personId ?? undefined,
+      parentTaskId: parent?.id ?? undefined,
+    },
+    select: { id: true, taskKey: true },
+  });
+}
+
+export async function ensureNearbyFlyerHangTasks(input: {
+  city?: string | null;
+  countryCode?: string | null;
+  createdByUserId: string;
+  fetchOverpass?: typeof fetchOverpassFlyerHangPlaces;
+  latitude: number;
+  limit?: number;
+  longitude: number;
+  personId?: string | null;
+  regionCode?: string | null;
+  userId: string;
+}): Promise<{
+  personalTaskId: string;
+  places: FlyerHangNearbyTask[];
+  usedOverpass: boolean;
+}> {
+  const limit = input.limit ?? FLYER_HANG_NEARBY_LIMIT;
+  const origin = {
+    latitude: input.latitude,
+    longitude: input.longitude,
+  };
+
+  const gridPlaces = buildGridSlotPlaceCandidates({
+    city: input.city,
+    countryCode: input.countryCode,
+    latitude: input.latitude,
+    longitude: input.longitude,
+    regionCode: input.regionCode,
+  });
+
+  let osmPlaces: FlyerHangPlaceCandidate[] = [];
+  let usedOverpass = false;
+  const fetchPlaces = input.fetchOverpass ?? fetchOverpassFlyerHangPlaces;
+  try {
+    osmPlaces = await fetchPlaces(origin);
+    usedOverpass = true;
+  } catch {
+    usedOverpass = false;
+  }
+
+  const merged: FlyerHangPlaceCandidate[] = [];
+  const seen = new Set<string>();
+  for (const place of [...osmPlaces, ...gridPlaces]) {
+    const key = taskKeyForFlyerHangPlace(place);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(place);
+    if (merged.length >= limit) break;
+  }
+
+  const parentTaskId = await resolveFlyerHangProgramParentId(
+    prisma,
+    input.createdByUserId,
+  );
+  const personal = await ensurePersonalHangFlyersTask({
+    createdByUserId: input.createdByUserId,
+    personId: input.personId,
+    userId: input.userId,
+  });
+
+  const upserted = [];
+  for (const place of merged) {
+    upserted.push(
+      await upsertPlaceTask(prisma, {
+        createdByUserId: input.createdByUserId,
+        parentTaskId,
+        place,
+      }),
+    );
+  }
+
+  const lastHung = await loadLastHungAtByTaskId(
+    prisma,
+    upserted.map((task) => task.id),
+  );
+
+  const places: FlyerHangNearbyTask[] = upserted
+    .map((task) => {
+      const latitude = task.workLocationLatitude ?? origin.latitude;
+      const longitude = task.workLocationLongitude ?? origin.longitude;
+      const lastHungAt = lastHung.get(task.id) ?? null;
+      const freshness = getFlyerHangFreshness({ lastHungAt });
+      return {
+        distanceKm: haversineKm(origin, { latitude, longitude }),
+        freshness,
+        href: getTaskPath(task.id),
+        id: task.id,
+        lastHungAt: lastHungAt?.toISOString() ?? null,
+        latitude,
+        locationText: task.locationText,
+        longitude,
+        name: task.locationText?.split(",")[0] ?? task.title,
+        source: parseFlyerHangSource(task.taskKey),
+        taskKey: task.taskKey ?? "",
+        title: task.title,
+      };
+    })
+    .sort((a, b) =>
+      compareFlyerHangPriority(
+        {
+          distanceKm: a.distanceKm,
+          isStale: a.freshness.isStale,
+          lastHungAt: a.freshness.lastHungAt,
+        },
+        {
+          distanceKm: b.distanceKm,
+          isStale: b.freshness.isStale,
+          lastHungAt: b.freshness.lastHungAt,
+        },
+      ),
+    );
+
+  return {
+    personalTaskId: personal.id,
+    places,
+    usedOverpass,
+  };
+}

--- a/packages/web/src/lib/flyer-hang/ensure-nearby.server.ts
+++ b/packages/web/src/lib/flyer-hang/ensure-nearby.server.ts
@@ -49,14 +49,13 @@ async function resolveFlyerHangProgramParentId(
   db: EnsureDb,
   createdByUserId: string,
 ) {
-  const existing = await db.task.findFirst({
-    where: { deletedAt: null, taskKey: FLYER_HANG_PROGRAM_TASK_KEY },
-    select: { id: true },
-  });
-  if (existing) return existing.id;
-
-  const created = await db.task.create({
-    data: {
+  // upsert, not findFirst-then-create: two concurrent first-callers can both
+  // miss the findFirst and both attempt create, and taskKey is unique, so
+  // the loser would throw and 500 the route. upsert lets Postgres resolve
+  // the race atomically.
+  const task = await db.task.upsert({
+    where: { taskKey: FLYER_HANG_PROGRAM_TASK_KEY },
+    create: {
       category: TaskCategory.OUTREACH,
       claimPolicy: TaskClaimPolicy.ASSIGNED_ONLY,
       createdByUserId,
@@ -69,9 +68,10 @@ async function resolveFlyerHangProgramParentId(
       taskKey: FLYER_HANG_PROGRAM_TASK_KEY,
       title: "Hang referral flyers in public places",
     },
+    update: {},
     select: { id: true },
   });
-  return created.id;
+  return task.id;
 }
 
 function descriptionForPlace(place: FlyerHangPlaceCandidate) {
@@ -175,10 +175,17 @@ async function loadLastHungAtByTaskId(
   taskIds: string[],
 ): Promise<Map<string, Date>> {
   if (taskIds.length === 0) return new Map();
+  // Verifying a claim on a public task requires an admin (see
+  // getTaskAccessWhere's VERIFY boundary in tasks.server.ts), and flyer-hang
+  // place tasks are public with an open-ended flow of claimants — admin
+  // review of every hang isn't realistic. Treat a claimant's own COMPLETED
+  // report (photo evidence required by completeTaskClaim) as "hung" too, so
+  // "Needs first hang" clears through the normal user flow instead of
+  // staying stuck pending an admin who will never see most of these.
   const claims = await db.taskClaim.findMany({
     where: {
       deletedAt: null,
-      status: TaskClaimStatus.VERIFIED,
+      status: { in: [TaskClaimStatus.COMPLETED, TaskClaimStatus.VERIFIED] },
       taskId: { in: taskIds },
     },
     select: {
@@ -186,13 +193,19 @@ async function loadLastHungAtByTaskId(
       taskId: true,
       verifiedAt: true,
     },
-    orderBy: { verifiedAt: "desc" },
   });
+  // Pick the most recent hang per task explicitly in JS rather than leaning
+  // on SQL ORDER BY + first-row-wins: verifiedAt is null for COMPLETED-only
+  // claims, and DB null-ordering defaults aren't something to depend on for
+  // correctness here.
   const map = new Map<string, Date>();
   for (const claim of claims) {
-    if (map.has(claim.taskId)) continue;
     const at = claim.verifiedAt ?? claim.completedAt;
-    if (at) map.set(claim.taskId, at);
+    if (!at) continue;
+    const current = map.get(claim.taskId);
+    if (!current || at.getTime() > current.getTime()) {
+      map.set(claim.taskId, at);
+    }
   }
   return map;
 }

--- a/packages/web/src/lib/flyer-hang/index.ts
+++ b/packages/web/src/lib/flyer-hang/index.ts
@@ -1,0 +1,17 @@
+export {
+  FLYER_HANG_NEARBY_LIMIT,
+  FLYER_HANG_SEARCH_RADIUS_KM,
+  FLYER_HANG_STALE_AFTER_DAYS,
+} from "./constants";
+export {
+  buildFlyerHangGridId,
+  buildGridSlotPlaceCandidates,
+  haversineKm,
+  parseOverpassFlyerHangPlaces,
+  taskKeyForFlyerHangPlace,
+} from "./places";
+export {
+  compareFlyerHangPriority,
+  getFlyerHangFreshness,
+} from "./staleness";
+export type { FlyerHangNearbyTask } from "./types";

--- a/packages/web/src/lib/flyer-hang/places.ts
+++ b/packages/web/src/lib/flyer-hang/places.ts
@@ -18,12 +18,13 @@ export type FlyerHangPlaceCandidate = {
   slotId?: FlyerHangGridSlotId;
 };
 
+function roundToGrid(value: number) {
+  return Math.round(value / FLYER_HANG_GRID_DEGREES) * FLYER_HANG_GRID_DEGREES;
+}
+
 export function buildFlyerHangGridId(latitude: number, longitude: number) {
-  const lat = (Math.round(latitude / FLYER_HANG_GRID_DEGREES) * FLYER_HANG_GRID_DEGREES)
-    .toFixed(2);
-  const lng = (
-    Math.round(longitude / FLYER_HANG_GRID_DEGREES) * FLYER_HANG_GRID_DEGREES
-  ).toFixed(2);
+  const lat = roundToGrid(latitude).toFixed(2);
+  const lng = roundToGrid(longitude).toFixed(2);
   return `${lat}:${lng}`;
 }
 
@@ -36,6 +37,14 @@ export function buildGridSlotPlaceCandidates(input: {
 }): FlyerHangPlaceCandidate[] {
   const gridId = buildFlyerHangGridId(input.latitude, input.longitude);
   const cityLabel = input.city?.trim() || "your area";
+  // taskKeyForFlyerHangPlace() derives the shared task's identity from
+  // gridId, so every user in the same cell upserts the same task. The
+  // candidate's own lat/lng must therefore come from that same rounded
+  // cell center, not each caller's raw origin — otherwise upsertPlaceTask's
+  // `update` branch keeps moving the shared task's map position to whoever
+  // last called in.
+  const cellLatitude = roundToGrid(input.latitude);
+  const cellLongitude = roundToGrid(input.longitude);
 
   return FLYER_HANG_GRID_SLOTS.map((slot, index) => {
     // Spread slots a few hundred meters around the grid center so ranking
@@ -45,8 +54,8 @@ export function buildGridSlotPlaceCandidates(input: {
     return {
       city: input.city?.trim() || null,
       countryCode: input.countryCode?.trim() || null,
-      latitude: input.latitude + offsetLat,
-      longitude: input.longitude + offsetLng,
+      latitude: cellLatitude + offsetLat,
+      longitude: cellLongitude + offsetLng,
       name: `${slot.title.replace(/^Hang a flyer at /i, "").replace(/^Hang a flyer /i, "")} (${cityLabel})`,
       placeId: `${gridId}:${slot.id}`,
       regionCode: input.regionCode?.trim() || null,

--- a/packages/web/src/lib/flyer-hang/places.ts
+++ b/packages/web/src/lib/flyer-hang/places.ts
@@ -1,0 +1,199 @@
+import { buildFlyerHangPlaceTaskKey } from "@optimitron/db/task-keys";
+import {
+  FLYER_HANG_GRID_DEGREES,
+  FLYER_HANG_GRID_SLOTS,
+  FLYER_HANG_SEARCH_RADIUS_KM,
+  type FlyerHangGridSlotId,
+} from "./constants";
+
+export type FlyerHangPlaceCandidate = {
+  city: string | null;
+  countryCode: string | null;
+  latitude: number;
+  longitude: number;
+  name: string;
+  placeId: string;
+  regionCode: string | null;
+  source: "grid" | "osm";
+  slotId?: FlyerHangGridSlotId;
+};
+
+export function buildFlyerHangGridId(latitude: number, longitude: number) {
+  const lat = (Math.round(latitude / FLYER_HANG_GRID_DEGREES) * FLYER_HANG_GRID_DEGREES)
+    .toFixed(2);
+  const lng = (
+    Math.round(longitude / FLYER_HANG_GRID_DEGREES) * FLYER_HANG_GRID_DEGREES
+  ).toFixed(2);
+  return `${lat}:${lng}`;
+}
+
+export function buildGridSlotPlaceCandidates(input: {
+  city?: string | null;
+  countryCode?: string | null;
+  latitude: number;
+  longitude: number;
+  regionCode?: string | null;
+}): FlyerHangPlaceCandidate[] {
+  const gridId = buildFlyerHangGridId(input.latitude, input.longitude);
+  const cityLabel = input.city?.trim() || "your area";
+
+  return FLYER_HANG_GRID_SLOTS.map((slot, index) => {
+    // Spread slots a few hundred meters around the grid center so ranking
+    // by distance is stable and maps are not stacked on one point.
+    const offsetLat = ((index % 3) - 1) * 0.002;
+    const offsetLng = (Math.floor(index / 3) - 0.5) * 0.002;
+    return {
+      city: input.city?.trim() || null,
+      countryCode: input.countryCode?.trim() || null,
+      latitude: input.latitude + offsetLat,
+      longitude: input.longitude + offsetLng,
+      name: `${slot.title.replace(/^Hang a flyer at /i, "").replace(/^Hang a flyer /i, "")} (${cityLabel})`,
+      placeId: `${gridId}:${slot.id}`,
+      regionCode: input.regionCode?.trim() || null,
+      slotId: slot.id,
+      source: "grid" as const,
+    };
+  });
+}
+
+export function haversineKm(
+  a: { latitude: number; longitude: number },
+  b: { latitude: number; longitude: number },
+) {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLng = toRad(b.longitude - a.longitude);
+  const lat1 = toRad(a.latitude);
+  const lat2 = toRad(b.latitude);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 6371 * 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+}
+
+type OverpassElement = {
+  id: number;
+  lat?: number;
+  lon?: number;
+  center?: { lat: number; lon: number };
+  tags?: Record<string, string>;
+  type: "node" | "way" | "relation";
+};
+
+function pickCoords(element: OverpassElement) {
+  if (typeof element.lat === "number" && typeof element.lon === "number") {
+    return { latitude: element.lat, longitude: element.lon };
+  }
+  if (
+    element.center &&
+    typeof element.center.lat === "number" &&
+    typeof element.center.lon === "number"
+  ) {
+    return { latitude: element.center.lat, longitude: element.center.lon };
+  }
+  return null;
+}
+
+function amenityLabel(tags: Record<string, string> | undefined) {
+  const amenity = tags?.amenity;
+  if (amenity === "library") return "Library";
+  if (amenity === "community_centre" || amenity === "community_center") {
+    return "Community center";
+  }
+  if (amenity === "university" || amenity === "college") return "Campus";
+  if (amenity === "cafe") return "Cafe board";
+  return "Public board";
+}
+
+export function parseOverpassFlyerHangPlaces(
+  payload: unknown,
+  origin: { latitude: number; longitude: number },
+): FlyerHangPlaceCandidate[] {
+  if (!payload || typeof payload !== "object") return [];
+  const elements = (payload as { elements?: OverpassElement[] }).elements;
+  if (!Array.isArray(elements)) return [];
+
+  const places: FlyerHangPlaceCandidate[] = [];
+  for (const element of elements) {
+    const coords = pickCoords(element);
+    if (!coords) continue;
+    const distanceKm = haversineKm(origin, coords);
+    if (distanceKm > FLYER_HANG_SEARCH_RADIUS_KM) continue;
+    const name =
+      element.tags?.name?.trim() ||
+      `${amenityLabel(element.tags)} near you`;
+    places.push({
+      city: element.tags?.["addr:city"]?.trim() || null,
+      countryCode: null,
+      latitude: coords.latitude,
+      longitude: coords.longitude,
+      name,
+      placeId: `${element.type}:${element.id}`,
+      regionCode: null,
+      source: "osm",
+    });
+  }
+
+  places.sort(
+    (a, b) => haversineKm(origin, a) - haversineKm(origin, b),
+  );
+  return places;
+}
+
+export function buildOverpassFlyerHangQuery(input: {
+  latitude: number;
+  longitude: number;
+  radiusMeters?: number;
+}) {
+  const radius = Math.round(
+    (input.radiusMeters ?? FLYER_HANG_SEARCH_RADIUS_KM * 1000),
+  );
+  const { latitude, longitude } = input;
+  return `
+[out:json][timeout:25];
+(
+  node["amenity"="library"](around:${radius},${latitude},${longitude});
+  way["amenity"="library"](around:${radius},${latitude},${longitude});
+  node["amenity"="community_centre"](around:${radius},${latitude},${longitude});
+  way["amenity"="community_centre"](around:${radius},${latitude},${longitude});
+  node["amenity"="university"](around:${radius},${latitude},${longitude});
+  node["amenity"="college"](around:${radius},${latitude},${longitude});
+  node["amenity"="cafe"]["board"="yes"](around:${radius},${latitude},${longitude});
+);
+out center tags 30;
+`.trim();
+}
+
+export async function fetchOverpassFlyerHangPlaces(
+  input: {
+    latitude: number;
+    longitude: number;
+  },
+  options?: {
+    fetchImpl?: typeof fetch;
+    endpoint?: string;
+  },
+): Promise<FlyerHangPlaceCandidate[]> {
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const endpoint =
+    options?.endpoint ?? "https://overpass-api.de/api/interpreter";
+  const query = buildOverpassFlyerHangQuery(input);
+  const response = await fetchImpl(endpoint, {
+    body: `data=${encodeURIComponent(query)}`,
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    method: "POST",
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Overpass request failed: ${response.status}`);
+  }
+  const payload = await response.json();
+  return parseOverpassFlyerHangPlaces(payload, input);
+}
+
+export function taskKeyForFlyerHangPlace(place: FlyerHangPlaceCandidate) {
+  return buildFlyerHangPlaceTaskKey({
+    placeId: place.placeId,
+    source: place.source,
+  });
+}

--- a/packages/web/src/lib/flyer-hang/server.ts
+++ b/packages/web/src/lib/flyer-hang/server.ts
@@ -1,0 +1,5 @@
+export {
+  ensureNearbyFlyerHangTasks,
+  ensurePersonalHangFlyersTask,
+} from "./ensure-nearby.server";
+export type { FlyerHangNearbyTask } from "./types";

--- a/packages/web/src/lib/flyer-hang/staleness.ts
+++ b/packages/web/src/lib/flyer-hang/staleness.ts
@@ -1,0 +1,56 @@
+import { FLYER_HANG_STALE_AFTER_DAYS } from "./constants";
+
+export function flyerHangStaleAfterMs(days = FLYER_HANG_STALE_AFTER_DAYS) {
+  return days * 86_400_000;
+}
+
+export function getFlyerHangFreshness(input: {
+  lastHungAt: Date | string | null | undefined;
+  now?: Date;
+  staleAfterDays?: number;
+}) {
+  const now = input.now ?? new Date();
+  const staleAfterMs = flyerHangStaleAfterMs(
+    input.staleAfterDays ?? FLYER_HANG_STALE_AFTER_DAYS,
+  );
+  if (!input.lastHungAt) {
+    return {
+      isStale: true,
+      lastHungAt: null as Date | null,
+      staleAgeDays: null as number | null,
+      status: "never_hung" as const,
+    };
+  }
+  const lastHungAt =
+    input.lastHungAt instanceof Date
+      ? input.lastHungAt
+      : new Date(input.lastHungAt);
+  const ageMs = now.getTime() - lastHungAt.getTime();
+  const staleAgeDays = ageMs / 86_400_000;
+  const isStale = ageMs >= staleAfterMs;
+  return {
+    isStale,
+    lastHungAt,
+    staleAgeDays,
+    status: isStale ? ("stale" as const) : ("fresh" as const),
+  };
+}
+
+export function compareFlyerHangPriority(a: {
+  distanceKm: number;
+  isStale: boolean;
+  lastHungAt: Date | null;
+}, b: {
+  distanceKm: number;
+  isStale: boolean;
+  lastHungAt: Date | null;
+}) {
+  if (a.isStale !== b.isStale) return a.isStale ? -1 : 1;
+  if (a.lastHungAt == null && b.lastHungAt != null) return -1;
+  if (a.lastHungAt != null && b.lastHungAt == null) return 1;
+  if (a.lastHungAt && b.lastHungAt) {
+    const ageDiff = a.lastHungAt.getTime() - b.lastHungAt.getTime();
+    if (ageDiff !== 0) return ageDiff; // older hang first among stale/fresh peers
+  }
+  return a.distanceKm - b.distanceKm;
+}

--- a/packages/web/src/lib/flyer-hang/types.ts
+++ b/packages/web/src/lib/flyer-hang/types.ts
@@ -1,0 +1,16 @@
+import type { getFlyerHangFreshness } from "./staleness";
+
+export type FlyerHangNearbyTask = {
+  distanceKm: number;
+  freshness: ReturnType<typeof getFlyerHangFreshness>;
+  href: string;
+  id: string;
+  lastHungAt: string | null;
+  latitude: number;
+  locationText: string | null;
+  longitude: number;
+  name: string;
+  source: string;
+  taskKey: string;
+  title: string;
+};

--- a/packages/web/src/lib/post-signin-sync.server.ts
+++ b/packages/web/src/lib/post-signin-sync.server.ts
@@ -109,9 +109,26 @@ export async function applyPostSigninSync({
     { actorUserId: userId },
   );
 
-  // Best-effort flyer hang inventory from saved/IP geo. Never fail signin
-  // if Overpass or task upserts error — the /poster page can retry with
-  // browser geolocation.
+  return {
+    personId: person.id,
+    referralRecorded,
+    userUpdated: Object.keys(updateData).length > 0,
+  };
+}
+
+/**
+ * Best-effort flyer hang inventory seed from saved/IP geo. Split out of
+ * applyPostSigninSync so the route handler can run it via Next's after()
+ * instead of awaiting it inline: Overpass can take up to 20s to answer
+ * (see fetchOverpassFlyerHangPlaces's AbortSignal.timeout), and every
+ * signin was blocking on that before returning a response. Never fail
+ * signin if Overpass or task upserts error — the /poster page can retry
+ * with browser geolocation.
+ */
+export async function seedNearbyFlyerHangTasksAfterSignin(
+  userId: string,
+  personId: string,
+) {
   const locatedUser = await prisma.user.findUnique({
     where: { id: userId },
     select: {
@@ -123,29 +140,25 @@ export async function applyPostSigninSync({
     },
   });
   if (
-    locatedUser?.latitude != null &&
-    locatedUser.longitude != null &&
-    Number.isFinite(locatedUser.latitude) &&
-    Number.isFinite(locatedUser.longitude)
+    locatedUser?.latitude == null ||
+    locatedUser.longitude == null ||
+    !Number.isFinite(locatedUser.latitude) ||
+    !Number.isFinite(locatedUser.longitude)
   ) {
-    try {
-      await ensureNearbyFlyerHangTasks({
-        city: locatedUser.city,
-        countryCode: locatedUser.countryCode,
-        createdByUserId: userId,
-        latitude: locatedUser.latitude,
-        longitude: locatedUser.longitude,
-        personId: person.id,
-        regionCode: locatedUser.regionCode,
-        userId,
-      });
-    } catch (error) {
-      console.error("[FLYER HANG] Failed to seed nearby hang tasks", userId, error);
-    }
+    return;
   }
-
-  return {
-    referralRecorded,
-    userUpdated: Object.keys(updateData).length > 0,
-  };
+  try {
+    await ensureNearbyFlyerHangTasks({
+      city: locatedUser.city,
+      countryCode: locatedUser.countryCode,
+      createdByUserId: userId,
+      latitude: locatedUser.latitude,
+      longitude: locatedUser.longitude,
+      personId,
+      regionCode: locatedUser.regionCode,
+      userId,
+    });
+  } catch (error) {
+    console.error("[FLYER HANG] Failed to seed nearby hang tasks", userId, error);
+  }
 }

--- a/packages/web/src/lib/post-signin-sync.server.ts
+++ b/packages/web/src/lib/post-signin-sync.server.ts
@@ -1,3 +1,4 @@
+import { ensureNearbyFlyerHangTasks } from "@/lib/flyer-hang/server";
 import { ensurePersonForUser } from "@/lib/person.server";
 import { prisma } from "@/lib/prisma";
 import { recordReferralAttributionForUser } from "@/lib/referral.server";
@@ -107,6 +108,41 @@ export async function applyPostSigninSync({
     }),
     { actorUserId: userId },
   );
+
+  // Best-effort flyer hang inventory from saved/IP geo. Never fail signin
+  // if Overpass or task upserts error — the /poster page can retry with
+  // browser geolocation.
+  const locatedUser = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      city: true,
+      countryCode: true,
+      latitude: true,
+      longitude: true,
+      regionCode: true,
+    },
+  });
+  if (
+    locatedUser?.latitude != null &&
+    locatedUser.longitude != null &&
+    Number.isFinite(locatedUser.latitude) &&
+    Number.isFinite(locatedUser.longitude)
+  ) {
+    try {
+      await ensureNearbyFlyerHangTasks({
+        city: locatedUser.city,
+        countryCode: locatedUser.countryCode,
+        createdByUserId: userId,
+        latitude: locatedUser.latitude,
+        longitude: locatedUser.longitude,
+        personId: person.id,
+        regionCode: locatedUser.regionCode,
+        userId,
+      });
+    } catch (error) {
+      console.error("[FLYER HANG] Failed to seed nearby hang tasks", userId, error);
+    }
+  }
 
   return {
     referralRecorded,

--- a/packages/web/src/lib/tasks.server.ts
+++ b/packages/web/src/lib/tasks.server.ts
@@ -8,6 +8,7 @@ import {
   TaskClaimStatus,
   TaskCompensationKind,
   TaskEdgeType,
+  TaskEngagementKind,
   TaskExecutionAttemptStatus,
   TaskExecutionMode,
   TaskImpactFrameKey,
@@ -81,12 +82,47 @@ const ACTIVE_CLAIM_STATUSES = [
   TaskClaimStatus.COMPLETED,
 ] as const;
 
-const CLAIM_STATUSES_THAT_BLOCK_RECLAIM = [
-  TaskClaimStatus.CLAIMED,
-  TaskClaimStatus.IN_PROGRESS,
-  TaskClaimStatus.COMPLETED,
-  TaskClaimStatus.VERIFIED,
-] as const;
+type ReclaimableTaskShape = {
+  compensationKind?: TaskCompensationKind | null;
+  engagementKind?: TaskEngagementKind | null;
+};
+
+/**
+ * Unpaid ONGOING tasks (flyer-hang spots) need the same volunteer to rehang
+ * after staleness. Paid/bounty claims stay non-reclaimable so verification
+ * cannot reset a TaskPayout row keyed 1:1 to the claim.
+ */
+function canReopenTerminalClaim(task: ReclaimableTaskShape) {
+  if (task.engagementKind !== TaskEngagementKind.ONGOING) {
+    return false;
+  }
+  if (
+    task.compensationKind === TaskCompensationKind.PAID ||
+    task.compensationKind === TaskCompensationKind.BOUNTY
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function claimStatusBlocksReclaim(
+  status: TaskClaimStatus,
+  task: ReclaimableTaskShape,
+) {
+  if (
+    status === TaskClaimStatus.CLAIMED ||
+    status === TaskClaimStatus.IN_PROGRESS
+  ) {
+    return true;
+  }
+  if (
+    status === TaskClaimStatus.COMPLETED ||
+    status === TaskClaimStatus.VERIFIED
+  ) {
+    return !canReopenTerminalClaim(task);
+  }
+  return false;
+}
 
 const personTaskProfilePersonSelect = {
   bio: true,
@@ -898,9 +934,7 @@ function hasViewerClaim(
   return task.claims.some(
     (claim) =>
       claim.userId === userId &&
-      CLAIM_STATUSES_THAT_BLOCK_RECLAIM.includes(
-        claim.status as (typeof CLAIM_STATUSES_THAT_BLOCK_RECLAIM)[number],
-      ),
+      claimStatusBlocksReclaim(claim.status as TaskClaimStatus, task),
   );
 }
 
@@ -2873,6 +2907,7 @@ export async function claimTask(taskId: string, userId: string) {
         compensationKind: true,
         compensationMaxAmountMinorUnits: true,
         compensationPaymentRails: true,
+        engagementKind: true,
         id: true,
         maxClaims: true,
         status: true,
@@ -2891,9 +2926,7 @@ export async function claimTask(taskId: string, userId: string) {
 
     if (
       existingClaim &&
-      CLAIM_STATUSES_THAT_BLOCK_RECLAIM.includes(
-        existingClaim.status as (typeof CLAIM_STATUSES_THAT_BLOCK_RECLAIM)[number],
-      )
+      claimStatusBlocksReclaim(existingClaim.status as TaskClaimStatus, task)
     ) {
       return existingClaim;
     }


### PR DESCRIPTION
## Summary
- After signup (when lat/lng is known), ensure shared nearby flyer-hang place Tasks (`OPEN_MANY`) from a grid of venue slots plus optional Overpass enrichment, plus a personal `hangFlyers` plan subtask pointing at `/poster`.
- `/poster` shows a nearby hang list (claim / open maps) alongside the existing AI route prompt; place tasks stay reusable for rehang via staleness ranking.
- Fix blank second sheet when printing letter posters by using a single dynamic `@page` with slightly undersized height (`10.95in` / `296mm`).

## Notes
- No Prisma schema change.
- Managed onboarding blueprint adds optional `hangFlyers` (`contributesToGate: false`); apply with `pnpm db:sync:managed-data -- --apply` when ready.
- Real credit remains QR referral votes; hang claims are coordination, not vanity points.

## Test plan
- [ ] Unit: `packages/db` flyer-hang task keys + `packages/web` flyer-hang place/staleness tests
- [ ] Sign in as a user with lat/lng; confirm personal hang task + shared nearby place tasks appear
- [ ] `/poster?logout=1` and logged-in: nearby panel loads / shows sign-in prompt
- [ ] Print letter and A4 posters: single sheet, no blank second page
- [ ] Claim a place task and confirm Maps link works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nearby flyer-hanging tasks to the poster page for signed-in users.
  * Supports optional browser location to find nearby places and task details.
  * Displays task freshness, distance, and priority information.
  * Automatically prepares nearby tasks after sign-in when location data is available.
  * Added a new onboarding task linking users to the poster page.

* **Bug Fixes**
  * Improved poster printing layout to prevent extra pages and support paper sizes.

* **Tests**
  * Added coverage for task generation, location discovery, freshness, and prioritization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->