### PR TITLE
Add authenticated visual coverage for standalone apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
               - 'packages/db/**'
               - 'packages/site-kit/**'
               - 'scripts/site-app-navigation.test.ts'
+              - 'scripts/site-app-visual-routes.mjs'
               - 'scripts/smoke-site-apps.mjs'
               - 'package.json'
               - 'pnpm-workspace.yaml'
@@ -291,13 +292,13 @@ jobs:
           - app: wishocracy
             variant: wishocracy.org
             port: 4013
-            postgres_image: ""
-            requires_database: false
+            postgres_image: postgres:16
+            requires_database: true
           - app: trialabundancesurvey
             variant: trialabundancesurvey.org
             port: 4014
-            postgres_image: ""
-            requires_database: false
+            postgres_image: postgres:16
+            requires_database: true
           - app: curedao
             variant: curedao.org
             port: 4015
@@ -365,6 +366,18 @@ jobs:
 
       - name: Build app dependencies
         run: pnpm build:app-dependencies
+
+      - name: Sync managed data for authenticated screenshots
+        if: ${{ matrix.requires_database && github.event_name == 'pull_request' }}
+        env:
+          MANAGED_DATA_SKIP_MEDICAL_REFERENCE: "1"
+        run: pnpm db:sync:managed-data -- --apply
+
+      - name: Prepare local authenticated visual fixtures
+        if: ${{ matrix.requires_database && github.event_name == 'pull_request' }}
+        env:
+          SITE_APP_VISUAL_FIXTURES: "1"
+        run: pnpm db:seed:site-app-visual
 
       - name: Build @apps/${{ matrix.app }}
         run: pnpm --filter "@apps/${{ matrix.app }}" run build

--- a/apps/DEPLOYMENT.md
+++ b/apps/DEPLOYMENT.md
@@ -5,6 +5,10 @@
 Keep `packages/web` on its existing Vercel project. Create one additional
 Vercel project for each app under `apps/*`.
 
+`apps/warondisease` is the source of truth for the campaign site. Its rich
+neobrutalist home and dashboard must pass public and authenticated visual review
+before `warondisease.org` moves off the temporary `packages/web` host.
+
 | Project                | Root Directory              | Production domain          |
 | ---------------------- | --------------------------- | -------------------------- |
 | `optimitron-web`       | `packages/web`              | `optimitron.com`           |
@@ -67,7 +71,7 @@ them manually. `NEXT_PUBLIC_SITE_VARIANT` is fixed in each app's Next config.
 2. Add Development, Preview, and Production variables for each project.
 3. Deploy `trialabundancesurvey` and verify `/embed?embed=1` before Accelerated Medicine.
 4. Deploy the remaining apps to Vercel preview URLs.
-5. Run page and API smoke checks against each preview.
+5. Run page, API, and authenticated screenshot checks against each preview.
 6. Move one custom domain at a time.
 7. Remove that host from the old multi-host deployment only after its new project is healthy.
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,7 +1,9 @@
 # Apps
 
 Deployable Next.js entrypoints for product brands that share `@optimitron/db`.
-**`packages/web` remains the main optimitron multi-site product.**
+**`apps/warondisease` is the canonical War on Disease campaign app.**
+`packages/web` owns Optimitron and remains a temporary multi-host fallback until
+each standalone app passes preview checks and its domain moves.
 
 **Landing this work:** one tip branch/PR into `main` (not a stack of per-app PRs). Shared shell lives in `@optimitron/site-kit`; apps stay thin wrappers.
 
@@ -9,7 +11,7 @@ Deployable Next.js entrypoints for product brands that share `@optimitron/db`.
 
 | App | Port | Domain | Owns |
 |-----|------|--------|------|
-| `@apps/warondisease` | 3010 | warondisease.org | Campaign: home, **full** dashboard (referrals/scores/badges), soldiers, orgs, institutes |
+| `@apps/warondisease` | 3010 | warondisease.org | Canonical campaign home and **full neobrutalist dashboard** (referrals/scores/badges), orgs, institutes |
 | `@apps/dfda` | 3011 | dfda.earth | Clinical encyclopedia |
 | `@apps/wishocracy` | 3013 | wishocracy.org | Wishocracy **allocations only** (pairbars + edit) — not the WoD campaign dashboard |
 | `@apps/trialabundancesurvey` | 3014 | trialabundancesurvey.org | **Survey host** + `/embed` + lite participant home + `embed.js` |
@@ -19,6 +21,10 @@ Deployable Next.js entrypoints for product brands that share `@optimitron/db`.
 Architecture decisions (host vs campaign, email, embeds): **`SURVEY-AND-SATELLITES.md`**.
 
 Satellite apps should stay thin: routes + brand `public/` + config. Shared UI/lib lives in `@optimitron/site-kit` / `neobrutalist-ui` / `impact-params` / `survey-embed`. Do not re-copy chart dumps, email templates, or campaign tests into satellites.
+
+War on Disease is the campaign exception: keep its rich home and dashboard fun,
+colorful, and neobrutalist. Do not replace that dashboard with the treaty-paper
+dashboard from `packages/web`.
 
 ## Shared packages
 
@@ -69,12 +75,17 @@ Partner snippet (after survey is deployed):
 
 Job **`site-apps-validate`** (on `apps/**` / `packages/db` changes):
 
-1. migrate + `prisma generate`
-2. **`pnpm typecheck:apps`** — all six `@apps/*`
-3. **`pnpm smoke:warondisease-db`** — ReferendumVote path
-4. **`pnpm test:apps:unit`** — vitest unit suites (not `tests/integration/`; not Playwright)
+1. verify public navigation and authenticated screenshot coverage
+2. migrate + `prisma generate`
+3. **`pnpm typecheck:apps`** — all six `@apps/*`
+4. **`pnpm smoke:warondisease-db`** — ReferendumVote path
+5. **`pnpm test:apps:unit`** — vitest unit suites (not `tests/integration/`; not Playwright)
+6. build every app and capture public and authenticated desktop/mobile states
 
-`packages/web` still has **web-static-validate**, **web-e2e-validate**, and deploy smoke. Brand production deploys are not CI-gated yet.
+The authenticated route inventory fails when a dashboard, admin, profile, or
+other auth-gated page lacks screenshots or a documented no-UI exemption.
+`packages/web` still has **web-static-validate**, **web-e2e-validate**, and deploy smoke.
+Standalone production deploys remain a separate cutover step.
 
 Local:
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -73,14 +73,17 @@ Partner snippet (after survey is deployed):
 
 ## CI
 
-Job **`site-apps-validate`** (on `apps/**` / `packages/db` changes):
+Job **`site-apps-static-validate`** (on `apps/**` / `packages/db` changes):
 
 1. verify public navigation and authenticated screenshot coverage
 2. migrate + `prisma generate`
 3. **`pnpm typecheck:apps`** — all six `@apps/*`
 4. **`pnpm smoke:warondisease-db`** — ReferendumVote path
 5. **`pnpm test:apps:unit`** — vitest unit suites (not `tests/integration/`; not Playwright)
