### PR TITLE
Add personal measurement update and delete tools

### DIFF
--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -155,7 +155,9 @@ const mocks = vi.hoisted(() => ({
   nOf1VariableUpdate: vi.fn(),
   nOf1VariableUpsert: vi.fn(),
   measurementUpsert: vi.fn(),
+  measurementFindFirst: vi.fn(),
   measurementFindMany: vi.fn(),
+  measurementUpdate: vi.fn(),
   queryRaw: vi.fn(),
   trackingReminderUpsert: vi.fn(),
   trackingReminderFindMany: vi.fn(),
@@ -466,7 +468,9 @@ vi.mock("../prisma", () => ({
       upsert: mocks.nOf1VariableUpsert,
     },
     measurement: {
+      findFirst: mocks.measurementFindFirst,
       findMany: mocks.measurementFindMany,
+      update: mocks.measurementUpdate,
       upsert: mocks.measurementUpsert,
     },
     trackingReminder: {
@@ -789,6 +793,8 @@ beforeEach(() => {
       upsert: mocks.nOf1VariableUpsert,
     },
     measurement: {
+      findFirst: mocks.measurementFindFirst,
+      update: mocks.measurementUpdate,
       upsert: mocks.measurementUpsert,
     },
     trackingReminder: {
@@ -3341,7 +3347,7 @@ describe("MCP server tool dispatch", () => {
       });
     });
 
-    it("rejects anonymous calls to getMyQueue / getAIQueue / getQueueAudit / listMeasurements with the same structured error", async () => {
+    it("rejects anonymous calls to personal queue and measurement tools with the same structured error", async () => {
       const client = await setup(undefined, ALL_SCOPES);
 
       for (const tool of [
@@ -3352,6 +3358,8 @@ describe("MCP server tool dispatch", () => {
         // userId undefined, and Prisma would drop the `subject.userId` filter
         // and return every user's measurements.
         "listMeasurements",
+        "updateMeasurement",
+        "deleteMeasurement",
       ] as const) {
         const result = await client.callTool({ name: tool, arguments: {} });
         expect(result.isError, `${tool} should error`).toBe(true);
@@ -9767,6 +9775,113 @@ describe("MCP server tool dispatch", () => {
       expect(body.message).toContain("Insufficient scope");
       expect(mocks.measurementFindMany).not.toHaveBeenCalled();
     });
+
+    it("updateMeasurement changes an owned measurement and refreshes summaries", async () => {
+      mocks.measurementFindFirst.mockResolvedValue({
+        globalVariableId: "gv-vitd",
+        id: "measurement-1",
+        nOf1VariableId: "nof1-1",
+      });
+      mocks.measurementUpdate.mockResolvedValue({
+        ...measurementRow("measurement-1", "2026-07-01T08:00:00.000Z"),
+        note: "corrected",
+        originalValue: 0,
+        value: 0,
+      });
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "updateMeasurement",
+        arguments: {
+          measurementId: "measurement-1",
+          note: "corrected",
+          value: 0,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.measurementFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            deletedAt: null,
+            id: "measurement-1",
+            subject: { userId: "user-1" },
+          },
+        }),
+      );
+      expect(mocks.measurementUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { note: "corrected", originalValue: 0, value: 0 },
+          where: { id: "measurement-1" },
+        }),
+      );
+      expect(mocks.globalVariableUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "gv-vitd" } }),
+      );
+      expect(mocks.nOf1VariableUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "nof1-1" } }),
+      );
+    });
+
+    it("deleteMeasurement soft-deletes an owned measurement and refreshes summaries", async () => {
+      mocks.measurementFindFirst.mockResolvedValue({
+        globalVariableId: "gv-vitd",
+        id: "measurement-1",
+        nOf1VariableId: "nof1-1",
+      });
+      const deletedAt = new Date("2026-08-13T00:00:00.000Z");
+      mocks.measurementUpdate.mockResolvedValue({
+        ...measurementRow("measurement-1", "2026-07-01T08:00:00.000Z"),
+        deletedAt,
+      });
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "deleteMeasurement",
+        arguments: { measurementId: "measurement-1" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const update = mocks.measurementUpdate.mock.calls[0]![0] as {
+        data: { deletedAt: Date };
+      };
+      expect(update.data.deletedAt).toBeInstanceOf(Date);
+      expect(mocks.globalVariableUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "gv-vitd" } }),
+      );
+      expect(mocks.nOf1VariableUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "nof1-1" } }),
+      );
+    });
+
+    it.each(["updateMeasurement", "deleteMeasurement"])(
+      "%s rejects a measurement that the caller does not own",
+      async (toolName) => {
+        mocks.measurementFindFirst.mockResolvedValue(null);
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: toolName,
+          arguments: {
+            measurementId: "measurement-other-user",
+            ...(toolName === "updateMeasurement" ? { value: 0 } : {}),
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(parseToolBody(result).message).toContain(
+          "Measurement not found: measurement-other-user",
+        );
+        expect(mocks.measurementFindFirst).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              subject: { userId: "user-1" },
+            }),
+          }),
+        );
+        expect(mocks.measurementUpdate).not.toHaveBeenCalled();
+      },
+    );
 
     it("upsertTrackingReminder keeps no-ID creation idempotent and defaults reminderFrequency to 86400", async () => {
       mocks.trackingReminderUpsert.mockResolvedValue({

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -9369,6 +9369,7 @@ describe("MCP server tool dispatch", () => {
       expect(mocks.measurementUpsert).toHaveBeenCalledTimes(1);
       const call = mocks.measurementUpsert.mock.calls[0]![0] as {
         create: Record<string, unknown>;
+        update: Record<string, unknown>;
         where: {
           subjectId_globalVariableId_startTime: Record<string, unknown>;
         };
@@ -9379,6 +9380,7 @@ describe("MCP server tool dispatch", () => {
         subjectId: "subject-1",
       });
       expect(call.create).toMatchObject({ unitId: "unit-iu", value: 5000 });
+      expect(call.update).toMatchObject({ deletedAt: null });
 
       const body = parseToolBody(result) as {
         result: { measurement: { subjectId: string; value: number } };
@@ -9781,6 +9783,8 @@ describe("MCP server tool dispatch", () => {
         globalVariableId: "gv-vitd",
         id: "measurement-1",
         nOf1VariableId: "nof1-1",
+        originalUnitId: "unit-iu",
+        unitId: "unit-iu",
       });
       mocks.measurementUpdate.mockResolvedValue({
         ...measurementRow("measurement-1", "2026-07-01T08:00:00.000Z"),
@@ -9828,6 +9832,8 @@ describe("MCP server tool dispatch", () => {
         globalVariableId: "gv-vitd",
         id: "measurement-1",
         nOf1VariableId: "nof1-1",
+        originalUnitId: "unit-iu",
+        unitId: "unit-iu",
       });
       const deletedAt = new Date("2026-08-13T00:00:00.000Z");
       mocks.measurementUpdate.mockResolvedValue({
@@ -9851,6 +9857,52 @@ describe("MCP server tool dispatch", () => {
       );
       expect(mocks.nOf1VariableUpdate).toHaveBeenCalledWith(
         expect.objectContaining({ where: { id: "nof1-1" } }),
+      );
+    });
+
+    it("updateMeasurement requires both representations for a converted measurement", async () => {
+      mocks.measurementFindFirst.mockResolvedValue({
+        globalVariableId: "gv-weight",
+        id: "measurement-converted",
+        nOf1VariableId: "nof1-weight",
+        originalUnitId: "unit-g",
+        unitId: "unit-mg",
+      });
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const missingOriginalValue = await client.callTool({
+        name: "updateMeasurement",
+        arguments: { measurementId: "measurement-converted", value: 2000 },
+      });
+
+      expect(missingOriginalValue.isError).toBe(true);
+      expect(parseToolBody(missingOriginalValue).message).toContain(
+        "originalValue is required",
+      );
+      expect(mocks.measurementUpdate).not.toHaveBeenCalled();
+
+      mocks.measurementUpdate.mockResolvedValue({
+        ...measurementRow(
+          "measurement-converted",
+          "2026-07-01T08:00:00.000Z",
+        ),
+        originalValue: 2,
+        value: 2000,
+      });
+      const corrected = await client.callTool({
+        name: "updateMeasurement",
+        arguments: {
+          measurementId: "measurement-converted",
+          originalValue: 2,
+          value: 2000,
+        },
+      });
+
+      expect(corrected.isError).toBeFalsy();
+      expect(mocks.measurementUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ originalValue: 2, value: 2000 }),
+        }),
       );
     });
 

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -9271,6 +9271,29 @@ describe("MCP server tool dispatch", () => {
   });
 
   describe("tracking reminders and measurements", () => {
+    it("advertises originalValue only on updateMeasurement", async () => {
+      const client = await setup("user-1", ALL_SCOPES);
+      const tools = await client.listTools();
+      const updateMeasurement = tools.tools.find(
+        (tool) => tool.name === "updateMeasurement",
+      );
+      const upsertRelationship = tools.tools.find(
+        (tool) => tool.name === "upsertVariableRelationshipEvidenceEstimate",
+      );
+
+      expect(updateMeasurement?.inputSchema.properties).toMatchObject({
+        originalValue: {
+          type: "number",
+          description: expect.stringContaining(
+            "Required when originalUnitId differs from unitId",
+          ),
+        },
+      });
+      expect(upsertRelationship?.inputSchema.properties).not.toHaveProperty(
+        "originalValue",
+      );
+    });
+
     const TRACKING_UNIT = {
       abbreviatedName: "IU",
       id: "unit-iu",
@@ -9882,10 +9905,7 @@ describe("MCP server tool dispatch", () => {
       expect(mocks.measurementUpdate).not.toHaveBeenCalled();
 
       mocks.measurementUpdate.mockResolvedValue({
-        ...measurementRow(
-          "measurement-converted",
-          "2026-07-01T08:00:00.000Z",
-        ),
+        ...measurementRow("measurement-converted", "2026-07-01T08:00:00.000Z"),
         originalValue: 2,
         value: 2000,
       });

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -3260,6 +3260,7 @@ async function recordTrackingMeasurementWithTx(
       value: input.value,
     },
     update: {
+      deletedAt: null,
       duration: input.duration,
       latitude: input.latitude,
       longitude: input.longitude,
@@ -3322,6 +3323,8 @@ async function findOwnedMeasurementForMutation(
       globalVariableId: true,
       id: true,
       nOf1VariableId: true,
+      originalUnitId: true,
+      unitId: true,
     },
     where: {
       deletedAt: null,
@@ -3346,6 +3349,10 @@ async function updateMeasurementForUser(
     );
   }
   const value = parseRequiredFiniteNumber(input.value, "value");
+  const suppliedOriginalValue = parseOptionalFiniteNumberInput(
+    input,
+    "originalValue",
+  );
   const prisma = await getPrisma();
   return prisma.$transaction(async (tx) => {
     const existing = await findOwnedMeasurementForMutation(
@@ -3353,10 +3360,18 @@ async function updateMeasurementForUser(
       measurementId,
       userId,
     );
+    if (
+      existing.originalUnitId !== existing.unitId &&
+      suppliedOriginalValue === undefined
+    ) {
+      throw new Error(
+        "originalValue is required because this measurement was converted between different units. Pass value in the normalized unit and originalValue in the original unit.",
+      );
+    }
     const measurement = await tx.measurement.update({
       data: {
         value,
-        originalValue: value,
+        originalValue: suppliedOriginalValue ?? value,
         ...(input.duration !== undefined
           ? {
               duration: parseOptionalNonnegativeInteger(
@@ -5156,6 +5171,11 @@ const EARTH_DATA_TOOL_DEFINITIONS = [
         metricKind: { type: "string" },
         sourceType: { type: "string" },
         value: { type: "number" },
+        originalValue: {
+          type: "number",
+          description:
+            "Corrected value in the existing original unit. Required when originalUnitId differs from unitId; otherwise defaults to value.",
+        },
         unitId: { type: "string" },
         confidenceScore: { type: "number" },
         participants: { type: "number" },

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -5425,11 +5425,6 @@ const EARTH_DATA_TOOL_DEFINITIONS = [
         metricKind: { type: "string" },
         sourceType: { type: "string" },
         value: { type: "number" },
-        originalValue: {
-          type: "number",
-          description:
-            "Corrected value in the existing original unit. Required when originalUnitId differs from unitId; otherwise defaults to value.",
-        },
         unitId: { type: "string" },
         confidenceScore: { type: "number" },
         participants: { type: "number" },
@@ -5806,12 +5801,17 @@ const TRACKING_TOOL_DEFINITIONS = [
   {
     name: UPDATE_MEASUREMENT_TOOL_NAME,
     description:
-      "Correct one of the authenticated user's measurements by ID. Use listMeasurements to get the ID. The required value replaces both the normalized and originally entered value; units and variable identity stay unchanged. Optional metadata fields patch the existing row. The tool rejects measurements owned by another user and refreshes cached summaries.",
+      "Correct one of the authenticated user's measurements by ID. Use listMeasurements to get the ID. Pass value in the normalized unit. If the measurement was converted between units, also pass originalValue in its original unit. Units and variable identity stay unchanged. Optional metadata fields patch the existing row. The tool rejects measurements owned by another user and refreshes cached summaries.",
     inputSchema: {
       type: "object" as const,
       properties: {
         measurementId: { type: "string" },
         value: { type: "number" },
+        originalValue: {
+          type: "number",
+          description:
+            "Corrected value in the existing original unit. Required when originalUnitId differs from unitId; otherwise defaults to value.",
+        },
         duration: {
           type: ["number", "null"],
           description: "Duration in seconds. Null clears it.",

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -179,6 +179,8 @@ export { MCP_SCOPE_DESCRIPTIONS, DEFAULT_CONSENT_SCOPES, ALL_SCOPES, McpScope };
 
 const UPLOAD_IMAGE_FROM_URL_TOOL_NAME = "uploadImageFromUrl" as const;
 const RECORD_MEASUREMENT_TOOL_NAME = "recordMeasurement" as const;
+const UPDATE_MEASUREMENT_TOOL_NAME = "updateMeasurement" as const;
+const DELETE_MEASUREMENT_TOOL_NAME = "deleteMeasurement" as const;
 
 const TOOL_SCOPES: Record<string, McpScope[]> = {
   // Explicitly public, read-only tools. Missing entries are a registry error.
@@ -325,6 +327,8 @@ const TOOL_SCOPES: Record<string, McpScope[]> = {
   getQueueAudit: [McpScope.TASKS_PERSONAL, McpScope.TASKS_ORGANIZATION],
   getTaskTreeAudit: [McpScope.TASKS_ADMIN],
   [RECORD_MEASUREMENT_TOOL_NAME]: [McpScope.TASKS_PERSONAL],
+  [UPDATE_MEASUREMENT_TOOL_NAME]: [McpScope.TASKS_PERSONAL],
+  [DELETE_MEASUREMENT_TOOL_NAME]: [McpScope.TASKS_PERSONAL],
   listMeasurements: [McpScope.TASKS_PERSONAL],
   upsertTrackingReminder: [McpScope.TASKS_PERSONAL],
   listTrackingReminders: [McpScope.TASKS_PERSONAL],
@@ -2793,6 +2797,7 @@ const TRACKING_REMINDER_INCLUDE = {
 
 const TRACKING_MEASUREMENT_SELECT = {
   createdAt: true,
+  deletedAt: true,
   duration: true,
   globalVariable: { select: TRACKING_VARIABLE_SELECT },
   globalVariableId: true,
@@ -3305,6 +3310,113 @@ async function recordTrackingMeasurement(
       value,
     }),
   );
+}
+
+async function findOwnedMeasurementForMutation(
+  tx: Prisma.TransactionClient,
+  measurementId: string,
+  userId: string,
+) {
+  const measurement = await tx.measurement.findFirst({
+    select: {
+      globalVariableId: true,
+      id: true,
+      nOf1VariableId: true,
+    },
+    where: {
+      deletedAt: null,
+      id: measurementId,
+      subject: { userId },
+    },
+  });
+  if (!measurement) {
+    throw new Error(`Measurement not found: ${measurementId}`);
+  }
+  return measurement;
+}
+
+async function updateMeasurementForUser(
+  input: Record<string, unknown>,
+  userId: string,
+) {
+  const measurementId = optionalString(input.measurementId);
+  if (!measurementId) {
+    throw new Error(
+      "measurementId is required. Use listMeasurements to find the measurement ID.",
+    );
+  }
+  const value = parseRequiredFiniteNumber(input.value, "value");
+  const prisma = await getPrisma();
+  return prisma.$transaction(async (tx) => {
+    const existing = await findOwnedMeasurementForMutation(
+      tx,
+      measurementId,
+      userId,
+    );
+    const measurement = await tx.measurement.update({
+      data: {
+        value,
+        originalValue: value,
+        ...(input.duration !== undefined
+          ? {
+              duration: parseOptionalNonnegativeInteger(
+                input.duration,
+                "duration",
+              ),
+            }
+          : {}),
+        ...(input.latitude !== undefined
+          ? {
+              latitude:
+                parseOptionalFiniteNumberInput(input, "latitude") ?? null,
+            }
+          : {}),
+        ...(input.longitude !== undefined
+          ? {
+              longitude:
+                parseOptionalFiniteNumberInput(input, "longitude") ?? null,
+            }
+          : {}),
+        ...(input.note !== undefined
+          ? { note: optionalStringInput(input, "note") }
+          : {}),
+        ...(input.sourceName !== undefined
+          ? { sourceName: optionalStringInput(input, "sourceName") }
+          : {}),
+      },
+      select: TRACKING_MEASUREMENT_SELECT,
+      where: { id: existing.id },
+    });
+    await refreshMeasurementSummaries(tx, existing);
+    return measurement;
+  });
+}
+
+async function deleteMeasurementForUser(
+  input: Record<string, unknown>,
+  userId: string,
+) {
+  const measurementId = optionalString(input.measurementId);
+  if (!measurementId) {
+    throw new Error(
+      "measurementId is required. Use listMeasurements to find the measurement ID.",
+    );
+  }
+  const prisma = await getPrisma();
+  return prisma.$transaction(async (tx) => {
+    const existing = await findOwnedMeasurementForMutation(
+      tx,
+      measurementId,
+      userId,
+    );
+    const measurement = await tx.measurement.update({
+      data: { deletedAt: new Date() },
+      select: TRACKING_MEASUREMENT_SELECT,
+      where: { id: existing.id },
+    });
+    await refreshMeasurementSummaries(tx, existing);
+    return measurement;
+  });
 }
 
 async function upsertTrackingReminderForUser(
@@ -5415,6 +5527,39 @@ const TRACKING_TOOL_DEFINITIONS = [
             "nextCursor from the previous page. Repeat the same filters until nextCursor is null.",
         },
       },
+    },
+  },
+  {
+    name: UPDATE_MEASUREMENT_TOOL_NAME,
+    description:
+      "Correct one of the authenticated user's measurements by ID. Use listMeasurements to get the ID. The required value replaces both the normalized and originally entered value; units and variable identity stay unchanged. Optional metadata fields patch the existing row. The tool rejects measurements owned by another user and refreshes cached summaries.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        measurementId: { type: "string" },
+        value: { type: "number" },
+        duration: {
+          type: ["number", "null"],
+          description: "Duration in seconds. Null clears it.",
+        },
+        note: { type: ["string", "null"] },
+        sourceName: { type: ["string", "null"] },
+        latitude: { type: ["number", "null"] },
+        longitude: { type: ["number", "null"] },
+      },
+      required: ["measurementId", "value"],
+    },
+  },
+  {
+    name: DELETE_MEASUREMENT_TOOL_NAME,
+    description:
+      "Soft-delete one of the authenticated user's measurements by ID. Use listMeasurements to get the ID. The tool rejects measurements owned by another user and refreshes cached summaries.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        measurementId: { type: "string" },
+      },
+      required: ["measurementId"],
     },
   },
   {
@@ -9861,6 +10006,28 @@ export function createMcpServer(
                 "This tool lists your personal tracking measurements.",
               );
             return ok(await listMeasurementsForUser(a, userId));
+          }
+
+          case UPDATE_MEASUREMENT_TOOL_NAME: {
+            if (!userId)
+              return authRequired(
+                name,
+                "This tool corrects your personal tracking measurements.",
+              );
+            return ok({
+              measurement: await updateMeasurementForUser(a, userId),
+            });
+          }
+
+          case DELETE_MEASUREMENT_TOOL_NAME: {
+            if (!userId)
+              return authRequired(
+                name,
+                "This tool deletes your personal tracking measurements.",
+              );
+            return ok({
+              measurement: await deleteMeasurementForUser(a, userId),
+            });
           }
 
           case "upsertTrackingReminder": {


### PR DESCRIPTION
## Summary
- add personal `updateMeasurement` and `deleteMeasurement` MCP tools
- scope every lookup to the authenticated user's active measurements
- soft-delete measurements, restore re-recorded rows, and refresh cached variable summaries after every mutation
- preserve separate normalized/original values for converted measurements

## Verification
- `pnpm --filter @optimitron/web exec vitest run src/lib/__tests__/mcp-server.test.ts -t "tracking|measurement"` (50 passed)
- full MCP suite: 300 passed; two unrelated existing 5-second timeout failures
- web typecheck reached unrelated existing flyer-hang task-key and wishocracy catalog errors; no changed-file errors
- review threads for restored soft-deleted rows and converted-unit semantics were fixed and resolved

Task: `cmsro8dg3003504l4lyswdjn4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools to update and soft-delete personal measurements.
  * Restoring a previously deleted measurement is supported when recording it again.
  * Measurement updates preserve units and variable details while refreshing summaries.
  * Added validation for converted measurements and ownership protection.

* **Bug Fixes**
  * Recording an existing measurement now clears its deleted status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->