### PR TITLE
Fix MCP OAuth Authorize host mismatch and legacy iss

### DIFF
--- a/packages/web/e2e/auth-callback-roundtrip.spec.ts
+++ b/packages/web/e2e/auth-callback-roundtrip.spec.ts
@@ -1,8 +1,11 @@
 /**
- * Auth-gated page → sign-in → back to the original page.
+ * Auth-gated page → sign-in → back to the original page (with query intact).
  *
  * Guards the regression where login drops `callbackUrl` and dumps the user on
  * home/dashboard/sign-in instead of the page that sent them to login.
+ *
+ * Also covers MCP OAuth consent: cold `/mcp/authorize` → sign-in keeps OAuth
+ * params in `callbackUrl` → return to consent → Authorize issues a code.
  *
  * Uses credentials API login (not the Try Demo button) so CI production builds
  * pass when `isDemoLoginEnabled` is false. AuthForm's demo path does the same
@@ -13,25 +16,43 @@
  * Run:
  *   pnpm --filter @optimitron/web exec playwright test e2e/auth-callback-roundtrip.spec.ts
  */
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { signInDemoUser } from "./utils/auth";
 
-const TARGET_PATH = "/dashboard?from=auth-callback-roundtrip";
+const DASHBOARD_TARGET = "/dashboard?from=auth-callback-roundtrip";
+const OAUTH_REDIRECT_ORIGIN = "http://127.0.0.1:34567";
+const OAUTH_REDIRECT_URI = `${OAUTH_REDIRECT_ORIGIN}/oauth-callback`;
+const OAUTH_STATE = "e2e-mcp-authorize-state";
+// RFC 7636 appendix B example challenge (consent stores it; token exchange not tested here).
+const OAUTH_CODE_CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+function pathAndSearch(urlLike: string, base: string): string {
+  const url = new URL(urlLike, base);
+  return `${url.pathname}${url.search}`;
+}
+
+async function readSignInCallbackUrl(page: Page): Promise<string> {
+  await page.waitForURL(/\/auth\/signin/, { timeout: 15_000 });
+
+  const signInUrl = new URL(page.url());
+  expect(signInUrl.pathname).toBe("/auth/signin");
+
+  const callbackUrl = signInUrl.searchParams.get("callbackUrl");
+  expect(callbackUrl).toBeTruthy();
+  return callbackUrl!;
+}
 
 test("auth-gated page -> login -> returns to the same callbackUrl", async ({
   page,
 }) => {
-  const response = await page.goto(TARGET_PATH);
+  const response = await page.goto(DASHBOARD_TARGET);
   if ((response?.status() ?? 0) >= 500) {
     test.skip(true, "Needs database");
     return;
   }
 
-  await page.waitForURL(/\/auth\/signin/, { timeout: 15_000 });
-
-  const signInUrl = new URL(page.url());
-  expect(signInUrl.pathname).toBe("/auth/signin");
-  expect(signInUrl.searchParams.get("callbackUrl")).toBe(TARGET_PATH);
+  const callbackUrl = await readSignInCallbackUrl(page);
+  expect(pathAndSearch(callbackUrl, page.url())).toBe(DASHBOARD_TARGET);
 
   const signedIn = await signInDemoUser(page);
   if (!signedIn) {
@@ -39,12 +60,104 @@ test("auth-gated page -> login -> returns to the same callbackUrl", async ({
     return;
   }
 
-  // Mirror AuthForm demo login: after credentials succeed, go to callbackUrl.
-  await page.goto(TARGET_PATH);
+  // Mirror AuthForm: after credentials succeed, go to callbackUrl on this origin.
+  await page.goto(pathAndSearch(callbackUrl, page.url()));
 
-  await expect(page).not.toHaveURL(/\/auth\/signin/);
+  await expect(page).not.toHaveURL(/\/auth\/signin/, { timeout: 15_000 });
 
   const landed = new URL(page.url());
   expect(landed.pathname).toBe("/dashboard");
   expect(landed.searchParams.get("from")).toBe("auth-callback-roundtrip");
+});
+
+test("MCP authorize -> login -> Authorize returns an OAuth code", async ({
+  page,
+}) => {
+  // Serve the OAuth client redirect so Authorize's window.location navigation
+  // does not hang on a closed port.
+  await page.route(`${OAUTH_REDIRECT_ORIGIN}/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/plain",
+      body: "oauth-callback-ok",
+    });
+  });
+
+  const register = await page.request.post("/api/mcp/oauth/register", {
+    data: {
+      client_name: "E2E MCP Authorize",
+      redirect_uris: [OAUTH_REDIRECT_URI],
+      grant_types: ["authorization_code"],
+      scope: "tasks:personal",
+    },
+  });
+  if (register.status() >= 500) {
+    test.skip(true, "Needs database");
+    return;
+  }
+  expect(register.status()).toBe(201);
+  const registration = (await register.json()) as { client_id?: string };
+  expect(registration.client_id).toBeTruthy();
+
+  const authorizePath =
+    `/mcp/authorize` +
+    `?response_type=code` +
+    `&client_id=${encodeURIComponent(registration.client_id!)}` +
+    `&redirect_uri=${encodeURIComponent(OAUTH_REDIRECT_URI)}` +
+    `&code_challenge=${encodeURIComponent(OAUTH_CODE_CHALLENGE)}` +
+    `&code_challenge_method=S256` +
+    `&state=${encodeURIComponent(OAUTH_STATE)}` +
+    `&scope=${encodeURIComponent("tasks:personal")}` +
+    `&client_name=${encodeURIComponent("E2E MCP Authorize")}`;
+
+  const response = await page.goto(authorizePath);
+  if ((response?.status() ?? 0) >= 500) {
+    test.skip(true, "Needs database");
+    return;
+  }
+
+  const callbackUrl = await readSignInCallbackUrl(page);
+  // Must be same-origin relative so localhost vs 127.0.0.1 does not drop cookies.
+  expect(callbackUrl.startsWith("/mcp/authorize?")).toBe(true);
+  expect(callbackUrl).not.toMatch(/^https?:\/\//);
+
+  const callback = new URL(callbackUrl, page.url());
+  expect(callback.pathname).toBe("/mcp/authorize");
+  expect(callback.searchParams.get("client_id")).toBe(registration.client_id);
+  expect(callback.searchParams.get("redirect_uri")).toBe(OAUTH_REDIRECT_URI);
+  expect(callback.searchParams.get("code_challenge")).toBe(OAUTH_CODE_CHALLENGE);
+  expect(callback.searchParams.get("state")).toBe(OAUTH_STATE);
+  expect(callback.searchParams.get("scope")).toBe("tasks:personal");
+
+  const signedIn = await signInDemoUser(page);
+  if (!signedIn) {
+    test.skip(true, "Demo credentials not available");
+    return;
+  }
+
+  await page.goto(pathAndSearch(callbackUrl, page.url()));
+
+  await expect(page).not.toHaveURL(/\/auth\/signin/);
+  await expect(page.locator("#mcp-authorize-heading")).toBeVisible({
+    timeout: 15_000,
+  });
+
+  const authorizeButton = page.getByRole("button", { name: "Authorize" });
+  await expect(authorizeButton).toBeEnabled({ timeout: 10_000 });
+
+  await Promise.all([
+    page.waitForURL(
+      (url) =>
+        url.origin === OAUTH_REDIRECT_ORIGIN &&
+        url.searchParams.has("code") &&
+        url.searchParams.get("state") === OAUTH_STATE,
+      { timeout: 15_000 },
+    ),
+    authorizeButton.click(),
+  ]);
+
+  const redirected = new URL(page.url());
+  expect(redirected.origin).toBe(OAUTH_REDIRECT_ORIGIN);
+  expect(redirected.searchParams.get("code")).toBeTruthy();
+  expect(redirected.searchParams.get("state")).toBe(OAUTH_STATE);
 });

--- a/packages/web/e2e/auth-callback-roundtrip.spec.ts
+++ b/packages/web/e2e/auth-callback-roundtrip.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Auth-gated page → sign-in → back to the original page.
+ *
+ * Guards the regression where login drops `callbackUrl` and dumps the user on
+ * home/dashboard/sign-in instead of the page that sent them to login.
+ *
+ * Requires: seeded demo credentials (`prisma db seed`).
+ *
+ * Run:
+ *   pnpm --filter @optimitron/web exec playwright test e2e/auth-callback-roundtrip.spec.ts
+ */
+import { test, expect } from "@playwright/test";
+
+const TARGET_PATH = "/dashboard?from=auth-callback-roundtrip";
+
+test("auth-gated page -> demo login -> returns to the same callbackUrl", async ({
+  page,
+}) => {
+  const response = await page.goto(TARGET_PATH);
+  if ((response?.status() ?? 0) >= 500) {
+    test.skip(true, "Needs database");
+    return;
+  }
+
+  await page.waitForURL(/\/auth\/signin/, { timeout: 15_000 });
+
+  const signInUrl = new URL(page.url());
+  expect(signInUrl.pathname).toBe("/auth/signin");
+  expect(signInUrl.searchParams.get("callbackUrl")).toBe(TARGET_PATH);
+
+  const demoButton = page.locator("button:has-text('Try Demo')");
+  await expect(demoButton).toBeVisible({ timeout: 10_000 });
+  await demoButton.click();
+
+  const authOutcome = await Promise.race([
+    page
+      .waitForURL(
+        (url) =>
+          url.pathname === "/dashboard" &&
+          url.searchParams.get("from") === "auth-callback-roundtrip",
+        { timeout: 15_000 },
+      )
+      .then(() => "returned" as const)
+      .catch(() => "timeout" as const),
+    page
+      .getByText(/Demo account not available/i)
+      .waitFor({ state: "visible", timeout: 15_000 })
+      .then(() => "demo-missing" as const)
+      .catch(() => "timeout" as const),
+  ]);
+
+  if (authOutcome === "demo-missing") {
+    test.skip(true, "Demo credentials not available");
+    return;
+  }
+
+  expect(authOutcome).toBe("returned");
+  expect(page.url()).not.toMatch(/\/auth\/signin/);
+
+  const landed = new URL(page.url());
+  expect(landed.pathname).toBe("/dashboard");
+  expect(landed.searchParams.get("from")).toBe("auth-callback-roundtrip");
+});

--- a/packages/web/e2e/auth-callback-roundtrip.spec.ts
+++ b/packages/web/e2e/auth-callback-roundtrip.spec.ts
@@ -4,16 +4,21 @@
  * Guards the regression where login drops `callbackUrl` and dumps the user on
  * home/dashboard/sign-in instead of the page that sent them to login.
  *
+ * Uses credentials API login (not the Try Demo button) so CI production builds
+ * pass when `isDemoLoginEnabled` is false. AuthForm's demo path does the same
+ * credentials sign-in then navigates to `callbackUrl`.
+ *
  * Requires: seeded demo credentials (`prisma db seed`).
  *
  * Run:
  *   pnpm --filter @optimitron/web exec playwright test e2e/auth-callback-roundtrip.spec.ts
  */
 import { test, expect } from "@playwright/test";
+import { signInDemoUser } from "./utils/auth";
 
 const TARGET_PATH = "/dashboard?from=auth-callback-roundtrip";
 
-test("auth-gated page -> demo login -> returns to the same callbackUrl", async ({
+test("auth-gated page -> login -> returns to the same callbackUrl", async ({
   page,
 }) => {
   const response = await page.goto(TARGET_PATH);
@@ -28,34 +33,16 @@ test("auth-gated page -> demo login -> returns to the same callbackUrl", async (
   expect(signInUrl.pathname).toBe("/auth/signin");
   expect(signInUrl.searchParams.get("callbackUrl")).toBe(TARGET_PATH);
 
-  const demoButton = page.locator("button:has-text('Try Demo')");
-  await expect(demoButton).toBeVisible({ timeout: 10_000 });
-  await demoButton.click();
-
-  const authOutcome = await Promise.race([
-    page
-      .waitForURL(
-        (url) =>
-          url.pathname === "/dashboard" &&
-          url.searchParams.get("from") === "auth-callback-roundtrip",
-        { timeout: 15_000 },
-      )
-      .then(() => "returned" as const)
-      .catch(() => "timeout" as const),
-    page
-      .getByText(/Demo account not available/i)
-      .waitFor({ state: "visible", timeout: 15_000 })
-      .then(() => "demo-missing" as const)
-      .catch(() => "timeout" as const),
-  ]);
-
-  if (authOutcome === "demo-missing") {
+  const signedIn = await signInDemoUser(page);
+  if (!signedIn) {
     test.skip(true, "Demo credentials not available");
     return;
   }
 
-  expect(authOutcome).toBe("returned");
-  expect(page.url()).not.toMatch(/\/auth\/signin/);
+  // Mirror AuthForm demo login: after credentials succeed, go to callbackUrl.
+  await page.goto(TARGET_PATH);
+
+  await expect(page).not.toHaveURL(/\/auth\/signin/);
 
   const landed = new URL(page.url());
   expect(landed.pathname).toBe("/dashboard");

--- a/packages/web/e2e/auth-callback-roundtrip.spec.ts
+++ b/packages/web/e2e/auth-callback-roundtrip.spec.ts
@@ -1,8 +1,8 @@
 /**
- * Auth-gated page → sign-in → back to the original page (with query intact).
+ * Auth-gated request → sign-in retains the callback → authenticated revisit.
  *
- * Guards the regression where login drops `callbackUrl` and dumps the user on
- * home/dashboard/sign-in instead of the page that sent them to login.
+ * Guards the server-side redirect and callback handoff. The test signs in via
+ * the credentials API, then revisits the captured callback on the same origin.
  *
  * Also covers MCP OAuth consent: cold `/mcp/authorize` → sign-in keeps OAuth
  * params in `callbackUrl` → return to consent → Authorize issues a code.
@@ -14,7 +14,7 @@
  * Requires: seeded demo credentials (`prisma db seed`).
  *
  * Run:
- *   pnpm --filter @optimitron/web exec playwright test e2e/auth-callback-roundtrip.spec.ts
+ *   pnpm --filter @optimitron/web run e2e -- smoke --grep "auth-gated request|MCP authorize"
  */
 import { test, expect, type Page } from "@playwright/test";
 import { signInDemoUser } from "./utils/auth";
@@ -42,12 +42,17 @@ async function readSignInCallbackUrl(page: Page): Promise<string> {
   return callbackUrl!;
 }
 
-test("auth-gated page -> login -> returns to the same callbackUrl", async ({
+function skipLocallyOrFailInCi(reason: string): void {
+  if (process.env.CI) throw new Error(reason);
+  test.skip(true, reason);
+}
+
+test("auth-gated request preserves callbackUrl for an authenticated revisit", async ({
   page,
 }) => {
   const response = await page.goto(DASHBOARD_TARGET);
   if ((response?.status() ?? 0) >= 500) {
-    test.skip(true, "Needs database");
+    skipLocallyOrFailInCi("Database unavailable for auth callback test");
     return;
   }
 
@@ -56,11 +61,11 @@ test("auth-gated page -> login -> returns to the same callbackUrl", async ({
 
   const signedIn = await signInDemoUser(page);
   if (!signedIn) {
-    test.skip(true, "Demo credentials not available");
+    skipLocallyOrFailInCi("Seeded demo credentials are unavailable");
     return;
   }
 
-  // Mirror AuthForm: after credentials succeed, go to callbackUrl on this origin.
+  // Revisit the server-provided callback on the authenticated browser context.
   await page.goto(pathAndSearch(callbackUrl, page.url()));
 
   await expect(page).not.toHaveURL(/\/auth\/signin/, { timeout: 15_000 });
@@ -70,7 +75,7 @@ test("auth-gated page -> login -> returns to the same callbackUrl", async ({
   expect(landed.searchParams.get("from")).toBe("auth-callback-roundtrip");
 });
 
-test("MCP authorize -> login -> Authorize returns an OAuth code", async ({
+test("MCP authorize preserves the login callback and returns an OAuth code", async ({
   page,
 }) => {
   // Serve the OAuth client redirect so Authorize's window.location navigation
@@ -92,7 +97,7 @@ test("MCP authorize -> login -> Authorize returns an OAuth code", async ({
     },
   });
   if (register.status() >= 500) {
-    test.skip(true, "Needs database");
+    skipLocallyOrFailInCi("Database unavailable for MCP authorize test");
     return;
   }
   expect(register.status()).toBe(201);
@@ -112,7 +117,7 @@ test("MCP authorize -> login -> Authorize returns an OAuth code", async ({
 
   const response = await page.goto(authorizePath);
   if ((response?.status() ?? 0) >= 500) {
-    test.skip(true, "Needs database");
+    skipLocallyOrFailInCi("Database unavailable for MCP authorize page");
     return;
   }
 
@@ -125,13 +130,15 @@ test("MCP authorize -> login -> Authorize returns an OAuth code", async ({
   expect(callback.pathname).toBe("/mcp/authorize");
   expect(callback.searchParams.get("client_id")).toBe(registration.client_id);
   expect(callback.searchParams.get("redirect_uri")).toBe(OAUTH_REDIRECT_URI);
-  expect(callback.searchParams.get("code_challenge")).toBe(OAUTH_CODE_CHALLENGE);
+  expect(callback.searchParams.get("code_challenge")).toBe(
+    OAUTH_CODE_CHALLENGE,
+  );
   expect(callback.searchParams.get("state")).toBe(OAUTH_STATE);
   expect(callback.searchParams.get("scope")).toBe("tasks:personal");
 
   const signedIn = await signInDemoUser(page);
   if (!signedIn) {
-    test.skip(true, "Demo credentials not available");
+    skipLocallyOrFailInCi("Seeded demo credentials are unavailable");
     return;
   }
 

--- a/packages/web/e2e/utils/auth.ts
+++ b/packages/web/e2e/utils/auth.ts
@@ -33,7 +33,20 @@ export async function signInViaApi(
     },
   );
 
-  return signInResponse.status() < 400;
+  if (signInResponse.status() >= 400) {
+    return false;
+  }
+
+  // Credentials can return 200 while the session cookie is still missing
+  // (wrong host / CSRF reuse). Confirm the browser context is actually signed in.
+  const sessionResponse = await request.get("/api/auth/session");
+  if (sessionResponse.status() >= 400) {
+    return false;
+  }
+  const session = (await sessionResponse.json()) as {
+    user?: { id?: string | null } | null;
+  };
+  return Boolean(session.user?.id);
 }
 
 export async function signInUser(

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -43,6 +43,11 @@ type DocumentReviewFixtureManifest = {
   version: 1;
 };
 
+type McpAuthorizeFixtureManifest = {
+  authorizePath: string;
+  version: 1;
+};
+
 function isDocumentReviewFixtureManifest(
   value: unknown,
 ): value is DocumentReviewFixtureManifest {
@@ -61,6 +66,19 @@ function isDocumentReviewFixtureManifest(
   );
 }
 
+function isMcpAuthorizeFixtureManifest(
+  value: unknown,
+): value is McpAuthorizeFixtureManifest {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    candidate.version === 1 && isNonEmptyString(candidate.authorizePath)
+  );
+}
+
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
@@ -73,6 +91,16 @@ const DOCUMENT_REVIEW_FIXTURE_MANIFEST_PATH = path.resolve(
   "visual-fixtures",
   "document-review.json",
 );
+const MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH = path.resolve(
+  WEB_ROOT,
+  "output",
+  "playwright",
+  "visual-fixtures",
+  "mcp-authorize.json",
+);
+const MCP_AUTHORIZE_PAGE_FILE = "packages/web/src/app/mcp/authorize/page.tsx";
+const MCP_CONSENT_FORM_FILE =
+  "packages/web/src/app/mcp/authorize/consent-form.tsx";
 const TASK_DETAIL_PAGE_FILE = "packages/web/src/app/tasks/[id]/page.tsx";
 const DOCUMENT_REVIEW_MANAGER_FILE =
   "packages/web/src/components/tasks/document-review-manager-panel.tsx";
@@ -391,6 +419,7 @@ const SEEDED_DYNAMIC_ROUTES: VisualRoute[] = [
     required: false,
   },
   ...loadDocumentReviewRoutes(),
+  ...loadMcpAuthorizeRoutes(),
 ];
 
 const PUBLIC_SCREENSHOT_ROUTES: VisualRoute[] = filterRedirectOnlyRoutes(
@@ -501,6 +530,42 @@ function dedupeRoutes(routes: VisualRoute[]): VisualRoute[] {
     deduped.push(route);
   }
   return deduped;
+}
+
+function loadMcpAuthorizeRoutes(): VisualRoute[] {
+  if (process.env.ROUTE_VISUAL_REVIEW !== "1") {
+    return [];
+  }
+
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(
+      readFileSync(MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH, "utf8"),
+    );
+  } catch (error) {
+    throw new Error(
+      `MCP authorize visual fixture manifest is missing at ${MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH}. The visual fixture seeder must run before Playwright.`,
+      { cause: error },
+    );
+  }
+
+  if (!isMcpAuthorizeFixtureManifest(manifest)) {
+    throw new Error(
+      `MCP authorize visual fixture manifest is invalid at ${MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH}.`,
+    );
+  }
+
+  return [
+    {
+      authenticated: true,
+      covers: [MCP_AUTHORIZE_PAGE_FILE, MCP_CONSENT_FORM_FILE],
+      name: "mcp-authorize-consent",
+      path: manifest.authorizePath,
+      required: true,
+      requiredSelector: "#mcp-authorize-heading",
+      requiredText: /^Authorize$/,
+    },
+  ];
 }
 
 function loadDocumentReviewRoutes(): VisualRoute[] {

--- a/packages/web/scripts/run-playwright.mjs
+++ b/packages/web/scripts/run-playwright.mjs
@@ -58,8 +58,13 @@ const MODE_SPECS = {
         "e2e/smoke.spec.ts",
         "e2e/contrast-audit.spec.ts",
         "e2e/treaty-page-structure.spec.ts",
+        "e2e/auth-callback-roundtrip.spec.ts",
       ]
-    : ["e2e/smoke.spec.ts", "e2e/treaty-page-structure.spec.ts"],
+    : [
+        "e2e/smoke.spec.ts",
+        "e2e/treaty-page-structure.spec.ts",
+        "e2e/auth-callback-roundtrip.spec.ts",
+      ],
   contrast: ["e2e/contrast-audit.spec.ts"],
   mobile: ["e2e/mobile-responsiveness-audit.spec.ts"],
   "new-user-flow-screenshots": ["e2e/new-user-flow-screenshots.spec.ts"],

--- a/packages/web/scripts/seed-visual-review-fixtures.ts
+++ b/packages/web/scripts/seed-visual-review-fixtures.ts
@@ -41,6 +41,17 @@ const FIXTURE_MANIFEST_PATH = path.resolve(
   "visual-fixtures",
   "document-review.json",
 );
+const MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH = path.resolve(
+  WEB_ROOT,
+  "output",
+  "playwright",
+  "visual-fixtures",
+  "mcp-authorize.json",
+);
+const MCP_AUTHORIZE_CLIENT_ID = "visual_mcp_authorize_client";
+const MCP_AUTHORIZE_REDIRECT_URI = "http://127.0.0.1/visual-mcp-callback";
+const MCP_AUTHORIZE_CODE_CHALLENGE =
+  "visualreviewcodechallengeaaaaaaaaaaaaaaaa";
 
 const ids = {
   activeTask: `${FIXTURE_PREFIX}active_task`,
@@ -82,7 +93,52 @@ function assertLocalFixtureDatabase() {
 }
 
 async function removeFixtureManifest() {
-  await rm(FIXTURE_MANIFEST_PATH, { force: true });
+  await Promise.all([
+    rm(FIXTURE_MANIFEST_PATH, { force: true }),
+    rm(MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH, { force: true }),
+  ]);
+}
+
+async function seedMcpAuthorizeFixture() {
+  await prisma.oAuthClient.upsert({
+    where: { clientId: MCP_AUTHORIZE_CLIENT_ID },
+    create: {
+      clientId: MCP_AUTHORIZE_CLIENT_ID,
+      clientName: "Visual Review MCP",
+      redirectUris: [MCP_AUTHORIZE_REDIRECT_URI],
+    },
+    update: {
+      clientName: "Visual Review MCP",
+      redirectUris: [MCP_AUTHORIZE_REDIRECT_URI],
+    },
+  });
+
+  const authorizePath = new URL("http://127.0.0.1/mcp/authorize");
+  authorizePath.searchParams.set("client_id", MCP_AUTHORIZE_CLIENT_ID);
+  authorizePath.searchParams.set("redirect_uri", MCP_AUTHORIZE_REDIRECT_URI);
+  authorizePath.searchParams.set("state", "visual-review");
+  authorizePath.searchParams.set("scope", "tasks:personal");
+  authorizePath.searchParams.set("code_challenge", MCP_AUTHORIZE_CODE_CHALLENGE);
+  authorizePath.searchParams.set("client_name", "Visual Review MCP");
+
+  await mkdir(path.dirname(MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH), {
+    recursive: true,
+  });
+  await writeFile(
+    MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH,
+    JSON.stringify(
+      {
+        authorizePath: `${authorizePath.pathname}${authorizePath.search}`,
+        version: 1,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  console.log(
+    `[visual-review] wrote ${MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH}`,
+  );
 }
 
 async function resetVisualReviewFixtures() {
@@ -583,6 +639,7 @@ async function main() {
     fixtureManager,
   });
 
+  await seedMcpAuthorizeFixture();
   await mkdir(path.dirname(FIXTURE_MANIFEST_PATH), { recursive: true });
   await writeFile(
     FIXTURE_MANIFEST_PATH,

--- a/packages/web/src/app/api/mcp/oauth/authorize/route.test.ts
+++ b/packages/web/src/app/api/mcp/oauth/authorize/route.test.ts
@@ -49,6 +49,7 @@ describe("MCP OAuth authorize route", () => {
     );
     expect(consent.searchParams.get("code_challenge")).toBe("abc");
     expect(consent.searchParams.get("state")).toBe("xyz");
+    expect(consent.searchParams.get("scope")).toBe("tasks:personal");
     expect(consent.searchParams.get("client_name")).toBe("Cursor");
   });
 });

--- a/packages/web/src/app/api/mcp/oauth/authorize/route.test.ts
+++ b/packages/web/src/app/api/mcp/oauth/authorize/route.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findClient: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    oAuthClient: {
+      findUnique: mocks.findClient,
+    },
+  },
+}));
+
+import { GET } from "./route";
+
+describe("MCP OAuth authorize route", () => {
+  beforeEach(() => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("NEXTAUTH_URL", "https://warondisease.org");
+    mocks.findClient.mockReset();
+    mocks.findClient.mockResolvedValue({
+      clientId: "mcp_client",
+      clientName: "Cursor",
+      redirectUris: ["http://127.0.0.1:9999/callback"],
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("redirects consent to optimitron.com even when authorize is hit on warondisease.org", async () => {
+    const response = await GET(
+      new Request(
+        "https://warondisease.org/api/mcp/oauth/authorize?response_type=code&client_id=mcp_client&redirect_uri=http%3A%2F%2F127.0.0.1%3A9999%2Fcallback&code_challenge=abc&state=xyz&scope=tasks%3Apersonal",
+      ),
+    );
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toBeTruthy();
+    const consent = new URL(location!);
+    expect(consent.origin).toBe("https://optimitron.com");
+    expect(consent.pathname).toBe("/mcp/authorize");
+    expect(consent.searchParams.get("client_id")).toBe("mcp_client");
+    expect(consent.searchParams.get("redirect_uri")).toBe(
+      "http://127.0.0.1:9999/callback",
+    );
+    expect(consent.searchParams.get("code_challenge")).toBe("abc");
+    expect(consent.searchParams.get("state")).toBe("xyz");
+    expect(consent.searchParams.get("client_name")).toBe("Cursor");
+  });
+});

--- a/packages/web/src/app/api/mcp/oauth/authorize/route.ts
+++ b/packages/web/src/app/api/mcp/oauth/authorize/route.ts
@@ -1,10 +1,17 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { isRedirectUriAllowed } from "@/lib/mcp-oauth";
+import {
+  buildMcpConsentAuthorizeUrl,
+  isRedirectUriAllowed,
+} from "@/lib/mcp-oauth";
 
 /**
  * OAuth authorization endpoint. Validates the request parameters and redirects
- * to the consent page where the user can approve/deny access.
+ * to the consent page where the user can authorize/deny access.
+ *
+ * Consent always lives on the canonical Optimitron issuer origin, even when
+ * the client discovered MCP on a campaign host like warondisease.org. Mixing
+ * those hosts breaks NextAuth cookies and the post-login return to consent.
  */
 export async function GET(req: Request) {
   const url = new URL(req.url);
@@ -26,14 +33,21 @@ export async function GET(req: Request) {
 
   if (!clientId || !redirectUri || !codeChallenge) {
     return NextResponse.json(
-      { error: "invalid_request", error_description: "client_id, redirect_uri, and code_challenge are required" },
+      {
+        error: "invalid_request",
+        error_description:
+          "client_id, redirect_uri, and code_challenge are required",
+      },
       { status: 400 },
     );
   }
 
   if (codeChallengeMethod && codeChallengeMethod !== "S256") {
     return NextResponse.json(
-      { error: "invalid_request", error_description: "Only S256 code_challenge_method is supported" },
+      {
+        error: "invalid_request",
+        error_description: "Only S256 code_challenge_method is supported",
+      },
       { status: 400 },
     );
   }
@@ -52,19 +66,22 @@ export async function GET(req: Request) {
 
   if (!isRedirectUriAllowed(client.redirectUris, redirectUri)) {
     return NextResponse.json(
-      { error: "invalid_request", error_description: "redirect_uri not registered for this client" },
+      {
+        error: "invalid_request",
+        error_description: "redirect_uri not registered for this client",
+      },
       { status: 400 },
     );
   }
 
-  // Redirect to the consent page with all params
-  const consentUrl = new URL("/mcp/authorize", url.origin);
-  consentUrl.searchParams.set("client_id", clientId);
-  consentUrl.searchParams.set("redirect_uri", redirectUri);
-  if (state) consentUrl.searchParams.set("state", state);
-  if (scope) consentUrl.searchParams.set("scope", scope);
-  consentUrl.searchParams.set("code_challenge", codeChallenge);
-  consentUrl.searchParams.set("client_name", client.clientName ?? clientId);
+  const consentUrl = buildMcpConsentAuthorizeUrl({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    state,
+    scope,
+    code_challenge: codeChallenge,
+    client_name: client.clientName ?? clientId,
+  });
 
   return NextResponse.redirect(consentUrl.toString());
 }

--- a/packages/web/src/app/api/mcp/oauth/consent/route.test.ts
+++ b/packages/web/src/app/api/mcp/oauth/consent/route.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  findClient: vi.fn(),
+  findUser: vi.fn(),
+  findMemberships: vi.fn(),
+  createAuthCode: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.getServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    oAuthClient: { findUnique: mocks.findClient },
+    user: { findUnique: mocks.findUser },
+    organizationMember: { findMany: mocks.findMemberships },
+    oAuthAuthCode: { create: mocks.createAuthCode },
+  },
+}));
+
+import { POST } from "./route";
+
+function consentRequest(body: Record<string, unknown>) {
+  return new Request("https://optimitron.com/api/mcp/oauth/consent", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("MCP OAuth consent route (Authorize)", () => {
+  beforeEach(() => {
+    mocks.getServerSession.mockReset();
+    mocks.findClient.mockReset();
+    mocks.findUser.mockReset();
+    mocks.findMemberships.mockReset();
+    mocks.createAuthCode.mockReset();
+
+    mocks.getServerSession.mockResolvedValue({
+      user: { id: "user_1", email: "mike@example.com" },
+    });
+    mocks.findClient.mockResolvedValue({
+      clientId: "mcp_client",
+      redirectUris: ["http://127.0.0.1:9999/callback"],
+    });
+    mocks.findUser.mockResolvedValue({ isAdmin: false });
+    mocks.findMemberships.mockResolvedValue([]);
+    mocks.createAuthCode.mockResolvedValue({ id: "code_row" });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a redirect_url with an auth code when Authorize succeeds", async () => {
+    const response = await POST(
+      consentRequest({
+        client_id: "mcp_client",
+        redirect_uri: "http://127.0.0.1:9999/callback",
+        state: "state-1",
+        scope: "tasks:personal",
+        code_challenge: "challenge",
+        approved: true,
+        organization_ids: [],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.redirect_url).toMatch(
+      /^http:\/\/127\.0\.0\.1:9999\/callback\?code=.+&state=state-1$/,
+    );
+    expect(mocks.createAuthCode).toHaveBeenCalledOnce();
+  });
+
+  it("rejects Authorize when the session is missing", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+
+    const response = await POST(
+      consentRequest({
+        client_id: "mcp_client",
+        redirect_uri: "http://127.0.0.1:9999/callback",
+        scope: "tasks:personal",
+        code_challenge: "challenge",
+        approved: true,
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.createAuthCode).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/app/mcp/authorize/consent-form.tsx
+++ b/packages/web/src/app/mcp/authorize/consent-form.tsx
@@ -102,12 +102,20 @@ export function McpConsentForm({
     const organizationSelectionRequired =
       selected.has(McpScope.TASKS_ORGANIZATION) &&
       selectedOrganizationIds.size === 0;
-    if (selected.size === 0 || organizationSelectionRequired) return;
+    if (selected.size === 0) {
+      setError("Select at least one permission.");
+      return;
+    }
+    if (organizationSelectionRequired) {
+      setError("Select at least one organization, or turn off organization access.");
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
       const res = await fetch("/api/mcp/oauth/consent", {
         method: "POST",
+        credentials: "same-origin",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           client_id: clientId,
@@ -122,7 +130,17 @@ export function McpConsentForm({
         }),
       });
 
-      const data = await res.json();
+      const data = (await res.json().catch(() => ({}))) as {
+        redirect_url?: string;
+        error?: string;
+        error_description?: string;
+      };
+      if (res.status === 401) {
+        setError("Your session expired. Sign in again, then authorize.");
+        setLoading(false);
+        window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.href)}`;
+        return;
+      }
       if (data.redirect_url) {
         window.location.href = data.redirect_url;
         return;
@@ -218,7 +236,10 @@ export function McpConsentForm({
 
       <div className="flex gap-3">
         <Button
-          onClick={handleApprove}
+          type="button"
+          onClick={() => {
+            void handleApprove();
+          }}
           disabled={
             loading ||
             selected.size === 0 ||
@@ -230,6 +251,7 @@ export function McpConsentForm({
           {loading ? "Authorizing..." : selected.size === 0 ? "Select Permissions" : "Authorize"}
         </Button>
         <Button
+          type="button"
           variant="outline"
           onClick={handleDeny}
           disabled={loading}

--- a/packages/web/src/app/mcp/authorize/consent-form.tsx
+++ b/packages/web/src/app/mcp/authorize/consent-form.tsx
@@ -8,11 +8,13 @@ import { McpScope, scopeToWire, scopesToWire } from "@/lib/mcp-scopes";
 const SCOPE_LABELS: Record<McpScope, { title: string; detail: string }> = {
   [McpScope.TASKS_ADMIN]: {
     title: "Admin public task management",
-    detail: "Create and manage public Optimitron tasks, people, organizations, estimates, dependencies, and milestones.",
+    detail:
+      "Create and manage public Optimitron tasks, people, organizations, estimates, dependencies, and milestones.",
   },
   [McpScope.TASKS_PERSONAL]: {
     title: "Manage private tasks",
-    detail: "Create, update, delete, prioritize, and comment on your private tasks.",
+    detail:
+      "Create, update, delete, prioritize, and comment on your private tasks.",
   },
   [McpScope.TASKS_ORGANIZATION]: {
     title: "Manage organization tasks",
@@ -24,19 +26,23 @@ const SCOPE_LABELS: Record<McpScope, { title: string; detail: string }> = {
   },
   [McpScope.EARTHDATA_WRITE]: {
     title: "Add Earth data",
-    detail: "Create sourced memorials, evidence, organization signatures, intervention reports, and correction reports.",
+    detail:
+      "Create sourced memorials, evidence, organization signatures, intervention reports, and correction reports.",
   },
   [McpScope.EARTHDATA_ADMIN]: {
     title: "Moderate Earth data",
-    detail: "Hide, restore, merge, and resolve public Earth-data records and reports.",
+    detail:
+      "Hide, restore, merge, and resolve public Earth-data records and reports.",
   },
   [McpScope.AGENT_RUN]: {
     title: "Run coordinated agents",
-    detail: "Acquire leases and log multi-agent runs for public optimize-earth workflows.",
+    detail:
+      "Acquire leases and log multi-agent runs for public optimize-earth workflows.",
   },
   [McpScope.GITHUB]: {
     title: "GitHub repo access",
-    detail: "Read code from the configured Optimitron repos and call the GitHub API on the server's behalf (issues, PRs, discussions, commit statuses).",
+    detail:
+      "Read code from the configured Optimitron repos and call the GitHub API on the server's behalf (issues, PRs, discussions, commit statuses).",
   },
 };
 
@@ -102,14 +108,7 @@ export function McpConsentForm({
     const organizationSelectionRequired =
       selected.has(McpScope.TASKS_ORGANIZATION) &&
       selectedOrganizationIds.size === 0;
-    if (selected.size === 0) {
-      setError("Select at least one permission.");
-      return;
-    }
-    if (organizationSelectionRequired) {
-      setError("Select at least one organization, or turn off organization access.");
-      return;
-    }
+    if (selected.size === 0 || organizationSelectionRequired) return;
     setLoading(true);
     setError(null);
     try {
@@ -178,15 +177,21 @@ export function McpConsentForm({
                 />
                 <div className="flex-1">
                   <div className="flex items-baseline gap-2 flex-wrap">
-                    <span className="font-black uppercase text-sm">{labels.title}</span>
-                    <code className="text-xs font-bold text-muted-foreground">{scopeToWire(scope)}</code>
+                    <span className="font-black uppercase text-sm">
+                      {labels.title}
+                    </span>
+                    <code className="text-xs font-bold text-muted-foreground">
+                      {scopeToWire(scope)}
+                    </code>
                     {!wasRequested ? (
                       <span className="text-[10px] font-black uppercase border-2 border-primary bg-background text-foreground px-1">
                         Not Requested
                       </span>
                     ) : null}
                   </div>
-                  <p className="text-xs font-bold text-muted-foreground mt-1">{labels.detail}</p>
+                  <p className="text-xs font-bold text-muted-foreground mt-1">
+                    {labels.detail}
+                  </p>
                 </div>
               </label>
             </li>
@@ -204,7 +209,9 @@ export function McpConsentForm({
                   <label className="flex gap-3 items-start cursor-pointer border-2 border-primary p-3 hover:bg-muted">
                     <Checkbox
                       checked={selectedOrganizationIds.has(organization.id)}
-                      onCheckedChange={() => toggleOrganization(organization.id)}
+                      onCheckedChange={() =>
+                        toggleOrganization(organization.id)
+                      }
                       className="mt-0.5"
                     />
                     <span className="flex-1 min-w-0">
@@ -248,7 +255,11 @@ export function McpConsentForm({
           }
           className="flex-1"
         >
-          {loading ? "Authorizing..." : selected.size === 0 ? "Select Permissions" : "Authorize"}
+          {loading
+            ? "Authorizing..."
+            : selected.size === 0
+              ? "Select Permissions"
+              : "Authorize"}
         </Button>
         <Button
           type="button"

--- a/packages/web/src/app/mcp/authorize/page.tsx
+++ b/packages/web/src/app/mcp/authorize/page.tsx
@@ -127,7 +127,12 @@ export default async function McpAuthorizePage({
     <div className="min-h-screen flex items-center justify-center px-4 py-12 bg-background text-foreground">
       <div className="w-full max-w-lg">
         <div className="border-4 border-primary bg-background text-foreground p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-          <h1 className="text-2xl font-black uppercase mb-2">Authorize App</h1>
+          <h1
+            id="mcp-authorize-heading"
+            className="text-2xl font-black uppercase mb-2"
+          >
+            Authorize App
+          </h1>
           <p className="font-bold text-muted-foreground mb-6">
             <span className="text-foreground">{clientName}</span> wants to
             access your Optimitron account. Tick the permissions you want to

--- a/packages/web/src/app/mcp/authorize/page.tsx
+++ b/packages/web/src/app/mcp/authorize/page.tsx
@@ -1,7 +1,15 @@
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
-import { isRedirectUriAllowed } from "@/lib/mcp-oauth";
+import {
+  buildMcpAuthorizeSignInPath,
+  buildMcpConsentAuthorizeUrl,
+  getIssuerUrl,
+  getMcpRequestOrigin,
+  isRedirectUriAllowed,
+  shouldRedirectMcpAuthorizeToIssuer,
+} from "@/lib/mcp-oauth";
 import {
   DEFAULT_CONSENT_SCOPES,
   allowedMcpScopesForUser,
@@ -30,11 +38,17 @@ export default async function McpAuthorizePage({
 }) {
   const params = await searchParams;
   const clientId = typeof params.client_id === "string" ? params.client_id : null;
-  const redirectUri = typeof params.redirect_uri === "string" ? params.redirect_uri : null;
+  const redirectUri =
+    typeof params.redirect_uri === "string" ? params.redirect_uri : null;
   const state = typeof params.state === "string" ? params.state : null;
-  const scope = typeof params.scope === "string" ? params.scope : scopesToWire(DEFAULT_CONSENT_SCOPES);
-  const codeChallenge = typeof params.code_challenge === "string" ? params.code_challenge : null;
-  const clientName = typeof params.client_name === "string" ? params.client_name : clientId;
+  const scope =
+    typeof params.scope === "string"
+      ? params.scope
+      : scopesToWire(DEFAULT_CONSENT_SCOPES);
+  const codeChallenge =
+    typeof params.code_challenge === "string" ? params.code_challenge : null;
+  const clientName =
+    typeof params.client_name === "string" ? params.client_name : clientId;
 
   if (!clientId || !redirectUri || !codeChallenge) {
     return invalidRequest("Missing required OAuth parameters.");
@@ -54,13 +68,31 @@ export default async function McpAuthorizePage({
     return invalidRequest("Redirect URI is not registered for this client.");
   }
 
+  const headerStore = await headers();
+  const requestOrigin = getMcpRequestOrigin(
+    new Request(`${getIssuerUrl()}/mcp/authorize`, {
+      headers: headerStore,
+    }),
+  );
+  if (shouldRedirectMcpAuthorizeToIssuer(requestOrigin)) {
+    // Campaign hosts can reach this page via shared deployment routing.
+    // Bounce to the canonical issuer before NextAuth so login cookies and
+    // the post-login callback stay on one origin.
+    redirect(
+      buildMcpConsentAuthorizeUrl({
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        state,
+        scope,
+        code_challenge: codeChallenge,
+        client_name: clientName,
+      }).toString(),
+    );
+  }
+
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
-    const currentUrl = new URL("/mcp/authorize", process.env.NEXTAUTH_URL ?? "http://localhost:3001");
-    for (const [key, value] of Object.entries(params)) {
-      if (typeof value === "string") currentUrl.searchParams.set(key, value);
-    }
-    redirect(`/auth/signin?callbackUrl=${encodeURIComponent(currentUrl.toString())}`);
+    redirect(buildMcpAuthorizeSignInPath(params));
   }
 
   const requestedScopes = scopesFromWire(scope);
@@ -97,7 +129,9 @@ export default async function McpAuthorizePage({
         <div className="border-4 border-primary bg-background text-foreground p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
           <h1 className="text-2xl font-black uppercase mb-2">Authorize App</h1>
           <p className="font-bold text-muted-foreground mb-6">
-            <span className="text-foreground">{clientName}</span> wants to access your Optimitron account. Tick the permissions you want to grant.
+            <span className="text-foreground">{clientName}</span> wants to
+            access your Optimitron account. Tick the permissions you want to
+            grant.
           </p>
 
           <McpConsentForm

--- a/packages/web/src/lib/__tests__/mcp-oauth-resource.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-oauth-resource.test.ts
@@ -1,10 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { SignJWT } from "jose";
 
 import {
+  buildMcpAuthorizeSignInPath,
+  buildMcpConsentAuthorizeUrl,
+  getAcceptedMcpIssuers,
   getMcpRequestOrigin,
   getProtectedResourceMetadata,
   resolveMcpResourceOrigin,
+  shouldRedirectMcpAuthorizeToIssuer,
+  signMcpAccessToken,
+  verifyMcpAccessToken,
 } from "@/lib/mcp-oauth";
+import { McpScope } from "@/lib/mcp-scopes";
 
 const CANONICAL = "https://optimitron.com";
 
@@ -66,6 +74,107 @@ describe("OAuth issuer", () => {
 
     expect(getOAuthMetadata().issuer).toBe(CANONICAL);
   });
+
+  it("accepts legacy warondisease.org access tokens while minting canonical ones", async () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("NEXTAUTH_SECRET", "test-nextauth-secret-for-iss-check");
+    vi.stubEnv("NEXTAUTH_URL", "https://warondisease.org");
+    vi.stubEnv("MCP_OAUTH_ISSUER", "");
+
+    expect(getAcceptedMcpIssuers()).toEqual([
+      CANONICAL,
+      "https://warondisease.org",
+      "https://www.warondisease.org",
+    ]);
+
+    const minted = await signMcpAccessToken(
+      "user_1",
+      "client_1",
+      [McpScope.TASKS_PERSONAL],
+      [],
+    );
+    await expect(verifyMcpAccessToken(minted)).resolves.toMatchObject({
+      sub: "user_1",
+      clientId: "client_1",
+    });
+
+    const legacy = await new SignJWT({
+      clientId: "client_1",
+      organizationIds: [],
+      scopes: [McpScope.TASKS_PERSONAL],
+      type: "access",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject("user_1")
+      .setIssuer("https://warondisease.org")
+      .setIssuedAt()
+      .setExpirationTime("1h")
+      .sign(new TextEncoder().encode(process.env.NEXTAUTH_SECRET));
+
+    await expect(verifyMcpAccessToken(legacy)).resolves.toMatchObject({
+      sub: "user_1",
+      clientId: "client_1",
+    });
+  });
+});
+
+describe("MCP authorize consent URL helpers", () => {
+  it("builds consent URLs on the canonical issuer even when discovery was on warondisease", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("NEXTAUTH_URL", "https://warondisease.org");
+
+    const url = buildMcpConsentAuthorizeUrl({
+      client_id: "mcp_abc",
+      redirect_uri: "http://127.0.0.1:1234/callback",
+      state: "state-1",
+      scope: "tasks:personal",
+      code_challenge: "challenge",
+      client_name: "Cursor",
+    });
+
+    expect(url.origin).toBe(CANONICAL);
+    expect(url.pathname).toBe("/mcp/authorize");
+    expect(url.searchParams.get("client_id")).toBe("mcp_abc");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "http://127.0.0.1:1234/callback",
+    );
+  });
+
+  it("returns a sign-in path whose callbackUrl is the canonical authorize page", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("NEXTAUTH_URL", "https://warondisease.org");
+
+    const path = buildMcpAuthorizeSignInPath({
+      client_id: "mcp_abc",
+      redirect_uri: "http://127.0.0.1:1234/callback",
+      code_challenge: "challenge",
+      scope: "tasks:personal",
+    });
+
+    expect(path.startsWith("/auth/signin?callbackUrl=")).toBe(true);
+    const callbackUrl = decodeURIComponent(
+      path.slice("/auth/signin?callbackUrl=".length),
+    );
+    expect(callbackUrl.startsWith(`${CANONICAL}/mcp/authorize?`)).toBe(true);
+    expect(callbackUrl).toContain("client_id=mcp_abc");
+    expect(callbackUrl).toContain("code_challenge=challenge");
+  });
+
+  it("bounces campaign-host authorize hits to the issuer without looping loopback aliases", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("NEXTAUTH_URL", "https://warondisease.org");
+
+    expect(shouldRedirectMcpAuthorizeToIssuer("https://warondisease.org")).toBe(
+      true,
+    );
+    expect(shouldRedirectMcpAuthorizeToIssuer(CANONICAL)).toBe(false);
+
+    vi.stubEnv("VERCEL_ENV", "development");
+    vi.stubEnv("MCP_OAUTH_ISSUER", "http://localhost:3001");
+    expect(shouldRedirectMcpAuthorizeToIssuer("http://127.0.0.1:3001")).toBe(
+      false,
+    );
+  });
 });
 
 describe("getProtectedResourceMetadata", () => {
@@ -73,12 +182,8 @@ describe("getProtectedResourceMetadata", () => {
     stubCanonicalOrigin();
     const metadata = getProtectedResourceMetadata("https://optimitron.com");
 
-    // The mismatch this guards against: `resource` naming a different host
-    // than the endpoint the client connected to, which clients reject during
-    // discovery.
     expect(metadata.resource).toBe("https://optimitron.com/api/mcp");
     expect(metadata.resource_documentation).toBe("https://optimitron.com/mcp");
-    // Sessions, consent, and token issuance live on exactly one origin.
     expect(metadata.authorization_servers).toEqual([CANONICAL]);
   });
 

--- a/packages/web/src/lib/__tests__/mcp-oauth-resource.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-oauth-resource.test.ts
@@ -11,6 +11,7 @@ import {
   shouldRedirectMcpAuthorizeToIssuer,
   signMcpAccessToken,
   verifyMcpAccessToken,
+  verifyMcpRefreshToken,
 } from "@/lib/mcp-oauth";
 import { McpScope } from "@/lib/mcp-scopes";
 
@@ -75,7 +76,7 @@ describe("OAuth issuer", () => {
     expect(getOAuthMetadata().issuer).toBe(CANONICAL);
   });
 
-  it("accepts legacy warondisease.org access tokens while minting canonical ones", async () => {
+  it("accepts legacy warondisease.org tokens while minting canonical ones", async () => {
     vi.stubEnv("VERCEL_ENV", "production");
     vi.stubEnv("NEXTAUTH_SECRET", "test-nextauth-secret-for-iss-check");
     vi.stubEnv("NEXTAUTH_URL", "https://warondisease.org");
@@ -115,6 +116,45 @@ describe("OAuth issuer", () => {
       sub: "user_1",
       clientId: "client_1",
     });
+
+    const legacyRefresh = await new SignJWT({
+      clientId: "client_1",
+      type: "refresh",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject("user_1")
+      .setIssuer("https://warondisease.org")
+      .setIssuedAt()
+      .setExpirationTime("1h")
+      .sign(new TextEncoder().encode(process.env.NEXTAUTH_SECRET));
+
+    await expect(verifyMcpRefreshToken(legacyRefresh)).resolves.toEqual({
+      sub: "user_1",
+      clientId: "client_1",
+    });
+  });
+
+  it("does not accept production legacy issuers outside production", async () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("NEXTAUTH_SECRET", "test-nextauth-secret-for-iss-check");
+    vi.stubEnv("MCP_OAUTH_ISSUER", "https://preview.example.com");
+
+    expect(getAcceptedMcpIssuers()).toEqual(["https://preview.example.com"]);
+
+    const legacy = await new SignJWT({
+      clientId: "client_1",
+      organizationIds: [],
+      scopes: [McpScope.TASKS_PERSONAL],
+      type: "access",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject("user_1")
+      .setIssuer("https://warondisease.org")
+      .setIssuedAt()
+      .setExpirationTime("1h")
+      .sign(new TextEncoder().encode(process.env.NEXTAUTH_SECRET));
+
+    await expect(verifyMcpAccessToken(legacy)).rejects.toThrow();
   });
 });
 
@@ -138,6 +178,10 @@ describe("MCP authorize consent URL helpers", () => {
     expect(url.searchParams.get("redirect_uri")).toBe(
       "http://127.0.0.1:1234/callback",
     );
+    expect(url.searchParams.get("state")).toBe("state-1");
+    expect(url.searchParams.get("scope")).toBe("tasks:personal");
+    expect(url.searchParams.get("code_challenge")).toBe("challenge");
+    expect(url.searchParams.get("client_name")).toBe("Cursor");
   });
 
   it("returns a sign-in path whose callbackUrl is the authorize path on this origin", () => {
@@ -157,8 +201,13 @@ describe("MCP authorize consent URL helpers", () => {
     );
     expect(callbackUrl.startsWith("/mcp/authorize?")).toBe(true);
     expect(callbackUrl).not.toMatch(/^https?:\/\//);
-    expect(callbackUrl).toContain("client_id=mcp_abc");
-    expect(callbackUrl).toContain("code_challenge=challenge");
+    const callback = new URL(callbackUrl, CANONICAL);
+    expect(callback.searchParams.get("client_id")).toBe("mcp_abc");
+    expect(callback.searchParams.get("redirect_uri")).toBe(
+      "http://127.0.0.1:1234/callback",
+    );
+    expect(callback.searchParams.get("scope")).toBe("tasks:personal");
+    expect(callback.searchParams.get("code_challenge")).toBe("challenge");
   });
 
   it("bounces campaign-host authorize hits to the issuer without looping loopback aliases", () => {

--- a/packages/web/src/lib/__tests__/mcp-oauth-resource.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-oauth-resource.test.ts
@@ -140,7 +140,7 @@ describe("MCP authorize consent URL helpers", () => {
     );
   });
 
-  it("returns a sign-in path whose callbackUrl is the canonical authorize page", () => {
+  it("returns a sign-in path whose callbackUrl is the authorize path on this origin", () => {
     vi.stubEnv("VERCEL_ENV", "production");
     vi.stubEnv("NEXTAUTH_URL", "https://warondisease.org");
 
@@ -155,7 +155,8 @@ describe("MCP authorize consent URL helpers", () => {
     const callbackUrl = decodeURIComponent(
       path.slice("/auth/signin?callbackUrl=".length),
     );
-    expect(callbackUrl.startsWith(`${CANONICAL}/mcp/authorize?`)).toBe(true);
+    expect(callbackUrl.startsWith("/mcp/authorize?")).toBe(true);
+    expect(callbackUrl).not.toMatch(/^https?:\/\//);
     expect(callbackUrl).toContain("client_id=mcp_abc");
     expect(callbackUrl).toContain("code_challenge=challenge");
   });

--- a/packages/web/src/lib/mcp-oauth.ts
+++ b/packages/web/src/lib/mcp-oauth.ts
@@ -31,7 +31,7 @@ function getSecret() {
   return new TextEncoder().encode(secret);
 }
 
-function getIssuerUrl(): string {
+export function getIssuerUrl(): string {
   // OAuth belongs to the Optimitron product even though the same Vercel
   // deployment serves campaign site variants. Production stays fixed to
   // the canonical issuer regardless of MCP_OAUTH_ISSUER so a variable
@@ -45,6 +45,76 @@ function getIssuerUrl(): string {
       ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
       : "http://localhost:3001")
   );
+}
+
+/**
+ * Issuers accepted when verifying MCP JWTs.
+ *
+ * Tokens are always minted with {@link getIssuerUrl}, but older production
+ * tokens were signed with campaign hosts (especially warondisease.org) before
+ * the issuer was pinned to optimitron.com. Accept those legacy hosts so
+ * existing Cursor/Claude connectors keep working until they refresh.
+ */
+export function getAcceptedMcpIssuers(): string[] {
+  const canonical = getIssuerUrl();
+  const legacy = ["https://warondisease.org", "https://www.warondisease.org"];
+  return Array.from(new Set([canonical, ...legacy]));
+}
+
+/** Consent + NextAuth for MCP OAuth always live on the canonical issuer. */
+export function buildMcpConsentAuthorizeUrl(
+  params: URLSearchParams | Record<string, string | null | undefined>,
+): URL {
+  const url = new URL("/mcp/authorize", getIssuerUrl());
+  const entries =
+    params instanceof URLSearchParams
+      ? params.entries()
+      : Object.entries(params);
+  for (const [key, value] of entries) {
+    if (typeof value === "string" && value.length > 0) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return url;
+}
+
+export function buildMcpAuthorizeSignInPath(
+  authorizeParams: Record<string, string | string[] | undefined>,
+): string {
+  const consentUrl = buildMcpConsentAuthorizeUrl(
+    Object.fromEntries(
+      Object.entries(authorizeParams).filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string",
+      ),
+    ),
+  );
+  return `/auth/signin?callbackUrl=${encodeURIComponent(consentUrl.toString())}`;
+}
+
+/**
+ * True when `/mcp/authorize` was hit on a campaign/variant host and must move
+ * to the canonical issuer before NextAuth. Loopback alias mismatches
+ * (localhost vs 127.0.0.1) are ignored so local dev does not redirect-loop.
+ */
+export function shouldRedirectMcpAuthorizeToIssuer(
+  requestOrigin: string | null | undefined,
+): boolean {
+  const issuer = getIssuerUrl();
+  if (!requestOrigin?.trim()) return false;
+  try {
+    const requestUrl = new URL(requestOrigin);
+    const issuerUrl = new URL(issuer);
+    if (requestUrl.origin === issuerUrl.origin) return false;
+    if (isLoopbackHost(requestUrl.hostname) && isLoopbackHost(issuerUrl.hostname)) {
+      return false;
+    }
+    return (
+      SERVED_MCP_HOSTS.has(requestUrl.hostname.toLowerCase()) &&
+      requestUrl.hostname.toLowerCase() !== issuerUrl.hostname.toLowerCase()
+    );
+  } catch {
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -90,7 +160,7 @@ export async function verifyMcpAccessToken(
   token: string,
 ): Promise<McpAccessTokenPayload> {
   const { payload } = await jwtVerify(token, getSecret(), {
-    issuer: getIssuerUrl(),
+    issuer: getAcceptedMcpIssuers(),
   });
   if (payload.type !== "access") {
     throw new Error("Not an access token");
@@ -113,7 +183,7 @@ export async function verifyMcpRefreshToken(
   token: string,
 ): Promise<{ sub: string; clientId: string }> {
   const { payload } = await jwtVerify(token, getSecret(), {
-    issuer: getIssuerUrl(),
+    issuer: getAcceptedMcpIssuers(),
   });
   if (payload.type !== "refresh") {
     throw new Error("Not a refresh token");

--- a/packages/web/src/lib/mcp-oauth.ts
+++ b/packages/web/src/lib/mcp-oauth.ts
@@ -57,6 +57,8 @@ export function getIssuerUrl(): string {
  */
 export function getAcceptedMcpIssuers(): string[] {
   const canonical = getIssuerUrl();
+  if (process.env.VERCEL_ENV !== "production") return [canonical];
+
   const legacy = ["https://warondisease.org", "https://www.warondisease.org"];
   return Array.from(new Set([canonical, ...legacy]));
 }
@@ -109,7 +111,10 @@ export function shouldRedirectMcpAuthorizeToIssuer(
     const requestUrl = new URL(requestOrigin);
     const issuerUrl = new URL(issuer);
     if (requestUrl.origin === issuerUrl.origin) return false;
-    if (isLoopbackHost(requestUrl.hostname) && isLoopbackHost(issuerUrl.hostname)) {
+    if (
+      isLoopbackHost(requestUrl.hostname) &&
+      isLoopbackHost(issuerUrl.hostname)
+    ) {
       return false;
     }
     return (

--- a/packages/web/src/lib/mcp-oauth.ts
+++ b/packages/web/src/lib/mcp-oauth.ts
@@ -88,7 +88,11 @@ export function buildMcpAuthorizeSignInPath(
       ),
     ),
   );
-  return `/auth/signin?callbackUrl=${encodeURIComponent(consentUrl.toString())}`;
+  // Relative callback keeps login on the same browser origin. Absolute issuer
+  // URLs break local loopback aliases (localhost vs 127.0.0.1) and drop the
+  // session cookie after credentials succeed.
+  const callbackPath = `${consentUrl.pathname}${consentUrl.search}`;
+  return `/auth/signin?callbackUrl=${encodeURIComponent(callbackPath)}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Keep MCP OAuth consent and post-login callback URLs on the canonical optimitron.com issuer, even when discovery hits warondisease.org.
- Accept legacy warondisease.org token issuers only in production, where the compatibility issue occurred.
- Keep preview and development token verification scoped to their own canonical issuer.
- Preserve OAuth state, scope, PKCE, client, and redirect parameters across host and sign-in boundaries.
- Handle expired consent sessions and cover access-token, refresh-token, authorize, consent, and callback behavior.

## Test plan
- [x] Focused OAuth unit tests: 18 passed.
- [x] Web test TypeScript check.
- [ ] GitHub CI and preview smoke on the final commit.
- [ ] Human connector check: authorize a cold connection to https://optimitron.com/api/mcp.