-6. build every app and capture public and authenticated desktop/mobile states
+
+Job **`site-apps-build`**:
+
+1. build every app and capture public and authenticated desktop/mobile states
 
 The authenticated route inventory fails when a dashboard, admin, profile, or
 other auth-gated page lacks screenshots or a documented no-UI exemption.

--- a/apps/warondisease/app/admin/organizations/admin-organizations-client.tsx
+++ b/apps/warondisease/app/admin/organizations/admin-organizations-client.tsx
@@ -175,6 +175,56 @@ export function AdminOrganizationsClient({
     )
   }
 
+  const renderActions = (org: Organization) => (
+    <div className="flex flex-wrap gap-2">
+      {org.slug && (
+        <Link href={`/organizations/${org.slug}`}>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 border-2 border-primary font-bold"
+          >
+            Manage
+          </Button>
+        </Link>
+      )}
+      {org.status === OrgStatus.PENDING && (
+        <>
+          <Button
+            aria-label={`Approve ${org.name}`}
+            onClick={() => handleStatusChange(org.id, OrgStatus.APPROVED)}
+            disabled={isUpdating === org.id}
+            size="sm"
+            className="h-8 border-2 border-primary bg-brutal-cyan font-bold text-foreground hover:bg-brutal-cyan/80"
+          >
+            <CheckCircle className="h-3 w-3" />
+          </Button>
+          <Button
+            aria-label={`Reject ${org.name}`}
+            onClick={() => handleStatusChange(org.id, OrgStatus.REJECTED)}
+            disabled={isUpdating === org.id}
+            size="sm"
+            className="h-8 border-2 border-primary bg-brutal-pink font-bold text-foreground hover:bg-brutal-pink/80"
+          >
+            <XCircle className="h-3 w-3" />
+          </Button>
+        </>
+      )}
+      {org.status === OrgStatus.APPROVED && org.slug && (
+        <Link href={`/survey/${org.slug}`} target="_blank">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 border-2 border-primary font-bold"
+            title="View survey page"
+          >
+            <ExternalLink className="h-3 w-3" />
+          </Button>
+        </Link>
+      )}
+    </div>
+  )
+
   return (
     <div className="min-h-screen bg-background">
       <div className="container max-w-7xl mx-auto py-8 px-4">
@@ -251,9 +301,48 @@ export function AdminOrganizationsClient({
           </div>
         </div>
 
-        {/* Table */}
-        <Card className="border-4 border-primary p-0 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] overflow-x-auto">
-          <table className="w-full text-sm">
+        {/* Mobile cards + desktop table */}
+        <Card className="overflow-hidden border-4 border-primary p-0 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+          <div className="divide-y-2 divide-primary md:hidden">
+            {sortedAndFiltered.length === 0 ? (
+              <div className="px-4 py-12 text-center font-bold text-muted-foreground">
+                No organizations found
+              </div>
+            ) : (
+              sortedAndFiltered.map((org) => (
+                <article key={org.id} className="space-y-4 p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <h2 className="font-black">{org.name}</h2>
+                      {org.slug && (
+                        <div className="truncate font-mono text-[11px] text-muted-foreground">
+                          {getSiteConfig().domain}/survey/{org.slug}
+                        </div>
+                      )}
+                    </div>
+                    <StatusBadge status={org.status} />
+                  </div>
+                  <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+                    <div>
+                      <dt className="text-[10px] font-black uppercase text-muted-foreground">Type</dt>
+                      <dd className="font-bold">{org.type || "—"}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-[10px] font-black uppercase text-muted-foreground">Applied</dt>
+                      <dd className="font-bold">{formatDate(org.createdAt)}</dd>
+                    </div>
+                    <div className="col-span-2">
+                      <dt className="text-[10px] font-black uppercase text-muted-foreground">Contact</dt>
+                      <dd className="break-all font-bold">{org.contactEmail || "—"}</dd>
+                    </div>
+                  </dl>
+                  {renderActions(org)}
+                </article>
+              ))
+            )}
+          </div>
+
+          <table className="hidden w-full text-sm md:table">
             <thead className="bg-foreground text-background">
               <tr>
                 <th className="text-left px-3 py-3"><SortHeader label="Name" k="name" /></th>
@@ -291,49 +380,7 @@ export function AdminOrganizationsClient({
                       {formatDate(org.createdAt)}
                     </td>
                     <td className="px-3 py-3 align-top">
-                      <div className="flex flex-wrap gap-1">
-                        <Link href={`/admin/organizations/${org.id}`}>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="border-2 border-primary font-bold h-8"
-                          >
-                            View
-                          </Button>
-                        </Link>
-                        {org.status === OrgStatus.PENDING && (
-                          <>
-                            <Button
-                              onClick={() => handleStatusChange(org.id, OrgStatus.APPROVED)}
-                              disabled={isUpdating === org.id}
-                              size="sm"
-                              className="bg-brutal-cyan text-foreground border-2 border-primary font-bold hover:bg-brutal-cyan/80 h-8"
-                            >
-                              <CheckCircle className="h-3 w-3" />
-                            </Button>
-                            <Button
-                              onClick={() => handleStatusChange(org.id, OrgStatus.REJECTED)}
-                              disabled={isUpdating === org.id}
-                              size="sm"
-                              className="bg-brutal-pink text-foreground border-2 border-primary font-bold hover:bg-brutal-pink/80 h-8"
-                            >
-                              <XCircle className="h-3 w-3" />
-                            </Button>
-                          </>
-                        )}
-                        {org.status === OrgStatus.APPROVED && org.slug && (
-                          <Link href={`/survey/${org.slug}`} target="_blank">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              className="border-2 border-primary font-bold h-8"
-                              title="View survey page"
-                            >
-                              <ExternalLink className="h-3 w-3" />
-                            </Button>
-                          </Link>
-                        )}
-                      </div>
+                      {renderActions(org)}
                     </td>
                   </tr>
                 ))

--- a/apps/warondisease/app/admin/organizations/admin-organizations-client.tsx
+++ b/apps/warondisease/app/admin/organizations/admin-organizations-client.tsx
@@ -303,7 +303,45 @@ export function AdminOrganizationsClient({
 
         {/* Mobile cards + desktop table */}
         <Card className="overflow-hidden border-4 border-primary p-0 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-          <div className="divide-y-2 divide-primary md:hidden">
+          <div className="flex items-end gap-2 border-b-2 border-primary bg-brutal-yellow p-3 lg:hidden">
+            <label className="flex min-w-0 flex-1 flex-col gap-1 text-[10px] font-black uppercase">
+              Sort organizations
+              <select
+                value={sortKey}
+                onChange={(event) => {
+                  setSortKey(event.target.value as SortKey)
+                  setSortDir("asc")
+                }}
+                className="h-9 w-full border-2 border-primary bg-background px-2 text-sm font-bold normal-case"
+              >
+                <option value="name">Name</option>
+                <option value="status">Status</option>
+                <option value="type">Type</option>
+                <option value="contactEmail">Contact</option>
+                <option value="createdAt">Applied</option>
+              </select>
+            </label>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              aria-label={`Sort ${sortDir === "asc" ? "descending" : "ascending"}`}
+              title={`Sort ${sortDir === "asc" ? "descending" : "ascending"}`}
+              onClick={() =>
+                setSortDir((direction) =>
+                  direction === "asc" ? "desc" : "asc"
+                )
+              }
+              className="h-9 border-2 border-primary bg-background"
+            >
+              {sortDir === "asc" ? (
+                <ArrowUp className="h-4 w-4" />
+              ) : (
+                <ArrowDown className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+          <div className="divide-y-2 divide-primary lg:hidden">
             {sortedAndFiltered.length === 0 ? (
               <div className="px-4 py-12 text-center font-bold text-muted-foreground">
                 No organizations found
@@ -342,7 +380,7 @@ export function AdminOrganizationsClient({
             )}
           </div>
 
-          <table className="hidden w-full text-sm md:table">
+          <table className="hidden w-full text-sm lg:table">
             <thead className="bg-foreground text-background">
               <tr>
                 <th className="text-left px-3 py-3"><SortHeader label="Name" k="name" /></th>

--- a/apps/warondisease/app/admin/page-scorecard/page.tsx
+++ b/apps/warondisease/app/admin/page-scorecard/page.tsx
@@ -152,7 +152,7 @@ export default async function PageScorecardPage() {
 
         {/* Mobile cards + desktop table */}
         <Card className="overflow-hidden border-4 border-primary bg-background p-0 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-          <div className="divide-y-2 divide-primary md:hidden">
+          <div className="divide-y-2 divide-primary lg:hidden">
             {rows.length === 0 && (
               <div className="px-4 py-8 text-center font-bold text-muted-foreground">
                 No data yet. Run the migration and wait for conversions.
@@ -207,7 +207,7 @@ export default async function PageScorecardPage() {
             })}
           </div>
 
-          <table className="hidden w-full text-sm md:table">
+          <table className="hidden w-full text-sm lg:table">
             <thead className="bg-foreground text-background">
               <tr>
                 <th className="text-left px-4 py-3 font-black uppercase">Source URL</th>

--- a/apps/warondisease/app/admin/page-scorecard/page.tsx
+++ b/apps/warondisease/app/admin/page-scorecard/page.tsx
@@ -150,9 +150,64 @@ export default async function PageScorecardPage() {
           </Card>
         </div>
 
-        {/* Table */}
-        <Card className="bg-background border-4 border-primary p-0 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] overflow-x-auto">
-          <table className="w-full text-sm">
+        {/* Mobile cards + desktop table */}
+        <Card className="overflow-hidden border-4 border-primary bg-background p-0 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+          <div className="divide-y-2 divide-primary md:hidden">
+            {rows.length === 0 && (
+              <div className="px-4 py-8 text-center font-bold text-muted-foreground">
+                No data yet. Run the migration and wait for conversions.
+              </div>
+            )}
+            {rows.map((row, i) => {
+              const yesPct = row.votes > 0 ? (row.yesVotes / row.votes) * 100 : 0
+              return (
+                <article key={i} className="space-y-4 p-4">
+                  <div>
+                    <div className="text-[10px] font-black uppercase text-muted-foreground">
+                      Source URL
+                    </div>
+                    <div className="break-all font-mono text-xs">
+                      {row.sourceUrl ?? <em className="opacity-60">(null)</em>}
+                    </div>
+                  </div>
+                  <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+                    <div>
+                      <dt className="text-[10px] font-black uppercase text-muted-foreground">Votes</dt>
+                      <dd className="font-black">{row.votes.toLocaleString()}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-[10px] font-black uppercase text-muted-foreground">Yes</dt>
+                      <dd className="font-bold">{row.votes > 0 ? `${yesPct.toFixed(0)}%` : "—"}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-[10px] font-black uppercase text-muted-foreground">Average military allocation</dt>
+                      <dd className="font-bold">
+                        {row.avgAllocation !== null ? `${row.avgAllocation.toFixed(0)}%` : "—"}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-[10px] font-black uppercase text-muted-foreground">Donations</dt>
+                      <dd className="font-bold">
+                        {row.donations > 0
+                          ? `${row.donations} (${formatDollars(row.donationAmountCents)})`
+                          : "—"}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-[10px] font-black uppercase text-muted-foreground">Pledges</dt>
+                      <dd className="font-bold">
+                        {row.pledges > 0
+                          ? `${row.pledges} (${formatDollars(row.pledgeAmountCents)})`
+                          : "—"}
+                      </dd>
+                    </div>
+                  </dl>
+                </article>
+              )
+            })}
+          </div>
+
+          <table className="hidden w-full text-sm md:table">
             <thead className="bg-foreground text-background">
               <tr>
                 <th className="text-left px-4 py-3 font-black uppercase">Source URL</th>

--- a/apps/warondisease/app/admin/users/admin-users-client.tsx
+++ b/apps/warondisease/app/admin/users/admin-users-client.tsx
@@ -174,6 +174,53 @@ export function AdminUsersClient({
     )
   }
 
+  const renderActions = (user: AdminUser, isCurrentAdmin: boolean) => (
+    <div className="flex flex-wrap gap-2">
+      {user.username && user.isPublic && (
+        <Link
+          href={buildRoute.userProfile(user.username)}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 border-2 border-primary font-bold"
+            title="View public profile"
+          >
+            <ExternalLink className="h-3 w-3" />
+          </Button>
+        </Link>
+      )}
+      <Button
+        onClick={() => handleAdminChange(user.id, !user.isAdmin)}
+        disabled={isUpdating === user.id || isCurrentAdmin}
+        size="sm"
+        className={cn(
+          "h-8 border-2 border-primary text-xs font-bold",
+          user.isAdmin
+            ? "bg-brutal-pink text-foreground hover:bg-brutal-pink/80"
+            : "bg-brutal-cyan text-foreground hover:bg-brutal-cyan/80"
+        )}
+        title={
+          isCurrentAdmin
+            ? "You can't change your own admin status"
+            : user.isAdmin
+            ? "Remove admin"
+            : "Make admin"
+        }
+      >
+        {isCurrentAdmin
+          ? "You"
+          : isUpdating === user.id
+          ? "…"
+          : user.isAdmin
+          ? "Demote"
+          : "Promote"}
+      </Button>
+    </div>
+  )
+
   return (
     <div className="min-h-screen bg-background">
       <div className="container max-w-7xl mx-auto py-8 px-4">
@@ -241,9 +288,61 @@ export function AdminUsersClient({
           </div>
         </div>
 
-        {/* Table */}
-        <Card className="border-4 border-primary p-0 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] overflow-x-auto">
-          <table className="w-full text-sm">
+        {/* Mobile cards + desktop table */}
+        <Card className="overflow-hidden border-4 border-primary p-0 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+          <div className="divide-y-2 divide-primary md:hidden">
+            {sortedAndFiltered.length === 0 ? (
+              <div className="px-4 py-12 text-center font-bold text-muted-foreground">
+                No users found
+              </div>
+            ) : (
+              sortedAndFiltered.map((user) => {
+                const displayName = user.name || user.username || user.email.split("@")[0]
+                const isCurrentAdmin = user.id === currentAdminId
+                return (
+                  <article key={user.id} className="space-y-4 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <h2 className="font-black">{displayName}</h2>
+                        {user.username && (
+                          <div className="font-mono text-[11px] text-muted-foreground">
+                            @{user.username}
+                          </div>
+                        )}
+                      </div>
+                      {user.isAdmin && (
+                        <Badge className="border-2 border-primary bg-brutal-cyan text-[10px] font-black">
+                          <ShieldCheck className="mr-0.5 h-2.5 w-2.5" /> ADMIN
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="break-all text-sm font-bold">{user.email}</div>
+                    <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+                      <div>
+                        <dt className="text-[10px] font-black uppercase text-muted-foreground">Verified</dt>
+                        <dd className="font-bold">{user.emailVerified ? "Yes" : "No"}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-[10px] font-black uppercase text-muted-foreground">Joined</dt>
+                        <dd className="font-bold">{formatDate(user.createdAt)}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-[10px] font-black uppercase text-muted-foreground">Organization</dt>
+                        <dd className="font-bold">{user.organization?.name || "—"}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-[10px] font-black uppercase text-muted-foreground">Organizations created</dt>
+                        <dd className="font-bold">{user._count.createdOrganizations}</dd>
+                      </div>
+                    </dl>
+                    {renderActions(user, isCurrentAdmin)}
+                  </article>
+                )
+              })
+            )}
+          </div>
+
+          <table className="hidden w-full text-sm md:table">
             <thead className="bg-foreground text-background">
               <tr>
                 <th className="text-left px-3 py-3"><SortHeader label="Name" k="name" /></th>
@@ -316,50 +415,7 @@ export function AdminUsersClient({
                         {formatDate(user.createdAt)}
                       </td>
                       <td className="px-3 py-3 align-top">
-                        <div className="flex flex-wrap gap-1">
-                          {user.username && user.isPublic && (
-                            <Link
-                              href={buildRoute.userProfile(user.username)}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                className="border-2 border-primary font-bold h-8"
-                                title="View public profile"
-                              >
-                                <ExternalLink className="h-3 w-3" />
-                              </Button>
-                            </Link>
-                          )}
-                          <Button
-                            onClick={() => handleAdminChange(user.id, !user.isAdmin)}
-                            disabled={isUpdating === user.id || isCurrentAdmin}
-                            size="sm"
-                            className={cn(
-                              "border-2 border-primary font-bold h-8 text-xs",
-                              user.isAdmin
-                                ? "bg-brutal-pink text-foreground hover:bg-brutal-pink/80"
-                                : "bg-brutal-cyan text-foreground hover:bg-brutal-cyan/80"
-                            )}
-                            title={
-                              isCurrentAdmin
-                                ? "You can't change your own admin status"
-                                : user.isAdmin
-                                ? "Remove admin"
-                                : "Make admin"
-                            }
-                          >
-                            {isCurrentAdmin
-                              ? "You"
-                              : isUpdating === user.id
-                              ? "…"
-                              : user.isAdmin
-                              ? "Demote"
-                              : "Promote"}
-                          </Button>
-                        </div>
+                        {renderActions(user, isCurrentAdmin)}
                       </td>
                     </tr>
                   )

--- a/apps/warondisease/app/admin/users/admin-users-client.tsx
+++ b/apps/warondisease/app/admin/users/admin-users-client.tsx
@@ -290,7 +290,46 @@ export function AdminUsersClient({
 
         {/* Mobile cards + desktop table */}
         <Card className="overflow-hidden border-4 border-primary p-0 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-          <div className="divide-y-2 divide-primary md:hidden">
+          <div className="flex items-end gap-2 border-b-2 border-primary bg-brutal-yellow p-3 lg:hidden">
+            <label className="flex min-w-0 flex-1 flex-col gap-1 text-[10px] font-black uppercase">
+              Sort users
+              <select
+                value={sortKey}
+                onChange={(event) => {
+                  setSortKey(event.target.value as SortKey)
+                  setSortDir("asc")
+                }}
+                className="h-9 w-full border-2 border-primary bg-background px-2 text-sm font-bold normal-case"
+              >
+                <option value="name">Name</option>
+                <option value="email">Email</option>
+                <option value="organization">Organization</option>
+                <option value="verified">Verified</option>
+                <option value="orgsCreated">Organizations created</option>
+                <option value="createdAt">Joined</option>
+              </select>
+            </label>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              aria-label={`Sort ${sortDir === "asc" ? "descending" : "ascending"}`}
+              title={`Sort ${sortDir === "asc" ? "descending" : "ascending"}`}
+              onClick={() =>
+                setSortDir((direction) =>
+                  direction === "asc" ? "desc" : "asc"
+                )
+              }
+              className="h-9 border-2 border-primary bg-background"
+            >
+              {sortDir === "asc" ? (
+                <ArrowUp className="h-4 w-4" />
+              ) : (
+                <ArrowDown className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+          <div className="divide-y-2 divide-primary lg:hidden">
             {sortedAndFiltered.length === 0 ? (
               <div className="px-4 py-12 text-center font-bold text-muted-foreground">
                 No users found
@@ -342,7 +381,7 @@ export function AdminUsersClient({
             )}
           </div>
 
-          <table className="hidden w-full text-sm md:table">
+          <table className="hidden w-full text-sm lg:table">
             <thead className="bg-foreground text-background">
               <tr>
                 <th className="text-left px-3 py-3"><SortHeader label="Name" k="name" /></th>

--- a/apps/warondisease/app/send/page.tsx
+++ b/apps/warondisease/app/send/page.tsx
@@ -3,6 +3,7 @@ import Layout from "@/components/layout"
 import { Container } from "@/components/ui/container"
 import { SendReferralInvitationClient } from "./send-referral-invitation-client"
 
+// visual-auth-state: required
 export const metadata: Metadata = {
   title: "Send One More",
   description: "Send one more 1% Treaty invitation.",

--- a/docs/SYSTEM_MAP.md
+++ b/docs/SYSTEM_MAP.md
@@ -80,7 +80,9 @@ queue.
 |---|---|---|
 | Database contract | `packages/db/prisma/schema.prisma` | Canonical models, enums, relations, indexes. |
 | Generated DB types | `packages/db/src/generated` and `@optimitron/db` exports | Prisma client for web only; pure types and validators for consumers. |
-| Web/API/MCP | `packages/web` | Next.js UI, REST, OAuth, MCP, authorization, server workflows. |
+| Optimitron Web/API/MCP | `packages/web` | `optimitron.com` UI, REST, OAuth, MCP, authorization, server workflows, and temporary legacy host variants during cutover. |
+| War on Disease campaign | `apps/warondisease` | Canonical rich campaign home and neobrutalist authenticated dashboard. |
+| Satellite sites | `apps/dfda`, `apps/wishocracy`, `apps/trialabundancesurvey`, `apps/curedao`, `apps/acceleratedmedicine` | Brand-specific deployable entrypoints over shared packages. |
 | Optimizer | `packages/optimizer` | Domain-agnostic causal and expected-value algorithms. No database runtime. |
 | Data | `packages/data` | Parameters, datasets, and importers. No database runtime. |
 | OPG/OBG/Wishocracy | `packages/opg`, `packages/obg`, `packages/wishocracy` | Domain engines above optimizer. |

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "db:test": "pnpm --filter @optimitron/db run test:integration",
     "db:push": "pnpm --filter @optimitron/db run prisma:push",
     "db:sync:managed-data": "node scripts/sync-managed-data.mjs",
+    "db:seed:site-app-visual": "pnpm --filter @optimitron/db exec tsx scripts/seed-site-app-visual-fixtures.ts",
     "audit:schema-usage": "pnpm --filter @optimitron/db run audit:schema-usage",
     "db:up": "docker compose up -d --wait postgres",
     "db:setup": "pnpm db:up && pnpm db:deploy && pnpm db:generate && pnpm db:sync:managed-data -- --apply",

--- a/packages/db/scripts/seed-site-app-visual-fixtures.ts
+++ b/packages/db/scripts/seed-site-app-visual-fixtures.ts
@@ -1,6 +1,8 @@
 import { PrismaPg } from "@prisma/adapter-pg";
+import { DEMO_ORGANIZATION_SLUG } from "@optimitron/data/campaign";
 import { TREATY_REFERENDUM_SLUG } from "../src/constants.js";
 import {
+  OrganizationMemberRole,
   PrismaClient,
   ReferendumVoteSource,
   VotePosition,
@@ -37,7 +39,17 @@ try {
   const [user, referendum] = await Promise.all([
     prisma.user.findUniqueOrThrow({
       where: { email: DEMO_EMAIL },
-      select: { id: true, personId: true },
+      select: {
+        id: true,
+        organizationMemberships: {
+          where: {
+            organization: { slug: DEMO_ORGANIZATION_SLUG },
+            role: OrganizationMemberRole.OWNER,
+          },
+          select: { id: true },
+        },
+        personId: true,
+      },
     }),
     prisma.referendum.findUniqueOrThrow({
       where: { slug: TREATY_REFERENDUM_SLUG },
@@ -47,6 +59,11 @@ try {
 
   if (!user.personId) {
     throw new Error("Managed demo user must have a Person before visual capture.");
+  }
+  if (user.organizationMemberships.length !== 1) {
+    throw new Error(
+      "Managed demo user must own the demo organization before visual capture.",
+    );
   }
 
   await prisma.$transaction([

--- a/packages/db/scripts/seed-site-app-visual-fixtures.ts
+++ b/packages/db/scripts/seed-site-app-visual-fixtures.ts
@@ -1,0 +1,85 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { TREATY_REFERENDUM_SLUG } from "../src/constants.js";
+import {
+  PrismaClient,
+  ReferendumVoteSource,
+  VotePosition,
+} from "../src/generated/prisma/client.js";
+import { DEMO_EMAIL } from "../src/managed-data/managed-demo-user.js";
+
+function assertLocalVisualFixtureTarget(connectionString: string) {
+  if (process.env.SITE_APP_VISUAL_FIXTURES !== "1") {
+    throw new Error(
+      "Refusing to write visual fixtures without SITE_APP_VISUAL_FIXTURES=1.",
+    );
+  }
+
+  const hostname = new URL(connectionString).hostname.toLowerCase();
+  if (!["localhost", "127.0.0.1", "::1", "postgres"].includes(hostname)) {
+    throw new Error(
+      `Refusing to write visual fixtures to non-local database host ${hostname}.`,
+    );
+  }
+}
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error("DATABASE_URL is required.");
+}
+
+assertLocalVisualFixtureTarget(connectionString);
+
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString }),
+});
+
+try {
+  const [user, referendum] = await Promise.all([
+    prisma.user.findUniqueOrThrow({
+      where: { email: DEMO_EMAIL },
+      select: { id: true, personId: true },
+    }),
+    prisma.referendum.findUniqueOrThrow({
+      where: { slug: TREATY_REFERENDUM_SLUG },
+      select: { id: true },
+    }),
+  ]);
+
+  if (!user.personId) {
+    throw new Error("Managed demo user must have a Person before visual capture.");
+  }
+
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id: user.id },
+      data: { isAdmin: true },
+    }),
+    prisma.referendumVote.upsert({
+      where: {
+        referendumId_personId: {
+          referendumId: referendum.id,
+          personId: user.personId,
+        },
+      },
+      update: {
+        answer: VotePosition.YES,
+        deletedAt: null,
+        isPublic: false,
+        voteSource: ReferendumVoteSource.SELF,
+      },
+      create: {
+        answer: VotePosition.YES,
+        isPublic: false,
+        originUrl: "http://127.0.0.1/site-app-visual-fixture",
+        personId: user.personId,
+        referendumId: referendum.id,
+        userId: user.id,
+        voteSource: ReferendumVoteSource.SELF,
+      },
+    }),
+  ]);
+
+  console.log("Prepared local authenticated site-app visual fixtures.");
+} finally {
+  await prisma.$disconnect();
+}

--- a/packages/web/e2e/utils/auth-api.mjs
+++ b/packages/web/e2e/utils/auth-api.mjs
@@ -1,0 +1,32 @@
+export const DEMO_EMAIL = "demo@thinkbynumbers.org";
+export const DEMO_PASSWORD = "demo1234";
+
+export async function signInViaApi(request, credentials = {}) {
+  const email = credentials.email ?? DEMO_EMAIL;
+  const password = credentials.password ?? DEMO_PASSWORD;
+  const csrfResponse = await request.get("/api/auth/csrf");
+  if (csrfResponse.status() >= 500) {
+    return false;
+  }
+
+  const { csrfToken } = await csrfResponse.json();
+  const signInResponse = await request.post("/api/auth/callback/credentials", {
+    form: {
+      email,
+      password,
+      csrfToken,
+      json: "true",
+    },
+  });
+
+  if (signInResponse.status() >= 400) {
+    return false;
+  }
+
+  const sessionResponse = await request.get("/api/auth/session");
+  if (sessionResponse.status() >= 400) {
+    return false;
+  }
+  const session = await sessionResponse.json();
+  return Boolean(session.user?.id);
+}

--- a/packages/web/e2e/utils/auth.ts
+++ b/packages/web/e2e/utils/auth.ts
@@ -1,7 +1,11 @@
 import type { APIRequestContext, Page } from "@playwright/test";
+import {
+  DEMO_EMAIL,
+  DEMO_PASSWORD,
+  signInViaApi as signInViaApiRuntime,
+} from "./auth-api.mjs";
 
-export const DEMO_EMAIL = "demo@thinkbynumbers.org";
-export const DEMO_PASSWORD = "demo1234";
+export { DEMO_EMAIL, DEMO_PASSWORD };
 
 export interface TestCredentials {
   email?: string;
@@ -12,41 +16,7 @@ export async function signInViaApi(
   request: APIRequestContext,
   credentials: TestCredentials = {},
 ): Promise<boolean> {
-  const email = credentials.email ?? DEMO_EMAIL;
-  const password = credentials.password ?? DEMO_PASSWORD;
-  const csrfResponse = await request.get("/api/auth/csrf");
-  if (csrfResponse.status() >= 500) {
-    return false;
-  }
-
-  const { csrfToken } = (await csrfResponse.json()) as { csrfToken: string };
-
-  const signInResponse = await request.post(
-    "/api/auth/callback/credentials",
-    {
-      form: {
-        email,
-        password,
-        csrfToken,
-        json: "true",
-      },
-    },
-  );
-
-  if (signInResponse.status() >= 400) {
-    return false;
-  }
-
-  // Credentials can return 200 while the session cookie is still missing
-  // (wrong host / CSRF reuse). Confirm the browser context is actually signed in.
-  const sessionResponse = await request.get("/api/auth/session");
-  if (sessionResponse.status() >= 400) {
-    return false;
-  }
-  const session = (await sessionResponse.json()) as {
-    user?: { id?: string | null } | null;
-  };
-  return Boolean(session.user?.id);
+  return signInViaApiRuntime(request, credentials);
 }
 
 export async function signInUser(

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,7 +26,7 @@
     "typecheck:app": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit --project tsconfig.next.json",
     "typecheck:tests": "cross-env NODE_OPTIONS=--max-old-space-size=6144 tsc --noEmit --project tsconfig.tests.json",
     "typecheck:full": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit",
-    "test": "node --test scripts/visual-review-coverage.test.mjs && pnpm exec vitest run",
+    "test": "node --test scripts/visual-review-coverage.test.mjs && pnpm exec vitest run --maxWorkers=4 --minWorkers=1",
     "generate": "tsx scripts/generate-web-data.ts",
     "fetch": "tsx scripts/fetch-and-generate.ts",
     "causal": "tsx scripts/generate-causal-reports.ts",

--- a/packages/web/scripts/build-visual-review.mjs
+++ b/packages/web/scripts/build-visual-review.mjs
@@ -1705,6 +1705,9 @@ function loadSiteAppRouteManifests() {
             typeof route.routePath === "string",
         )
         .map((route) => ({
+          authenticated: route.authenticated === true,
+          authRole:
+            typeof route.authRole === "string" ? route.authRole : null,
           covers: Array.isArray(route.covers)
             ? route.covers.filter((filePath) => typeof filePath === "string")
             : [],
@@ -1732,7 +1735,8 @@ function registerSiteAppRouteSpecs(specs, paths, manifests) {
       const name = `site-app-${siteVariant}-${route.routeName}`;
       specs.set(name, {
         activationSelector: "body",
-        authenticated: false,
+        authenticated: route.authenticated,
+        authRole: route.authRole,
         covers: route.covers,
         path: route.routePath,
         required: true,

--- a/scripts/site-app-navigation.test.ts
+++ b/scripts/site-app-navigation.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -14,6 +14,30 @@ const repoRoot = path.resolve(
   "..",
 );
 const pageExtensions = ["tsx", "ts", "jsx", "js"];
+
+function normalizePath(filePath: string) {
+  return filePath.split(path.sep).join("/");
+}
+
+function listPageFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return listPageFiles(entryPath);
+    return /^page\.(?:tsx|ts|jsx|js)$/.test(entry.name) ? [entryPath] : [];
+  });
+}
+
+function isAuthenticatedPage(filePath: string) {
+  const normalized = normalizePath(path.relative(repoRoot, filePath));
+  if (/^apps\/[^/]+\/app\/(?:admin|dashboard|profile)(?:\/|$)/.test(normalized)) {
+    return true;
+  }
+
+  const source = readFileSync(filePath, "utf8");
+  return /\b(?:requireAdmin|requireAuth|requireOrganizationAccess|requireUser|getCurrentUser)\s*\(/.test(
+    source,
+  );
+}
 
 test("every internal site-app navigation route has a Next.js page", async (t) => {
   const { getInternalNavigationRoutesForVariant, VARIANTS } = await import(
@@ -54,4 +78,62 @@ test("every internal site-app navigation route has a Next.js page", async (t) =>
       }
     });
   }
+});
+
+test("every authenticated site-app page has visual coverage or a documented exemption", async () => {
+  const {
+    authenticatedSiteAppRouteExemptions,
+    authenticatedSiteAppRoutes,
+  } = await import("./site-app-visual-routes.mjs");
+
+  const declaredPages = new Set<string>();
+  const routeNames = new Set<string>();
+
+  for (const [appName, routes] of Object.entries(authenticatedSiteAppRoutes)) {
+    assert.ok(routes.length > 0, `${appName} must declare at least one authenticated route`);
+    for (const route of routes) {
+      assert.equal(route.authenticated, true, `${appName}:${route.routeName} must be authenticated`);
+      assert.ok(route.authRole, `${appName}:${route.routeName} must name its auth role`);
+      assert.ok(route.routePath.startsWith("/"), `${appName}:${route.routeName} must use an absolute route path`);
+      assert.ok(route.sourcePage, `${appName}:${route.routeName} must name its source page`);
+      assert.ok(route.covers.includes(route.sourcePage), `${appName}:${route.routeName} must cover its source page`);
+      assert.ok(
+        existsSync(path.join(repoRoot, route.sourcePage)),
+        `${appName}:${route.routeName} references missing page ${route.sourcePage}`,
+      );
+
+      const uniqueRouteName = `${appName}:${route.routeName}`;
+      assert.ok(!routeNames.has(uniqueRouteName), `Duplicate visual route ${uniqueRouteName}`);
+      routeNames.add(uniqueRouteName);
+      declaredPages.add(route.sourcePage);
+    }
+  }
+
+  const exemptPages = new Set<string>();
+  for (const exemption of authenticatedSiteAppRouteExemptions) {
+    assert.ok(exemption.reason?.trim(), `${exemption.sourcePage} needs an exemption reason`);
+    assert.ok(
+      existsSync(path.join(repoRoot, exemption.sourcePage)),
+      `Exemption references missing page ${exemption.sourcePage}`,
+    );
+    exemptPages.add(exemption.sourcePage);
+  }
+
+  const authenticatedPages = readdirSync(path.join(repoRoot, "apps"), {
+    withFileTypes: true,
+  })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => listPageFiles(path.join(repoRoot, "apps", entry.name, "app")))
+    .filter(isAuthenticatedPage)
+    .map((filePath) => normalizePath(path.relative(repoRoot, filePath)))
+    .sort();
+
+  const missing = authenticatedPages.filter(
+    (filePath) => !declaredPages.has(filePath) && !exemptPages.has(filePath),
+  );
+  assert.deepEqual(
+    missing,
+    [],
+    `Authenticated pages need desktop/mobile screenshots or an exemption:\n${missing.join("\n")}`,
+  );
 });

--- a/scripts/site-app-navigation.test.ts
+++ b/scripts/site-app-navigation.test.ts
@@ -34,8 +34,10 @@ function isAuthenticatedPage(filePath: string) {
   }
 
   const source = readFileSync(filePath, "utf8");
-  return /\b(?:requireAdmin|requireAuth|requireOrganizationAccess|requireUser|getCurrentUser)\s*\(/.test(
-    source,
+  return (
+    /\b(?:requireAdmin|requireAuth|requireOrganizationAccess|requireUser|getCurrentUser)\s*\(/.test(
+      source,
+    ) || /\/\/\s*visual-auth-state:\s*required\b/.test(source)
   );
 }
 
@@ -100,6 +102,10 @@ test("every authenticated site-app page has visual coverage or a documented exem
       assert.ok(
         existsSync(path.join(repoRoot, route.sourcePage)),
         `${appName}:${route.routeName} references missing page ${route.sourcePage}`,
+      );
+      assert.ok(
+        isAuthenticatedPage(path.join(repoRoot, route.sourcePage)),
+        `${appName}:${route.routeName} source page needs an independent auth guard or visual-auth-state marker`,
       );
 
       const uniqueRouteName = `${appName}:${route.routeName}`;

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -1,0 +1,149 @@
+const warOnDiseaseDashboardFiles = [
+  "packages/site-kit/src/components/dashboard/DashboardClient.tsx",
+  "packages/site-kit/src/components/dashboard/StatsOverview.tsx",
+  "packages/site-kit/src/components/dashboard/ProfileCard.tsx",
+  "packages/site-kit/src/components/dashboard/ReferralGoalCard.tsx",
+  "packages/site-kit/src/components/dashboard/ReferralInvitationsCard.tsx",
+  "packages/site-kit/src/components/dashboard/ImpactLedgerCard.tsx",
+  "packages/site-kit/src/components/dashboard/ImpactTreeCard.tsx",
+  "packages/site-kit/src/components/dashboard/OrganizationsCard.tsx",
+  "packages/site-kit/src/components/dashboard/StickyShareFooter.tsx",
+];
+
+export const authenticatedSiteAppRoutes = Object.freeze({
+  warondisease: [
+    {
+      authenticated: true,
+      authRole: "user",
+      covers: [
+        "apps/warondisease/app/dashboard/page.tsx",
+        "apps/warondisease/app/dashboard/dashboard-client.tsx",
+        ...warOnDiseaseDashboardFiles,
+      ],
+      label: "Campaign dashboard — signed-in user",
+      routeName: "dashboard-authenticated",
+      routePath: "/dashboard",
+      sourcePage: "apps/warondisease/app/dashboard/page.tsx",
+    },
+    {
+      authenticated: true,
+      authRole: "user",
+      covers: [
+        "apps/warondisease/app/dashboard/settings/page.tsx",
+        "apps/warondisease/app/dashboard/settings/settings-client.tsx",
+        "packages/site-kit/src/components/dashboard/SettingsClient.tsx",
+      ],
+      label: "Dashboard settings — signed-in user",
+      routeName: "dashboard-settings-authenticated",
+      routePath: "/dashboard/settings",
+      sourcePage: "apps/warondisease/app/dashboard/settings/page.tsx",
+    },
+    {
+      authenticated: true,
+      authRole: "user",
+      covers: [
+        "apps/warondisease/app/profile/edit/page.tsx",
+        "apps/warondisease/app/profile/edit/profile-edit-client.tsx",
+      ],
+      label: "Profile editor — signed-in user",
+      routeName: "profile-edit-authenticated",
+      routePath: "/profile/edit",
+      sourcePage: "apps/warondisease/app/profile/edit/page.tsx",
+    },
+    {
+      authenticated: true,
+      authRole: "organization-owner",
+      covers: ["apps/warondisease/app/organizations/[slug]/page.tsx"],
+      label: "Organization dashboard — signed-in owner",
+      routeName: "organization-dashboard-authenticated",
+      routePath: "/organizations/demo-organization",
+      sourcePage: "apps/warondisease/app/organizations/[slug]/page.tsx",
+    },
+    {
+      authenticated: true,
+      authRole: "user",
+      covers: [
+        "apps/warondisease/app/send/page.tsx",
+        "apps/warondisease/app/send/send-referral-invitation-client.tsx",
+      ],
+      label: "Send an invitation — signed-in user",
+      routeName: "send-authenticated",
+      routePath: "/send",
+      sourcePage: "apps/warondisease/app/send/page.tsx",
+    },
+    {
+      authenticated: true,
+      authRole: "admin",
+      covers: [
+        "apps/warondisease/app/admin/layout.tsx",
+        "apps/warondisease/app/admin/organizations/page.tsx",
+        "apps/warondisease/app/admin/organizations/admin-organizations-client.tsx",
+      ],
+      label: "Organizations — signed-in administrator",
+      routeName: "admin-organizations-authenticated",
+      routePath: "/admin/organizations",
+      sourcePage: "apps/warondisease/app/admin/organizations/page.tsx",
+    },
+    {
+      authenticated: true,
+      authRole: "admin",
+      covers: [
+        "apps/warondisease/app/admin/layout.tsx",
+        "apps/warondisease/app/admin/users/page.tsx",
+        "apps/warondisease/app/admin/users/admin-users-client.tsx",
+      ],
+      label: "Users — signed-in administrator",
+      routeName: "admin-users-authenticated",
+      routePath: "/admin/users",
+      sourcePage: "apps/warondisease/app/admin/users/page.tsx",
+    },
+    {
+      authenticated: true,
+      authRole: "admin",
+      covers: [
+        "apps/warondisease/app/admin/layout.tsx",
+        "apps/warondisease/app/admin/page-scorecard/page.tsx",
+      ],
+      label: "Page scorecard — signed-in administrator",
+      routeName: "admin-page-scorecard-authenticated",
+      routePath: "/admin/page-scorecard",
+      sourcePage: "apps/warondisease/app/admin/page-scorecard/page.tsx",
+    },
+  ],
+  wishocracy: [
+    {
+      authenticated: true,
+      authRole: "user",
+      covers: [
+        "apps/wishocracy/app/dashboard/page.tsx",
+        "apps/wishocracy/app/dashboard/dashboard-client.tsx",
+      ],
+      label: "Allocation dashboard — signed-in user",
+      routeName: "dashboard-authenticated",
+      routePath: "/dashboard",
+      sourcePage: "apps/wishocracy/app/dashboard/page.tsx",
+    },
+  ],
+  trialabundancesurvey: [
+    {
+      authenticated: true,
+      authRole: "user",
+      covers: ["apps/trialabundancesurvey/app/dashboard/page.tsx"],
+      label: "Survey dashboard — signed-in user",
+      routeName: "dashboard-authenticated",
+      routePath: "/dashboard",
+      sourcePage: "apps/trialabundancesurvey/app/dashboard/page.tsx",
+    },
+  ],
+});
+
+export const authenticatedSiteAppRouteExemptions = Object.freeze([
+  {
+    reason: "This page only redirects to the captured Wishocracy dashboard.",
+    sourcePage: "apps/wishocracy/app/dashboard/settings/page.tsx",
+  },
+]);
+
+export function getAuthenticatedSiteAppRoutes(appName) {
+  return authenticatedSiteAppRoutes[appName] ?? [];
+}

--- a/scripts/smoke-site-apps.mjs
+++ b/scripts/smoke-site-apps.mjs
@@ -12,6 +12,8 @@ import {
   forceAnimationsComplete,
   prepareFullPageVisualCapture,
 } from "../packages/web/e2e/utils/visual-settle.mjs";
+import { signInViaApi } from "../packages/web/e2e/utils/auth-api.mjs";
+import { getAuthenticatedSiteAppRoutes } from "./site-app-visual-routes.mjs";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -143,7 +145,7 @@ async function verifyWarOnDiseaseHome(baseUrl) {
   }
 }
 
-function getScreenshotRoutes(siteVariant) {
+function getScreenshotRoutes(appName, siteVariant) {
   const routes = getInternalNavigationRoutesForVariant(siteVariant).map(
     ({ label, path: routePath }) => ({
       label,
@@ -170,12 +172,17 @@ function getScreenshotRoutes(siteVariant) {
       captureSelector: "footer",
       covers: campaignHomeFiles,
     });
-    routes.push({
-      label: "Shared campaign plan",
-      routeName: "the-plan",
-      routePath: "/the-plan",
-      covers: [campaignPlanPageFile],
-    });
+    const planRoute = routes.find(({ routePath }) => routePath === "/the-plan");
+    if (planRoute) {
+      planRoute.covers = [campaignPlanPageFile];
+    } else {
+      routes.push({
+        label: "Shared campaign plan",
+        routeName: "the-plan",
+        routePath: "/the-plan",
+        covers: [campaignPlanPageFile],
+      });
+    }
   }
 
   if (siteVariant === VARIANTS.ACCELERATED_MEDICINE) {
@@ -198,7 +205,20 @@ function getScreenshotRoutes(siteVariant) {
     });
   }
 
-  return routes;
+  const screenshotRoutes = [
+    ...routes,
+    ...getAuthenticatedSiteAppRoutes(appName),
+  ];
+  const routeNames = new Set();
+  for (const route of screenshotRoutes) {
+    if (routeNames.has(route.routeName)) {
+      throw new Error(
+        `@apps/${appName}: duplicate screenshot route name ${route.routeName}`,
+      );
+    }
+    routeNames.add(route.routeName);
+  }
+  return screenshotRoutes;
 }
 
 async function captureScreenshots(appName, siteVariant, baseUrl) {
@@ -206,7 +226,7 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
     return;
   }
 
-  const screenshotRoutes = getScreenshotRoutes(siteVariant);
+  const screenshotRoutes = getScreenshotRoutes(appName, siteVariant);
   const requireFromWeb = createRequire(
     path.join(repoRoot, "packages", "web", "package.json"),
   );
@@ -236,15 +256,37 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
       screenshotProjects.map(async ([projectName, contextOptions]) => {
         const outputDirectory = path.resolve(screenshotRoot, projectName);
         await mkdir(outputDirectory, { recursive: true });
-        const context = await browser.newContext(contextOptions);
-        const page = await context.newPage();
+        const loggedOutContext = await browser.newContext({
+          ...contextOptions,
+          baseURL: baseUrl,
+        });
+        const authenticatedContext = await browser.newContext({
+          ...contextOptions,
+          baseURL: baseUrl,
+        });
+        const loggedOutPage = await loggedOutContext.newPage();
+        const authenticatedPage = await authenticatedContext.newPage();
 
         try {
+          const needsAuthentication = screenshotRoutes.some(
+            ({ authenticated }) => authenticated,
+          );
+          if (
+            needsAuthentication &&
+            !(await signInViaApi(authenticatedContext.request))
+          ) {
+            throw new Error(
+              `@apps/${appName}: managed demo user could not sign in for authenticated screenshots`,
+            );
+          }
+
           for (const {
+            authenticated,
             routeName,
             routePath,
             captureSelector,
           } of screenshotRoutes) {
+            const page = authenticated ? authenticatedPage : loggedOutPage;
             const pageUrl = new URL(routePath, baseUrl);
             if (appName === "acceleratedmedicine" && routeName === "home") {
               pageUrl.searchParams.set("visual", "1");
@@ -258,6 +300,15 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
               throw new Error(
                 `${url} returned HTTP ${response?.status() ?? "unknown"}`,
               );
+            }
+            if (authenticated) {
+              const expectedPath = pageUrl.pathname;
+              const actualPath = new URL(page.url()).pathname;
+              if (actualPath !== expectedPath) {
+                throw new Error(
+                  `${url} redirected to ${page.url()} instead of rendering its authenticated state`,
+                );
+              }
             }
             await page
               .waitForLoadState("networkidle", { timeout: 15_000 })
@@ -290,7 +341,10 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
             }
           }
         } finally {
-          await context.close();
+          await Promise.all([
+            loggedOutContext.close(),
+            authenticatedContext.close(),
+          ]);
         }
       }),
     );


### PR DESCRIPTION
## User story

As a reviewer, I can see every authenticated standalone-app page on desktop and mobile before it ships. This protects the War on Disease campaign dashboard and keeps visual regressions from slowing treaty work.

## What changed

- Declare `apps/warondisease` as the canonical War on Disease campaign app while keeping its colorful neobrutalist home and dashboard.
- Add one explicit authenticated screenshot registry for War on Disease, Wishocracy, and Trial Abundance Survey.
- Fail CI when an authenticated page lacks a desktop/mobile screenshot or a documented no-UI exemption. The previously missing War on Disease dashboard now fails this check if removed.
- Sign the smoke runner into safe local fixtures and fail on login redirects.
- Capture admin, dashboard, settings, profile, organization-owner, and signed-in invitation states.
- Replace clipped mobile admin tables with neobrutalist cards while retaining the desktop tables.
- Cap Vitest at four workers to prevent the contention failures found during verification.
- Document the separate Vercel-project cutover; this PR does not move the production domain.

## Review states

- War on Disease: `/dashboard`, `/dashboard/settings`, `/profile/edit`, `/organizations/demo-organization`, `/send`, `/admin/organizations`, `/admin/users`, `/admin/page-scorecard`
- Wishocracy: `/dashboard`
- Trial Abundance Survey: `/dashboard`
- Every state is captured at 1440×900 and 390×844.

## Copy evidence

- Before: `View` linked to a nonexistent admin route.
- After: `Manage` links to the real organization management page.
- New mobile labels expose the same data and actions as the desktop admin tables.

## Validation

- `pnpm test:site-app-navigation`
- `pnpm test:apps:unit`
- `pnpm typecheck:apps`
- `pnpm lint:apps`
- production builds for War on Disease, Wishocracy, and Trial Abundance Survey
- `pnpm --filter @optimitron/web run typecheck:fast`
- `pnpm --filter @optimitron/web run lint`
- `pnpm --filter @optimitron/web run test`
- 64 current screenshots captured and inspected locally; review coverage reports all three changed UI files captured.

## Human review

- [ ] Confirm the War on Disease dashboard still feels fun and neobrutalist.
- [ ] Confirm the authenticated mobile admin cards retain all needed information and actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved War on Disease admin organization and user management with mobile-friendly cards and clearer actions.
  * Added responsive scorecard views for mobile and desktop, preserving key metrics and empty states.
  * Expanded authenticated page and dashboard visual coverage across site apps.

* **Bug Fixes**
  * Improved authenticated route checks to help prevent unexpected redirects and incomplete page coverage.

* **Documentation**
  * Clarified War on Disease campaign ownership, deployment verification, and site-app validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->