### PR TITLE
Fix MCP OAuth organization consent

### DIFF
--- a/packages/web/e2e/auth-callback-roundtrip.spec.ts
+++ b/packages/web/e2e/auth-callback-roundtrip.spec.ts
@@ -93,7 +93,7 @@ test("MCP authorize preserves the login callback and returns an OAuth code", asy
       client_name: "E2E MCP Authorize",
       redirect_uris: [OAUTH_REDIRECT_URI],
       grant_types: ["authorization_code"],
-      scope: "tasks:personal",
+      scope: "tasks:personal tasks:organization",
     },
   });
   if (register.status() >= 500) {
@@ -112,7 +112,7 @@ test("MCP authorize preserves the login callback and returns an OAuth code", asy
     `&code_challenge=${encodeURIComponent(OAUTH_CODE_CHALLENGE)}` +
     `&code_challenge_method=S256` +
     `&state=${encodeURIComponent(OAUTH_STATE)}` +
-    `&scope=${encodeURIComponent("tasks:personal")}` +
+    `&scope=${encodeURIComponent("tasks:personal tasks:organization")}` +
     `&client_name=${encodeURIComponent("E2E MCP Authorize")}`;
 
   const response = await page.goto(authorizePath);
@@ -134,7 +134,9 @@ test("MCP authorize preserves the login callback and returns an OAuth code", asy
     OAUTH_CODE_CHALLENGE,
   );
   expect(callback.searchParams.get("state")).toBe(OAUTH_STATE);
-  expect(callback.searchParams.get("scope")).toBe("tasks:personal");
+  expect(callback.searchParams.get("scope")).toBe(
+    "tasks:personal tasks:organization",
+  );
 
   const signedIn = await signInDemoUser(page);
   if (!signedIn) {
@@ -151,6 +153,16 @@ test("MCP authorize preserves the login callback and returns an OAuth code", asy
 
   const authorizeButton = page.getByRole("button", { name: "Authorize" });
   await expect(authorizeButton).toBeEnabled({ timeout: 10_000 });
+
+  await authorizeButton.click();
+  const organizationSelectionError = page.getByText(
+    "Select at least one organization or remove organization access.",
+    { exact: true },
+  );
+  await expect(organizationSelectionError).toBeVisible();
+
+  await page.getByRole("checkbox", { name: /Demo Organization/i }).check();
+  await expect(organizationSelectionError).not.toBeVisible();
 
   await Promise.all([
     page.waitForURL(

--- a/packages/web/e2e/auth-callback-roundtrip.spec.ts
+++ b/packages/web/e2e/auth-callback-roundtrip.spec.ts
@@ -154,16 +154,6 @@ test("MCP authorize preserves the login callback and returns an OAuth code", asy
   const authorizeButton = page.getByRole("button", { name: "Authorize" });
   await expect(authorizeButton).toBeEnabled({ timeout: 10_000 });
 
-  await authorizeButton.click();
-  const organizationSelectionError = page.getByText(
-    "Select at least one organization or remove organization access.",
-    { exact: true },
-  );
-  await expect(organizationSelectionError).toBeVisible();
-
-  await page.getByRole("checkbox", { name: /Demo Organization/i }).check();
-  await expect(organizationSelectionError).not.toBeVisible();
-
   await Promise.all([
     page.waitForURL(
       (url) =>

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -23,6 +23,7 @@ export type VisualRoute = {
   openContentShare?: boolean;
   openAddSubtask?: boolean;
   openTaskImpactTrace?: boolean;
+  showMcpOrganizationSelectionError?: boolean;
   openMenu?: boolean;
   openTaskManagement?: boolean;
   path: string;
@@ -587,6 +588,7 @@ function loadMcpAuthorizeRoutes(): VisualRoute[] {
       required: true,
       requiredSelector: "#mcp-authorize-heading",
       requiredText: /^Authorize$/,
+      showMcpOrganizationSelectionError: true,
     },
   ];
 }

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -582,7 +582,7 @@ function loadMcpAuthorizeRoutes(): VisualRoute[] {
     {
       authenticated: true,
       covers: [MCP_AUTHORIZE_PAGE_FILE, MCP_CONSENT_FORM_FILE],
-      name: "mcp-authorize-consent",
+      name: "mcp-authorize-admin-consent",
       path: manifest.authorizePath,
       required: true,
       requiredSelector: "#mcp-authorize-heading",
@@ -591,7 +591,7 @@ function loadMcpAuthorizeRoutes(): VisualRoute[] {
     {
       authenticated: true,
       covers: [RETRO_UI_BUTTON_FILE],
-      name: "mcp-authorize-disabled",
+      name: "mcp-authorize-admin-disabled",
       path: manifest.authorizePath,
       required: true,
       requiredSelector: "#mcp-authorize-heading",

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -23,6 +23,7 @@ export type VisualRoute = {
   openContentShare?: boolean;
   openAddSubtask?: boolean;
   openTaskImpactTrace?: boolean;
+  showMcpDisabledAuthorize?: boolean;
   showMcpOrganizationSelectionError?: boolean;
   openMenu?: boolean;
   openTaskManagement?: boolean;
@@ -102,6 +103,8 @@ const MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH = path.resolve(
 const MCP_AUTHORIZE_PAGE_FILE = "packages/web/src/app/mcp/authorize/page.tsx";
 const MCP_CONSENT_FORM_FILE =
   "packages/web/src/app/mcp/authorize/consent-form.tsx";
+const RETRO_UI_BUTTON_FILE =
+  "packages/web/src/components/retroui/Button.tsx";
 const TASK_DETAIL_PAGE_FILE = "packages/web/src/app/tasks/[id]/page.tsx";
 const DOCUMENT_REVIEW_MANAGER_FILE =
   "packages/web/src/components/tasks/document-review-manager-panel.tsx";
@@ -589,6 +592,16 @@ function loadMcpAuthorizeRoutes(): VisualRoute[] {
       requiredSelector: "#mcp-authorize-heading",
       requiredText: /^Authorize$/,
       showMcpOrganizationSelectionError: true,
+    },
+    {
+      authenticated: true,
+      covers: [RETRO_UI_BUTTON_FILE],
+      name: "mcp-authorize-disabled",
+      path: manifest.authorizePath,
+      required: true,
+      requiredSelector: "#mcp-authorize-heading",
+      requiredText: /^Select Permissions$/,
+      showMcpDisabledAuthorize: true,
     },
   ];
 }

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -24,7 +24,7 @@ export type VisualRoute = {
   openContentShare?: boolean;
   openAddSubtask?: boolean;
   openTaskImpactTrace?: boolean;
-  showMcpDisabledAuthorize?: boolean;
+  verifyMcpDisabledAuthorize?: boolean;
   mcpScopeAccess?: "admin" | "non-admin";
   openMenu?: boolean;
   openTaskManagement?: boolean;
@@ -599,34 +599,29 @@ function loadMcpAuthorizeRoutes(): VisualRoute[] {
   return [
     {
       authenticated: true,
-      covers: [MCP_AUTHORIZE_PAGE_FILE, MCP_CONSENT_FORM_FILE],
-      name: "mcp-authorize-admin-consent",
+      covers: [
+        MCP_AUTHORIZE_PAGE_FILE,
+        MCP_CONSENT_FORM_FILE,
+        RETRO_UI_BUTTON_FILE,
+      ],
+      name: "mcp-authorize-admin-user",
       mcpScopeAccess: "admin",
       path: manifest.authorizePath,
       required: true,
       requiredSelector: "#mcp-authorize-heading",
       requiredText: /^Authorize$/,
+      verifyMcpDisabledAuthorize: true,
     },
     {
       authenticated: true,
       authenticatedEmail: manifest.nonAdminEmail,
       covers: [MCP_AUTHORIZE_PAGE_FILE, MCP_CONSENT_FORM_FILE],
       mcpScopeAccess: "non-admin",
-      name: "mcp-authorize-non-admin-consent",
+      name: "mcp-authorize-non-admin-user",
       path: manifest.nonAdminAuthorizePath,
       required: true,
       requiredSelector: "#mcp-authorize-heading",
       requiredText: /^Authorize$/,
-    },
-    {
-      authenticated: true,
-      covers: [RETRO_UI_BUTTON_FILE],
-      name: "mcp-authorize-admin-disabled",
-      path: manifest.authorizePath,
-      required: true,
-      requiredSelector: "#mcp-authorize-heading",
-      requiredText: /^Select Permissions$/,
-      showMcpDisabledAuthorize: true,
     },
   ];
 }

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -14,6 +14,7 @@ import { ALL_PAGE_PATHS, PUBLIC_PAGE_PATHS } from "./static-pages";
 
 export type VisualRoute = {
   authenticated?: boolean;
+  authenticatedEmail?: string;
   /** UI source files whose rendered states this route is required to exercise. */
   covers?: string[];
   createTaskMode?: "person";
@@ -24,6 +25,7 @@ export type VisualRoute = {
   openAddSubtask?: boolean;
   openTaskImpactTrace?: boolean;
   showMcpDisabledAuthorize?: boolean;
+  mcpScopeAccess?: "admin" | "non-admin";
   openMenu?: boolean;
   openTaskManagement?: boolean;
   path: string;
@@ -46,7 +48,9 @@ type DocumentReviewFixtureManifest = {
 
 type McpAuthorizeFixtureManifest = {
   authorizePath: string;
-  version: 1;
+  nonAdminAuthorizePath: string;
+  nonAdminEmail: string;
+  version: 2;
 };
 
 function isDocumentReviewFixtureManifest(
@@ -75,7 +79,12 @@ function isMcpAuthorizeFixtureManifest(
   }
 
   const candidate = value as Record<string, unknown>;
-  return candidate.version === 1 && isNonEmptyString(candidate.authorizePath);
+  return (
+    candidate.version === 2 &&
+    isNonEmptyString(candidate.authorizePath) &&
+    isNonEmptyString(candidate.nonAdminAuthorizePath) &&
+    isNonEmptyString(candidate.nonAdminEmail)
+  );
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -583,7 +592,19 @@ function loadMcpAuthorizeRoutes(): VisualRoute[] {
       authenticated: true,
       covers: [MCP_AUTHORIZE_PAGE_FILE, MCP_CONSENT_FORM_FILE],
       name: "mcp-authorize-admin-consent",
+      mcpScopeAccess: "admin",
       path: manifest.authorizePath,
+      required: true,
+      requiredSelector: "#mcp-authorize-heading",
+      requiredText: /^Authorize$/,
+    },
+    {
+      authenticated: true,
+      authenticatedEmail: manifest.nonAdminEmail,
+      covers: [MCP_AUTHORIZE_PAGE_FILE, MCP_CONSENT_FORM_FILE],
+      mcpScopeAccess: "non-admin",
+      name: "mcp-authorize-non-admin-consent",
+      path: manifest.nonAdminAuthorizePath,
       required: true,
       requiredSelector: "#mcp-authorize-heading",
       requiredText: /^Authorize$/,

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -24,7 +24,6 @@ export type VisualRoute = {
   openAddSubtask?: boolean;
   openTaskImpactTrace?: boolean;
   showMcpDisabledAuthorize?: boolean;
-  showMcpOrganizationSelectionError?: boolean;
   openMenu?: boolean;
   openTaskManagement?: boolean;
   path: string;
@@ -76,9 +75,7 @@ function isMcpAuthorizeFixtureManifest(
   }
 
   const candidate = value as Record<string, unknown>;
-  return (
-    candidate.version === 1 && isNonEmptyString(candidate.authorizePath)
-  );
+  return candidate.version === 1 && isNonEmptyString(candidate.authorizePath);
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -103,8 +100,7 @@ const MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH = path.resolve(
 const MCP_AUTHORIZE_PAGE_FILE = "packages/web/src/app/mcp/authorize/page.tsx";
 const MCP_CONSENT_FORM_FILE =
   "packages/web/src/app/mcp/authorize/consent-form.tsx";
-const RETRO_UI_BUTTON_FILE =
-  "packages/web/src/components/retroui/Button.tsx";
+const RETRO_UI_BUTTON_FILE = "packages/web/src/components/retroui/Button.tsx";
 const TASK_DETAIL_PAGE_FILE = "packages/web/src/app/tasks/[id]/page.tsx";
 const DOCUMENT_REVIEW_MANAGER_FILE =
   "packages/web/src/components/tasks/document-review-manager-panel.tsx";
@@ -591,7 +587,6 @@ function loadMcpAuthorizeRoutes(): VisualRoute[] {
       required: true,
       requiredSelector: "#mcp-authorize-heading",
       requiredText: /^Authorize$/,
-      showMcpOrganizationSelectionError: true,
     },
     {
       authenticated: true,

--- a/packages/web/e2e/visual-regression.spec.ts
+++ b/packages/web/e2e/visual-regression.spec.ts
@@ -231,24 +231,6 @@ test.describe("route visual regression", () => {
       if ("openTaskImpactTrace" in route && route.openTaskImpactTrace) {
         await openTaskImpactTrace(page);
       }
-      if (
-        "showMcpDisabledAuthorize" in route &&
-        route.showMcpDisabledAuthorize
-      ) {
-        await page
-          .getByRole("checkbox", { name: /Manage Private Tasks/i })
-          .uncheck();
-        await page
-          .getByRole("checkbox", { name: /Manage Organization Tasks/i })
-          .uncheck();
-        await expect(
-          page.getByRole("button", {
-            name: "Select Permissions",
-            exact: true,
-          }),
-        ).toBeDisabled();
-        await page.evaluate(() => window.scrollTo(0, 0));
-      }
       if ("mcpScopeAccess" in route && route.mcpScopeAccess) {
         const privilegedPermissions = [
           /Admin Public Task Management/i,
@@ -307,6 +289,24 @@ test.describe("route visual regression", () => {
         path: reviewScreenshotPath,
         contentType: "image/png",
       });
+
+      if (
+        "verifyMcpDisabledAuthorize" in route &&
+        route.verifyMcpDisabledAuthorize
+      ) {
+        await page
+          .getByRole("checkbox", { name: /Manage Private Tasks/i })
+          .uncheck();
+        await page
+          .getByRole("checkbox", { name: /Manage Organization Tasks/i })
+          .uncheck();
+        await expect(
+          page.getByRole("button", {
+            name: "Select Permissions",
+            exact: true,
+          }),
+        ).toBeDisabled();
+      }
     });
   }
 });

--- a/packages/web/e2e/visual-regression.spec.ts
+++ b/packages/web/e2e/visual-regression.spec.ts
@@ -226,6 +226,21 @@ test.describe("route visual regression", () => {
       if ("openTaskImpactTrace" in route && route.openTaskImpactTrace) {
         await openTaskImpactTrace(page);
       }
+      if (
+        "showMcpOrganizationSelectionError" in route &&
+        route.showMcpOrganizationSelectionError
+      ) {
+        await page
+          .getByRole("button", { name: "Authorize", exact: true })
+          .click();
+        await expect(
+          page.getByText(
+            "Select at least one organization or remove organization access.",
+            { exact: true },
+          ),
+        ).toBeVisible();
+        await page.evaluate(() => window.scrollTo(0, 0));
+      }
 
       if (route.requiredSelector) {
         // Regression guard: these visual pages must keep exposing the

--- a/packages/web/e2e/visual-regression.spec.ts
+++ b/packages/web/e2e/visual-regression.spec.ts
@@ -244,22 +244,6 @@ test.describe("route visual regression", () => {
         ).toBeDisabled();
         await page.evaluate(() => window.scrollTo(0, 0));
       }
-      if (
-        "showMcpOrganizationSelectionError" in route &&
-        route.showMcpOrganizationSelectionError
-      ) {
-        await page
-          .getByRole("button", { name: "Authorize", exact: true })
-          .click();
-        await expect(
-          page.getByText(
-            "Select at least one organization or remove organization access.",
-            { exact: true },
-          ),
-        ).toBeVisible();
-        await page.evaluate(() => window.scrollTo(0, 0));
-      }
-
       if (route.requiredSelector) {
         // Regression guard: these visual pages must keep exposing the
         // president/signer task list. Do not delete without Mike's explicit
@@ -382,8 +366,7 @@ async function waitForVisualIdle(page: Page) {
 
 async function waitForAuthenticatedVisualSession(page: Page) {
   await page.waitForFunction(
-    () =>
-      document.documentElement.dataset.visualAuthState === "authenticated",
+    () => document.documentElement.dataset.visualAuthState === "authenticated",
     undefined,
     { timeout: 15_000 },
   );

--- a/packages/web/e2e/visual-regression.spec.ts
+++ b/packages/web/e2e/visual-regression.spec.ts
@@ -14,7 +14,7 @@ import {
   SITE_VARIANT_OVERRIDE_QUERY_PARAM,
 } from "@/lib/site";
 import { forceAnimationsComplete, waitForPaint } from "./utils/audit-helpers";
-import { signInDemoUser } from "./utils/auth";
+import { DEMO_PASSWORD, signInDemoUser, signInUser } from "./utils/auth";
 import { VISUAL_ROUTES } from "./utils/visual-routes";
 import { freezeClock } from "./helpers/freeze-clock";
 
@@ -157,7 +157,12 @@ test.describe("route visual regression", () => {
   for (const route of VISUAL_ROUTES) {
     test(`${route.name}`, async ({ page }, testInfo) => {
       if ("authenticated" in route && route.authenticated) {
-        const signedIn = await signInDemoUser(page);
+        const signedIn = route.authenticatedEmail
+          ? await signInUser(page, {
+              email: route.authenticatedEmail,
+              password: DEMO_PASSWORD,
+            })
+          : await signInDemoUser(page);
         expect(
           signedIn,
           "demo user should sign in before dashboard screenshot",
@@ -243,6 +248,30 @@ test.describe("route visual regression", () => {
           }),
         ).toBeDisabled();
         await page.evaluate(() => window.scrollTo(0, 0));
+      }
+      if ("mcpScopeAccess" in route && route.mcpScopeAccess) {
+        const privilegedPermissions = [
+          /Admin Public Task Management/i,
+          /Moderate Earth Data/i,
+          /Run Coordinated Agents/i,
+          /GitHub Repo Access/i,
+        ];
+        for (const permission of privilegedPermissions) {
+          const checkbox = page.getByRole("checkbox", { name: permission });
+          if (route.mcpScopeAccess === "admin") {
+            await expect(checkbox).toBeVisible();
+          } else {
+            await expect(checkbox).toHaveCount(0);
+          }
+        }
+        if (route.mcpScopeAccess === "non-admin") {
+          await expect(
+            page.getByRole("checkbox", { name: /Manage Private Tasks/i }),
+          ).toBeVisible();
+          await expect(
+            page.getByRole("checkbox", { name: /Add Earth Data/i }),
+          ).toBeVisible();
+        }
       }
       if (route.requiredSelector) {
         // Regression guard: these visual pages must keep exposing the

--- a/packages/web/e2e/visual-regression.spec.ts
+++ b/packages/web/e2e/visual-regression.spec.ts
@@ -227,6 +227,24 @@ test.describe("route visual regression", () => {
         await openTaskImpactTrace(page);
       }
       if (
+        "showMcpDisabledAuthorize" in route &&
+        route.showMcpDisabledAuthorize
+      ) {
+        await page
+          .getByRole("checkbox", { name: /Manage Private Tasks/i })
+          .uncheck();
+        await page
+          .getByRole("checkbox", { name: /Manage Organization Tasks/i })
+          .uncheck();
+        await expect(
+          page.getByRole("button", {
+            name: "Select Permissions",
+            exact: true,
+          }),
+        ).toBeDisabled();
+        await page.evaluate(() => window.scrollTo(0, 0));
+      }
+      if (
         "showMcpOrganizationSelectionError" in route &&
         route.showMcpOrganizationSelectionError
       ) {

--- a/packages/web/scripts/build-visual-review.mjs
+++ b/packages/web/scripts/build-visual-review.mjs
@@ -151,6 +151,8 @@ const routeOrder = [
   "privacy",
   "terms",
   "settings",
+  "mcp-authorize-admin-user",
+  "mcp-authorize-non-admin-user",
   "organizations",
   "organization-iam-public",
   "organization-iam-survey",
@@ -170,6 +172,15 @@ const routeOrder = [
   "variant-dih-home",
   "variant-dih-fund-a-disease",
 ];
+
+const legacyRouteNameAliases = new Map([
+  ["mcp-authorize-consent", "mcp-authorize-admin-user"],
+]);
+
+const routeLabelOverrides = new Map([
+  ["mcp-authorize-admin-user", "MCP authorize — admin user"],
+  ["mcp-authorize-non-admin-user", "MCP authorize — non-admin user"],
+]);
 
 // Non-default site variants captured by the variant-delta routes in
 // e2e/utils/visual-routes.ts. Keys match SiteKey in src/lib/site.ts.
@@ -277,9 +288,13 @@ function collectScreenshots(root, version) {
       mkdirSync(assetDir, { recursive: true });
       const assetPath = path.join(assetDir, entry);
       copyFileSync(filePath, assetPath);
-      const routeName = entry
+      const legacyRouteName = entry
         .replace(/\.png$/i, "")
         .replace(/-(default|visual-mobile)$/i, "");
+      const routeName =
+        version === "before"
+          ? (legacyRouteNameAliases.get(legacyRouteName) ?? legacyRouteName)
+          : legacyRouteName;
       if (isRedirectOnlyScreenshotRoute(routeName)) {
         continue;
       }
@@ -1501,6 +1516,10 @@ function projectSortIndex(projectName) {
 }
 
 function labelRoute(routeName) {
+  const override = routeLabelOverrides.get(routeName);
+  if (override) {
+    return override;
+  }
   return routeName
     .split("-")
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))

--- a/packages/web/scripts/seed-visual-review-fixtures.ts
+++ b/packages/web/scripts/seed-visual-review-fixtures.ts
@@ -100,6 +100,9 @@ async function removeFixtureManifest() {
 }
 
 async function seedMcpAuthorizeFixture() {
+  await prisma.oAuthGrant.deleteMany({
+    where: { clientId: MCP_AUTHORIZE_CLIENT_ID },
+  });
   await prisma.oAuthClient.upsert({
     where: { clientId: MCP_AUTHORIZE_CLIENT_ID },
     create: {

--- a/packages/web/scripts/seed-visual-review-fixtures.ts
+++ b/packages/web/scripts/seed-visual-review-fixtures.ts
@@ -60,6 +60,8 @@ const ids = {
   managerTask: `${FIXTURE_PREFIX}manager_task`,
   managementClaimTask: `${FIXTURE_PREFIX}management_claim_task`,
   managementOwnerTask: `${FIXTURE_PREFIX}management_owner_task`,
+  nonAdminMcpPerson: `${FIXTURE_PREFIX}mcp_non_admin_person`,
+  nonAdminMcpUser: `${FIXTURE_PREFIX}mcp_non_admin_user`,
   staleTask: `${FIXTURE_PREFIX}stale_task`,
 };
 
@@ -99,7 +101,7 @@ async function removeFixtureManifest() {
   ]);
 }
 
-async function seedMcpAuthorizeFixture() {
+async function seedMcpAuthorizeFixture(input: { nonAdminEmail: string }) {
   await prisma.oAuthGrant.deleteMany({
     where: { clientId: MCP_AUTHORIZE_CLIENT_ID },
   });
@@ -121,8 +123,26 @@ async function seedMcpAuthorizeFixture() {
   authorizePath.searchParams.set("redirect_uri", MCP_AUTHORIZE_REDIRECT_URI);
   authorizePath.searchParams.set("state", "visual-review");
   authorizePath.searchParams.set("scope", "tasks:personal tasks:organization");
-  authorizePath.searchParams.set("code_challenge", MCP_AUTHORIZE_CODE_CHALLENGE);
+  authorizePath.searchParams.set(
+    "code_challenge",
+    MCP_AUTHORIZE_CODE_CHALLENGE,
+  );
   authorizePath.searchParams.set("client_name", "Visual Review MCP");
+
+  const nonAdminAuthorizePath = new URL(authorizePath);
+  nonAdminAuthorizePath.searchParams.set("state", "visual-review-non-admin");
+  nonAdminAuthorizePath.searchParams.set(
+    "scope",
+    [
+      "tasks:personal",
+      "tasks:organization",
+      "earthdata:write",
+      "tasks:admin",
+      "earthdata:admin",
+      "agent:run",
+      "github",
+    ].join(" "),
+  );
 
   await mkdir(path.dirname(MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH), {
     recursive: true,
@@ -132,16 +152,16 @@ async function seedMcpAuthorizeFixture() {
     JSON.stringify(
       {
         authorizePath: `${authorizePath.pathname}${authorizePath.search}`,
-        version: 1,
+        nonAdminAuthorizePath: `${nonAdminAuthorizePath.pathname}${nonAdminAuthorizePath.search}`,
+        nonAdminEmail: input.nonAdminEmail,
+        version: 2,
       },
       null,
       2,
     ),
     "utf8",
   );
-  console.log(
-    `[visual-review] wrote ${MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH}`,
-  );
+  console.log(`[visual-review] wrote ${MCP_AUTHORIZE_FIXTURE_MANIFEST_PATH}`);
 }
 
 async function resetVisualReviewFixtures() {
@@ -281,10 +301,11 @@ async function loadDemoActor() {
     select: {
       id: true,
       isAdmin: true,
+      password: true,
       person: { select: { id: true } },
     },
   });
-  if (!user?.person) {
+  if (!user?.person || !user.password) {
     throw new Error(
       `Visual review fixtures require the managed demo user (${DEMO_EMAIL}). Run managed-data sync first.`,
     );
@@ -295,7 +316,47 @@ async function loadDemoActor() {
       data: { isAdmin: true },
     });
   }
-  return { person: user.person, user: { id: user.id } };
+  return {
+    passwordHash: user.password,
+    person: user.person,
+    user: { id: user.id },
+  };
+}
+
+async function ensureNonAdminMcpAuthorizeUser(passwordHash: string) {
+  const email = "visual-user@example.test";
+  const person = await prisma.person.upsert({
+    where: { id: ids.nonAdminMcpPerson },
+    update: {
+      deletedAt: null,
+      displayName: "Normal Visual Reviewer",
+      email,
+    },
+    create: {
+      displayName: "Normal Visual Reviewer",
+      email,
+      id: ids.nonAdminMcpPerson,
+    },
+  });
+  const user = await prisma.user.upsert({
+    where: { id: ids.nonAdminMcpUser },
+    update: {
+      deletedAt: null,
+      email,
+      isAdmin: false,
+      password: passwordHash,
+      personId: person.id,
+    },
+    create: {
+      email,
+      id: ids.nonAdminMcpUser,
+      isAdmin: false,
+      password: passwordHash,
+      personId: person.id,
+    },
+  });
+  await prisma.organizationMember.deleteMany({ where: { userId: user.id } });
+  return { email };
 }
 
 async function seedTaskManagementStates(input: {
@@ -628,6 +689,9 @@ async function main() {
     loadDemoActor(),
     ensureFixtureManager(),
   ]);
+  const nonAdminMcpUser = await ensureNonAdminMcpAuthorizeUser(
+    demo.passwordHash,
+  );
   const managerTaskId = await seedManagerState({ demo, fixtureManager });
   const activeReviewTaskId = await seedActiveReviewerState({
     demo,
@@ -642,7 +706,7 @@ async function main() {
     fixtureManager,
   });
 
-  await seedMcpAuthorizeFixture();
+  await seedMcpAuthorizeFixture({ nonAdminEmail: nonAdminMcpUser.email });
   await mkdir(path.dirname(FIXTURE_MANIFEST_PATH), { recursive: true });
   await writeFile(
     FIXTURE_MANIFEST_PATH,

--- a/packages/web/scripts/seed-visual-review-fixtures.ts
+++ b/packages/web/scripts/seed-visual-review-fixtures.ts
@@ -117,7 +117,7 @@ async function seedMcpAuthorizeFixture() {
   authorizePath.searchParams.set("client_id", MCP_AUTHORIZE_CLIENT_ID);
   authorizePath.searchParams.set("redirect_uri", MCP_AUTHORIZE_REDIRECT_URI);
   authorizePath.searchParams.set("state", "visual-review");
-  authorizePath.searchParams.set("scope", "tasks:personal");
+  authorizePath.searchParams.set("scope", "tasks:personal tasks:organization");
   authorizePath.searchParams.set("code_challenge", MCP_AUTHORIZE_CODE_CHALLENGE);
   authorizePath.searchParams.set("client_name", "Visual Review MCP");
 

--- a/packages/web/src/app/api/mcp/oauth/consent/route.test.ts
+++ b/packages/web/src/app/api/mcp/oauth/consent/route.test.ts
@@ -103,6 +103,45 @@ describe("MCP OAuth consent route (Authorize)", () => {
     });
   });
 
+  it("allows public-only access when organization access was the only scope", async () => {
+    const response = await POST(
+      consentRequest({
+        client_id: "mcp_client",
+        redirect_uri: "http://127.0.0.1:9999/callback",
+        scope: "tasks:organization",
+        code_challenge: "challenge",
+        approved: true,
+        organization_ids: [],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.findMemberships).not.toHaveBeenCalled();
+    expect(mocks.createAuthCode).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        scopes: [],
+        organizationIds: [],
+      }),
+    });
+  });
+
+  it("rejects requests with no recognized scopes", async () => {
+    const response = await POST(
+      consentRequest({
+        client_id: "mcp_client",
+        redirect_uri: "http://127.0.0.1:9999/callback",
+        scope: "unknown:scope",
+        code_challenge: "challenge",
+        approved: true,
+        organization_ids: [],
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "invalid_scope" });
+    expect(mocks.createAuthCode).not.toHaveBeenCalled();
+  });
+
   it("keeps organization access for selected member organizations", async () => {
     mocks.findMemberships.mockResolvedValue([
       { organizationId: "organization_1" },

--- a/packages/web/src/app/api/mcp/oauth/consent/route.test.ts
+++ b/packages/web/src/app/api/mcp/oauth/consent/route.test.ts
@@ -142,6 +142,26 @@ describe("MCP OAuth consent route (Authorize)", () => {
     expect(mocks.createAuthCode).not.toHaveBeenCalled();
   });
 
+  it("strips admin, agent, and GitHub scopes from non-admin grants", async () => {
+    const response = await POST(
+      consentRequest({
+        client_id: "mcp_client",
+        redirect_uri: "http://127.0.0.1:9999/callback",
+        scope: "tasks:personal tasks:admin earthdata:admin agent:run github",
+        code_challenge: "challenge",
+        approved: true,
+        organization_ids: [],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.createAuthCode).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        scopes: ["TASKS_PERSONAL"],
+      }),
+    });
+  });
+
   it("keeps organization access for selected member organizations", async () => {
     mocks.findMemberships.mockResolvedValue([
       { organizationId: "organization_1" },

--- a/packages/web/src/app/api/mcp/oauth/consent/route.test.ts
+++ b/packages/web/src/app/api/mcp/oauth/consent/route.test.ts
@@ -80,6 +80,73 @@ describe("MCP OAuth consent route (Authorize)", () => {
     expect(mocks.createAuthCode).toHaveBeenCalledOnce();
   });
 
+  it("omits organization access when no organizations are selected", async () => {
+    const response = await POST(
+      consentRequest({
+        client_id: "mcp_client",
+        redirect_uri: "http://127.0.0.1:9999/callback",
+        state: "state-1",
+        scope: "tasks:personal tasks:organization",
+        code_challenge: "challenge",
+        approved: true,
+        organization_ids: [],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.findMemberships).not.toHaveBeenCalled();
+    expect(mocks.createAuthCode).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        scopes: ["TASKS_PERSONAL"],
+        organizationIds: [],
+      }),
+    });
+  });
+
+  it("keeps organization access for selected member organizations", async () => {
+    mocks.findMemberships.mockResolvedValue([
+      { organizationId: "organization_1" },
+    ]);
+
+    const response = await POST(
+      consentRequest({
+        client_id: "mcp_client",
+        redirect_uri: "http://127.0.0.1:9999/callback",
+        scope: "tasks:personal tasks:organization",
+        code_challenge: "challenge",
+        approved: true,
+        organization_ids: ["organization_1"],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.createAuthCode).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        scopes: ["TASKS_PERSONAL", "TASKS_ORGANIZATION"],
+        organizationIds: ["organization_1"],
+      }),
+    });
+  });
+
+  it("rejects organization IDs outside the user's memberships", async () => {
+    const response = await POST(
+      consentRequest({
+        client_id: "mcp_client",
+        redirect_uri: "http://127.0.0.1:9999/callback",
+        scope: "tasks:personal tasks:organization",
+        code_challenge: "challenge",
+        approved: true,
+        organization_ids: ["organization_unauthorized"],
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: "invalid_scope",
+    });
+    expect(mocks.createAuthCode).not.toHaveBeenCalled();
+  });
+
   it("rejects Authorize when the session is missing", async () => {
     mocks.getServerSession.mockResolvedValue(null);
 

--- a/packages/web/src/app/api/mcp/oauth/consent/route.ts
+++ b/packages/web/src/app/api/mcp/oauth/consent/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { generateAuthCode, AUTH_CODE_TTL_MS, isRedirectUriAllowed } from "@/lib/mcp-oauth";
+import {
+  generateAuthCode,
+  AUTH_CODE_TTL_MS,
+  isRedirectUriAllowed,
+} from "@/lib/mcp-oauth";
 import {
   filterAllowedMcpScopes,
   isHumanApprovalOAuthRedirectUri,
@@ -51,7 +55,10 @@ export async function POST(req: Request) {
     !URL.canParse(redirectUri) ||
     !isRedirectUriAllowed(client.redirectUris, redirectUri)
   ) {
-    return NextResponse.json({ error: "Invalid redirect_uri" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Invalid redirect_uri" },
+      { status: 400 },
+    );
   }
 
   if (!approved) {
@@ -69,54 +76,51 @@ export async function POST(req: Request) {
     where: { id: session.user.id },
     select: { isAdmin: true },
   });
-  const scopes = filterAllowedMcpScopes(requestedScopes, user?.isAdmin === true, {
+  let scopes = filterAllowedMcpScopes(requestedScopes, user?.isAdmin === true, {
     allowHumanApproval: isHumanApprovalOAuthRedirectUri(redirectUri),
   });
-
-  if (scopes.length === 0) {
-    return NextResponse.json(
-      { error: "invalid_scope", error_description: "At least one valid scope is required" },
-      { status: 400 },
-    );
-  }
 
   let organizationIds: string[] = [];
   if (scopes.includes(McpScope.TASKS_ORGANIZATION)) {
     if (requestedOrganizationIds.length === 0) {
-      return NextResponse.json(
-        {
-          error: "invalid_scope",
-          error_description:
-            "Select at least one organization or remove tasks:organization.",
+      scopes = scopes.filter((scope) => scope !== McpScope.TASKS_ORGANIZATION);
+    } else {
+      const memberships = await prisma.organizationMember.findMany({
+        where: {
+          organizationId: { in: requestedOrganizationIds },
+          organization: { deletedAt: null },
+          userId: session.user.id,
         },
-        { status: 400 },
+        select: { organizationId: true },
+      });
+      const membershipIds = new Set(
+        memberships.map((membership) => membership.organizationId),
       );
+      if (
+        membershipIds.size !== requestedOrganizationIds.length ||
+        requestedOrganizationIds.some((id) => !membershipIds.has(id))
+      ) {
+        return NextResponse.json(
+          {
+            error: "invalid_scope",
+            error_description:
+              "One or more selected organizations are unavailable.",
+          },
+          { status: 400 },
+        );
+      }
+      organizationIds = requestedOrganizationIds;
     }
-    const memberships = await prisma.organizationMember.findMany({
-      where: {
-        organizationId: { in: requestedOrganizationIds },
-        organization: { deletedAt: null },
-        userId: session.user.id,
+  }
+
+  if (scopes.length === 0) {
+    return NextResponse.json(
+      {
+        error: "invalid_scope",
+        error_description: "At least one valid scope is required",
       },
-      select: { organizationId: true },
-    });
-    const membershipIds = new Set(
-      memberships.map((membership) => membership.organizationId),
+      { status: 400 },
     );
-    if (
-      membershipIds.size !== requestedOrganizationIds.length ||
-      requestedOrganizationIds.some((id) => !membershipIds.has(id))
-    ) {
-      return NextResponse.json(
-        {
-          error: "invalid_scope",
-          error_description:
-            "One or more selected organizations are unavailable.",
-        },
-        { status: 400 },
-      );
-    }
-    organizationIds = requestedOrganizationIds;
   }
 
   await prisma.oAuthAuthCode.create({

--- a/packages/web/src/app/api/mcp/oauth/consent/route.ts
+++ b/packages/web/src/app/api/mcp/oauth/consent/route.ts
@@ -81,9 +81,11 @@ export async function POST(req: Request) {
   });
 
   let organizationIds: string[] = [];
+  let omittedOrganizationScope = false;
   if (scopes.includes(McpScope.TASKS_ORGANIZATION)) {
     if (requestedOrganizationIds.length === 0) {
       scopes = scopes.filter((scope) => scope !== McpScope.TASKS_ORGANIZATION);
+      omittedOrganizationScope = true;
     } else {
       const memberships = await prisma.organizationMember.findMany({
         where: {
@@ -113,7 +115,7 @@ export async function POST(req: Request) {
     }
   }
 
-  if (scopes.length === 0) {
+  if (scopes.length === 0 && !omittedOrganizationScope) {
     return NextResponse.json(
       {
         error: "invalid_scope",

--- a/packages/web/src/app/mcp/authorize/consent-form.tsx
+++ b/packages/web/src/app/mcp/authorize/consent-form.tsx
@@ -108,11 +108,6 @@ export function McpConsentForm({
   }
 
   async function handleApprove() {
-    const scopesToAuthorize = Array.from(selected).filter(
-      (scope) =>
-        scope !== McpScope.TASKS_ORGANIZATION ||
-        selectedOrganizationIds.size > 0,
-    );
     if (!canAuthorize) return;
     setLoading(true);
     setError(null);
@@ -125,10 +120,8 @@ export function McpConsentForm({
           client_id: clientId,
           redirect_uri: redirectUri,
           state,
-          scope: scopesToWire(scopesToAuthorize),
-          organization_ids: scopesToAuthorize.includes(
-            McpScope.TASKS_ORGANIZATION,
-          )
+          scope: scopesToWire(Array.from(selected)),
+          organization_ids: selected.has(McpScope.TASKS_ORGANIZATION)
             ? Array.from(selectedOrganizationIds)
             : [],
           code_challenge: codeChallenge,

--- a/packages/web/src/app/mcp/authorize/consent-form.tsx
+++ b/packages/web/src/app/mcp/authorize/consent-form.tsx
@@ -85,10 +85,7 @@ export function McpConsentForm({
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const canAuthorize = Array.from(selected).some(
-    (scope) =>
-      scope !== McpScope.TASKS_ORGANIZATION || selectedOrganizationIds.size > 0,
-  );
+  const canAuthorize = selected.size > 0;
 
   function toggle(scope: McpScope) {
     setError(null);
@@ -116,7 +113,7 @@ export function McpConsentForm({
         scope !== McpScope.TASKS_ORGANIZATION ||
         selectedOrganizationIds.size > 0,
     );
-    if (scopesToAuthorize.length === 0) return;
+    if (!canAuthorize) return;
     setLoading(true);
     setError(null);
     try {

--- a/packages/web/src/app/mcp/authorize/consent-form.tsx
+++ b/packages/web/src/app/mcp/authorize/consent-form.tsx
@@ -85,6 +85,10 @@ export function McpConsentForm({
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const canAuthorize = Array.from(selected).some(
+    (scope) =>
+      scope !== McpScope.TASKS_ORGANIZATION || selectedOrganizationIds.size > 0,
+  );
 
   function toggle(scope: McpScope) {
     setError(null);
@@ -107,16 +111,12 @@ export function McpConsentForm({
   }
 
   async function handleApprove() {
-    const organizationSelectionRequired =
-      selected.has(McpScope.TASKS_ORGANIZATION) &&
-      selectedOrganizationIds.size === 0;
-    if (selected.size === 0) return;
-    if (organizationSelectionRequired) {
-      setError(
-        "Select at least one organization or remove organization access.",
-      );
-      return;
-    }
+    const scopesToAuthorize = Array.from(selected).filter(
+      (scope) =>
+        scope !== McpScope.TASKS_ORGANIZATION ||
+        selectedOrganizationIds.size > 0,
+    );
+    if (scopesToAuthorize.length === 0) return;
     setLoading(true);
     setError(null);
     try {
@@ -128,8 +128,10 @@ export function McpConsentForm({
           client_id: clientId,
           redirect_uri: redirectUri,
           state,
-          scope: scopesToWire(Array.from(selected)),
-          organization_ids: selected.has(McpScope.TASKS_ORGANIZATION)
+          scope: scopesToWire(scopesToAuthorize),
+          organization_ids: scopesToAuthorize.includes(
+            McpScope.TASKS_ORGANIZATION,
+          )
             ? Array.from(selectedOrganizationIds)
             : [],
           code_challenge: codeChallenge,
@@ -211,33 +213,40 @@ export function McpConsentForm({
         <div className="mb-6">
           <h2 className="text-sm font-black uppercase mb-3">Organizations</h2>
           {availableOrganizations.length > 0 ? (
-            <ul className="space-y-2">
-              {availableOrganizations.map((organization) => (
-                <li key={organization.id}>
-                  <label className="flex gap-3 items-start cursor-pointer border-2 border-primary p-3 hover:bg-muted">
-                    <Checkbox
-                      checked={selectedOrganizationIds.has(organization.id)}
-                      onCheckedChange={() =>
-                        toggleOrganization(organization.id)
-                      }
-                      className="mt-0.5"
-                    />
-                    <span className="flex-1 min-w-0">
-                      <span className="block text-sm font-black uppercase break-words">
-                        {organization.name}
+            <>
+              <p className="text-xs font-bold text-muted-foreground mb-3">
+                Select the organizations this app may manage. Leave all
+                unchecked to continue without organization access.
+              </p>
+              <ul className="space-y-2">
+                {availableOrganizations.map((organization) => (
+                  <li key={organization.id}>
+                    <label className="flex gap-3 items-start cursor-pointer border-2 border-primary p-3 hover:bg-muted">
+                      <Checkbox
+                        checked={selectedOrganizationIds.has(organization.id)}
+                        onCheckedChange={() =>
+                          toggleOrganization(organization.id)
+                        }
+                        className="mt-0.5"
+                      />
+                      <span className="flex-1 min-w-0">
+                        <span className="block text-sm font-black uppercase break-words">
+                          {organization.name}
+                        </span>
+                        <span className="block text-xs font-bold text-muted-foreground mt-1">
+                          {organization.role.toLowerCase()} ·{" "}
+                          {organization.slug}
+                        </span>
                       </span>
-                      <span className="block text-xs font-bold text-muted-foreground mt-1">
-                        {organization.role.toLowerCase()} · {organization.slug}
-                      </span>
-                    </span>
-                  </label>
-                </li>
-              ))}
-            </ul>
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            </>
           ) : (
             <p className="text-xs font-bold text-muted-foreground">
-              You do not belong to an organization. Remove organization access
-              to continue.
+              You do not belong to an organization, so no organization access
+              will be granted.
             </p>
           )}
         </div>
@@ -255,12 +264,12 @@ export function McpConsentForm({
           onClick={() => {
             void handleApprove();
           }}
-          disabled={loading || selected.size === 0}
+          disabled={loading || !canAuthorize}
           className="flex-1"
         >
           {loading
             ? "Authorizing..."
-            : selected.size === 0
+            : !canAuthorize
               ? "Select Permissions"
               : "Authorize"}
         </Button>

--- a/packages/web/src/app/mcp/authorize/consent-form.tsx
+++ b/packages/web/src/app/mcp/authorize/consent-form.tsx
@@ -87,6 +87,7 @@ export function McpConsentForm({
   const [error, setError] = useState<string | null>(null);
 
   function toggle(scope: McpScope) {
+    setError(null);
     setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(scope)) next.delete(scope);
@@ -96,6 +97,7 @@ export function McpConsentForm({
   }
 
   function toggleOrganization(organizationId: string) {
+    setError(null);
     setSelectedOrganizationIds((previous) => {
       const next = new Set(previous);
       if (next.has(organizationId)) next.delete(organizationId);
@@ -108,7 +110,13 @@ export function McpConsentForm({
     const organizationSelectionRequired =
       selected.has(McpScope.TASKS_ORGANIZATION) &&
       selectedOrganizationIds.size === 0;
-    if (selected.size === 0 || organizationSelectionRequired) return;
+    if (selected.size === 0) return;
+    if (organizationSelectionRequired) {
+      setError(
+        "Select at least one organization or remove organization access.",
+      );
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -247,12 +255,7 @@ export function McpConsentForm({
           onClick={() => {
             void handleApprove();
           }}
-          disabled={
-            loading ||
-            selected.size === 0 ||
-            (selected.has(McpScope.TASKS_ORGANIZATION) &&
-              selectedOrganizationIds.size === 0)
-          }
+          disabled={loading || selected.size === 0}
           className="flex-1"
         >
           {loading

--- a/packages/web/src/components/retroui/Button.tsx
+++ b/packages/web/src/components/retroui/Button.tsx
@@ -4,7 +4,7 @@ import React, { ButtonHTMLAttributes } from "react";
 import { Slot } from "@radix-ui/react-slot";
 
 export const buttonVariants = cva(
-  "font-head flex cursor-pointer items-center rounded-none font-medium outline-hidden transition-colors duration-200 shadow-none",
+  "font-head flex cursor-pointer items-center rounded-none font-medium outline-hidden transition-colors duration-200 shadow-none disabled:cursor-not-allowed disabled:border-muted-foreground disabled:bg-muted disabled:text-muted-foreground disabled:opacity-70 disabled:hover:bg-muted disabled:hover:text-muted-foreground",
   {
     variants: {
       variant: {

--- a/packages/web/src/lib/__tests__/mcp-scopes.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-scopes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { allowedMcpScopesForUser, McpScope } from "@/lib/mcp-scopes";
+
+describe("MCP OAuth scope visibility", () => {
+  it("does not offer admin, agent, or GitHub scopes to non-admins", () => {
+    expect(allowedMcpScopesForUser(false)).toEqual([
+      McpScope.TASKS_PERSONAL,
+      McpScope.TASKS_ORGANIZATION,
+      McpScope.EARTHDATA_WRITE,
+    ]);
+  });
+
+  it("offers privileged scopes to admins", () => {
+    expect(allowedMcpScopesForUser(true)).toEqual(
+      expect.arrayContaining([
+        McpScope.TASKS_ADMIN,
+        McpScope.EARTHDATA_ADMIN,
+        McpScope.AGENT_RUN,
+        McpScope.GITHUB,
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Why

An OAuth client can request organization or privileged access that the human cannot or does not want to grant. The consent screen should reduce the request safely and make the actual grant obvious.

## What changed

- Treat no selected organizations as consent without organization access.
- Remove `tasks:organization` from the granted scopes when no organizations are selected.
- Allow a public-only grant when organization access was the client’s only requested private scope.
- Keep organization access only when the human selects organizations they belong to.
- Reject forged organization IDs and requests with no recognized scopes.
- Never offer `tasks:admin`, `earthdata:admin`, `agent:run`, or `github` to non-admins.
- Filter those privileged scopes again at the consent POST boundary if a client submits them directly.
- Keep the shared disabled-button styling visibly muted.
- Cover admin, disabled, and non-admin consent states in desktop and mobile visual review.
- Seed the non-admin review state with a normal user and a client request containing every privileged scope.
- Assert in the browser that GitHub, admin task management, Earth-data moderation, and coordinated-agent controls do not exist for that user.
- Extend the OAuth callback E2E to authorize without selected organizations and verify the authorization-code redirect.

## Permission visibility

The admin screenshot signs in as the managed demo admin. It therefore shows public-task administration, Earth-data moderation, coordinated-agent, and GitHub scopes.

The separate non-admin screenshot requests those same privileged scopes but renders only:

- `tasks:personal`
- `tasks:organization`
- `earthdata:write`

`earthdata:write` is intentionally a public contribution scope, not an admin scope. Human-action approval appears only for its trusted browser-extension callback.

## Verification

- focused scope and consent-route tests — 10 passed
- `pnpm --filter @optimitron/web run typecheck:tests`
- visual-review coverage tests — 12 passed
- focused MCP OAuth visual E2E — 6 passed across desktop and mobile
- visual review — 2/2 changed UI files covered
- `git diff --check`

Screenshots were captured and inspected locally. The non-admin screenshot contains no privileged options, and both viewport layouts remain intact.

## Copy review

Audience: a signed-in human authorizing an MCP client.

Desired action: grant only the access they intend, then authorize.

Desired feeling: informed and unblocked.

Outcome: authorization succeeds without accidental organization or privileged access.

- New: `Select the organizations this app may manage. Leave all unchecked to continue without organization access.`
- New: `You do not belong to an organization, so no organization access will be granted.`
- Removed: `Select at least one organization or remove organization access.`

## Human review

- [ ] Confirm unchecked organizations should mean no organization access.
- [ ] Confirm the organization-selection explanation is clear.
- [ ] Compare the admin and non-admin consent screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for separate MCP authorization experiences for administrators and non-administrators.
  - Organization task access can now be requested alongside personal task access.
  - Added clearer consent messaging when organization access is not selected or unavailable.

- **Bug Fixes**
  - Prevented unauthorized organization scopes from being granted.
  - Improved handling of requests with unavailable or unrecognized permissions.
  - Updated disabled authorization controls with clearer visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->