### PR TITLE
Fix reminder response semantics, batch blast radius, and UTC times

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -176,7 +176,7 @@ verified against `feature/private-execution-system` (2026-07-17).
 
 - **Layer:** personal
 - **Status:** implemented
-- **Summary:** Personal health-variable reminders can be created, edited in place, listed, queried by due date, and answered as tracked, skipped, or snoozed through MCP. Answering a tracked reminder writes a `Measurement`; `listMeasurements` reads those measurements back for one variable or all of them. Reminders are queried on demand rather than delivered by a scheduler or UI.
+- **Summary:** Personal health-variable reminders can be created, edited in place, listed, queried by due date, and answered as tracked or snoozed through MCP. A not-taken day is recorded as value 0, not skipped, so the off periods stay in the series as baseline. Answering a tracked reminder writes a `Measurement`; `listMeasurements` reads those measurements back for one variable or all of them. Reminders are queried on demand rather than delivered by a scheduler or UI.
 - **Evidence:** `upsertTrackingReminder`, `listTrackingReminders`, `listDueTrackingReminders`, `respondToTrackingReminder`, and `listMeasurements` in packages/web/src/lib/mcp-server.ts
 - **Acceptance:** An authenticated caller can preserve a reminder's ID and response history while changing its schedule, a tracked response writes a measurement, and `listMeasurements` returns that measurement scoped to the caller's own subject.
 - **Roadmap:** shipped MCP workflow — task-queue or push delivery remains in OPT-HEALTH-06.

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -427,6 +427,30 @@ An unknown variable name is an error rather than an empty page, so a typo does
 not read as "nothing logged". Pages return `nextCursor`; repeat the same call
 with `cursor` set until it is null.
 
+### Answering Tracking Reminders
+
+A reminder has two answers: `TRACKED` records a measurement, `SNOOZED` defers
+the occurrence. Record `value: 0` on a day the treatment, food, or activity was
+not taken. Those zero days are the baseline an n-of-1 analysis compares against,
+so a gap costs confidence in every relationship inferred from that variable.
+Deactivate the reminder when it stops applying; do not leave holes.
+
+`SKIPPED` is retired. Calls that still send it record a zero and get a
+deprecation notice back. A variable whose `minimumAllowedValue` is above zero
+(a 1-5 rating, say) rejects the conversion instead, because there is no zero to
+record. Stored `SKIPPED` rows keep their status: nothing after the fact can tell
+whether an old skip meant zero or meant nobody answered.
+
+`listTrackingReminderNotifications` returns `notifyAtLocal` (compact: `due`) in
+the user's zone with the offset attached, plus the raw UTC instant in
+`notifyAt` (compact: `dueUtc`). `dateKey` and the day boundaries are local.
+
+`respondToTrackingReminderNotifications` answers several at once. Send only
+`except` entries to answer specific reminders; everything else stays untouched.
+`defaultStatus` is for answering the whole day and reaches only notifications
+that are due and still unanswered. An `except` entry can also correct a response
+already recorded.
+
 `serving`, `servings`, and the UCUM code `{serving}` resolve to the seeded
 `servings` unit. Use servings for simple behavior or adherence tracking. Use a
 specific mass, volume, energy, or nutrient unit such as `g`, `mL`, or `kcal`

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -10379,7 +10379,8 @@ describe("MCP server tool dispatch", () => {
         dateKey: "2026-08-03",
         failed: [],
         results: [],
-        skippedCount: 0,
+        // Nothing written, so every scheduled reminder counts as untouched.
+        skippedCount: 1,
         unknownExceptionIds: ["misheard-reminder"],
       });
       expect(mocks.transaction).not.toHaveBeenCalled();
@@ -10637,6 +10638,17 @@ describe("MCP server tool dispatch", () => {
           results: [{ reminderId: "reminder-2", source: "exception" }],
           unknownExceptionIds: [],
         });
+        // The correction anchors to the scheduled occurrence, so it upserts
+        // the same measurement row instead of adding a stale duplicate at
+        // the wall-clock time.
+        const correctionUpsert = mocks.measurementUpsert.mock.calls.at(-1)![0];
+        expect(
+          correctionUpsert.where.subjectId_globalVariableId_startTime,
+        ).toMatchObject({
+          // reminder-2's 09:00 occurrence, not the 20:00 wall clock.
+          startTime: new Date("2026-08-03T09:00:00.000Z"),
+        });
+        expect(correctionUpsert.create).toMatchObject({ value: 4 });
       } finally {
         now.mockRestore();
       }
