### PR TITLE
Improve search discovery and suggestions

### DIFF
--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -298,7 +298,7 @@ const SPECIAL_STATE_ROUTES: VisualRoute[] = [
     name: "search-empty",
     path: ROUTES.search,
     required: true,
-    requiredSelector: '[aria-label="Featured destinations"]',
+    requiredSelector: '[aria-label="Search the site"]',
     siteVariant: "optimitron",
   },
   {

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -25,6 +25,7 @@ export type VisualRoute = {
   openTaskImpactTrace?: boolean;
   openMenu?: boolean;
   openTaskManagement?: boolean;
+  submitSearch?: boolean;
   typeSearchQuery?: string;
   path: string;
   required: boolean;
@@ -298,7 +299,8 @@ const SPECIAL_STATE_ROUTES: VisualRoute[] = [
     name: "search-empty",
     path: ROUTES.search,
     required: true,
-    requiredSelector: '[aria-label="Search the site"]',
+    requiredSelector: '[data-search-popular] a[href="/tasks"]',
+    requiredText: /Popular pages/i,
     siteVariant: "optimitron",
   },
   {
@@ -309,6 +311,17 @@ const SPECIAL_STATE_ROUTES: VisualRoute[] = [
     requiredSelector: '[data-search-suggestions] a[href="/donate"]',
     siteVariant: "optimitron",
     typeSearchQuery: "donate",
+  },
+  {
+    covers: [SEARCH_DISCOVERY_FILE],
+    name: "search-loading",
+    path: ROUTES.search,
+    required: true,
+    requiredSelector: 'form[aria-busy="true"] button:disabled',
+    requiredText: /^Searching…$/i,
+    siteVariant: "optimitron",
+    submitSearch: true,
+    typeSearchQuery: "vote",
   },
   {
     covers: [SEARCH_PAGE_FILE],

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -311,6 +311,14 @@ const SPECIAL_STATE_ROUTES: VisualRoute[] = [
     typeSearchQuery: "donate",
   },
   {
+    covers: [SEARCH_PAGE_FILE],
+    name: "search-results",
+    path: `${ROUTES.search}?q=vote`,
+    required: true,
+    requiredSelector: 'a[href="/vote"]',
+    siteVariant: "optimitron",
+  },
+  {
     covers: [STANDALONE_VIDEO_PAGE_FILE],
     name: "campaign-video",
     path: ROUTES.video,

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -25,6 +25,7 @@ export type VisualRoute = {
   openTaskImpactTrace?: boolean;
   openMenu?: boolean;
   openTaskManagement?: boolean;
+  typeSearchQuery?: string;
   path: string;
   required: boolean;
   requiredSelector?: string;
@@ -74,9 +75,7 @@ function isMcpAuthorizeFixtureManifest(
   }
 
   const candidate = value as Record<string, unknown>;
-  return (
-    candidate.version === 1 && isNonEmptyString(candidate.authorizePath)
-  );
+  return candidate.version === 1 && isNonEmptyString(candidate.authorizePath);
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -126,6 +125,9 @@ const HEALTH_ECONOMICS_DISPLAY_FILE =
   "packages/web/src/components/treatment/HealthEconomicsDisplay.tsx";
 const PERSONAL_QUEUE_SECTION_FILE =
   "packages/web/src/components/dashboard/PersonalQueueSection.tsx";
+const SEARCH_PAGE_FILE = "packages/web/src/app/search/page.tsx";
+const SEARCH_DISCOVERY_FILE =
+  "packages/web/src/app/search/search-discovery.tsx";
 const STANDALONE_VIDEO_PAGE_FILE = "packages/web/src/app/video/page.tsx";
 const CAMPAIGN_VOTE_AND_SHARE_SLIDE_FILE =
   "packages/web/src/components/demo/slides/sierra/slide-vote-and-share.tsx";
@@ -291,6 +293,23 @@ const VISUAL_PATH_OVERRIDE_BY_PATH = new Map<string, string>([
 ]);
 
 const SPECIAL_STATE_ROUTES: VisualRoute[] = [
+  {
+    covers: [SEARCH_PAGE_FILE, SEARCH_DISCOVERY_FILE],
+    name: "search-empty",
+    path: ROUTES.search,
+    required: true,
+    requiredSelector: '[aria-label="Featured destinations"]',
+    siteVariant: "optimitron",
+  },
+  {
+    covers: [SEARCH_DISCOVERY_FILE],
+    name: "search-typeahead",
+    path: ROUTES.search,
+    required: true,
+    requiredSelector: '[data-search-suggestions] a[href="/donate"]',
+    siteVariant: "optimitron",
+    typeSearchQuery: "donate",
+  },
   {
     covers: [STANDALONE_VIDEO_PAGE_FILE],
     name: "campaign-video",

--- a/packages/web/e2e/visual-regression.spec.ts
+++ b/packages/web/e2e/visual-regression.spec.ts
@@ -234,11 +234,22 @@ test.describe("route visual regression", () => {
         await searchbox.fill(route.typeSearchQuery);
         await expect(searchbox).toHaveValue(route.typeSearchQuery);
       }
+      if ("submitSearch" in route && route.submitSearch) {
+        const searchbox = page.getByRole("searchbox", {
+          name: "Search the site",
+        });
+        await searchbox.evaluate((element) => {
+          const form = (element as HTMLInputElement).form;
+          if (!form) throw new Error("Search input is not inside a form.");
+          form.addEventListener("submit", (event) => event.preventDefault(), {
+            once: true,
+          });
+        });
+        await page.getByRole("button", { name: "Search", exact: true }).click();
+      }
 
       if (route.requiredSelector) {
-        // Regression guard: these visual pages must keep exposing the
-        // president/signer task list. Do not delete without Mike's explicit
-        // approval.
+        // Regression guard for route-specific content that must be visible.
         await expect(page.locator(route.requiredSelector)).toBeVisible();
       }
 

--- a/packages/web/e2e/visual-regression.spec.ts
+++ b/packages/web/e2e/visual-regression.spec.ts
@@ -226,6 +226,11 @@ test.describe("route visual regression", () => {
       if ("openTaskImpactTrace" in route && route.openTaskImpactTrace) {
         await openTaskImpactTrace(page);
       }
+      if ("typeSearchQuery" in route && route.typeSearchQuery) {
+        await page
+          .getByRole("searchbox", { name: "Search the site" })
+          .fill(route.typeSearchQuery);
+      }
 
       if (route.requiredSelector) {
         // Regression guard: these visual pages must keep exposing the
@@ -349,8 +354,7 @@ async function waitForVisualIdle(page: Page) {
 
 async function waitForAuthenticatedVisualSession(page: Page) {
   await page.waitForFunction(
-    () =>
-      document.documentElement.dataset.visualAuthState === "authenticated",
+    () => document.documentElement.dataset.visualAuthState === "authenticated",
     undefined,
     { timeout: 15_000 },
   );

--- a/packages/web/e2e/visual-regression.spec.ts
+++ b/packages/web/e2e/visual-regression.spec.ts
@@ -227,9 +227,12 @@ test.describe("route visual regression", () => {
         await openTaskImpactTrace(page);
       }
       if ("typeSearchQuery" in route && route.typeSearchQuery) {
-        await page
-          .getByRole("searchbox", { name: "Search the site" })
-          .fill(route.typeSearchQuery);
+        const searchbox = page.getByRole("searchbox", {
+          name: "Search the site",
+        });
+        await expect(searchbox).toHaveAttribute("data-search-ready", "true");
+        await searchbox.fill(route.typeSearchQuery);
+        await expect(searchbox).toHaveValue(route.typeSearchQuery);
       }
 
       if (route.requiredSelector) {

--- a/packages/web/src/app/search/page.logged-out.md
+++ b/packages/web/src/app/search/page.logged-out.md
@@ -14,7 +14,7 @@
 ## Visible Page Copy
 
 - SEARCH
-## Search IC2EWD
+- Search IC2EWD
 - Vote now, read the treaty, fund outreach, or open the manual. Search for anything else.
 - [Vote VOTE Answer one question for humanity](/vote)
 - [Sign the Treaty TREATY Redirect 1% from weapons to medicine](/treaty)

--- a/packages/web/src/app/search/page.logged-out.md
+++ b/packages/web/src/app/search/page.logged-out.md
@@ -14,9 +14,4 @@
 ## Visible Page Copy
 
 - SEARCH
-- Search IC2EWD
-- Vote now, read the treaty, fund outreach, or open the manual. Search for anything else.
-- [Vote VOTE Answer one question for humanity](/vote)
-- [Sign the Treaty TREATY Redirect 1% from weapons to medicine](/treaty)
-- [Prevent 2 yrs of suffering for $1 OUTREACH Fund survey outreach](/donate)
-- [Earth Repair Manual MANUAL The complete idiot's guide to legally bribing your way to utopia. Contains pictures, because reading is hard when you are diseased and dying.](https://manual.warondisease.org)
+- Search pages, tasks, documents, and the Earth Repair Manual.

--- a/packages/web/src/app/search/page.logged-out.md
+++ b/packages/web/src/app/search/page.logged-out.md
@@ -14,4 +14,10 @@
 ## Visible Page Copy
 
 - SEARCH
-- Search pages, tasks, documents, and the Earth Repair Manual.
+- Find tasks, people, organizations, treatments, and the Earth Repair Manual.
+### POPULAR PAGES
+- [🎯Earth Optimization Tasks PRIMARY What waiting costs](/tasks)
+- [👥Humans Who Can End War and Disease TELL SOMEONE ELSE Find the right human](/people)
+- [🩺Conditions POPULAR Find disease evidence](/agencies/dfda/conditions)
+- [💊Treatments POPULAR Compare treatment evidence](/agencies/dfda/treatments)
+- [📖Earth Repair Manual MANUAL The complete idiot's guide to legally bribing your way to utopia. Contains pictures, because reading is hard when you are diseased and dying.](https://manual.warondisease.org)

--- a/packages/web/src/app/search/page.logged-out.md
+++ b/packages/web/src/app/search/page.logged-out.md
@@ -3,22 +3,20 @@
 ## Metadata
 
 - Page title: Search | International Campaign to End War and Disease
-- Meta description: Search pages, tasks, and the manual.
+- Meta description: Search pages, tasks, and the Earth Repair Manual.
 - Canonical: https://warondisease.org/search
 - Open Graph title: Search
-- Open Graph description: Search pages, tasks, and the manual.
+- Open Graph description: Search pages, tasks, and the Earth Repair Manual.
 - Open Graph image: https://warondisease.org/api/og/route?path=%2Fsearch
 - Twitter title: Search
-- Twitter description: Search pages, tasks, and the manual.
+- Twitter description: Search pages, tasks, and the Earth Repair Manual.
 
 ## Visible Page Copy
 
 - SEARCH
 ## Search IC2EWD
-- Find pages, tasks, and manual entries.
-- [treaty](/search?q=treaty)
-- [clinical trials](/search?q=clinical%20trials)
-- [leader reminders](/search?q=leader%20reminders)
-- [signatories](/search?q=signatories)
-- [government waste](/search?q=government%20waste)
-- [donation math](/search?q=donation%20math)
+- Vote now, read the treaty, fund outreach, or open the manual. Search for anything else.
+- [Vote VOTE Answer one question for humanity](/vote)
+- [Sign the Treaty TREATY Redirect 1% from weapons to medicine](/treaty)
+- [Prevent 2 yrs of suffering for $1 OUTREACH Fund survey outreach](/donate)
+- [Earth Repair Manual MANUAL The complete idiot's guide to legally bribing your way to utopia. Contains pictures, because reading is hard when you are diseased and dying.](https://manual.warondisease.org)

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -1,11 +1,23 @@
 import Link from "next/link";
 import { headers } from "next/headers";
 import { getServerSession } from "next-auth";
+import { getTaskDescriptionSummary } from "@/components/tasks/task-description";
 import { authOptions } from "@/lib/auth";
 import { getRouteMetadata } from "@/lib/metadata";
-import { ROUTES, searchLink } from "@/lib/routes";
+import {
+  conditionsLink,
+  fullManualPaperLink,
+  peopleLink,
+  ROUTES,
+  searchLink,
+  tasksLink,
+  treatmentsLink,
+} from "@/lib/routes";
 import { searchSiteContent } from "@/lib/site-search.server";
-import { getStaticSiteSearchDocuments } from "@/lib/site-search";
+import {
+  getStaticSiteSearchDocuments,
+  type StaticSiteSearchDocument,
+} from "@/lib/site-search";
 import { getConfiguredSiteOrigin, getSiteFromHeaders } from "@/lib/site";
 import { SearchDiscovery } from "./search-discovery";
 
@@ -37,6 +49,34 @@ const SEARCH_SCOPE_PRIORITY: Record<SearchResultItem["scope"], number> = {
   manual: 2,
   tasks: 1,
 };
+
+function getPopularDocuments(
+  documents: StaticSiteSearchDocument[],
+): StaticSiteSearchDocument[] {
+  const popularLinks = [
+    tasksLink,
+    peopleLink,
+    conditionsLink,
+    treatmentsLink,
+    fullManualPaperLink,
+  ];
+
+  return popularLinks.map((link) => {
+    const indexedDocument = documents.find(
+      (document) => document.href === link.href,
+    );
+
+    return {
+      ...indexedDocument,
+      description: link.tagline ?? link.description,
+      emoji: link.emoji,
+      external: link.external,
+      href: link.href,
+      section: indexedDocument?.section ?? "Popular",
+      title: link === fullManualPaperLink ? "Earth Repair Manual" : link.label,
+    };
+  });
+}
 
 function dedupeResultItems(items: SearchResultItem[]) {
   const seen = new Set<string>();
@@ -123,7 +163,7 @@ function getResultItems(
     }));
 
   const taskItems: SearchResultItem[] = results.tasks.map((task) => ({
-    description: task.snippet ?? "Task result",
+    description: getTaskDescriptionSummary(task.snippet ?? "Task result", 180),
     emoji: "✅",
     external: false,
     href: task.href,
@@ -331,7 +371,9 @@ export default async function SearchPage({
     <div className="min-h-screen bg-background pb-20">
       <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
         <SearchDiscovery
+          key={`${query}:${scope}`}
           documents={pageDocuments}
+          popularDocuments={getPopularDocuments(pageDocuments)}
           initialQuery={query}
           scope={scope === "all" ? null : scope}
           siteName={site.shortName}

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -344,7 +344,7 @@ export default async function SearchPage({
   const params = await searchParams;
   const hdrs = await headers();
   const site = getSiteFromHeaders(hdrs);
-  const query = typeof params.q === "string" ? params.q : "";
+  const query = typeof params.q === "string" ? params.q.trim() : "";
   const scope: SearchScope =
     params.scope === "content" ||
     params.scope === "pages" ||

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -1,22 +1,11 @@
 import Link from "next/link";
 import { headers } from "next/headers";
 import { getServerSession } from "next-auth";
-import { Avatar } from "@/components/retroui/Avatar";
 import { authOptions } from "@/lib/auth";
 import { getRouteMetadata } from "@/lib/metadata";
-import {
-  fullManualPaperLink,
-  donateLink,
-  ROUTES,
-  searchLink,
-  treatyLink,
-  voteLink,
-} from "@/lib/routes";
+import { ROUTES, searchLink } from "@/lib/routes";
 import { searchSiteContent } from "@/lib/site-search.server";
-import {
-  getStaticSiteSearchDocuments,
-  type StaticSiteSearchDocument,
-} from "@/lib/site-search";
+import { getStaticSiteSearchDocuments } from "@/lib/site-search";
 import { getConfiguredSiteOrigin, getSiteFromHeaders } from "@/lib/site";
 import { SearchDiscovery } from "./search-discovery";
 
@@ -32,6 +21,7 @@ type SearchScope = "all" | "content" | "manual" | "pages" | "tasks";
 
 type SearchResultItem = {
   description: string;
+  emoji: string;
   external: boolean;
   href: string;
   meta: string | null;
@@ -108,6 +98,7 @@ function getResultItems(
 ): SearchResultItem[] {
   const contentItems: SearchResultItem[] = results.content.map((item) => ({
     description: item.snippet,
+    emoji: item.kind === "collectionRecord" ? "🗂️" : "📄",
     external: false,
     href: item.url,
     meta: item.kind === "collectionRecord" ? "Collection" : null,
@@ -121,6 +112,7 @@ function getResultItems(
     .filter((page) => !page.external)
     .map((page) => ({
       description: page.description,
+      emoji: page.emoji ?? "📄",
       external: false,
       href: page.href,
       meta: page.section,
@@ -132,6 +124,7 @@ function getResultItems(
 
   const taskItems: SearchResultItem[] = results.tasks.map((task) => ({
     description: task.snippet ?? "Task result",
+    emoji: "✅",
     external: false,
     href: task.href,
     meta: [
@@ -149,6 +142,7 @@ function getResultItems(
 
   const manualItems: SearchResultItem[] = results.manual.map((entry) => ({
     description: entry.description,
+    emoji: "📖",
     external: true,
     href: entry.href,
     meta: entry.section ?? null,
@@ -203,32 +197,6 @@ function getResultItems(
   });
 }
 
-function getFeaturedDocuments(
-  documents: StaticSiteSearchDocument[],
-): StaticSiteSearchDocument[] {
-  const featuredLinks = [
-    { link: voteLink, section: "Vote" },
-    { link: treatyLink, section: "Treaty" },
-    { link: donateLink, section: "Outreach" },
-    { link: fullManualPaperLink, section: "Manual" },
-  ];
-
-  return featuredLinks.map(({ link, section }) => {
-    const indexedDocument = documents.find(
-      (document) => document.href === link.href,
-    );
-
-    return {
-      ...indexedDocument,
-      description: link.tagline ?? link.description,
-      external: link.external,
-      href: link.href,
-      section,
-      title: link === fullManualPaperLink ? "Earth Repair Manual" : link.label,
-    };
-  });
-}
-
 function SearchTab({
   count,
   href,
@@ -273,30 +241,20 @@ function formatDisplayUrl(href: string, external: boolean) {
 
 function SearchResultRow({
   description,
+  emoji,
   external,
   href,
   meta,
   source,
   title,
 }: Omit<SearchResultItem, "scope" | "score">) {
-  const absoluteUrl = new URL(href, SITE_ORIGIN);
   const displayUrl = formatDisplayUrl(href, external);
-  const faviconUrl = external
-    ? `${absoluteUrl.origin}/favicon.ico`
-    : "/favicon.ico";
   const row = (
-    <div className="space-y-1">
-      <div className="flex items-center gap-3">
-        <Avatar className="h-5 w-5 border border-primary/25 bg-background">
-          <Avatar.Image
-            src={faviconUrl}
-            alt=""
-            className="h-full w-full object-cover"
-          />
-          <Avatar.Fallback className="bg-background text-[9px] font-black text-foreground">
-            {source.charAt(0)}
-          </Avatar.Fallback>
-        </Avatar>
+    <div className="flex items-start gap-3">
+      <span aria-hidden="true" className="w-7 shrink-0 text-xl leading-7">
+        {emoji}
+      </span>
+      <div className="min-w-0 flex-1 space-y-1">
         <div className="min-w-0">
           <div className="truncate text-xs font-bold text-foreground">
             {source}
@@ -306,18 +264,18 @@ function SearchResultRow({
             {meta ? <span>{` / ${meta}`}</span> : null}
           </div>
         </div>
+        <h2 className="text-xl font-bold text-foreground transition-colors hover:text-primary">
+          {title}
+        </h2>
+        <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+          {description}
+        </p>
       </div>
-      <h2 className="text-xl font-bold text-foreground transition-colors hover:text-primary">
-        {title}
-      </h2>
-      <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
-        {description}
-      </p>
     </div>
   );
 
   return (
-    <div className="border-b border-primary/20 pb-6">
+    <div className="border-b border-primary/20 pb-6 last:border-b-0">
       {external ? (
         <a
           href={href}
@@ -374,7 +332,6 @@ export default async function SearchPage({
       <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
         <SearchDiscovery
           documents={pageDocuments}
-          featuredDocuments={getFeaturedDocuments(pageDocuments)}
           initialQuery={query}
           scope={scope === "all" ? null : scope}
           siteName={site.shortName}
@@ -451,6 +408,7 @@ export default async function SearchPage({
                     <SearchResultRow
                       key={`${result.scope}:${result.href}:${result.title}`}
                       description={result.description}
+                      emoji={result.emoji}
                       external={result.external}
                       href={result.href}
                       meta={result.meta}

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -1,14 +1,24 @@
 import Link from "next/link";
 import { headers } from "next/headers";
 import { getServerSession } from "next-auth";
-import { Search } from "lucide-react";
 import { Avatar } from "@/components/retroui/Avatar";
-import { Input } from "@/components/retroui/Input";
 import { authOptions } from "@/lib/auth";
 import { getRouteMetadata } from "@/lib/metadata";
-import { ROUTES, searchLink } from "@/lib/routes";
+import {
+  fullManualPaperLink,
+  donateLink,
+  ROUTES,
+  searchLink,
+  treatyLink,
+  voteLink,
+} from "@/lib/routes";
 import { searchSiteContent } from "@/lib/site-search.server";
+import {
+  getStaticSiteSearchDocuments,
+  type StaticSiteSearchDocument,
+} from "@/lib/site-search";
 import { getConfiguredSiteOrigin, getSiteFromHeaders } from "@/lib/site";
+import { SearchDiscovery } from "./search-discovery";
 
 export const dynamic = "force-dynamic";
 export const metadata = getRouteMetadata(searchLink);
@@ -17,15 +27,6 @@ const SITE_ORIGIN = getConfiguredSiteOrigin({
   allowLocalFallback: process.env.NODE_ENV !== "production",
 });
 const SITE_BASE_ORIGIN = new URL(SITE_ORIGIN).origin;
-
-const sampleQueries = [
-  "treaty",
-  "clinical trials",
-  "leader reminders",
-  "signatories",
-  "government waste",
-  "donation math",
-];
 
 type SearchScope = "all" | "content" | "manual" | "pages" | "tasks";
 
@@ -153,16 +154,40 @@ function getResultItems(
     meta: entry.section ?? null,
     scope: "manual",
     score: entry.score,
-    source: "Instruction Manual",
+    source: "Earth Repair Manual",
     title: entry.title,
   }));
 
-  return dedupeResultItems([
+  const items = dedupeResultItems([
     ...contentItems,
     ...pageItems,
     ...taskItems,
     ...manualItems,
-  ]).sort((left, right) => {
+  ]);
+  const normalizedQuery = results.query.toLowerCase();
+  const isDirectPageMatch = (item: SearchResultItem) => {
+    if (item.scope !== "pages") {
+      return false;
+    }
+
+    const pathname = new URL(item.href, SITE_ORIGIN).pathname
+      .replace(/^\/+|\/+$/gu, "")
+      .toLowerCase();
+
+    return (
+      pathname === normalizedQuery ||
+      item.title.toLowerCase() === normalizedQuery
+    );
+  };
+
+  return items.sort((left, right) => {
+    const directPageDelta =
+      Number(isDirectPageMatch(right)) - Number(isDirectPageMatch(left));
+
+    if (directPageDelta !== 0) {
+      return directPageDelta;
+    }
+
     const priorityDelta =
       SEARCH_SCOPE_PRIORITY[right.scope] - SEARCH_SCOPE_PRIORITY[left.scope];
 
@@ -175,6 +200,32 @@ function getResultItems(
     }
 
     return left.title.localeCompare(right.title);
+  });
+}
+
+function getFeaturedDocuments(
+  documents: StaticSiteSearchDocument[],
+): StaticSiteSearchDocument[] {
+  const featuredLinks = [
+    { link: voteLink, section: "Vote" },
+    { link: treatyLink, section: "Treaty" },
+    { link: donateLink, section: "Outreach" },
+    { link: fullManualPaperLink, section: "Manual" },
+  ];
+
+  return featuredLinks.map(({ link, section }) => {
+    const indexedDocument = documents.find(
+      (document) => document.href === link.href,
+    );
+
+    return {
+      ...indexedDocument,
+      description: link.tagline ?? link.description,
+      external: link.external,
+      href: link.href,
+      section,
+      title: link === fullManualPaperLink ? "Earth Repair Manual" : link.label,
+    };
   });
 }
 
@@ -303,6 +354,7 @@ export default async function SearchPage({
       : "all";
   const session = await getServerSession(authOptions);
   const userId = session?.user.id ?? null;
+  const pageDocuments = getStaticSiteSearchDocuments(site);
   const results = await searchSiteContent(query, {
     contentLimit: 24,
     pageLimit: 24,
@@ -320,138 +372,97 @@ export default async function SearchPage({
   return (
     <div className="min-h-screen bg-background pb-20">
       <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
-        <section className="space-y-4 border-b border-primary/30 pb-4">
-          <form
-            action={ROUTES.search}
-            className="flex flex-col gap-3 md:flex-row md:items-center"
-          >
-            <div className="relative flex-1">
-              <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                aria-label="Search the site"
-                autoFocus
-                className="h-14 rounded-none border-2 border-foreground bg-background pl-12 text-base font-bold md:max-w-3xl"
-                defaultValue={query}
-                name="q"
-                placeholder="Search pages, tasks, treaty docs, policy analysis..."
-                type="search"
-              />
-            </div>
-            {scope !== "all" ? (
-              <input type="hidden" name="scope" value={scope} />
-            ) : null}
-            <button
-              type="submit"
-              className="inline-flex h-14 items-center justify-center border-2 border-foreground bg-foreground px-6 text-sm font-black uppercase tracking-[0.14em] text-background transition-colors hover:bg-background hover:text-foreground"
-            >
-              Search
-            </button>
-          </form>
-
+        <SearchDiscovery
+          documents={pageDocuments}
+          featuredDocuments={getFeaturedDocuments(pageDocuments)}
+          initialQuery={query}
+          scope={scope === "all" ? null : scope}
+          siteName={site.shortName}
+        >
           {query ? (
-            <div className="flex flex-wrap items-center gap-5 overflow-x-auto">
-              <SearchTab
-                count={counts.all}
-                href={buildScopeHref(query, "all")}
-                isActive={scope === "all"}
-                label="All"
-              />
-              <SearchTab
-                count={counts.content}
-                href={buildScopeHref(query, "content")}
-                isActive={scope === "content"}
-                label="Documents & records"
-              />
-              <SearchTab
-                count={counts.pages}
-                href={buildScopeHref(query, "pages")}
-                isActive={scope === "pages"}
-                label="Pages"
-              />
-              <SearchTab
-                count={counts.tasks}
-                href={buildScopeHref(query, "tasks")}
-                isActive={scope === "tasks"}
-                label="Tasks"
-              />
-              <SearchTab
-                count={counts.manual}
-                href={buildScopeHref(query, "manual")}
-                isActive={scope === "manual"}
-                label="Instruction Manual"
-              />
-            </div>
-          ) : null}
-        </section>
-
-        {query ? (
-          <>
-            <section className="space-y-2">
-              <p className="text-sm font-bold text-muted-foreground">
-                {visibleResults.length.toLocaleString()} result
-                {visibleResults.length === 1 ? "" : "s"} for{" "}
-                <span className="text-foreground">
-                  &quot;{results.query}&quot;
-                </span>
-                {scope !== "all" ? <span>{` in ${scope}`}</span> : null}
-              </p>
-              {results.manualError ? (
-                <div className="max-w-3xl border-2 border-primary bg-background px-4 py-3 text-sm font-bold text-foreground">
-                  {results.manualError}
-                </div>
-              ) : null}
-            </section>
-
-            {visibleResults.length === 0 ? (
-              <section className="max-w-3xl border-2 border-foreground bg-background p-6">
-                <h2 className="text-2xl font-black uppercase text-foreground">
-                  No Matches
-                </h2>
-                <p className="mt-3 text-sm font-bold leading-6 text-muted-foreground">
-                  Try a broader term, a person name, a system name, or a
-                  concrete phrase like &quot;clinical trials&quot; or &quot;fund
-                  optimization&quot;.
-                </p>
-              </section>
-            ) : null}
-
-            {visibleResults.length > 0 ? (
-              <section className="max-w-4xl space-y-6">
-                {visibleResults.map((result) => (
-                  <SearchResultRow
-                    key={`${result.scope}:${result.href}:${result.title}`}
-                    description={result.description}
-                    external={result.external}
-                    href={result.href}
-                    meta={result.meta}
-                    source={result.source}
-                    title={result.title}
+            <>
+              <section className="border-b border-foreground/30 pb-4">
+                <div className="flex flex-wrap items-center gap-5 overflow-x-auto">
+                  <SearchTab
+                    count={counts.all}
+                    href={buildScopeHref(query, "all")}
+                    isActive={scope === "all"}
+                    label="All"
                   />
-                ))}
+                  <SearchTab
+                    count={counts.content}
+                    href={buildScopeHref(query, "content")}
+                    isActive={scope === "content"}
+                    label="Documents & records"
+                  />
+                  <SearchTab
+                    count={counts.pages}
+                    href={buildScopeHref(query, "pages")}
+                    isActive={scope === "pages"}
+                    label="Pages"
+                  />
+                  <SearchTab
+                    count={counts.tasks}
+                    href={buildScopeHref(query, "tasks")}
+                    isActive={scope === "tasks"}
+                    label="Tasks"
+                  />
+                  <SearchTab
+                    count={counts.manual}
+                    href={buildScopeHref(query, "manual")}
+                    isActive={scope === "manual"}
+                    label="Earth Repair Manual"
+                  />
+                </div>
               </section>
-            ) : null}
-          </>
-        ) : (
-          <section className="max-w-3xl space-y-5">
-            <h1 className="text-4xl font-black tracking-tight text-foreground md:text-5xl">
-              Search {site.shortName}
-            </h1>
-            <p className="text-base font-bold leading-7 text-muted-foreground">
-              Find pages, tasks, and manual entries.
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {sampleQueries.map((sampleQuery) => (
-                <Link
-                  key={sampleQuery}
-                  href={`${ROUTES.search}?q=${encodeURIComponent(sampleQuery)}`}
-                  className="border border-foreground px-4 py-2 text-sm font-bold text-foreground transition-colors hover:bg-foreground hover:text-background"
-                >
-                  {sampleQuery}
-                </Link>
-              ))}
-            </div>
-          </section>
-        )}
+
+              <section className="space-y-2">
+                <p className="text-sm font-bold text-muted-foreground">
+                  {visibleResults.length.toLocaleString()} result
+                  {visibleResults.length === 1 ? "" : "s"} for{" "}
+                  <span className="text-foreground">
+                    &quot;{results.query}&quot;
+                  </span>
+                  {scope !== "all" ? <span>{` in ${scope}`}</span> : null}
+                </p>
+                {results.manualError ? (
+                  <div className="max-w-3xl border-2 border-primary bg-background px-4 py-3 text-sm font-bold text-foreground">
+                    {results.manualError}
+                  </div>
+                ) : null}
+              </section>
+
+              {visibleResults.length === 0 ? (
+                <section className="max-w-3xl border-2 border-foreground bg-background p-6">
+                  <h2 className="text-2xl font-black uppercase text-foreground">
+                    No Matches
+                  </h2>
+                  <p className="mt-3 text-sm font-bold leading-6 text-muted-foreground">
+                    Try a broader term, a person name, a system name, or a
+                    concrete phrase like &quot;clinical trials&quot; or
+                    &quot;fund optimization&quot;.
+                  </p>
+                </section>
+              ) : null}
+
+              {visibleResults.length > 0 ? (
+                <section className="max-w-4xl space-y-6">
+                  {visibleResults.map((result) => (
+                    <SearchResultRow
+                      key={`${result.scope}:${result.href}:${result.title}`}
+                      description={result.description}
+                      external={result.external}
+                      href={result.href}
+                      meta={result.meta}
+                      source={result.source}
+                      title={result.title}
+                    />
+                  ))}
+                </section>
+              ) : null}
+            </>
+          ) : null}
+        </SearchDiscovery>
       </div>
     </div>
   );

--- a/packages/web/src/app/search/search-discovery.tsx
+++ b/packages/web/src/app/search/search-discovery.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Search } from "lucide-react";
+import { LoaderCircle, Search } from "lucide-react";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Input } from "@/components/retroui/Input";
 import { ROUTES } from "@/lib/routes";
@@ -14,6 +14,7 @@ type SearchDiscoveryProps = {
   children?: ReactNode;
   documents: StaticSiteSearchDocument[];
   initialQuery: string;
+  popularDocuments: StaticSiteSearchDocument[];
   scope: "content" | "manual" | "pages" | "tasks" | null;
   siteName: string;
 };
@@ -66,11 +67,13 @@ export function SearchDiscovery({
   children,
   documents,
   initialQuery,
+  popularDocuments,
   scope,
   siteName,
 }: SearchDiscoveryProps) {
   const [inputValue, setInputValue] = useState(initialQuery);
   const [isInteractive, setIsInteractive] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
 
   useEffect(() => {
     setIsInteractive(true);
@@ -98,7 +101,12 @@ export function SearchDiscovery({
   return (
     <>
       <section className="space-y-3">
-        <form action={ROUTES.search} className="flex items-center gap-2">
+        <form
+          action={ROUTES.search}
+          aria-busy={isSearching}
+          className="flex items-center gap-2"
+          onSubmit={() => setIsSearching(true)}
+        >
           <div className="relative flex-1">
             <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
             <Input
@@ -109,8 +117,11 @@ export function SearchDiscovery({
               className="h-14 rounded-none border-2 border-foreground bg-background pl-12 text-base font-bold md:max-w-3xl"
               data-search-ready={isInteractive ? "true" : undefined}
               name="q"
-              onChange={(event) => setInputValue(event.target.value)}
-              placeholder="Search pages, tasks, treaty docs, policy analysis..."
+              onChange={(event) => {
+                setInputValue(event.target.value);
+                setIsSearching(false);
+              }}
+              placeholder="Search tasks, people, treatments, or organizations..."
               type="search"
               value={inputValue}
             />
@@ -118,15 +129,28 @@ export function SearchDiscovery({
           {scope ? <input type="hidden" name="scope" value={scope} /> : null}
           <button
             type="submit"
-            className="inline-flex h-14 shrink-0 items-center justify-center border-2 border-foreground bg-foreground px-5 text-sm font-black uppercase tracking-[0.14em] text-background transition-colors hover:bg-background hover:text-foreground"
+            aria-live="polite"
+            disabled={isSearching}
+            className="inline-flex h-14 shrink-0 items-center justify-center border-2 border-foreground bg-foreground px-5 text-sm font-black uppercase tracking-[0.14em] text-background transition-colors hover:bg-background hover:text-foreground disabled:cursor-wait disabled:opacity-60 disabled:hover:bg-foreground disabled:hover:text-background"
           >
-            Search
+            {isSearching ? (
+              <>
+                <LoaderCircle
+                  aria-hidden="true"
+                  className="mr-2 h-4 w-4 animate-spin"
+                />
+                Searching…
+              </>
+            ) : (
+              "Search"
+            )}
           </button>
         </form>
 
         {!trimmedInput ? (
           <p className="text-sm font-bold text-muted-foreground">
-            Search pages, tasks, documents, and the Earth Repair Manual.
+            Find tasks, people, organizations, treatments, and the Earth Repair
+            Manual.
           </p>
         ) : null}
 
@@ -155,6 +179,19 @@ export function SearchDiscovery({
       </section>
 
       <h1 className="sr-only">Search {siteName}</h1>
+
+      {!trimmedInput ? (
+        <section className="max-w-4xl" data-search-popular>
+          <h2 className="mb-1 text-sm font-black uppercase tracking-[0.14em] text-foreground">
+            Popular pages
+          </h2>
+          <nav aria-label="Popular pages">
+            {popularDocuments.map((document) => (
+              <SearchDestination document={document} key={document.href} />
+            ))}
+          </nav>
+        </section>
+      ) : null}
 
       {initialQuery && !isEditingSubmittedQuery ? children : null}
     </>

--- a/packages/web/src/app/search/search-discovery.tsx
+++ b/packages/web/src/app/search/search-discovery.tsx
@@ -13,7 +13,6 @@ import {
 type SearchDiscoveryProps = {
   children?: ReactNode;
   documents: StaticSiteSearchDocument[];
-  featuredDocuments: StaticSiteSearchDocument[];
   initialQuery: string;
   scope: "content" | "manual" | "pages" | "tasks" | null;
   siteName: string;
@@ -25,20 +24,27 @@ function SearchDestination({
   document: StaticSiteSearchDocument;
 }) {
   const content = (
-    <>
-      <div className="flex items-center justify-between gap-4">
-        <h2 className="text-lg font-black text-foreground">{document.title}</h2>
-        <span className="shrink-0 text-xs font-black uppercase tracking-[0.14em] text-muted-foreground">
-          {document.section}
-        </span>
+    <div className="flex items-start gap-3">
+      <span aria-hidden="true" className="w-7 shrink-0 text-xl leading-7">
+        {document.emoji ?? "📄"}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-4">
+          <h2 className="text-lg font-black text-foreground">
+            {document.title}
+          </h2>
+          <span className="shrink-0 text-xs font-black uppercase tracking-[0.14em] text-muted-foreground">
+            {document.section}
+          </span>
+        </div>
+        <p className="mt-2 text-sm font-bold leading-6 text-muted-foreground">
+          {document.description}
+        </p>
       </div>
-      <p className="mt-2 text-sm font-bold leading-6 text-muted-foreground">
-        {document.description}
-      </p>
-    </>
+    </div>
   );
   const className =
-    "block border-b border-foreground/25 py-4 transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground";
+    "block border-b border-foreground/25 py-4 transition-colors last:border-b-0 hover:bg-muted focus-visible:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground";
 
   return document.external ? (
     <a
@@ -59,7 +65,6 @@ function SearchDestination({
 export function SearchDiscovery({
   children,
   documents,
-  featuredDocuments,
   initialQuery,
   scope,
   siteName,
@@ -92,7 +97,7 @@ export function SearchDiscovery({
 
   return (
     <>
-      <section className="space-y-4 border-b border-foreground/30 pb-4">
+      <section className="space-y-3">
         <form action={ROUTES.search} className="flex items-center gap-2">
           <div className="relative flex-1">
             <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
@@ -119,6 +124,12 @@ export function SearchDiscovery({
           </button>
         </form>
 
+        {!trimmedInput ? (
+          <p className="text-sm font-bold text-muted-foreground">
+            Search pages, tasks, documents, and the Earth Repair Manual.
+          </p>
+        ) : null}
+
         {showSuggestions ? (
           <section
             aria-label="Page suggestions"
@@ -144,28 +155,6 @@ export function SearchDiscovery({
       </section>
 
       <h1 className="sr-only">Search {siteName}</h1>
-
-      {!trimmedInput ? (
-        <section className="max-w-4xl space-y-5">
-          <div className="space-y-2">
-            <p
-              aria-hidden="true"
-              className="text-4xl font-black tracking-tight text-foreground md:text-5xl"
-            >
-              Search {siteName}
-            </p>
-            <p className="text-base font-bold leading-7 text-muted-foreground">
-              Vote now, read the treaty, fund outreach, or open the manual.
-              Search for anything else.
-            </p>
-          </div>
-          <nav aria-label="Featured destinations">
-            {featuredDocuments.map((document) => (
-              <SearchDestination document={document} key={document.href} />
-            ))}
-          </nav>
-        </section>
-      ) : null}
 
       {initialQuery && !isEditingSubmittedQuery ? children : null}
     </>

--- a/packages/web/src/app/search/search-discovery.tsx
+++ b/packages/web/src/app/search/search-discovery.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { Search } from "lucide-react";
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Input } from "@/components/retroui/Input";
 import { ROUTES } from "@/lib/routes";
 import {
@@ -65,6 +65,12 @@ export function SearchDiscovery({
   siteName,
 }: SearchDiscoveryProps) {
   const [inputValue, setInputValue] = useState(initialQuery);
+  const [isInteractive, setIsInteractive] = useState(false);
+
+  useEffect(() => {
+    setIsInteractive(true);
+  }, []);
+
   const trimmedInput = inputValue.trim();
   const isEditingSubmittedQuery = trimmedInput !== initialQuery.trim();
   const suggestions = useMemo(
@@ -96,6 +102,7 @@ export function SearchDiscovery({
               autoComplete="off"
               autoFocus
               className="h-14 rounded-none border-2 border-foreground bg-background pl-12 text-base font-bold md:max-w-3xl"
+              data-search-ready={isInteractive ? "true" : undefined}
               name="q"
               onChange={(event) => setInputValue(event.target.value)}
               placeholder="Search pages, tasks, treaty docs, policy analysis..."
@@ -136,22 +143,27 @@ export function SearchDiscovery({
         ) : null}
       </section>
 
+      <h1 className="sr-only">Search {siteName}</h1>
+
       {!trimmedInput ? (
         <section className="max-w-4xl space-y-5">
           <div className="space-y-2">
-            <h1 className="text-4xl font-black tracking-tight text-foreground md:text-5xl">
+            <p
+              aria-hidden="true"
+              className="text-4xl font-black tracking-tight text-foreground md:text-5xl"
+            >
               Search {siteName}
-            </h1>
+            </p>
             <p className="text-base font-bold leading-7 text-muted-foreground">
               Vote now, read the treaty, fund outreach, or open the manual.
               Search for anything else.
             </p>
           </div>
-          <div aria-label="Featured destinations">
+          <nav aria-label="Featured destinations">
             {featuredDocuments.map((document) => (
               <SearchDestination document={document} key={document.href} />
             ))}
-          </div>
+          </nav>
         </section>
       ) : null}
 

--- a/packages/web/src/app/search/search-discovery.tsx
+++ b/packages/web/src/app/search/search-discovery.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import Link from "next/link";
+import { Search } from "lucide-react";
+import { useMemo, useState, type ReactNode } from "react";
+import { Input } from "@/components/retroui/Input";
+import { ROUTES } from "@/lib/routes";
+import {
+  searchSiteDocuments,
+  type StaticSiteSearchDocument,
+} from "@/lib/site-search-ranking";
+
+type SearchDiscoveryProps = {
+  children?: ReactNode;
+  documents: StaticSiteSearchDocument[];
+  featuredDocuments: StaticSiteSearchDocument[];
+  initialQuery: string;
+  scope: "content" | "manual" | "pages" | "tasks" | null;
+  siteName: string;
+};
+
+function SearchDestination({
+  document,
+}: {
+  document: StaticSiteSearchDocument;
+}) {
+  const content = (
+    <>
+      <div className="flex items-center justify-between gap-4">
+        <h2 className="text-lg font-black text-foreground">{document.title}</h2>
+        <span className="shrink-0 text-xs font-black uppercase tracking-[0.14em] text-muted-foreground">
+          {document.section}
+        </span>
+      </div>
+      <p className="mt-2 text-sm font-bold leading-6 text-muted-foreground">
+        {document.description}
+      </p>
+    </>
+  );
+  const className =
+    "block border-b border-foreground/25 py-4 transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground";
+
+  return document.external ? (
+    <a
+      className={className}
+      href={document.href}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      {content}
+    </a>
+  ) : (
+    <Link className={className} href={document.href}>
+      {content}
+    </Link>
+  );
+}
+
+export function SearchDiscovery({
+  children,
+  documents,
+  featuredDocuments,
+  initialQuery,
+  scope,
+  siteName,
+}: SearchDiscoveryProps) {
+  const [inputValue, setInputValue] = useState(initialQuery);
+  const trimmedInput = inputValue.trim();
+  const isEditingSubmittedQuery = trimmedInput !== initialQuery.trim();
+  const suggestions = useMemo(
+    () => searchSiteDocuments(trimmedInput, documents, 6),
+    [documents, trimmedInput],
+  );
+  const showSuggestions = Boolean(trimmedInput && isEditingSubmittedQuery);
+  const suggestionsId = "search-page-suggestions";
+  const serverSearchLabel =
+    scope === "content"
+      ? "documents and records"
+      : scope === "manual"
+        ? "the Earth Repair Manual"
+        : scope === "pages"
+          ? "pages"
+          : scope === "tasks"
+            ? "tasks"
+            : "tasks, documents, and the Earth Repair Manual";
+
+  return (
+    <>
+      <section className="space-y-4 border-b border-foreground/30 pb-4">
+        <form action={ROUTES.search} className="flex items-center gap-2">
+          <div className="relative flex-1">
+            <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              aria-controls={showSuggestions ? suggestionsId : undefined}
+              aria-label="Search the site"
+              autoComplete="off"
+              autoFocus
+              className="h-14 rounded-none border-2 border-foreground bg-background pl-12 text-base font-bold md:max-w-3xl"
+              name="q"
+              onChange={(event) => setInputValue(event.target.value)}
+              placeholder="Search pages, tasks, treaty docs, policy analysis..."
+              type="search"
+              value={inputValue}
+            />
+          </div>
+          {scope ? <input type="hidden" name="scope" value={scope} /> : null}
+          <button
+            type="submit"
+            className="inline-flex h-14 shrink-0 items-center justify-center border-2 border-foreground bg-foreground px-5 text-sm font-black uppercase tracking-[0.14em] text-background transition-colors hover:bg-background hover:text-foreground"
+          >
+            Search
+          </button>
+        </form>
+
+        {showSuggestions ? (
+          <section
+            aria-label="Page suggestions"
+            aria-live="polite"
+            data-search-suggestions
+            id={suggestionsId}
+            className="max-w-3xl"
+          >
+            <h2 className="sr-only">Suggested pages</h2>
+            {suggestions.length > 0 ? (
+              <div className="mt-1">
+                {suggestions.map((document) => (
+                  <SearchDestination document={document} key={document.href} />
+                ))}
+              </div>
+            ) : (
+              <p className="mt-3 text-sm font-bold text-muted-foreground">
+                No page matches yet. Press Enter to search {serverSearchLabel}.
+              </p>
+            )}
+          </section>
+        ) : null}
+      </section>
+
+      {!trimmedInput ? (
+        <section className="max-w-4xl space-y-5">
+          <div className="space-y-2">
+            <h1 className="text-4xl font-black tracking-tight text-foreground md:text-5xl">
+              Search {siteName}
+            </h1>
+            <p className="text-base font-bold leading-7 text-muted-foreground">
+              Vote now, read the treaty, fund outreach, or open the manual.
+              Search for anything else.
+            </p>
+          </div>
+          <div aria-label="Featured destinations">
+            {featuredDocuments.map((document) => (
+              <SearchDestination document={document} key={document.href} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {initialQuery && !isEditingSubmittedQuery ? children : null}
+    </>
+  );
+}

--- a/packages/web/src/components/tasks/task-description.test.ts
+++ b/packages/web/src/components/tasks/task-description.test.ts
@@ -15,6 +15,19 @@ describe("getTaskDescriptionSummary", () => {
       getTaskDescriptionSummary("# Heading\\n\\nFirst paragraph\\n\\n- Action"),
     ).toBe("First paragraph");
   });
+
+  it("strips markdown and truncates search-card summaries", () => {
+    const summary = getTaskDescriptionSummary(
+      "## Internal heading\\n\\n**Fix** the [public search](https://example.com) so `humans` can find it. " +
+        "Do not expose raw markdown in compact results.",
+      72,
+    );
+
+    expect(summary).toBe(
+      "Fix the public search so humans can find it. Do not expose raw markdown...",
+    );
+    expect(summary).not.toMatch(/[\[*`#]/u);
+  });
 });
 
 describe("TaskDescription", () => {

--- a/packages/web/src/lib/__tests__/site-search.test.ts
+++ b/packages/web/src/lib/__tests__/site-search.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { ROUTES } from "../routes";
+import { ROUTES, voteLink } from "../routes";
 import { getSiteConfig } from "../site";
 import {
   scoreSearchRecord,
@@ -14,6 +14,14 @@ describe("site search helpers", () => {
     const hrefs = staticSiteSearchDocuments.map((document) => document.href);
 
     expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+
+  it("keeps route emojis in the search index", () => {
+    const voteDocument = staticSiteSearchDocuments.find(
+      (document) => document.href === voteLink.href,
+    );
+
+    expect(voteDocument?.emoji).toBe(voteLink.emoji);
   });
 
   it("finds the government size page from a direct query", () => {

--- a/packages/web/src/lib/__tests__/site-search.test.ts
+++ b/packages/web/src/lib/__tests__/site-search.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { ROUTES, voteLink } from "../routes";
+import { ROUTES } from "../routes";
 import { getSiteConfig } from "../site";
 import {
   scoreSearchRecord,
@@ -14,14 +14,6 @@ describe("site search helpers", () => {
     const hrefs = staticSiteSearchDocuments.map((document) => document.href);
 
     expect(new Set(hrefs).size).toBe(hrefs.length);
-  });
-
-  it("keeps route emojis in the search index", () => {
-    const voteDocument = staticSiteSearchDocuments.find(
-      (document) => document.href === voteLink.href,
-    );
-
-    expect(voteDocument?.emoji).toBe(voteLink.emoji);
   });
 
   it("finds the government size page from a direct query", () => {

--- a/packages/web/src/lib/__tests__/site-search.test.ts
+++ b/packages/web/src/lib/__tests__/site-search.test.ts
@@ -4,6 +4,7 @@ import { ROUTES } from "../routes";
 import { getSiteConfig } from "../site";
 import {
   scoreSearchRecord,
+  searchSiteDocuments,
   searchStaticSiteDocuments,
   staticSiteSearchDocuments,
 } from "../site-search";
@@ -18,7 +19,9 @@ describe("site search helpers", () => {
   it("finds the government size page from a direct query", () => {
     const results = searchStaticSiteDocuments("government size");
 
-    expect(results.map((result) => result.href)).toContain(ROUTES.governmentSize);
+    expect(results.map((result) => result.href)).toContain(
+      ROUTES.governmentSize,
+    );
   });
 
   it("scopes static page results to the War on Disease site", () => {
@@ -40,6 +43,33 @@ describe("site search helpers", () => {
     expect(results.map((result) => result.href)).toContain(ROUTES.tasks);
   });
 
+  it.each(["vote", "donate"] as const)(
+    "keeps the obvious %s destination searchable on Optimitron",
+    (query) => {
+      const results = searchStaticSiteDocuments(query, {
+        site: getSiteConfig("optimitron"),
+      });
+
+      expect(results[0]?.href).toBe(ROUTES[query]);
+    },
+  );
+
+  it("includes campaign footer destinations in variant search", () => {
+    const results = searchStaticSiteDocuments("donate", {
+      site: getSiteConfig("warOnDisease"),
+    });
+
+    expect(results[0]?.href).toBe(ROUTES.donate);
+  });
+
+  it("finds the Earth Repair Manual by its new name", () => {
+    const results = searchStaticSiteDocuments("earth repair manual", {
+      site: getSiteConfig("optimitron"),
+    });
+
+    expect(results[0]?.title).toBe("Earth Repair Manual");
+  });
+
   it("prioritizes direct title matches over generic descriptions", () => {
     const titleMatch = scoreSearchRecord("tasks", {
       title: "Tasks",
@@ -55,5 +85,14 @@ describe("site search helpers", () => {
     });
 
     expect(titleMatch).toBeGreaterThan(weakMatch);
+  });
+
+  it("returns ranked page suggestions without a server search", () => {
+    const results = searchSiteDocuments("treaty", staticSiteSearchDocuments, 5);
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.length).toBeLessThanOrEqual(5);
+    expect(results[0]?.href).toBe(ROUTES.treaty);
+    expect(results.every((result) => result.score > 0)).toBe(true);
   });
 });

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -593,9 +593,11 @@ export const searchLink: NavItem = {
   href: ROUTES.search,
   label: "Search",
   emoji: "🔎",
-  description: "Search pages, tasks, and the manual.",
-  tagline: "Search pages, tasks, and manual",
+  description: "Search pages, tasks, and the Earth Repair Manual.",
+  tagline: "Search pages, tasks, and the Earth Repair Manual",
   matchPrefixes: [ROUTES.search],
+  copyPreview: true,
+  screenshot: true,
   cta: "Search Site",
 };
 

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -597,7 +597,6 @@ export const searchLink: NavItem = {
   tagline: "Search pages, tasks, and the Earth Repair Manual",
   matchPrefixes: [ROUTES.search],
   copyPreview: true,
-  screenshot: true,
   cta: "Search Site",
 };
 
@@ -1929,6 +1928,7 @@ export const routeReviewNavItems = [
   foundationsLink,
   signatoriesLink,
   presidentManagementLink,
+  searchLink,
   dashboardLink,
   editProfileLink,
   tasksLink,

--- a/packages/web/src/lib/site-search-ranking.ts
+++ b/packages/web/src/lib/site-search-ranking.ts
@@ -31,6 +31,7 @@ export interface SearchScorableRecord {
 
 export interface StaticSiteSearchDocument {
   description: string;
+  emoji?: string;
   external?: boolean;
   href: string;
   keywords?: string[];

--- a/packages/web/src/lib/site-search-ranking.ts
+++ b/packages/web/src/lib/site-search-ranking.ts
@@ -1,0 +1,165 @@
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "for",
+  "from",
+  "how",
+  "into",
+  "not",
+  "the",
+  "this",
+  "that",
+  "what",
+  "with",
+  "you",
+  "your",
+]);
+
+export interface SearchTerms {
+  normalizedQuery: string;
+  terms: string[];
+}
+
+export interface SearchScorableRecord {
+  title: string;
+  description?: string | null;
+  href?: string | null;
+  keywords?: string[];
+  section?: string | null;
+}
+
+export interface StaticSiteSearchDocument {
+  description: string;
+  external?: boolean;
+  href: string;
+  keywords?: string[];
+  section: string;
+  title: string;
+}
+
+export function getSearchTerms(query: string): SearchTerms {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  if (!normalizedQuery) {
+    return {
+      normalizedQuery,
+      terms: [],
+    };
+  }
+
+  const terms = Array.from(
+    new Set(
+      normalizedQuery
+        .split(/[^a-z0-9%]+/i)
+        .map((term) => term.trim())
+        .filter((term) => term.length >= 2 && !STOP_WORDS.has(term)),
+    ),
+  );
+
+  return {
+    normalizedQuery,
+    terms,
+  };
+}
+
+export function scoreSearchRecord(
+  query: string | SearchTerms,
+  record: SearchScorableRecord,
+) {
+  const searchTerms = typeof query === "string" ? getSearchTerms(query) : query;
+
+  if (!searchTerms.normalizedQuery) {
+    return 0;
+  }
+
+  const title = record.title.toLowerCase();
+  const description = (record.description ?? "").toLowerCase();
+  const href = (record.href ?? "").toLowerCase();
+  const hrefPath = href
+    .replace(/^https?:\/\/[^/]+/u, "")
+    .split(/[?#]/u)[0]
+    ?.replace(/^\/+|\/+$/gu, "");
+  const section = (record.section ?? "").toLowerCase();
+  const keywords =
+    record.keywords?.map((keyword) => keyword.toLowerCase()) ?? [];
+
+  let score = 0;
+
+  if (hrefPath === searchTerms.normalizedQuery) {
+    score += 24;
+  }
+
+  if (title.includes(searchTerms.normalizedQuery)) {
+    score += 14;
+  }
+
+  if (
+    keywords.some((keyword) => keyword.includes(searchTerms.normalizedQuery))
+  ) {
+    score += 10;
+  }
+
+  if (description.includes(searchTerms.normalizedQuery)) {
+    score += 8;
+  }
+
+  if (section.includes(searchTerms.normalizedQuery)) {
+    score += 4;
+  }
+
+  if (href.includes(searchTerms.normalizedQuery)) {
+    score += 4;
+  }
+
+  for (const term of searchTerms.terms) {
+    if (title.includes(term)) {
+      score += 5;
+    }
+
+    if (keywords.some((keyword) => keyword.includes(term))) {
+      score += 3;
+    }
+
+    if (description.includes(term)) {
+      score += 2;
+    }
+
+    if (section.includes(term)) {
+      score += 1.5;
+    }
+
+    if (href.includes(term)) {
+      score += 1.5;
+    }
+  }
+
+  return Number(score.toFixed(3));
+}
+
+export function searchSiteDocuments(
+  query: string,
+  documents: StaticSiteSearchDocument[],
+  limit = 12,
+) {
+  const searchTerms = getSearchTerms(query);
+
+  if (!searchTerms.normalizedQuery) {
+    return [];
+  }
+
+  return documents
+    .map((document) => ({
+      ...document,
+      score: scoreSearchRecord(searchTerms, document),
+    }))
+    .filter((document) => document.score > 0)
+    .sort((left, right) => {
+      if (right.score !== left.score) {
+        return right.score - left.score;
+      }
+
+      return left.title.localeCompare(right.title);
+    })
+    .slice(0, limit);
+}

--- a/packages/web/src/lib/site-search.ts
+++ b/packages/web/src/lib/site-search.ts
@@ -1,45 +1,24 @@
-import { ROUTES, navSections, type NavItem } from "@/lib/routes";
+import {
+  fullManualPaperLink,
+  ROUTES,
+  navSections,
+  routeReviewNavItems,
+  type NavItem,
+} from "@/lib/routes";
 import type { SiteConfig } from "@/lib/site";
+import {
+  searchSiteDocuments,
+  type StaticSiteSearchDocument,
+} from "@/lib/site-search-ranking";
 
-const STOP_WORDS = new Set([
-  "a",
-  "an",
-  "and",
-  "for",
-  "from",
-  "how",
-  "into",
-  "not",
-  "the",
-  "this",
-  "that",
-  "what",
-  "with",
-  "you",
-  "your",
-]);
-
-export interface SearchTerms {
-  normalizedQuery: string;
-  terms: string[];
-}
-
-export interface SearchScorableRecord {
-  title: string;
-  description?: string | null;
-  href?: string | null;
-  keywords?: string[];
-  section?: string | null;
-}
-
-export interface StaticSiteSearchDocument {
-  description: string;
-  external?: boolean;
-  href: string;
-  keywords?: string[];
-  section: string;
-  title: string;
-}
+export {
+  getSearchTerms,
+  scoreSearchRecord,
+  searchSiteDocuments,
+  type SearchScorableRecord,
+  type SearchTerms,
+  type StaticSiteSearchDocument,
+} from "@/lib/site-search-ranking";
 
 function dedupeByHref(documents: StaticSiteSearchDocument[]) {
   const seen = new Set<string>();
@@ -82,6 +61,14 @@ const extraStaticDocuments: StaticSiteSearchDocument[] = [
     ],
   },
   {
+    description: fullManualPaperLink.description,
+    external: true,
+    href: fullManualPaperLink.href,
+    keywords: ["guide", "handbook", "instruction manual", "manual"],
+    section: "Manual",
+    title: "Earth Repair Manual",
+  },
+  {
     href: ROUTES.mcp,
     title: "Optimitron MCP",
     description:
@@ -107,6 +94,9 @@ export const staticSiteSearchDocuments: StaticSiteSearchDocument[] =
         buildDocumentFromNavItem(section.label, item),
       ),
     ),
+    ...routeReviewNavItems.map((item) =>
+      buildDocumentFromNavItem("Pages", item),
+    ),
   ]);
 
 function buildHomeDocument(site: SiteConfig): StaticSiteSearchDocument {
@@ -119,108 +109,25 @@ function buildHomeDocument(site: SiteConfig): StaticSiteSearchDocument {
   };
 }
 
-function getStaticSiteSearchDocuments(site?: SiteConfig) {
+export function getStaticSiteSearchDocuments(site?: SiteConfig) {
   if (!site || site.key === "optimitron") {
     return staticSiteSearchDocuments;
   }
 
   return dedupeByHref([
     buildHomeDocument(site),
+    ...extraStaticDocuments.filter(
+      (document) => document.href === fullManualPaperLink.href,
+    ),
     ...site.ui.nav.sections.flatMap((section) =>
-      section.items.map((item) => buildDocumentFromNavItem(section.label, item)),
+      section.items.map((item) =>
+        buildDocumentFromNavItem(section.label, item),
+      ),
+    ),
+    ...site.ui.footer.columns.flatMap((column) =>
+      column.items.map((item) => buildDocumentFromNavItem(column.title, item)),
     ),
   ]);
-}
-
-export function getSearchTerms(query: string): SearchTerms {
-  const normalizedQuery = query.trim().toLowerCase();
-
-  if (!normalizedQuery) {
-    return {
-      normalizedQuery,
-      terms: [],
-    };
-  }
-
-  const terms = Array.from(
-    new Set(
-      normalizedQuery
-        .split(/[^a-z0-9%]+/i)
-        .map((term) => term.trim())
-        .filter((term) => term.length >= 2 && !STOP_WORDS.has(term)),
-    ),
-  );
-
-  return {
-    normalizedQuery,
-    terms,
-  };
-}
-
-export function scoreSearchRecord(
-  query: string | SearchTerms,
-  record: SearchScorableRecord,
-) {
-  const searchTerms = typeof query === "string" ? getSearchTerms(query) : query;
-
-  if (!searchTerms.normalizedQuery) {
-    return 0;
-  }
-
-  const title = record.title.toLowerCase();
-  const description = (record.description ?? "").toLowerCase();
-  const href = (record.href ?? "").toLowerCase();
-  const section = (record.section ?? "").toLowerCase();
-  const keywords =
-    record.keywords?.map((keyword) => keyword.toLowerCase()) ?? [];
-
-  let score = 0;
-
-  if (title.includes(searchTerms.normalizedQuery)) {
-    score += 14;
-  }
-
-  if (
-    keywords.some((keyword) => keyword.includes(searchTerms.normalizedQuery))
-  ) {
-    score += 10;
-  }
-
-  if (description.includes(searchTerms.normalizedQuery)) {
-    score += 8;
-  }
-
-  if (section.includes(searchTerms.normalizedQuery)) {
-    score += 4;
-  }
-
-  if (href.includes(searchTerms.normalizedQuery)) {
-    score += 4;
-  }
-
-  for (const term of searchTerms.terms) {
-    if (title.includes(term)) {
-      score += 5;
-    }
-
-    if (keywords.some((keyword) => keyword.includes(term))) {
-      score += 3;
-    }
-
-    if (description.includes(term)) {
-      score += 2;
-    }
-
-    if (section.includes(term)) {
-      score += 1.5;
-    }
-
-    if (href.includes(term)) {
-      score += 1.5;
-    }
-  }
-
-  return Number(score.toFixed(3));
 }
 
 export function searchStaticSiteDocuments(
@@ -230,25 +137,11 @@ export function searchStaticSiteDocuments(
     site?: SiteConfig;
   },
 ) {
-  const searchTerms = getSearchTerms(query);
   const limit = options?.limit ?? 12;
 
-  if (!searchTerms.normalizedQuery) {
-    return [];
-  }
-
-  return getStaticSiteSearchDocuments(options?.site)
-    .map((document) => ({
-      ...document,
-      score: scoreSearchRecord(searchTerms, document),
-    }))
-    .filter((document) => document.score > 0)
-    .sort((left, right) => {
-      if (right.score !== left.score) {
-        return right.score - left.score;
-      }
-
-      return left.title.localeCompare(right.title);
-    })
-    .slice(0, limit);
+  return searchSiteDocuments(
+    query,
+    getStaticSiteSearchDocuments(options?.site),
+    limit,
+  );
 }

--- a/packages/web/src/lib/site-search.ts
+++ b/packages/web/src/lib/site-search.ts
@@ -39,6 +39,7 @@ function buildDocumentFromNavItem(
 ): StaticSiteSearchDocument {
   return {
     description: item.tagline ?? item.description,
+    emoji: item.emoji || undefined,
     external: item.external,
     href: item.href,
     section,
@@ -50,6 +51,7 @@ const extraStaticDocuments: StaticSiteSearchDocument[] = [
   {
     href: ROUTES.home,
     title: "Optimitron",
+    emoji: "🏠",
     description:
       "Landing page for the Earth Optimization Game, the 1% Treaty, the prize mechanics, and the core argument for fixing public systems with evidence.",
     section: "Primary",
@@ -62,6 +64,7 @@ const extraStaticDocuments: StaticSiteSearchDocument[] = [
   },
   {
     description: fullManualPaperLink.description,
+    emoji: fullManualPaperLink.emoji,
     external: true,
     href: fullManualPaperLink.href,
     keywords: ["guide", "handbook", "instruction manual", "manual"],
@@ -71,6 +74,7 @@ const extraStaticDocuments: StaticSiteSearchDocument[] = [
   {
     href: ROUTES.mcp,
     title: "Optimitron MCP",
+    emoji: "🔌",
     description:
       "Connect AI agents to the live Optimitron task graph so they can take the highest-value action to optimize Earth.",
     section: "Developer Tools",
@@ -104,6 +108,7 @@ function buildHomeDocument(site: SiteConfig): StaticSiteSearchDocument {
     href: ROUTES.home,
     title: site.shortName,
     description: site.rootMetadata.description,
+    emoji: "🏠",
     section: "Primary",
     keywords: site.rootMetadata.keywords,
   };


### PR DESCRIPTION
## Outcome

Makes `/search` useful before and during typing without turning the empty state into a second campaign menu.

## What changed

- Removed the sample-query tags and promotional shortcut block.
- Restored a compact empty state with five likely destinations: tasks, people, conditions, treatments, and the Earth Repair Manual.
- Replaced the internal-sounding “treaty docs” placeholder with concrete things people can search for.
- Added instant client-side page suggestions while typing; full task, document, and manual search still runs on submit.
- Added a disabled spinner state while a submitted search loads.
- Uses `routes.ts` as the page index, including each route's existing emoji.
- Strips Markdown from task descriptions and caps compact task summaries at 180 characters.
- Keeps exact route matches such as `vote` and `donate` ranked first.
- Hides submitted results while the user edits the query so stale results never contradict live suggestions.

## Root cause fixed

A polish commit removed the empty-state results and weakened the `search-empty` visual E2E guard to assert only that the input existed. The published screenshot was accurate; this was not a delayed-data artifact.

The route now fails E2E unless “Popular pages” and the `/tasks` destination render. A second state verifies the disabled “Searching…” control.

## Copy review

Audience: a person who knows what they want but not where it lives.
Action: open a likely destination, type for instant suggestions, or submit a full search.
Motivation: reach the right page without hunting through navigation.

Before → After

- “Search pages, tasks, treaty docs, policy analysis...” → “Search tasks, people, treatments, or organizations...”
- Empty whitespace → five likely destinations.
- Raw, multi-paragraph task Markdown → plain first-paragraph summaries capped at 180 characters.
- Search button with no pending feedback → disabled spinner with “Searching…”.

## Verification

- `pnpm --filter @optimitron/web run typecheck:app`
- `pnpm --filter @optimitron/web run typecheck:tests`
- `pnpm --filter @optimitron/web exec vitest run src/components/tasks/task-description.test.ts src/lib/__tests__/site-search.test.ts` (13 tests)
- `pnpm --filter @optimitron/web exec node --test scripts/visual-review-coverage.test.mjs` (12 tests)
- focused visual E2E: empty, typeahead, loading, and submitted-results states (8 desktop/mobile checks)
- visual review: 4 search states; 2/2 changed UI files covered
- `/search` copy preview regenerated

Screenshots were captured and inspected locally. The final pass showed no overlap, raw Markdown, stale-results state, or responsive breakage.

## Review pages

- `/search?site=optimitron&logout=1`
- `/search?site=optimitron&logout=1` then type `donate`
- `/search?site=optimitron&logout=1` then submit `vote`
- `/search?q=vote&site=optimitron&logout=1`
