### PR TITLE
Stop mandating treaty-style migrations on UI touches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,10 +90,7 @@
 
 ## UI Style
 
-- **New components default to treaty style.** The simple black-and-white style used by the `warondisease.org` variant — white paper, black ink, thin black rules, square corners, restrained typography, no decorative color — is the default for all new public UI. Don't introduce neobrutalist tokens on a new component because surrounding components still use them; use treaty tokens and let the surrounding UI catch up via the migration rule below.
-- **Migration rule:** when touching existing public UI, remove neobrutalist styling instead of copying it forward. The goal is full migration to treaty style across all public surfaces. Admin-only status chips, charts, game/demo/Sierra screens, and email-client markup may keep their own specialized colors when the color carries functional meaning — the rule is about public recruitment surfaces, not every internal admin tool.
-- Use semantic/treaty tokens such as `bg-background`, `text-foreground`, `border-foreground`, `text-muted-foreground`, and `var(--treaty-*)`.
-- Do not add neobrutalist styling to public UI: avoid `brutal-*` color fills, hard shadows, gradients, rounded cards, beige/cream backgrounds, thick novelty borders, and decorative emoji/icons unless the user explicitly asks for them.
+- Match the surrounding page style. Do not migrate styling as a side effect of an unrelated bug fix or feature.
 - Keep UI minimal. Do not add wrapper boxes, divider lines, shadows, icons, labels, helper text, or other extra elements unless they clarify the action, improve scanning, or solve a real usability problem.
 - Do not lead campaign landing pages with raw counters, scoreboards, totals, leaderboards, or internal status panels. The first screen of `warondisease.org` must lead with the treaty vote/referral action; social proof belongs after the action is understood.
 - Make actionable things look actionable. If a link starts or completes a user task, especially an external workflow, render it as a clear button or command control, not only as inline text. Use plain inline links for references, citations, navigation, and secondary reading.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,7 +35,6 @@ as a parallel Now track, dogfooded by the operator as user #1.
 - Production Task rows own operational development status, dependencies, and
   human decisions. Managed synchronization owns only stable system roots and
   fixtures; it must not overwrite ordinary development children.
-- Black-and-white treaty style stays the default on public campaign surfaces.
 - Roadmap lines cite feature IDs so status claims live in one place.
 
 ## Now
@@ -222,6 +221,3 @@ Infra hygiene (lower priority):
     `job-*.log`, `.tmp-pr79-*.json`, `.tmp-clone-*`.
 12. Extension test coverage — OPT-EXT-01 ships with zero tests.
 13. `packages/wishonia-widget` README.
-14. Black-and-white style migration — ~46 files still reference `brutal-*`
-    components; standing migrate-on-touch policy rather than a big-bang
-    sweep.

--- a/docs/game-design-guidelines.md
+++ b/docs/game-design-guidelines.md
@@ -1,10 +1,8 @@
 # Game UI Design Guidelines
 
 > **Scope:** applies only to `/demo`, the Sierra slide decks, and other
-> explicitly game/demo screens. Public treaty/campaign surfaces use the
-> black-and-white treaty/editorial style mandated in [../AGENTS.md](../AGENTS.md)
-> and [../CLAUDE.md](../CLAUDE.md) — when the two conflict on a public page,
-> treaty style wins.
+> explicitly game/demo screens. Do not apply these game styles to public
+> campaign or product pages; match the surrounding page style there instead.
 
 > **The game IS the app.** Optimitron looks like a Sierra Online adventure game because the core
 > metaphor is "Earth is a game and we're playing it wrong." Every page should feel like a screen

--- a/packages/web/AGENTS.md
+++ b/packages/web/AGENTS.md
@@ -19,9 +19,8 @@ Imports from ALL `@optimitron/*` packages. This is the integration layer.
 ## Rules
 
 - **Prisma is OK here.** This is the only package that uses Prisma client at runtime.