@@ -11078,6 +11090,57 @@ describe("MCP server tool dispatch", () => {
       };
       expect(body.result.recordedAsZero).toBe(true);
       expect(body.result.deprecationNotice).toContain("SKIPPED is retired");
+    });
+
+    it("respondToTrackingReminder ignores a value sent with a retired SKIPPED", async () => {
+      mocks.trackingReminderFindFirst.mockResolvedValue({
+        defaultValue: 3,
+        deletedAt: null,
+        globalVariable: TRACKING_VARIABLE,
+        globalVariableId: "gv-vitd",
+        id: "reminder-1",
+        nOf1Variable: NOF1_VARIABLE,
+        reminderFrequency: 86_400,
+        reminderStartTime: "08:00",
+        userId: "user-1",
+      });
+      mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
+      mocks.trackingReminderNotificationCreate.mockResolvedValue({
+        id: "notification-2",
+        status: NotificationStatus.TRACKED,
+        trackedValue: 0,
+        trackingReminderId: "reminder-1",
+        userId: "user-1",
+      });
+      mocks.measurementUpsert.mockResolvedValue({
+        globalVariableId: "gv-vitd",
+        id: "measurement-1",
+        subjectId: "subject-1",
+        unitId: "unit-iu",
+        value: 0,
+      });
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "respondToTrackingReminder",
+        arguments: {
+          dateKey: "2026-07-01",
+          status: "SKIPPED",
+          trackingReminderId: "reminder-1",
+          value: 5,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      // recordedAsZero must not report a zero while storing something else.
+      expect(mocks.measurementUpsert.mock.calls[0]![0]).toMatchObject({
+        create: expect.objectContaining({ value: 0 }),
+      });
+      expect(
+        mocks.trackingReminderNotificationCreate.mock.calls[0]![0],
+      ).toMatchObject({
+        data: expect.objectContaining({ trackedValue: 0 }),
+      });
     });
 
     it("respondToTrackingReminder refuses a zero the variable cannot hold", async () => {

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -5443,13 +5443,12 @@ describe("MCP server tool dispatch", () => {
       expect(createTask?.description).toContain("never as bare IDs");
       expect(updateTask?.description).toContain("never as bare IDs");
       expect(respondToTrackingReminder).toMatchObject({
-        description: expect.stringContaining("TRACKED with value 0"),
+        description: expect.stringContaining("Record value 0"),
         inputSchema: {
           properties: {
             status: {
-              description: expect.stringContaining(
-                "SKIPPED records no measurement",
-              ),
+              enum: ["TRACKED", "SNOOZED"],
+              description: expect.stringContaining("SKIPPED is accepted"),
             },
           },
         },
@@ -9275,6 +9274,8 @@ describe("MCP server tool dispatch", () => {
       defaultUnit: TRACKING_UNIT,
       defaultUnitId: "unit-iu",
       id: "gv-vitd",
+      maximumAllowedValue: null,
+      minimumAllowedValue: null,
       name: "Vitamin D",
       variableCategory: { id: "cat-treatment", name: "Treatment" },
       variableCategoryId: "cat-treatment",
@@ -10199,23 +10200,64 @@ describe("MCP server tool dispatch", () => {
           dateKey: "2026-08-03",
           notifications: [
             {
-              due: "2026-08-03T08:00:00.000Z",
+              due: "2026-08-03T08:00:00+00:00",
+              dueUtc: "2026-08-03T08:00:00.000Z",
               id: "reminder-1",
               name: "Vitamin D",
               status: "OVERDUE",
             },
           ],
+          timeZone: "UTC",
         });
         expect(parseToolBody(deprecatedAlias)).toEqual({
           dateKey: "2026-08-03",
           reminders: [
             {
-              due: "2026-08-03T08:00:00.000Z",
+              due: "2026-08-03T08:00:00+00:00",
+              dueUtc: "2026-08-03T08:00:00.000Z",
               id: "reminder-1",
               name: "Vitamin D",
               status: "OVERDUE",
             },
           ],
+          timeZone: "UTC",
+        });
+      } finally {
+        now.mockRestore();
+      }
+    });
+
+    it("reports notification times in the user's local zone, not UTC", async () => {
+      const now = vi
+        .spyOn(Date, "now")
+        .mockReturnValue(new Date("2026-08-03T20:00:00.000Z").getTime());
+      try {
+        mocks.userFindUnique.mockResolvedValue({
+          timeZone: "America/Chicago",
+        });
+        mocks.trackingReminderFindMany.mockResolvedValue([
+          EXISTING_TRACKING_REMINDER,
+        ]);
+        mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "listTrackingReminderNotifications",
+          arguments: { dateKey: "2026-08-03" },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(parseToolBody(result)).toMatchObject({
+          notifications: [
+            {
+              // 08:00 Central, the time the reminder is actually set for.
+              notifyAt: "2026-08-03T13:00:00.000Z",
+              notifyAtLocal: "2026-08-03T08:00:00-05:00",
+              reminderStartTime: "08:00",
+              utcOffsetMinutes: -300,
+            },
+          ],
+          timeZone: "America/Chicago",
         });
       } finally {
         now.mockRestore();
@@ -10324,7 +10366,7 @@ describe("MCP server tool dispatch", () => {
           defaultStatus: "TRACKED",
           except: [
             {
-              status: "SKIPPED",
+              status: "SNOOZED",
               trackingReminderId: "misheard-reminder",
             },
           ],
@@ -10337,6 +10379,7 @@ describe("MCP server tool dispatch", () => {
         dateKey: "2026-08-03",
         failed: [],
         results: [],
+        skippedCount: 0,
         unknownExceptionIds: ["misheard-reminder"],
       });
       expect(mocks.transaction).not.toHaveBeenCalled();
@@ -10388,7 +10431,7 @@ describe("MCP server tool dispatch", () => {
           defaultStatus: "TRACKED",
           except: [
             {
-              status: "SKIPPED",
+              status: "SNOOZED",
               trackingReminderId: "reminder-2",
             },
           ],
@@ -10400,8 +10443,16 @@ describe("MCP server tool dispatch", () => {
         answeredCount: 2,
         failed: [],
         results: [
-          { reminderId: "reminder-1", status: NotificationStatus.TRACKED },
-          { reminderId: "reminder-2", status: NotificationStatus.SKIPPED },
+          {
+            reminderId: "reminder-1",
+            source: "default",
+            status: NotificationStatus.TRACKED,
+          },
+          {
+            reminderId: "reminder-2",
+            source: "exception",
+            status: NotificationStatus.SNOOZED,
+          },
         ],
         unknownExceptionIds: [],
       });
@@ -10410,8 +10461,185 @@ describe("MCP server tool dispatch", () => {
         mocks.trackingReminderNotificationCreate.mock.calls.map(
           ([call]) => call.data.status,
         ),
-      ).toEqual([NotificationStatus.TRACKED, NotificationStatus.SKIPPED]);
+      ).toEqual([NotificationStatus.TRACKED, NotificationStatus.SNOOZED]);
       expect(mocks.measurementUpsert).toHaveBeenCalledTimes(1);
+    });
+
+    it("answers only the except entries when defaultStatus is omitted", async () => {
+      const now = vi
+        .spyOn(Date, "now")
+        .mockReturnValue(new Date("2026-08-03T20:00:00.000Z").getTime());
+      try {
+        const secondReminder = {
+          ...EXISTING_TRACKING_REMINDER,
+          globalVariable: {
+            ...TRACKING_VARIABLE,
+            id: "gv-magnesium",
+            name: "Magnesium",
+          },
+          globalVariableId: "gv-magnesium",
+          id: "reminder-2",
+          reminderStartTime: "09:00",
+        };
+        const reminders = [EXISTING_TRACKING_REMINDER, secondReminder];
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+        mocks.trackingReminderFindMany.mockResolvedValue(reminders);
+        mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
+        mocks.trackingReminderFindFirst.mockImplementation(
+          async ({ where }: { where: { id: string } }) =>
+            reminders.find((reminder) => reminder.id === where.id) ?? null,
+        );
+        mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
+        mocks.trackingReminderNotificationCreate.mockImplementation(
+          async ({ data }: { data: Record<string, unknown> }) => ({
+            ...data,
+            id: `notification-${String(data.trackingReminderId)}`,
+          }),
+        );
+        mocks.measurementUpsert.mockResolvedValue({
+          globalVariableId: "gv-vitd",
+          id: "measurement-1",
+          subjectId: "subject-1",
+          unitId: "unit-iu",
+          value: 1,
+        });
+        mocks.trackingReminderUpdate.mockResolvedValue({ id: "reminder-1" });
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "respondToTrackingReminderNotifications",
+          arguments: {
+            dateKey: "2026-08-03",
+            except: [
+              {
+                status: "TRACKED",
+                trackingReminderId: "reminder-1",
+                value: 2,
+              },
+            ],
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(parseToolBody(result)).toMatchObject({
+          answeredCount: 1,
+          failed: [],
+          results: [
+            {
+              reminderId: "reminder-1",
+              source: "exception",
+              status: NotificationStatus.TRACKED,
+            },
+          ],
+          skippedCount: 1,
+        });
+        expect(mocks.trackingReminderNotificationCreate).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(
+          mocks.trackingReminderNotificationCreate.mock.calls[0]?.[0],
+        ).toMatchObject({
+          data: expect.objectContaining({ trackingReminderId: "reminder-1" }),
+        });
+      } finally {
+        now.mockRestore();
+      }
+    });
+
+    it("rejects a bulk call with neither defaultStatus nor exceptions", async () => {
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "respondToTrackingReminderNotifications",
+        arguments: { dateKey: "2026-08-03" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).message).toContain("Provide defaultStatus");
+      expect(mocks.trackingReminderFindMany).not.toHaveBeenCalled();
+      expect(mocks.trackingReminderNotificationCreate).not.toHaveBeenCalled();
+    });
+
+    it("leaves an already-answered notification alone but lets an exception correct it", async () => {
+      const now = vi
+        .spyOn(Date, "now")
+        .mockReturnValue(new Date("2026-08-03T20:00:00.000Z").getTime());
+      try {
+        const secondReminder = {
+          ...EXISTING_TRACKING_REMINDER,
+          globalVariable: {
+            ...TRACKING_VARIABLE,
+            id: "gv-magnesium",
+            name: "Magnesium",
+          },
+          globalVariableId: "gv-magnesium",
+          id: "reminder-2",
+          reminderStartTime: "09:00",
+        };
+        const reminders = [EXISTING_TRACKING_REMINDER, secondReminder];
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+        mocks.trackingReminderFindMany.mockResolvedValue(reminders);
+        // reminder-2 is already TRACKED for the day.
+        mocks.trackingReminderNotificationFindMany.mockResolvedValue([
+          {
+            deletedAt: null,
+            id: "notification-2",
+            notifyAt: new Date("2026-08-03T09:00:00.000Z"),
+            status: NotificationStatus.TRACKED,
+            trackedValue: 1,
+            trackingReminderId: "reminder-2",
+            userId: "user-1",
+          },
+        ]);
+        mocks.trackingReminderFindFirst.mockImplementation(
+          async ({ where }: { where: { id: string } }) =>
+            reminders.find((reminder) => reminder.id === where.id) ?? null,
+        );
+        mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
+        mocks.trackingReminderNotificationCreate.mockImplementation(
+          async ({ data }: { data: Record<string, unknown> }) => ({
+            ...data,
+            id: `notification-${String(data.trackingReminderId)}`,
+          }),
+        );
+        mocks.measurementUpsert.mockResolvedValue({
+          globalVariableId: "gv-vitd",
+          id: "measurement-1",
+          subjectId: "subject-1",
+          unitId: "unit-iu",
+          value: 1,
+        });
+        mocks.trackingReminderUpdate.mockResolvedValue({ id: "reminder-1" });
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const defaultOnly = await client.callTool({
+          name: "respondToTrackingReminderNotifications",
+          arguments: { dateKey: "2026-08-03", defaultStatus: "TRACKED" },
+        });
+
+        expect(parseToolBody(defaultOnly)).toMatchObject({
+          answeredCount: 1,
+          results: [{ reminderId: "reminder-1", source: "default" }],
+          skippedCount: 1,
+        });
+
+        const correction = await client.callTool({
+          name: "respondToTrackingReminderNotifications",
+          arguments: {
+            dateKey: "2026-08-03",
+            except: [
+              { status: "TRACKED", trackingReminderId: "reminder-2", value: 4 },
+            ],
+          },
+        });
+
+        expect(parseToolBody(correction)).toMatchObject({
+          answeredCount: 1,
+          results: [{ reminderId: "reminder-2", source: "exception" }],
+          unknownExceptionIds: [],
+        });
+      } finally {
+        now.mockRestore();
+      }
     });
 
     it("bulk responses leave later notifications untouched", async () => {
@@ -10452,7 +10680,7 @@ describe("MCP server tool dispatch", () => {
           name: "respondToTrackingReminderNotifications",
           arguments: {
             dateKey: "2026-08-03",
-            defaultStatus: "SKIPPED",
+            defaultStatus: "SNOOZED",
           },
         });
 
@@ -10461,8 +10689,9 @@ describe("MCP server tool dispatch", () => {
           answeredCount: 1,
           failed: [],
           results: [
-            { reminderId: "reminder-1", status: NotificationStatus.SKIPPED },
+            { reminderId: "reminder-1", status: NotificationStatus.SNOOZED },
           ],
+          skippedCount: 1,
         });
         expect(mocks.trackingReminderNotificationCreate).toHaveBeenCalledTimes(
           1,
@@ -10744,10 +10973,17 @@ describe("MCP server tool dispatch", () => {
       mocks.trackingReminderNotificationUpdate.mockResolvedValue({
         id: "notification-at-old-time",
         notifyAt: new Date("2026-07-01T13:00:00.000Z"),
-        status: NotificationStatus.SKIPPED,
-        trackedValue: null,
+        status: NotificationStatus.TRACKED,
+        trackedValue: 0,
         trackingReminderId: "reminder-1",
         userId: "user-1",
+      });
+      mocks.measurementUpsert.mockResolvedValue({
+        globalVariableId: "gv-vitd",
+        id: "measurement-1",
+        subjectId: "subject-1",
+        unitId: "unit-iu",
+        value: 0,
       });
 
       const client = await setup("user-1", ALL_SCOPES);
@@ -10755,8 +10991,9 @@ describe("MCP server tool dispatch", () => {
         name: "respondToTrackingReminder",
         arguments: {
           dateKey: "2026-07-01",
-          status: "SKIPPED",
+          status: "TRACKED",
           trackingReminderId: "reminder-1",
+          value: 0,
         },
       });
 
@@ -10775,15 +11012,15 @@ describe("MCP server tool dispatch", () => {
       expect(mocks.trackingReminderNotificationUpdate).toHaveBeenCalledWith({
         data: {
           receivedAt: expect.any(Date),
-          status: NotificationStatus.SKIPPED,
-          trackedValue: null,
+          status: NotificationStatus.TRACKED,
+          trackedValue: 0,
         },
         where: { id: "notification-at-old-time" },
       });
       expect(mocks.trackingReminderNotificationCreate).not.toHaveBeenCalled();
     });
 
-    it("respondToTrackingReminder SKIPPED writes the notification but no Measurement", async () => {
+    it("respondToTrackingReminder records a retired SKIPPED as zero, not the default dose", async () => {
       mocks.trackingReminderFindFirst.mockResolvedValue({
         defaultValue: 3,
         deletedAt: null,
@@ -10798,10 +11035,17 @@ describe("MCP server tool dispatch", () => {
       mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
       mocks.trackingReminderNotificationCreate.mockResolvedValue({
         id: "notification-2",
-        status: NotificationStatus.SKIPPED,
-        trackedValue: null,
+        status: NotificationStatus.TRACKED,
+        trackedValue: 0,
         trackingReminderId: "reminder-1",
         userId: "user-1",
+      });
+      mocks.measurementUpsert.mockResolvedValue({
+        globalVariableId: "gv-vitd",
+        id: "measurement-1",
+        subjectId: "subject-1",
+        unitId: "unit-iu",
+        value: 0,
       });
 
       const client = await setup("user-1", ALL_SCOPES);
@@ -10821,16 +11065,56 @@ describe("MCP server tool dispatch", () => {
         mocks.trackingReminderNotificationCreate.mock.calls[0]![0],
       ).toMatchObject({
         data: expect.objectContaining({
-          status: NotificationStatus.SKIPPED,
-          trackedValue: null,
+          status: NotificationStatus.TRACKED,
+          trackedValue: 0,
         }),
       });
-      expect(mocks.measurementUpsert).not.toHaveBeenCalled();
-      expect(mocks.trackingReminderUpdate).not.toHaveBeenCalled();
+      expect(mocks.measurementUpsert).toHaveBeenCalledTimes(1);
+      expect(mocks.measurementUpsert.mock.calls[0]![0]).toMatchObject({
+        create: expect.objectContaining({ value: 0 }),
+      });
       const body = parseToolBody(result) as {
-        result: { measurement: unknown };
+        result: { deprecationNotice: string; recordedAsZero: boolean };
       };
-      expect(body.result.measurement).toBeNull();
+      expect(body.result.recordedAsZero).toBe(true);
+      expect(body.result.deprecationNotice).toContain("SKIPPED is retired");
+    });
+
+    it("respondToTrackingReminder refuses a zero the variable cannot hold", async () => {
+      mocks.trackingReminderFindFirst.mockResolvedValue({
+        defaultValue: 3,
+        deletedAt: null,
+        globalVariable: {
+          ...TRACKING_VARIABLE,
+          id: "gv-mood",
+          minimumAllowedValue: 1,
+          name: "Mood",
+        },
+        globalVariableId: "gv-mood",
+        id: "reminder-1",
+        nOf1Variable: NOF1_VARIABLE,
+        reminderFrequency: 86_400,
+        reminderStartTime: "08:00",
+        userId: "user-1",
+      });
+      mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "respondToTrackingReminder",
+        arguments: {
+          dateKey: "2026-07-01",
+          status: "SKIPPED",
+          trackingReminderId: "reminder-1",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).message).toContain(
+        "Zero is below the minimum allowed value",
+      );
+      expect(mocks.trackingReminderNotificationCreate).not.toHaveBeenCalled();
+      expect(mocks.measurementUpsert).not.toHaveBeenCalled();
     });
 
     it("rejects a caller lacking TASKS_PERSONAL scope", async () => {

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -3858,15 +3858,19 @@ function resolveTrackingResponseStatus(status: NotificationStatus) {
  * the reminder off.
  */
 function assertZeroIsMeasurable(variable: {
+  maximumAllowedValue: number | null;
   minimumAllowedValue: number | null;
   name: string;
 }) {
-  if (
-    variable.minimumAllowedValue != null &&
-    variable.minimumAllowedValue > 0
-  ) {
+  const bound =
+    variable.minimumAllowedValue != null && variable.minimumAllowedValue > 0
+      ? { label: "below the minimum", value: variable.minimumAllowedValue }
+      : variable.maximumAllowedValue != null && variable.maximumAllowedValue < 0
+        ? { label: "above the maximum", value: variable.maximumAllowedValue }
+        : null;
+  if (bound) {
     throw new Error(
-      `Zero is below the minimum allowed value (${variable.minimumAllowedValue}) for ${variable.name}, so "not taken" cannot be recorded as zero. Pass an explicit value, use SNOOZED, or deactivate the reminder.`,
+      `Zero is ${bound.label} allowed value (${bound.value}) for ${variable.name}, so "not taken" cannot be recorded as zero. Pass an explicit value, use SNOOZED, or deactivate the reminder.`,
     );
   }
 }
@@ -3956,7 +3960,8 @@ async function respondToTrackingReminderNotificationsForUser(
       dateKey: due.dateKey,
       failed: [],
       results: [],
-      skippedCount: 0,
+      // Nothing was written, so every scheduled reminder was left untouched.
+      skippedCount: due.notifications.length,
       unknownExceptionIds,
     };
   }
@@ -3999,6 +4004,11 @@ async function respondToTrackingReminderNotificationsForUser(
           // Pass the requested status, not the resolved one, so a retired
           // SKIPPED still lands as a zero instead of the reminder's default.
           status: requestedStatus,
+          // Anchor the measurement to the scheduled occurrence rather than
+          // the wall clock. Answering the same notification twice then
+          // upserts one row, so an exception that corrects an earlier batch
+          // answer overwrites it instead of leaving a stale duplicate.
+          trackedAt: item.notifyAt,
           trackingReminderId: item.reminderId,
           value: override?.value,
         },
@@ -4067,14 +4077,16 @@ async function respondToTrackingReminderForUser(
       throw new Error(`TrackingReminder not found: ${trackingReminderId}`);
     }
     const explicitValue = parseOptionalFiniteNumberInput(input, "value");
-    if (recordedAsZero && explicitValue == null) {
+    if (recordedAsZero) {
       assertZeroIsMeasurable(reminder.globalVariable);
     }
     const trackedValue =
       status === NotificationStatus.TRACKED
         ? recordedAsZero
-          ? // "Not taken" is zero, never the reminder's default dose.
-            (explicitValue ?? 0)
+          ? // A retired SKIPPED means not taken, so it is always zero: never
+            // the reminder's default dose, and never a value sent alongside
+            // it. Anything else would contradict the recordedAsZero result.
+            0
           : (explicitValue ?? cleanNumber(reminder.defaultValue))
         : null;
     if (status === NotificationStatus.TRACKED && trackedValue == null) {

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -125,7 +125,9 @@ import { IMAGE_UPLOAD_KINDS, isImageUploadKind } from "./image-upload-types";
 import { refreshMeasurementSummaries } from "./measurement-summaries.server";
 import { ensureSubjectForUser } from "./subject.server";
 import {
+  formatZonedIsoString,
   getStartOfZonedDayUtc,
+  getTimeZoneOffsetMinutes,
   getZonedDateKey,
   getZonedDateTimeUtc,
   parseDateKey as parseZonedDateKey,
@@ -2770,6 +2772,8 @@ const TRACKING_VARIABLE_SELECT = {
   defaultUnit: { select: TRACKING_UNIT_SELECT },
   defaultUnitId: true,
   id: true,
+  maximumAllowedValue: true,
+  minimumAllowedValue: true,
   name: true,
   variableCategory: { select: { id: true, name: true } },
   variableCategoryId: true,
@@ -3662,7 +3666,8 @@ async function listDueTrackingRemindersForUser(
     occurrenceByReminderId.set(reminder.id, occurrence);
     return true;
   });
-  if (dueReminders.length === 0) return { dateKey, notifications: [] };
+  if (dueReminders.length === 0)
+    return { dateKey, notifications: [], timeZone };
 
   const notifications = await prisma.trackingReminderNotification.findMany({
     orderBy: [{ notifyAt: "asc" }],
@@ -3716,12 +3721,21 @@ async function listDueTrackingRemindersForUser(
         isOverdue,
         notification,
         notifyAt,
+        // Reminders are scheduled in local wall-clock time, so report that
+        // alongside the UTC instant. Reading only notifyAt makes an 08:00
+        // Central reminder look like it fires at 13:00.
+        notifyAtLocal: formatZonedIsoString(notifyAt, timeZone),
         overdueSince: isOverdue ? notifyAt : null,
+        overdueSinceLocal: isOverdue
+          ? formatZonedIsoString(notifyAt, timeZone)
+          : null,
         reminderEndTime: reminder.reminderEndTime,
         reminderFrequency: reminder.reminderFrequency,
         reminderId: reminder.id,
         reminderStartTime: reminder.reminderStartTime,
         status,
+        timeZone,
+        utcOffsetMinutes: getTimeZoneOffsetMinutes(notifyAt, timeZone),
       };
     })
     .filter((reminder) => {
@@ -3737,7 +3751,7 @@ async function listDueTrackingRemindersForUser(
         reminder.status === NotificationStatus.SENT
       );
     });
-  return { dateKey, notifications: remindersWithStatus };
+  return { dateKey, notifications: remindersWithStatus, timeZone };
 }
 
 function toCompactTrackingNotifications(
@@ -3746,11 +3760,15 @@ function toCompactTrackingNotifications(
   return {
     dateKey: result.dateKey,
     notifications: result.notifications.map((notification) => ({
-      due: notification.notifyAt,
+      // `due` is the user's local time so a voice client can read it aloud
+      // without converting. `dueUtc` keeps the raw instant for machines.
+      due: notification.notifyAtLocal,
+      dueUtc: notification.notifyAt,
       id: notification.reminderId,
       name: notification.globalVariable.name,
       status: notification.derivedStatus,
     })),
+    timeZone: result.timeZone,
   };
 }
 
@@ -3816,7 +3834,40 @@ function assertTrackingReminderResponseStatus(
     status !== NotificationStatus.SKIPPED &&
     status !== NotificationStatus.SNOOZED
   ) {
-    throw new Error(`${fieldName} must be TRACKED, SKIPPED, or SNOOZED.`);
+    throw new Error(`${fieldName} must be TRACKED or SNOOZED.`);
+  }
+}
+
+/**
+ * SKIPPED is retired. A day a treatment, food, or activity was not taken is a
+ * zero, not a missing value: the off periods are the baseline that n-of-1
+ * causal inference needs. Callers that still send SKIPPED record a zero.
+ * Stored SKIPPED rows keep their status; we cannot know after the fact whether
+ * an old skip meant zero or meant nobody answered.
+ */
+function resolveTrackingResponseStatus(status: NotificationStatus) {
+  return status === NotificationStatus.SKIPPED
+    ? { recordedAsZero: true, status: NotificationStatus.TRACKED }
+    : { recordedAsZero: false, status };
+}
+
+/**
+ * Zero is the right entry for "not taken" only when zero is a value the
+ * variable can hold. A 1-5 mood rating has no zero, so nobody answering it is
+ * a genuine gap and the caller has to pick: a real value, a snooze, or turning
+ * the reminder off.
+ */
+function assertZeroIsMeasurable(variable: {
+  minimumAllowedValue: number | null;
+  name: string;
+}) {
+  if (
+    variable.minimumAllowedValue != null &&
+    variable.minimumAllowedValue > 0
+  ) {
+    throw new Error(
+      `Zero is below the minimum allowed value (${variable.minimumAllowedValue}) for ${variable.name}, so "not taken" cannot be recorded as zero. Pass an explicit value, use SNOOZED, or deactivate the reminder.`,
+    );
   }
 }
 
@@ -3829,7 +3880,9 @@ async function respondToTrackingReminderNotificationsForUser(
     input.defaultStatus,
     "defaultStatus",
   );
-  assertTrackingReminderResponseStatus(defaultStatus, "defaultStatus");
+  if (defaultStatus !== undefined) {
+    assertTrackingReminderResponseStatus(defaultStatus, "defaultStatus");
+  }
 
   const globalSnoozeMinutes =
     input.snoozeMinutes === undefined ? undefined : parseSnoozeMinutes(input);
@@ -3847,6 +3900,12 @@ async function respondToTrackingReminderNotificationsForUser(
     }
   >();
 
+  if (defaultStatus === undefined && exceptions.length === 0) {
+    throw new Error(
+      "Provide defaultStatus, at least one except entry, or both. Without either there is nothing to answer.",
+    );
+  }
+
   for (const raw of exceptions) {
     if (raw === null || typeof raw !== "object") {
       throw new Error("Each except entry must be an object.");
@@ -3859,6 +3918,11 @@ async function respondToTrackingReminderNotificationsForUser(
     const status =
       parseEnumInput(NotificationStatus, entry.status, "status") ??
       defaultStatus;
+    if (status === undefined) {
+      throw new Error(
+        `Each except entry needs a status when defaultStatus is omitted. Missing status for ${trackingReminderId}.`,
+      );
+    }
     assertTrackingReminderResponseStatus(status, "status");
     overrideById.set(trackingReminderId, {
       note: entry.note,
@@ -3871,17 +3935,19 @@ async function respondToTrackingReminderNotificationsForUser(
     });
   }
 
+  // Read the whole day, answered rows included, so an exception can correct a
+  // response that already exists. The single-reminder tool has always allowed
+  // that; rejecting it here made the two tools disagree.
   const due = await listDueTrackingRemindersForUser(
-    { dateKey: input.dateKey },
+    { dateKey: input.dateKey, includeCompleted: true },
     userId,
   );
   const now = Date.now();
-  const dueNotifications = due.notifications.filter(
-    (item) => item.notifyAt.getTime() <= now,
+  const scheduledIds = new Set(
+    due.notifications.map((item) => item.reminderId),
   );
-  const dueIds = new Set(dueNotifications.map((item) => item.reminderId));
   const unknownExceptionIds = [...overrideById.keys()].filter(
-    (id) => !dueIds.has(id),
+    (id) => !scheduledIds.has(id),
   );
 
   if (unknownExceptionIds.length > 0) {
@@ -3890,32 +3956,60 @@ async function respondToTrackingReminderNotificationsForUser(
       dateKey: due.dateKey,
       failed: [],
       results: [],
+      skippedCount: 0,
       unknownExceptionIds,
     };
   }
 
+  // defaultStatus only reaches notifications that are due and still
+  // unanswered. Answering one reminder must never overwrite the rest of the
+  // day, and an already-recorded response is not the default's business.
+  const isUnanswered = (item: (typeof due.notifications)[number]) =>
+    item.status === NotificationStatus.PENDING ||
+    item.status === NotificationStatus.SENT ||
+    (item.status === NotificationStatus.SNOOZED &&
+      item.notifyAt.getTime() <= now);
+  const targets = due.notifications.filter((item) => {
+    if (overrideById.has(item.reminderId)) return true;
+    if (defaultStatus === undefined) return false;
+    return item.notifyAt.getTime() <= now && isUnanswered(item);
+  });
+  const skippedCount = due.notifications.length - targets.length;
+
   const results: Array<{
+    recordedAsZero: boolean;
     reminderId: string;
+    source: "default" | "exception";
     status: NotificationStatus;
   }> = [];
   const failed: Array<{ reminderId: string; error: string }> = [];
 
-  for (const item of dueNotifications) {
+  for (const item of targets) {
     const override = overrideById.get(item.reminderId);
-    const status = override?.status ?? defaultStatus;
+    const requestedStatus = override?.status ?? defaultStatus;
+    if (requestedStatus === undefined) continue;
+    const { recordedAsZero, status } =
+      resolveTrackingResponseStatus(requestedStatus);
     try {
       await respondToTrackingReminderForUser(
         {
           dateKey: due.dateKey,
           note: override?.note ?? input.note,
           snoozeMinutes: override?.snoozeMinutes ?? globalSnoozeMinutes,
-          status,
+          // Pass the requested status, not the resolved one, so a retired
+          // SKIPPED still lands as a zero instead of the reminder's default.
+          status: requestedStatus,
           trackingReminderId: item.reminderId,
           value: override?.value,
         },
         userId,
       );
-      results.push({ reminderId: item.reminderId, status });
+      results.push({
+        recordedAsZero,
+        reminderId: item.reminderId,
+        source: override ? "exception" : "default",
+        status,
+      });
     } catch (error) {
       failed.push({
         error: error instanceof Error ? error.message : String(error),
@@ -3929,6 +4023,8 @@ async function respondToTrackingReminderNotificationsForUser(
     dateKey: due.dateKey,
     failed,
     results,
+    // Reminders scheduled today that this call deliberately left alone.
+    skippedCount,
     unknownExceptionIds,
   };
 }
@@ -3937,10 +4033,12 @@ async function respondToTrackingReminderForUser(
   input: Record<string, unknown>,
   userId: string,
 ) {
-  const status =
+  const requestedStatus =
     parseEnumInput(NotificationStatus, input.status, "status") ??
     NotificationStatus.TRACKED;
-  assertTrackingReminderResponseStatus(status, "status");
+  assertTrackingReminderResponseStatus(requestedStatus, "status");
+  const { recordedAsZero, status } =
+    resolveTrackingResponseStatus(requestedStatus);
   const trackingReminderId = optionalString(input.trackingReminderId);
   if (!trackingReminderId) throw new Error("trackingReminderId is required.");
   const snoozeMinutes =
@@ -3968,10 +4066,16 @@ async function respondToTrackingReminderForUser(
     if (!reminder) {
       throw new Error(`TrackingReminder not found: ${trackingReminderId}`);
     }
+    const explicitValue = parseOptionalFiniteNumberInput(input, "value");
+    if (recordedAsZero && explicitValue == null) {
+      assertZeroIsMeasurable(reminder.globalVariable);
+    }
     const trackedValue =
       status === NotificationStatus.TRACKED
-        ? (parseOptionalFiniteNumberInput(input, "value") ??
-          cleanNumber(reminder.defaultValue))
+        ? recordedAsZero
+          ? // "Not taken" is zero, never the reminder's default dose.
+            (explicitValue ?? 0)
+          : (explicitValue ?? cleanNumber(reminder.defaultValue))
         : null;
     if (status === NotificationStatus.TRACKED && trackedValue == null) {
       throw new Error(
@@ -4039,7 +4143,19 @@ async function respondToTrackingReminderForUser(
         where: { id: reminder.id },
       });
     }
-    return { dateKey, measurement, notification, reminderId: reminder.id };
+    return {
+      dateKey,
+      measurement,
+      notification,
+      recordedAsZero,
+      reminderId: reminder.id,
+      ...(recordedAsZero
+        ? {
+            deprecationNotice:
+              "SKIPPED is retired. This response recorded a zero measurement so the not-taken day counts as baseline. Send TRACKED with value 0 instead.",
+          }
+        : {}),
+    };
   });
 }
 
@@ -5292,7 +5408,7 @@ const TRACKING_TOOL_DEFINITIONS = [
   {
     name: "upsertTrackingReminder",
     description:
-      "Create or edit a personal tracking reminder for medications, food, symptoms, mood, sleep, activity, labs, or vitals. When creating a new variable, pass categoryName; Food defaults to servings. To edit a reminder in place, first get its ID from listTrackingReminders, then pass trackingReminderId plus only the fields to change. Omit trackingReminderId to create or idempotently update the reminder identified by variable, start time, and frequency. The reminder can later be answered as TRACKED, SKIPPED, or SNOOZED.",
+      "Create or edit a personal tracking reminder for medications, food, symptoms, mood, sleep, activity, labs, or vitals. When creating a new variable, pass categoryName; Food defaults to servings. To edit a reminder in place, first get its ID from listTrackingReminders, then pass trackingReminderId plus only the fields to change. Omit trackingReminderId to create or idempotently update the reminder identified by variable, start time, and frequency. The reminder can later be answered as TRACKED (value 0 for a not-taken day) or SNOOZED.",
     inputSchema: {
       type: "object" as const,
       anyOf: [
@@ -5372,7 +5488,7 @@ const TRACKING_TOOL_DEFINITIONS = [
   {
     name: "listTrackingReminderNotifications",
     description:
-      "List due tracking reminder notifications. A reminder defines a schedule. A notification is one occurrence that you answer. Most pending notifications have no stored row. Use compact mode for voice or chat clients.",
+      "List due tracking reminder notifications. A reminder defines a schedule. A notification is one occurrence that you answer. Most pending notifications have no stored row. Use compact mode for voice or chat clients. Times come back in the user's time zone as notifyAtLocal (compact: due), with the UTC instant in notifyAt (compact: dueUtc).",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -5412,7 +5528,7 @@ const TRACKING_TOOL_DEFINITIONS = [
         includeCompleted: {
           type: "boolean",
           description:
-            "When true, include reminders already TRACKED, SKIPPED, or SNOOZED for the date.",
+            "When true, include reminders already answered or snoozed for the date.",
         },
       },
     },
@@ -5420,7 +5536,7 @@ const TRACKING_TOOL_DEFINITIONS = [
   {
     name: "respondToTrackingReminderNotifications",
     description:
-      "Answer notifications whose due time has arrived. Apply one default status and optional exceptions. If any exception ID is not due, this tool writes nothing. Valid reminders continue when one response fails.",
+      "Answer several tracking reminder notifications in one call. To answer specific reminders, send only except entries and omit defaultStatus; every other reminder stays untouched. Send defaultStatus only when you intend to answer the whole day. An except entry can also correct a response you already recorded. If any exception ID is not scheduled for the date, this tool writes nothing.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -5430,21 +5546,21 @@ const TRACKING_TOOL_DEFINITIONS = [
         },
         defaultStatus: {
           type: "string",
-          enum: ["TRACKED", "SKIPPED", "SNOOZED"],
+          enum: ["TRACKED", "SNOOZED"],
           description:
-            "Apply this status to each notification without an exception.",
+            "Optional. Apply this status to every due and unanswered notification without an exception. Omit it to answer only the except entries. Already-answered notifications are never touched by the default.",
         },
         except: {
           type: "array",
           description:
-            "Override individual notifications by trackingReminderId.",
+            "Answer or correct individual notifications by trackingReminderId. Each entry needs a status when defaultStatus is omitted.",
           items: {
             type: "object",
             properties: {
               trackingReminderId: { type: "string" },
               status: {
                 type: "string",
-                enum: ["TRACKED", "SKIPPED", "SNOOZED"],
+                enum: ["TRACKED", "SNOOZED"],
               },
               value: { type: "number" },
               snoozeMinutes: { type: "number" },
@@ -5460,22 +5576,21 @@ const TRACKING_TOOL_DEFINITIONS = [
             "Set the snooze duration. The default is 30 minutes. The server caps the deferred time at the local day's end.",
         },
       },
-      required: ["defaultStatus"],
     },
   },
   {
     name: "respondToTrackingReminder",
     description:
-      "Answer a due tracking reminder. TRACKED records a measurement; use TRACKED with value 0 when the value was definitely zero so analysis counts it. SKIPPED dismisses the occurrence without a measurement and leaves a gap. SNOOZED defers it.",
+      "Answer a due tracking reminder. TRACKED records a measurement. Record value 0 when the treatment, food, or activity was not taken; those zero days are the baseline that causal analysis needs. SNOOZED defers the notification. Deactivate the reminder when it no longer applies. SKIPPED is retired: it now records a zero and returns a deprecation notice.",
     inputSchema: {
       type: "object" as const,
       properties: {
         trackingReminderId: { type: "string" },
         status: {
           type: "string",
-          enum: ["TRACKED", "SKIPPED", "SNOOZED"],
+          enum: ["TRACKED", "SNOOZED"],
           description:
-            "TRACKED records a measurement. SKIPPED records no measurement. SNOOZED defers the notification.",
+            "TRACKED records a measurement; pass value 0 for a not-taken day. SNOOZED defers the notification. SKIPPED is accepted but retired and records a zero.",
         },
         snoozeMinutes: {
           type: "number",
@@ -10887,8 +11002,7 @@ export function createMcpServer(
             // which is the primary way Claude Code and Codex connect
             // locally — defeating the pre-edit lease/execution inspection
             // this tool exists for.
-            const coordination =
-              await lease.getTaskCoordinationContext(taskId);
+            const coordination = await lease.getTaskCoordinationContext(taskId);
             return ok({
               coordination,
               task: enrichTaskForMcp(result.task),

--- a/packages/web/src/lib/time-zone.ts
+++ b/packages/web/src/lib/time-zone.ts
@@ -91,6 +91,24 @@ export function getZonedDateKey(date: Date, timeZone: string) {
   return `${parts.year}-${padNumber(parts.month)}-${padNumber(parts.day)}`;
 }
 
+export function getTimeZoneOffsetMinutes(date: Date, timeZone: string) {
+  return Math.round(getTimeZoneOffsetMs(date, timeZone) / 60_000);
+}
+
+/**
+ * Format an instant as an ISO 8601 string in the given zone, offset included.
+ * `2026-08-03T08:00:00-05:00` names the same instant as its UTC form but reads
+ * as the wall-clock time the user set the reminder for.
+ */
+export function formatZonedIsoString(date: Date, timeZone: string) {
+  const parts = getZonedDateParts(date, timeZone);
+  const offsetMinutes = getTimeZoneOffsetMinutes(date, timeZone);
+  const sign = offsetMinutes < 0 ? "-" : "+";
+  const absolute = Math.abs(offsetMinutes);
+  const offset = `${sign}${padNumber(Math.floor(absolute / 60))}:${padNumber(absolute % 60)}`;
+  return `${parts.year}-${padNumber(parts.month)}-${padNumber(parts.day)}T${padNumber(parts.hour)}:${padNumber(parts.minute)}:${padNumber(parts.second)}${offset}`;
+}
+
 export function parseDateKey(dateKey: string) {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateKey);
   if (!match) return null;


### PR DESCRIPTION
Closes three MCP tracking-reminder defects captured 2026-08-10:

- `optimitron:dev:remove-skip-prefer-zero`
- `optimitron:dev:fix-batch-reminder-default-footgun`
- `optimitron:dev:reminder-notifications-local-timezone`

## 1. SKIPPED is retired; not-taken records a zero

A day a treatment, food, or activity was not taken is a `0`, not a missing value. The off periods are the baseline that n-of-1 causal inference compares against, so a skip leaves a hole exactly where the analysis needs data.

- `TRACKED` and `SNOOZED` are the only statuses in the tool schemas now.
- Callers that still send `SKIPPED` record a zero measurement and get `recordedAsZero: true` plus a `deprecationNotice` back. Nothing breaks mid-day for a voice client that hasn't updated.
- The zero is forced, never the reminder's `defaultValue` — a not-taken day must not silently log the normal dose.
- **Guard:** a variable whose `minimumAllowedValue` is above zero (a 1-5 mood rating) rejects the conversion with an explicit error instead of inventing a value the scale cannot hold. That case is a genuine gap, and the caller picks: real value, snooze, or deactivate the reminder.

**Existing SKIP history:** left as-is. Nothing after the fact can distinguish an old skip that meant zero from one that meant nobody answered, so backfilling would manufacture data. The `NotificationStatus` enum keeps `SKIPPED` for those rows — **no schema change in this PR**.

## 2. `respondToTrackingReminderNotifications` no longer overwrites the day

The reported failure: answering one item with `defaultStatus=SKIPPED` + one exception marked ~23 unrelated reminders as skipped.

- `defaultStatus` is now **optional**. Send only `except` entries to answer specific reminders; everything else stays untouched.
- When `defaultStatus` is present it reaches only notifications that are **due and still unanswered** — an already-recorded response is not the default's business.
- Exceptions resolve against everything scheduled for the date, so a batch call can now **correct a response that already exists**. The single-item tool always could; the two tools disagreed.
- A call with neither `defaultStatus` nor exceptions is an error rather than a silent no-op.
- Response adds `source: "default" | "exception"` and `recordedAsZero` per result, plus `skippedCount` for what the call deliberately left alone.

## 3. Notification times come back local, not UTC

An 08:00 Central reminder read as `13:00`, making a correct schedule look broken.

- Full mode adds `notifyAtLocal` (ISO with offset, e.g. `2026-08-03T08:00:00-05:00`), `utcOffsetMinutes`, `overdueSinceLocal`, and `timeZone` on the result. `notifyAt` keeps the raw UTC instant.
- Compact mode's `due` is now the local time (what a voice client reads aloud); the UTC instant moves to `dueUtc`.
- `dateKey` and the day boundaries already used local time via `getStartOfZonedDayUtc` — confirmed, and the existing DST test still passes.

## Tests

`packages/web` mcp-server suite: **297 passed** (292 before, 5 added).

New coverage: retired-SKIPPED records zero rather than the default dose; the zero guard rejects a sub-zero-minimum variable; except-only batch leaves the rest of the day alone; batch with neither default nor exceptions errors; an already-answered notification survives a default pass but an exception corrects it; notification times report in `America/Chicago` with the right offset.

`packages/web` typecheck clean. The full web suite has 11-15 pre-existing failures that vary run to run (funding/escrow/forms/document-review integration tests needing a live Postgres); the same set fails on unmodified `main`, and every one of them passes in isolation on this branch.

## Review notes

MCP tool layer only — no UI surface renders reminders (`TrackingReminder` appears nowhere under `src/app` or `src/components`), so there are no screenshots to capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
