### PR TITLE
Complete MCP notification queue reads

### DIFF
--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -10264,6 +10264,79 @@ describe("MCP server tool dispatch", () => {
       }
     });
 
+    it("filters an inclusive notification range by reminder and overdue status", async () => {
+      const now = vi
+        .spyOn(Date, "now")
+        .mockReturnValue(new Date("2026-08-04T10:00:00.000Z").getTime());
+      try {
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+        mocks.trackingReminderFindMany.mockResolvedValue([
+          EXISTING_TRACKING_REMINDER,
+          {
+            ...EXISTING_TRACKING_REMINDER,
+            globalVariable: {
+              ...TRACKING_VARIABLE,
+              id: "gv-mood",
+              name: "Mood",
+            },
+            globalVariableId: "gv-mood",
+            id: "reminder-2",
+          },
+        ]);
+        mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "listTrackingReminderNotifications",
+          arguments: {
+            endDateKey: "2026-08-03",
+            startDateKey: "2026-08-02",
+            status: "OVERDUE",
+            trackingReminderId: "reminder-1",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(parseToolBody(result)).toMatchObject({
+          endDateKey: "2026-08-03",
+          notifications: [
+            {
+              dateKey: "2026-08-02",
+              derivedStatus: "OVERDUE",
+              reminderId: "reminder-1",
+            },
+            {
+              dateKey: "2026-08-03",
+              derivedStatus: "OVERDUE",
+              reminderId: "reminder-1",
+            },
+          ],
+          startDateKey: "2026-08-02",
+          timeZone: "UTC",
+        });
+        expect(mocks.userFindUnique).toHaveBeenCalledTimes(1);
+        expect(mocks.trackingReminderFindMany).toHaveBeenCalledTimes(2);
+      } finally {
+        now.mockRestore();
+      }
+    });
+
+    it("rejects a notification range longer than 31 days before querying reminders", async () => {
+      mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listTrackingReminderNotifications",
+        arguments: {
+          endDateKey: "2026-08-01",
+          startDateKey: "2026-07-01",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).message).toContain("at most 31 days");
+      expect(mocks.trackingReminderFindMany).not.toHaveBeenCalled();
+    });
+
     it("restores a snoozed notification after its deferred time", async () => {
       const now = vi
         .spyOn(Date, "now")
@@ -10290,7 +10363,21 @@ describe("MCP server tool dispatch", () => {
           name: "listTrackingReminderNotifications",
           arguments: { dateKey: "2026-08-03" },
         });
-        expect(parseToolBody(before)).toMatchObject({ notifications: [] });
+        expect(parseToolBody(before)).toMatchObject({
+          notifications: [
+            {
+              derivedStatus: NotificationStatus.SNOOZED,
+              isOverdue: false,
+              notificationId: "notification-1",
+              notifyAt: "2026-08-03T10:30:00.000Z",
+              reminderId: "reminder-1",
+              scheduledAt: "2026-08-03T08:00:00.000Z",
+              snoozeDelayMinutes: 150,
+              snoozedUntil: "2026-08-03T10:30:00.000Z",
+              status: NotificationStatus.SNOOZED,
+            },
+          ],
+        });
 
         now.mockReturnValue(new Date("2026-08-03T10:30:00.000Z").getTime());
         const atDeferredTime = await client.callTool({

--- a/packages/web/src/lib/__tests__/mcp-server.test.ts
+++ b/packages/web/src/lib/__tests__/mcp-server.test.ts
@@ -10337,6 +10337,48 @@ describe("MCP server tool dispatch", () => {
       expect(mocks.trackingReminderFindMany).not.toHaveBeenCalled();
     });
 
+    it("returns stored tracked history after a reminder is deactivated", async () => {
+      mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+      mocks.trackingReminderFindMany.mockResolvedValue([]);
+      mocks.trackingReminderNotificationFindMany.mockResolvedValue([
+        {
+          deletedAt: null,
+          id: "historical-notification",
+          notifyAt: new Date("2026-08-03T08:00:00.000Z"),
+          status: NotificationStatus.TRACKED,
+          trackedValue: 3,
+          trackingReminder: {
+            ...EXISTING_TRACKING_REMINDER,
+            active: false,
+            reminderStartTime: "17:00",
+          },
+          trackingReminderId: "reminder-1",
+          userId: "user-1",
+        },
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listTrackingReminderNotifications",
+        arguments: { dateKey: "2026-08-03", status: "TRACKED" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolBody(result)).toMatchObject({
+        dateKey: "2026-08-03",
+        notifications: [
+          {
+            derivedStatus: NotificationStatus.TRACKED,
+            notificationId: "historical-notification",
+            reminderId: "reminder-1",
+            scheduledAt: null,
+            status: NotificationStatus.TRACKED,
+            trackedValue: 3,
+          },
+        ],
+      });
+    });
+
     it("restores a snoozed notification after its deferred time", async () => {
       const now = vi
         .spyOn(Date, "now")

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -3984,12 +3984,21 @@ async function listTrackingReminderNotificationsForUser(
     });
   const unmatchedStoredNotifications = storedNotifications
     .filter(
-      (notification) =>
-        !scheduledNotificationIds.has(notification.id) &&
-        (input.includeCompleted === true ||
-          status !== null ||
-          (notification.trackingReminder.active &&
-            notification.status === NotificationStatus.SNOOZED)),
+      (notification) => {
+        if (scheduledNotificationIds.has(notification.id)) return false;
+        if (status !== null) return true;
+        const isAnswered =
+          notification.status === NotificationStatus.TRACKED ||
+          notification.status === NotificationStatus.SKIPPED;
+        const isOutstanding =
+          notification.status === NotificationStatus.PENDING ||
+          notification.status === NotificationStatus.SENT ||
+          notification.status === NotificationStatus.SNOOZED;
+        return (
+          (input.includeCompleted === true && isAnswered) ||
+          (notification.trackingReminder.active && isOutstanding)
+        );
+      },
     )
     .map((notification) =>
       storedTrackingNotificationToQueueItem(notification, timeZone),

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -3988,9 +3988,8 @@ async function listTrackingReminderNotificationsForUser(
         !scheduledNotificationIds.has(notification.id) &&
         (input.includeCompleted === true ||
           status !== null ||
-          notification.status === NotificationStatus.PENDING ||
-          notification.status === NotificationStatus.SENT ||
-          notification.status === NotificationStatus.SNOOZED),
+          (notification.trackingReminder.active &&
+            notification.status === NotificationStatus.SNOOZED)),
     )
     .map((notification) =>
       storedTrackingNotificationToQueueItem(notification, timeZone),

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -3983,23 +3983,21 @@ async function listTrackingReminderNotificationsForUser(
       },
     });
   const unmatchedStoredNotifications = storedNotifications
-    .filter(
-      (notification) => {
-        if (scheduledNotificationIds.has(notification.id)) return false;
-        if (status !== null) return true;
-        const isAnswered =
-          notification.status === NotificationStatus.TRACKED ||
-          notification.status === NotificationStatus.SKIPPED;
-        const isOutstanding =
-          notification.status === NotificationStatus.PENDING ||
-          notification.status === NotificationStatus.SENT ||
-          notification.status === NotificationStatus.SNOOZED;
-        return (
-          (input.includeCompleted === true && isAnswered) ||
-          (notification.trackingReminder.active && isOutstanding)
-        );
-      },
-    )
+    .filter((notification) => {
+      if (scheduledNotificationIds.has(notification.id)) return false;
+      if (status !== null) return true;
+      const isAnswered =
+        notification.status === NotificationStatus.TRACKED ||
+        notification.status === NotificationStatus.SKIPPED;
+      const isOutstanding =
+        notification.status === NotificationStatus.PENDING ||
+        notification.status === NotificationStatus.SENT ||
+        notification.status === NotificationStatus.SNOOZED;
+      return (
+        (input.includeCompleted === true && isAnswered) ||
+        (notification.trackingReminder.active && isOutstanding)
+      );
+    })
     .map((notification) =>
       storedTrackingNotificationToQueueItem(notification, timeZone),
     );

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -5650,7 +5650,7 @@ const TRACKING_TOOL_DEFINITIONS = [
   {
     name: "listTrackingReminderNotifications",
     description:
-      "List the authenticated user's tracking notification queue for one local day or an inclusive local-date range. A reminder defines a schedule; a notification is one occurrence. Filter by trackingReminderId or stored/derived status, including OVERDUE. Results expose scheduledAt, effective notifyAt, and snoozedUntil so clients can tell exactly how far a snooze moved an occurrence. Set includeCompleted to include recent TRACKED notifications. Times include the user's local zone and the UTC instant. Use compact mode for voice or chat clients.",
+      "List the authenticated user's tracking notification queue for one local day or an inclusive local-date range. A reminder defines a schedule; a notification is one occurrence. Filter by trackingReminderId or effective status, including OVERDUE. Results expose scheduledAt, effective notifyAt, and snoozedUntil so clients can tell exactly how far a snooze moved an occurrence. Set includeCompleted to include recent TRACKED notifications. Times include the user's local zone and the UTC instant. Use compact mode for voice or chat clients.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -5677,7 +5677,7 @@ const TRACKING_TOOL_DEFINITIONS = [
           type: "string",
           enum: ["PENDING", "SENT", "TRACKED", "SKIPPED", "SNOOZED", "OVERDUE"],
           description:
-            "Return only this stored or derived status. OVERDUE means effective notifyAt is in the past and the occurrence remains unanswered.",
+            "Return only this effective status. An elapsed snooze becomes PENDING or OVERDUE. OVERDUE means effective notifyAt is in the past and the occurrence remains unanswered.",
         },
         compact: {
           type: "boolean",

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -2791,6 +2791,10 @@ const TRACKING_REMINDER_INCLUDE = {
   },
 } satisfies Prisma.TrackingReminderInclude;
 
+const TRACKING_NOTIFICATION_WITH_REMINDER_INCLUDE = {
+  trackingReminder: { include: TRACKING_REMINDER_INCLUDE },
+} satisfies Prisma.TrackingReminderNotificationInclude;
+
 const TRACKING_MEASUREMENT_SELECT = {
   createdAt: true,
   duration: true,
@@ -3825,6 +3829,64 @@ function parseTrackingNotificationStatus(value: unknown) {
   return normalized as NotificationStatus | TrackingReminderDerivedStatus;
 }
 
+function storedTrackingNotificationToQueueItem(
+  notification: Prisma.TrackingReminderNotificationGetPayload<{
+    include: typeof TRACKING_NOTIFICATION_WITH_REMINDER_INCLUDE;
+  }>,
+  timeZone: string,
+) {
+  const reminder = notification.trackingReminder;
+  const notifyAt = notification.notifyAt;
+  const dateKey = getZonedDateKey(notifyAt, timeZone);
+  const snoozeElapsed =
+    notification.status === NotificationStatus.SNOOZED &&
+    notifyAt.getTime() <= Date.now();
+  const isOverdue =
+    (notification.status === NotificationStatus.PENDING ||
+      notification.status === NotificationStatus.SENT ||
+      snoozeElapsed) &&
+    notifyAt.getTime() < Date.now();
+  return {
+    dateKey,
+    defaultValue: cleanNumber(reminder.defaultValue),
+    derivedStatus: isOverdue
+      ? TrackingReminderDerivedStatus.OVERDUE
+      : snoozeElapsed
+        ? NotificationStatus.PENDING
+        : notification.status,
+    globalVariable: reminder.globalVariable,
+    instructions: reminder.instructions,
+    isOverdue,
+    notification,
+    notificationId: notification.id,
+    notifyAt,
+    notifyAtLocal: formatZonedIsoString(notifyAt, timeZone),
+    overdueSince: isOverdue ? notifyAt : null,
+    overdueSinceLocal: isOverdue
+      ? formatZonedIsoString(notifyAt, timeZone)
+      : null,
+    reminderEndTime: reminder.reminderEndTime,
+    reminderFrequency: reminder.reminderFrequency,
+    reminderId: reminder.id,
+    reminderStartTime: reminder.reminderStartTime,
+    // A current schedule cannot reconstruct the historical scheduled instant
+    // after the reminder was edited. Keep it null instead of inventing one.
+    scheduledAt: null,
+    scheduledAtLocal: null,
+    snoozedUntil:
+      notification.status === NotificationStatus.SNOOZED ? notifyAt : null,
+    snoozedUntilLocal:
+      notification.status === NotificationStatus.SNOOZED
+        ? formatZonedIsoString(notifyAt, timeZone)
+        : null,
+    snoozeDelayMinutes: null,
+    status: notification.status,
+    timeZone,
+    trackedValue: cleanNumber(notification.trackedValue),
+    utcOffsetMinutes: getTimeZoneOffsetMinutes(notifyAt, timeZone),
+  };
+}
+
 function trackingNotificationDateKeys(
   input: Record<string, unknown>,
   fallbackDateKey: string,
@@ -3900,14 +3962,50 @@ async function listTrackingReminderNotificationsForUser(
       ),
     );
   }
-  const notifications = dayResults
-    .flatMap((result) => result.notifications)
+  const scheduledNotifications = dayResults.flatMap(
+    (result) => result.notifications,
+  );
+  const scheduledNotificationIds = new Set(
+    scheduledNotifications.flatMap((notification) =>
+      notification.notificationId ? [notification.notificationId] : [],
+    ),
+  );
+  const firstRange = dayRange(dateKeys[0]!, timeZone);
+  const lastRange = dayRange(dateKeys[dateKeys.length - 1]!, timeZone);
+  const storedNotifications =
+    await prisma.trackingReminderNotification.findMany({
+      include: TRACKING_NOTIFICATION_WITH_REMINDER_INCLUDE,
+      orderBy: [{ notifyAt: "asc" }],
+      where: {
+        deletedAt: null,
+        notifyAt: { gte: firstRange.start, lt: lastRange.end },
+        userId,
+      },
+    });
+  const unmatchedStoredNotifications = storedNotifications
+    .filter(
+      (notification) =>
+        !scheduledNotificationIds.has(notification.id) &&
+        (input.includeCompleted === true ||
+          status !== null ||
+          notification.status === NotificationStatus.PENDING ||
+          notification.status === NotificationStatus.SENT ||
+          notification.status === NotificationStatus.SNOOZED),
+    )
+    .map((notification) =>
+      storedTrackingNotificationToQueueItem(notification, timeZone),
+    );
+  const notifications = [
+    ...scheduledNotifications,
+    ...unmatchedStoredNotifications,
+  ]
     .filter(
       (notification) =>
         (!trackingReminderId ||
           notification.reminderId === trackingReminderId) &&
         (!status || notification.derivedStatus === status),
-    );
+    )
+    .sort((left, right) => left.notifyAt.getTime() - right.notifyAt.getTime());
   const result =
     dateKeys.length === 1
       ? { dateKey: dateKeys[0]!, notifications, timeZone }

--- a/packages/web/src/lib/mcp-server.ts
+++ b/packages/web/src/lib/mcp-server.ts
@@ -3615,17 +3615,23 @@ async function listTrackingRemindersForUser(
 
 /** Default snooze length when a caller does not name one. */
 const DEFAULT_SNOOZE_MINUTES = 30;
+const MAX_TRACKING_NOTIFICATION_RANGE_DAYS = 31;
 
 async function listDueTrackingRemindersForUser(
   input: Record<string, unknown>,
   userId: string,
+  knownTimeZone?: string,
 ) {
   const prisma = await getPrisma();
-  const user = await prisma.user.findUnique({
-    select: { timeZone: true },
-    where: { id: userId },
-  });
-  const timeZone = user?.timeZone ?? "UTC";
+  const timeZone =
+    knownTimeZone ??
+    (
+      await prisma.user.findUnique({
+        select: { timeZone: true },
+        where: { id: userId },
+      })
+    )?.timeZone ??
+    "UTC";
   const dateKey = parseDateKey(
     input.dateKey,
     getZonedDateKey(new Date(), timeZone),
@@ -3692,9 +3698,9 @@ async function listDueTrackingRemindersForUser(
       const existingNotification = byReminderId.get(reminder.id);
       const notification =
         existingNotification === undefined ? null : existingNotification;
-      const notifyAt =
-        notification?.notifyAt ?? occurrenceByReminderId.get(reminder.id);
-      if (!notifyAt) {
+      const scheduledAt = occurrenceByReminderId.get(reminder.id);
+      const notifyAt = notification?.notifyAt ?? scheduledAt;
+      if (!notifyAt || !scheduledAt) {
         throw new Error(
           `Missing scheduled occurrence for tracking reminder ${reminder.id}.`,
         );
@@ -3720,6 +3726,7 @@ async function listDueTrackingRemindersForUser(
         instructions: reminder.instructions,
         isOverdue,
         notification,
+        notificationId: notification?.id ?? null,
         notifyAt,
         // Reminders are scheduled in local wall-clock time, so report that
         // alongside the UTC instant. Reading only notifyAt makes an 08:00
@@ -3733,13 +3740,31 @@ async function listDueTrackingRemindersForUser(
         reminderFrequency: reminder.reminderFrequency,
         reminderId: reminder.id,
         reminderStartTime: reminder.reminderStartTime,
+        scheduledAt,
+        scheduledAtLocal: formatZonedIsoString(scheduledAt, timeZone),
+        snoozedUntil: status === NotificationStatus.SNOOZED ? notifyAt : null,
+        snoozedUntilLocal:
+          status === NotificationStatus.SNOOZED
+            ? formatZonedIsoString(notifyAt, timeZone)
+            : null,
+        snoozeDelayMinutes:
+          status === NotificationStatus.SNOOZED
+            ? Math.max(0, (notifyAt.getTime() - scheduledAt.getTime()) / 60_000)
+            : null,
         status,
         timeZone,
+        trackedValue: cleanNumber(notification?.trackedValue),
         utcOffsetMinutes: getTimeZoneOffsetMinutes(notifyAt, timeZone),
       };
     })
     .filter((reminder) => {
       if (input.includeCompleted === true) return true;
+      if (
+        input.includeSnoozed === true &&
+        reminder.status === NotificationStatus.SNOOZED
+      ) {
+        return true;
+      }
       if (
         reminder.status === NotificationStatus.SNOOZED &&
         reminder.notifyAt.getTime() <= Date.now()
@@ -3754,11 +3779,23 @@ async function listDueTrackingRemindersForUser(
   return { dateKey, notifications: remindersWithStatus, timeZone };
 }
 
-function toCompactTrackingNotifications(
-  result: Awaited<ReturnType<typeof listDueTrackingRemindersForUser>>,
-) {
+function toCompactTrackingNotifications(result: {
+  dateKey?: string;
+  endDateKey?: string;
+  notifications: Array<{
+    derivedStatus: NotificationStatus | TrackingReminderDerivedStatus;
+    globalVariable: { name: string };
+    notifyAt: Date;
+    notifyAtLocal: string;
+    reminderId: string;
+  }>;
+  startDateKey?: string;
+  timeZone: string;
+}) {
   return {
-    dateKey: result.dateKey,
+    ...(result.dateKey ? { dateKey: result.dateKey } : {}),
+    ...(result.startDateKey ? { startDateKey: result.startDateKey } : {}),
+    ...(result.endDateKey ? { endDateKey: result.endDateKey } : {}),
     notifications: result.notifications.map((notification) => ({
       // `due` is the user's local time so a voice client can read it aloud
       // without converting. `dueUtc` keeps the raw instant for machines.
@@ -3770,6 +3807,119 @@ function toCompactTrackingNotifications(
     })),
     timeZone: result.timeZone,
   };
+}
+
+function parseTrackingNotificationStatus(value: unknown) {
+  if (value == null || value === "") return null;
+  if (typeof value !== "string") {
+    throw new Error("status must be a string.");
+  }
+  const normalized = value.trim().toUpperCase();
+  const validStatuses = new Set<string>([
+    ...Object.values(NotificationStatus),
+    TrackingReminderDerivedStatus.OVERDUE,
+  ]);
+  if (!validStatuses.has(normalized)) {
+    throw new Error(`status must be one of ${[...validStatuses].join(", ")}.`);
+  }
+  return normalized as NotificationStatus | TrackingReminderDerivedStatus;
+}
+
+function trackingNotificationDateKeys(
+  input: Record<string, unknown>,
+  fallbackDateKey: string,
+) {
+  const hasDateKey = input.dateKey != null && input.dateKey !== "";
+  const hasRange =
+    (input.startDateKey != null && input.startDateKey !== "") ||
+    (input.endDateKey != null && input.endDateKey !== "");
+  if (hasDateKey && hasRange) {
+    throw new Error(
+      "Use dateKey for one day or startDateKey/endDateKey for a range, not both.",
+    );
+  }
+  if (!hasRange) {
+    return [parseDateKey(input.dateKey, fallbackDateKey)];
+  }
+
+  const endFallback = parseDateKey(input.endDateKey, fallbackDateKey);
+  const startDateKey = parseDateKey(input.startDateKey, endFallback);
+  const endDateKey = parseDateKey(input.endDateKey, startDateKey);
+  if (startDateKey > endDateKey) {
+    throw new Error("startDateKey must be on or before endDateKey.");
+  }
+
+  const dateKeys: string[] = [];
+  let currentDateKey = startDateKey;
+  while (true) {
+    dateKeys.push(currentDateKey);
+    if (currentDateKey === endDateKey) break;
+    if (dateKeys.length >= MAX_TRACKING_NOTIFICATION_RANGE_DAYS) {
+      throw new Error(
+        `Tracking notification ranges may include at most ${MAX_TRACKING_NOTIFICATION_RANGE_DAYS} days.`,
+      );
+    }
+    const nextDateKey = shiftDateKey(currentDateKey, 1);
+    if (!nextDateKey) throw new Error("Invalid tracking date range.");
+    currentDateKey = nextDateKey;
+  }
+  return dateKeys;
+}
+
+async function listTrackingReminderNotificationsForUser(
+  input: Record<string, unknown>,
+  userId: string,
+) {
+  const trackingReminderId = optionalString(input.trackingReminderId);
+  if ("trackingReminderId" in input && !trackingReminderId) {
+    throw new Error("trackingReminderId must be a non-empty string.");
+  }
+  const status = parseTrackingNotificationStatus(input.status);
+  const prisma = await getPrisma();
+  const user = await prisma.user.findUnique({
+    select: { timeZone: true },
+    where: { id: userId },
+  });
+  const timeZone = user?.timeZone ?? "UTC";
+  const dateKeys = trackingNotificationDateKeys(
+    input,
+    getZonedDateKey(new Date(), timeZone),
+  );
+  const dayResults = [];
+  for (const dateKey of dateKeys) {
+    dayResults.push(
+      await listDueTrackingRemindersForUser(
+        {
+          ...input,
+          dateKey,
+          includeCompleted: input.includeCompleted === true || status !== null,
+          includeSnoozed: true,
+        },
+        userId,
+        timeZone,
+      ),
+    );
+  }
+  const notifications = dayResults
+    .flatMap((result) => result.notifications)
+    .filter(
+      (notification) =>
+        (!trackingReminderId ||
+          notification.reminderId === trackingReminderId) &&
+        (!status || notification.derivedStatus === status),
+    );
+  const result =
+    dateKeys.length === 1
+      ? { dateKey: dateKeys[0]!, notifications, timeZone }
+      : {
+          endDateKey: dateKeys[dateKeys.length - 1]!,
+          notifications,
+          startDateKey: dateKeys[0]!,
+          timeZone,
+        };
+  return input.compact === true
+    ? toCompactTrackingNotifications(result)
+    : result;
 }
 
 async function findOrCreateTrackingNotification(
@@ -5500,13 +5650,34 @@ const TRACKING_TOOL_DEFINITIONS = [
   {
     name: "listTrackingReminderNotifications",
     description:
-      "List due tracking reminder notifications. A reminder defines a schedule. A notification is one occurrence that you answer. Most pending notifications have no stored row. Use compact mode for voice or chat clients. Times come back in the user's time zone as notifyAtLocal (compact: due), with the UTC instant in notifyAt (compact: dueUtc).",
+      "List the authenticated user's tracking notification queue for one local day or an inclusive local-date range. A reminder defines a schedule; a notification is one occurrence. Filter by trackingReminderId or stored/derived status, including OVERDUE. Results expose scheduledAt, effective notifyAt, and snoozedUntil so clients can tell exactly how far a snooze moved an occurrence. Set includeCompleted to include recent TRACKED notifications. Times include the user's local zone and the UTC instant. Use compact mode for voice or chat clients.",
     inputSchema: {
       type: "object" as const,
       properties: {
         dateKey: {
           type: "string",
-          description: "Local date in YYYY-MM-DD. Defaults to today.",
+          description:
+            "One local date in YYYY-MM-DD. Defaults to today. Do not combine with startDateKey or endDateKey.",
+        },
+        startDateKey: {
+          type: "string",
+          description:
+            "First local date in an inclusive range. Defaults to endDateKey when omitted.",
+        },
+        endDateKey: {
+          type: "string",
+          description:
+            "Last local date in an inclusive range. Defaults to startDateKey when omitted. Ranges may include at most 31 days.",
+        },
+        trackingReminderId: {
+          type: "string",
+          description: "Return occurrences for only this reminder.",
+        },
+        status: {
+          type: "string",
+          enum: ["PENDING", "SENT", "TRACKED", "SKIPPED", "SNOOZED", "OVERDUE"],
+          description:
+            "Return only this stored or derived status. OVERDUE means effective notifyAt is in the past and the occurrence remains unanswered.",
         },
         compact: {
           type: "boolean",
@@ -5516,7 +5687,7 @@ const TRACKING_TOOL_DEFINITIONS = [
         includeCompleted: {
           type: "boolean",
           description:
-            "Include completed notifications and snoozes that have not elapsed.",
+            "Include answered TRACKED or legacy SKIPPED occurrences. SNOOZED occurrences are always returned with snoozedUntil.",
         },
       },
     },
@@ -9893,11 +10064,13 @@ export function createMcpServer(
                 "This tool lists your due personal tracking reminder notifications.",
               );
             const result =
-              a.compact === true
-                ? toCompactTrackingNotifications(
-                    await listDueTrackingRemindersForUser(a, userId),
-                  )
-                : await listDueTrackingRemindersForUser(a, userId);
+              name === "listTrackingReminderNotifications"
+                ? await listTrackingReminderNotificationsForUser(a, userId)
+                : a.compact === true
+                  ? toCompactTrackingNotifications(
+                      await listDueTrackingRemindersForUser(a, userId),
+                    )
+                  : await listDueTrackingRemindersForUser(a, userId);
             if (name === "listDueTrackingReminders") {
               const { notifications, ...rest } = result;
               return ok({ ...rest, reminders: notifications });


### PR DESCRIPTION
## Summary
- extend `listTrackingReminderNotifications` from a one-day view to a bounded inclusive date range
- add `trackingReminderId` and effective-status filters, including `OVERDUE`
- return notification IDs, original schedule times, effective notify times, snoozed-until times, delay minutes, and tracked values
- include persisted history after reminders are deactivated or rescheduled
- preserve the deprecated `listDueTrackingReminders` response behavior

## Verification
- `pnpm --filter @optimitron/web exec vitest run src/lib/__tests__/mcp-server.test.ts` (301 passed)
- focused notification/reminder/tracking run (51 passed)
- `git diff --check`
- web TypeScript check reached only existing flyer-hang task-key and wishocracy catalog export errors; no changed-file errors
- fixed and resolved the stored-history review finding

Task: `cmsku79py000b04l43atbunb0`