-- **Follow the design system.** See root `CLAUDE.md` for the War on Disease black-and-white treaty style, approved tokens, and component guidance.
-- **Migrate public UI away from neobrutalist styling.** New or touched treaty/campaign/dashboard surfaces should use simple semantic/treaty tokens: `bg-background`, `text-foreground`, `border-foreground`, `text-muted-foreground`, and `var(--treaty-*)`. Avoid adding `brutal-*` fills, hard shadows, gradients, rounded cards, beige/cream backgrounds, and decorative color.
-- **Use primitives for behavior, not decoration.** Check `src/components/retroui/` and existing domain components before hand-rolling buttons, inputs, checkboxes, dialogs, tables, menus, accordions, or other standard controls. Prefer the RetroUI primitive when it provides the right behavior; if its visual chrome conflicts with the simple black-and-white treaty style, migrate the primitive or its usage instead of duplicating a one-off control.
+- **Match surrounding style.** Do not migrate styling as a side effect of an unrelated bug fix or feature.
+- **Use primitives for behavior, not decoration.** Check `src/components/retroui/` and existing domain components before hand-rolling buttons, inputs, checkboxes, dialogs, tables, menus, accordions, or other standard controls.
 - **Metadata from routes.ts.** Use `getRouteMetadata()` — don't hardcode page titles.
 - **Metadata is cold-link copy.** Titles name the page in normal words. Descriptions say what is on the page, who should click, and why now. Do not put in-page workflow steps like "share", "hire two", "sign in", or "click yes/no" in metadata unless that route is exactly that action surface.
 - **Wishonia's voice.** All user-facing copy is in Wishonia's voice. Read `docs/h2ewd.md` before writing or rewriting public copy.
@@ -30,7 +29,7 @@ Imports from ALL `@optimitron/*` packages. This is the integration layer.
 - **Conversion copy, not internal narration.** Speak directly to the audience, tell them what to do, and show the value of doing it. Keep it concise, funny where appropriate, and allergic to generic nonprofit/consultant language.
 - **No implementation leaks in copy.** Do not expose internal planning terms like "site variant", "program graph", "initiative landing page", "approved organizations get", route policy language, or admin labels unless the user explicitly wants that exact wording surfaced.
 - **Treat every empty state as an action surface.** If the user needs to invite humans, embed a survey, vote, assign Earth optimization tasks, or check status, show the useful control before explaining the absence of data.
-- **Contrast rules.** Black-and-white treaty surfaces must keep text legible through semantic/treaty tokens. Use color only where it carries functional meaning, such as admin status, charts, games/demos, or email-client markup.
+- **Contrast rules.** Keep text legible. Use color only where it carries functional meaning, such as admin status, charts, games/demos, or email-client markup.
 - **Prefer the Playwright wrapper.** For web verification, use `pnpm --filter @optimitron/web run e2e -- <mode>` instead of calling Playwright or `next build` directly.
 - **Treaty screenshots use the wrapper.** Use `pnpm --filter @optimitron/web run e2e -- treaty-screenshots --reporter=list` for the treaty vote/post-vote screenshot audit; do not call `pnpm exec playwright ...` directly for that spec.
 - **Reuse an existing dev server when available.** The wrapper checks `BASE_URL`, `http://127.0.0.1:3001`, and `http://localhost:3001` first and reuses that server before falling back to a production build.


### PR DESCRIPTION
## Summary
- Remove the AGENTS.md / packages/web AGENTS.md rules that told agents to migrate every touched public surface to treaty styling
- Keep a short rule: match surrounding style; do not restyle as a side effect of unrelated fixes

## Why
Codex/CodeRabbit were citing that migration mandate on crash-fix PRs (e.g. #219) and asking for full component restyles.

## Test plan
- [ ] Confirm bots no longer have that AGENTS citation on future UI bugfix PRs

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated UI styling guidance to match each page’s surrounding visual style.
  * Clarified that game-specific styling applies only to game and demo screens.
  * Simplified accessibility guidance around text legibility and meaningful color use.
  * Removed outdated requirements for treaty-style defaults and broad styling migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->