### PR TITLE
Stabilize visual review captures

### DIFF
--- a/apps/warondisease/app/admin/organizations/page.tsx
+++ b/apps/warondisease/app/admin/organizations/page.tsx
@@ -34,6 +34,7 @@ async function getOrganizations(status?: OrgStatus) {
     orderBy: [
       { status: "asc" }, // PENDING first
       { createdAt: "desc" },
+      { slug: "asc" },
     ],
   })
 

--- a/apps/warondisease/app/admin/users/page.tsx
+++ b/apps/warondisease/app/admin/users/page.tsx
@@ -66,6 +66,7 @@ async function getUsers(filter?: UserAdminFilter) {
     orderBy: [
       { isAdmin: "desc" },
       { createdAt: "desc" },
+      { email: "asc" },
     ],
   }).then((users) =>
     users.map((u) => ({

--- a/packages/db/scripts/seed-site-app-visual-fixtures.ts
+++ b/packages/db/scripts/seed-site-app-visual-fixtures.ts
@@ -34,6 +34,7 @@ assertLocalVisualFixtureTarget(connectionString);
 const prisma = new PrismaClient({
   adapter: new PrismaPg({ connectionString }),
 });
+const VISUAL_FIXTURE_CREATED_AT = new Date("2026-01-15T12:00:00.000Z");
 
 try {
   const [user, referendum] = await Promise.all([
@@ -67,6 +68,14 @@ try {
   }
 
   await prisma.$transaction([
+    prisma.organization.updateMany({
+      where: { deletedAt: null },
+      data: { createdAt: VISUAL_FIXTURE_CREATED_AT },
+    }),
+    prisma.user.updateMany({
+      where: { deletedAt: null },
+      data: { createdAt: VISUAL_FIXTURE_CREATED_AT },
+    }),
     prisma.user.update({
       where: { id: user.id },
       data: { isAdmin: true },

--- a/packages/site-kit/src/components/landing/treaty-vote-section.tsx
+++ b/packages/site-kit/src/components/landing/treaty-vote-section.tsx
@@ -68,6 +68,8 @@ export default function TreatyVoteSection({
   const shareCardRef = useRef<HTMLDivElement>(null)
   const sliderSectionRef = useRef<HTMLDivElement>(null)
   const animationFrameRef = useRef<number | null>(null)
+  const introAnimationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const visualCaptureRef = useRef(false)
 
   // Restore state from localStorage on mount
   useEffect(() => {
@@ -91,9 +93,17 @@ export default function TreatyVoteSection({
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
-          if (entry.isIntersecting && !userHasDragged) {
+          if (
+            entry.isIntersecting &&
+            !userHasDragged &&
+            !visualCaptureRef.current &&
+            !introAnimationTimeoutRef.current
+          ) {
             // Start animation after a brief delay
-            setTimeout(() => setShowAnimation(true), 500)
+            introAnimationTimeoutRef.current = setTimeout(() => {
+              introAnimationTimeoutRef.current = null
+              if (!visualCaptureRef.current) setShowAnimation(true)
+            }, 500)
           }
         })
       },
@@ -102,7 +112,37 @@ export default function TreatyVoteSection({
 
     observer.observe(sliderSectionRef.current)
 
-    return () => observer.disconnect()
+    return () => {
+      observer.disconnect()
+      if (introAnimationTimeoutRef.current) {
+        clearTimeout(introAnimationTimeoutRef.current)
+        introAnimationTimeoutRef.current = null
+      }
+    }
+  }, [userHasDragged])
+
+  useEffect(() => {
+    const completeVisualCapture = () => {
+      visualCaptureRef.current = true
+      if (introAnimationTimeoutRef.current) {
+        clearTimeout(introAnimationTimeoutRef.current)
+        introAnimationTimeoutRef.current = null
+      }
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current)
+        animationFrameRef.current = null
+      }
+      if (!userHasDragged) {
+        setAnimatedValue(50)
+        setMilitaryAllocation(50)
+      }
+      setShowAnimation(false)
+    }
+
+    window.addEventListener("optimitron:visual-capture", completeVisualCapture)
+    return () => {
+      window.removeEventListener("optimitron:visual-capture", completeVisualCapture)
+    }
   }, [userHasDragged])
 
   // Animate the slider thumb across the track until the user interacts.
@@ -124,6 +164,7 @@ export default function TreatyVoteSection({
     const centerValue = 50
 
     const animate = (timestamp: number) => {
+      if (visualCaptureRef.current) return
       if (!startTime) startTime = timestamp
       const elapsed = timestamp - startTime
 

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -131,6 +131,8 @@ const TASK_DEPENDENCIES_SECTION_FILE =
   "packages/web/src/components/tasks/TaskDependenciesSection.tsx";
 const TASK_TREE_VIEW_FILE =
   "packages/web/src/components/tasks/TaskTreeView.tsx";
+const TASK_LIST_CONTROLS_FILE =
+  "packages/web/src/components/tasks/task-list-controls.tsx";
 const TASK_IMPACT_TRACE_DISCLOSURE_FILE =
   "packages/web/src/components/tasks/task-impact-trace-disclosure.tsx";
 const OBG_CATEGORY_PAGE_FILE = "packages/web/src/app/obg/[slug]/page.tsx";
@@ -546,9 +548,11 @@ const VARIANT_DELTA_ROUTES: VisualRoute[] = [
     siteVariant: "optimitron",
   },
   {
+    covers: [TASK_LIST_CONTROLS_FILE],
     name: "variant-optimitron-tasks",
     path: ROUTES.tasks,
     required: true,
+    requiredSelector: 'input[placeholder="Filter tasks..."]',
     siteVariant: "optimitron",
   },
   {

--- a/packages/web/e2e/utils/visual-routes.ts
+++ b/packages/web/e2e/utils/visual-routes.ts
@@ -548,7 +548,6 @@ const VARIANT_DELTA_ROUTES: VisualRoute[] = [
     siteVariant: "optimitron",
   },
   {
-    covers: [TASK_LIST_CONTROLS_FILE],
     name: "variant-optimitron-tasks",
     path: ROUTES.tasks,
     required: true,
@@ -557,7 +556,7 @@ const VARIANT_DELTA_ROUTES: VisualRoute[] = [
   },
   {
     authenticated: true,
-    covers: [PERSONAL_QUEUE_SECTION_FILE],
+    covers: [PERSONAL_QUEUE_SECTION_FILE, TASK_LIST_CONTROLS_FILE],
     name: "variant-optimitron-dashboard-auth",
     path: ROUTES.dashboard,
     required: true,

--- a/packages/web/e2e/visual-regression.spec.ts
+++ b/packages/web/e2e/visual-regression.spec.ts
@@ -13,7 +13,12 @@ import {
   SITE_VARIANT_OVERRIDE_COOKIE,
   SITE_VARIANT_OVERRIDE_QUERY_PARAM,
 } from "@/lib/site";
-import { forceAnimationsComplete, waitForPaint } from "./utils/audit-helpers";
+import { VISUAL_CAPTURE_VERSION } from "../scripts/visual-capture-contract.mjs";
+import {
+  forceAnimationsComplete,
+  prepareFullPageVisualCapture,
+  waitForPaint,
+} from "./utils/audit-helpers";
 import { DEMO_PASSWORD, signInDemoUser, signInUser } from "./utils/auth";
 import { VISUAL_ROUTES } from "./utils/visual-routes";
 import { freezeClock } from "./helpers/freeze-clock";
@@ -92,7 +97,11 @@ const REVIEW_AFTER_ROOT = path.resolve(
   "after",
 );
 const ROUTE_MANIFEST_PATH = path.join(SCREENSHOT_ROOT, "routes.json");
-const ROUTE_REVIEW_MANIFEST = buildRouteReviewManifest();
+const ROUTE_REVIEW_MANIFEST = {
+  version: 2,
+  captureVersion: VISUAL_CAPTURE_VERSION,
+  routes: buildRouteReviewManifest(),
+};
 
 function buildRouteReviewManifest() {
   const entries = VISUAL_ROUTES.map((route) => ({
@@ -290,6 +299,7 @@ test.describe("route visual regression", () => {
       if (route.waitForImages) {
         await waitForVisualImages(page);
       }
+      await prepareFullPageVisualCapture(page);
       const screenshotFileName = `${route.name}.png`;
       const reviewScreenshotDir = path.join(
         REVIEW_AFTER_ROOT,
@@ -303,7 +313,11 @@ test.describe("route visual regression", () => {
       const screenshotPath = path.join(screenshotDir, screenshotFileName);
       await mkdir(reviewScreenshotDir, { recursive: true });
       await mkdir(screenshotDir, { recursive: true });
-      await page.screenshot({ path: reviewScreenshotPath, fullPage: true });
+      await page.screenshot({
+        path: reviewScreenshotPath,
+        fullPage: true,
+        animations: "disabled",
+      });
       await copyFile(reviewScreenshotPath, screenshotPath);
       await testInfo.attach(`${route.name}-${testInfo.project.name}`, {
         path: reviewScreenshotPath,

--- a/packages/web/e2e/visual-regression.spec.ts
+++ b/packages/web/e2e/visual-regression.spec.ts
@@ -300,6 +300,7 @@ test.describe("route visual regression", () => {
         await waitForVisualImages(page);
       }
       await prepareFullPageVisualCapture(page);
+      await forceAnimationsComplete(page);
       const screenshotFileName = `${route.name}.png`;
       const reviewScreenshotDir = path.join(
         REVIEW_AFTER_ROOT,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,7 +26,7 @@
     "typecheck:app": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit --project tsconfig.next.json",
     "typecheck:tests": "cross-env NODE_OPTIONS=--max-old-space-size=6144 tsc --noEmit --project tsconfig.tests.json",
     "typecheck:full": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit",
-    "test": "node --test scripts/visual-review-coverage.test.mjs && pnpm exec vitest run --maxWorkers=4 --minWorkers=1",
+    "test": "node --test scripts/visual-review-coverage.test.mjs scripts/visual-capture-contract.test.mjs && pnpm exec vitest run --maxWorkers=4 --minWorkers=1",
     "generate": "tsx scripts/generate-web-data.ts",
     "fetch": "tsx scripts/fetch-and-generate.ts",
     "causal": "tsx scripts/generate-causal-reports.ts",

--- a/packages/web/scripts/build-visual-review.mjs
+++ b/packages/web/scripts/build-visual-review.mjs
@@ -25,6 +25,10 @@ import {
   buildChangedFileDiscoveryArgs,
   buildVisualCoverage,
 } from "./visual-review-coverage.mjs";
+import {
+  getVisualCaptureVersion,
+  normalizeVisualRouteManifest,
+} from "./visual-capture-contract.mjs";
 import { renderReviewHtml } from "./visual-review-page.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -38,6 +42,9 @@ const screenshotsRoot = process.env.VISUAL_AFTER_ROOT
 const routeManifestPath = path.join(screenshotsRoot, "routes.json");
 const beforeScreenshotsRoot = process.env.VISUAL_BEFORE_ROOT
   ? resolveInputPath(process.env.VISUAL_BEFORE_ROOT)
+  : null;
+const beforeRouteManifestPath = beforeScreenshotsRoot
+  ? path.join(beforeScreenshotsRoot, "routes.json")
   : null;
 const beforeCopySnapshotsRoot = process.env.VISUAL_COPY_BEFORE_ROOT
   ? resolveInputPath(process.env.VISUAL_COPY_BEFORE_ROOT)
@@ -92,7 +99,16 @@ const reviewCommitSha =
   process.env.GITHUB_SHA ??
   null;
 const reviewGeneratedAt = new Date();
-const routeSpecs = loadRouteSpecs();
+const routeManifest = loadRouteManifest(routeManifestPath);
+const beforeRouteManifest = beforeRouteManifestPath
+  ? loadRouteManifest(beforeRouteManifestPath)
+  : null;
+const routeSpecs = routeManifest.routeSpecs;
+const webCaptureProtocolMismatch = Boolean(
+  beforeScreenshotsRoot &&
+  routeSpecs.size > 0 &&
+  routeManifest.captureVersion !== beforeRouteManifest?.captureVersion,
+);
 const routePaths = new Map(
   [...routeSpecs.entries()].map(([name, spec]) => [name, spec.path]),
 );
@@ -205,8 +221,22 @@ const SITE_APP_ORDER = [
   "acceleratedmedicine",
 ];
 
-const siteAppRoutesByVariant = loadSiteAppRouteManifests();
-registerSiteAppRouteSpecs(routeSpecs, routePaths, siteAppRoutesByVariant);
+const siteAppManifestsByVariant = loadSiteAppRouteManifests(screenshotsRoot);
+const beforeSiteAppManifestsByVariant = beforeScreenshotsRoot
+  ? loadSiteAppRouteManifests(beforeScreenshotsRoot)
+  : new Map();
+const incompatibleSiteAppVariants = new Set(
+  [...siteAppManifestsByVariant.entries()]
+    .filter(
+      ([siteVariant, manifest]) =>
+        beforeScreenshotsRoot &&
+        manifest.captureVersion !==
+          (beforeSiteAppManifestsByVariant.get(siteVariant)?.captureVersion ??
+            1),
+    )
+    .map(([siteVariant]) => siteVariant),
+);
+registerSiteAppRouteSpecs(routeSpecs, routePaths, siteAppManifestsByVariant);
 
 main().catch((error) => {
   console.error(
@@ -219,10 +249,11 @@ async function main() {
   mkdirSync(outputRoot, { recursive: true });
   rmSync(assetRoot, { recursive: true, force: true });
 
+  const beforeScreenshots = beforeScreenshotsRoot
+    ? collectScreenshots(beforeScreenshotsRoot, "before")
+    : [];
   const screenshots = [
-    ...(beforeScreenshotsRoot
-      ? collectScreenshots(beforeScreenshotsRoot, "before")
-      : []),
+    ...beforeScreenshots.filter(isCompatibleBaselineScreenshot),
     ...collectScreenshots(screenshotsRoot, "after"),
   ];
   const grouped = appendCopyOnlyGroups(
@@ -435,12 +466,32 @@ function buildBaselineDescription() {
   const copyRefLabel = /^[0-9a-f]{40}$/i.test(copyRef)
     ? shortSha(copyRef)
     : copyRef;
-  return [
-    beforeScreenshotsRoot
-      ? "screenshots vs main baseline artifact"
-      : "no screenshot baseline artifact",
-    `copy vs ${copyRefLabel}`,
-  ].join(" · ");
+  const skippedBaselines = [];
+  if (webCaptureProtocolMismatch) {
+    skippedBaselines.push(
+      `web capture protocol v${beforeRouteManifest?.captureVersion} -> v${routeManifest.captureVersion}`,
+    );
+  }
+  if (incompatibleSiteAppVariants.size > 0) {
+    skippedBaselines.push(
+      `site-app capture protocol changed: ${[...incompatibleSiteAppVariants].join(", ")}`,
+    );
+  }
+  const screenshotBaseline = beforeScreenshotsRoot
+    ? skippedBaselines.length > 0
+      ? `baseline skipped for ${skippedBaselines.join("; ")}`
+      : "screenshots vs main baseline artifact"
+    : "no screenshot baseline artifact";
+
+  return [screenshotBaseline, `copy vs ${copyRefLabel}`].join(" · ");
+}
+
+function isCompatibleBaselineScreenshot(screenshot) {
+  const siteVariant = getSiteAppVariantFromRouteName(screenshot.routeName);
+  if (siteVariant) {
+    return !incompatibleSiteAppVariants.has(siteVariant);
+  }
+  return !webCaptureProtocolMismatch;
 }
 
 function buildReviewPageRoute(group) {
@@ -1600,19 +1651,18 @@ function shortSha(value) {
   return String(value).slice(0, 12);
 }
 
-function loadRouteSpecs() {
-  if (!existsSync(routeManifestPath)) {
-    return new Map();
+function loadRouteManifest(manifestPath) {
+  if (!manifestPath || !existsSync(manifestPath)) {
+    const manifest = normalizeVisualRouteManifest(null);
+    return { ...manifest, routeSpecs: new Map() };
   }
 
   try {
-    const parsed = JSON.parse(readFileSync(routeManifestPath, "utf8"));
-    if (!Array.isArray(parsed)) {
-      return new Map();
-    }
+    const parsed = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const manifest = normalizeVisualRouteManifest(parsed);
 
-    return new Map(
-      parsed
+    const routeSpecs = new Map(
+      manifest.routes
         .filter(
           (entry) =>
             entry &&
@@ -1642,11 +1692,13 @@ function loadRouteSpecs() {
           },
         ]),
     );
+    return { ...manifest, routeSpecs };
   } catch (error) {
     console.warn(
-      `[visual-review] Could not read route manifest at ${routeManifestPath}: ${error instanceof Error ? error.message : String(error)}`,
+      `[visual-review] Could not read route manifest at ${manifestPath}: ${error instanceof Error ? error.message : String(error)}`,
     );
-    return new Map();
+    const manifest = normalizeVisualRouteManifest(null);
+    return { ...manifest, routeSpecs: new Map() };
   }
 }
 
@@ -1678,11 +1730,9 @@ function getRouteSiteVariant(routeName) {
 }
 
 function getSiteAppRoute(routeName) {
-  for (const siteVariant of SITE_APP_ORDER) {
+  const siteVariant = getSiteAppVariantFromRouteName(routeName);
+  if (siteVariant) {
     const prefix = `site-app-${siteVariant}-`;
-    if (!routeName.startsWith(prefix)) {
-      continue;
-    }
     const siteAppRouteName = routeName.slice(prefix.length);
     const route = getSiteAppRoutes(siteVariant).find(
       (candidate) => candidate.routeName === siteAppRouteName,
@@ -1698,13 +1748,21 @@ function getSiteAppRoute(routeName) {
   return null;
 }
 
-function getSiteAppRoutes(siteVariant) {
-  return siteAppRoutesByVariant.get(siteVariant) ?? [];
+function getSiteAppVariantFromRouteName(routeName) {
+  return (
+    SITE_APP_ORDER.find((siteVariant) =>
+      routeName.startsWith(`site-app-${siteVariant}-`),
+    ) ?? null
+  );
 }
 
-function loadSiteAppRouteManifests() {
+function getSiteAppRoutes(siteVariant) {
+  return siteAppManifestsByVariant.get(siteVariant)?.routes ?? [];
+}
+
+function loadSiteAppRouteManifests(root) {
   const manifests = new Map();
-  const manifestDirectory = path.join(screenshotsRoot, "site-app-manifests");
+  const manifestDirectory = path.join(root, "site-app-manifests");
 
   for (const fileName of safeReadDir(manifestDirectory)) {
     if (!fileName.toLowerCase().endsWith(".json")) {
@@ -1744,7 +1802,10 @@ function loadSiteAppRouteManifests() {
       if (routes.length === 0) {
         throw new Error("manifest contains no routes");
       }
-      manifests.set(manifest.appName, routes);
+      manifests.set(manifest.appName, {
+        captureVersion: getVisualCaptureVersion(manifest),
+        routes,
+      });
     } catch (error) {
       console.warn(
         `[visual-review] Could not read site-app route manifest at ${manifestPath}: ${error instanceof Error ? error.message : String(error)}`,
@@ -1756,8 +1817,8 @@ function loadSiteAppRouteManifests() {
 }
 
 function registerSiteAppRouteSpecs(specs, paths, manifests) {
-  for (const [siteVariant, routes] of manifests) {
-    for (const route of routes) {
+  for (const [siteVariant, manifest] of manifests) {
+    for (const route of manifest.routes) {
       const name = `site-app-${siteVariant}-${route.routeName}`;
       specs.set(name, {
         activationSelector: "body",

--- a/packages/web/scripts/visual-capture-contract.mjs
+++ b/packages/web/scripts/visual-capture-contract.mjs
@@ -1,0 +1,33 @@
+export const LEGACY_VISUAL_CAPTURE_VERSION = 1;
+export const VISUAL_CAPTURE_VERSION = 2;
+export const SITE_APP_VISUAL_CAPTURE_VERSION = 2;
+
+export function getVisualCaptureVersion(value) {
+  return value &&
+    typeof value === "object" &&
+    Number.isInteger(value.captureVersion) &&
+    value.captureVersion > 0
+    ? value.captureVersion
+    : LEGACY_VISUAL_CAPTURE_VERSION;
+}
+
+export function normalizeVisualRouteManifest(value) {
+  if (Array.isArray(value)) {
+    return {
+      captureVersion: LEGACY_VISUAL_CAPTURE_VERSION,
+      routes: value,
+    };
+  }
+
+  if (value && typeof value === "object" && Array.isArray(value.routes)) {
+    return {
+      captureVersion: getVisualCaptureVersion(value),
+      routes: value.routes,
+    };
+  }
+
+  return {
+    captureVersion: LEGACY_VISUAL_CAPTURE_VERSION,
+    routes: [],
+  };
+}

--- a/packages/web/scripts/visual-capture-contract.test.mjs
+++ b/packages/web/scripts/visual-capture-contract.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getVisualCaptureVersion,
+  LEGACY_VISUAL_CAPTURE_VERSION,
+  normalizeVisualRouteManifest,
+} from "./visual-capture-contract.mjs";
+
+test("treats array route manifests as the legacy capture protocol", () => {
+  const routes = [{ name: "home", path: "/" }];
+
+  assert.deepEqual(normalizeVisualRouteManifest(routes), {
+    captureVersion: LEGACY_VISUAL_CAPTURE_VERSION,
+    routes,
+  });
+});
+
+test("reads the capture version from versioned route manifests", () => {
+  const routes = [{ name: "home", path: "/" }];
+
+  assert.deepEqual(
+    normalizeVisualRouteManifest({ captureVersion: 3, routes, version: 2 }),
+    { captureVersion: 3, routes },
+  );
+});
+
+test("defaults unversioned site-app manifests to the legacy protocol", () => {
+  assert.equal(
+    getVisualCaptureVersion({ appName: "warondisease", routes: [] }),
+    LEGACY_VISUAL_CAPTURE_VERSION,
+  );
+  assert.equal(getVisualCaptureVersion({ captureVersion: 2 }), 2);
+});

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -287,7 +287,10 @@ function SearchResultRow({
   meta,
   source,
   title,
-}: Omit<SearchResultItem, "scope" | "score">) {
+  volatileDisplayUrl = false,
+}: Omit<SearchResultItem, "scope" | "score"> & {
+  volatileDisplayUrl?: boolean;
+}) {
   const displayUrl = formatDisplayUrl(href, external);
   const row = (
     <div className="flex items-start gap-3">
@@ -300,7 +303,16 @@ function SearchResultRow({
             {source}
           </div>
           <div className="truncate text-xs text-muted-foreground">
-            {displayUrl}
+            {volatileDisplayUrl && displayUrl.startsWith("/tasks/") ? (
+              <>
+                /tasks/
+                <span data-volatile="task-id">
+                  {displayUrl.slice("/tasks/".length)}
+                </span>
+              </>
+            ) : (
+              displayUrl
+            )}
             {meta ? <span>{` / ${meta}`}</span> : null}
           </div>
         </div>
@@ -456,6 +468,7 @@ export default async function SearchPage({
                       meta={result.meta}
                       source={result.source}
                       title={result.title}
+                      volatileDisplayUrl={result.scope === "tasks"}
                     />
                   ))}
                 </section>

--- a/packages/web/src/components/tasks/task-list-controls.test.ts
+++ b/packages/web/src/components/tasks/task-list-controls.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { compareTaskListValues } from "./task-list-sort";
+
+describe("compareTaskListValues", () => {
+  it("uses the task title to stabilize tied primary sort values", () => {
+    const alpha = { id: "task-a", title: "Alpha" };
+    const bravo = { id: "task-b", title: "Bravo" };
+
+    expect(
+      [bravo, alpha]
+        .sort((a, b) => compareTaskListValues(a, b, 100, 100, "desc"))
+        .map((item) => item.title),
+    ).toEqual(["Alpha", "Bravo"]);
+  });
+
+  it("uses stable task keys before generated IDs for duplicate titles", () => {
+    const first = { id: "z-generated", taskKey: "task-a", title: "Same" };
+    const second = { id: "a-generated", taskKey: "task-b", title: "Same" };
+
+    expect(
+      [second, first]
+        .sort((a, b) => compareTaskListValues(a, b, 100, 100, "desc"))
+        .map((item) => item.taskKey),
+    ).toEqual(["task-a", "task-b"]);
+  });
+});

--- a/packages/web/src/components/tasks/task-list-controls.tsx
+++ b/packages/web/src/components/tasks/task-list-controls.tsx
@@ -9,6 +9,7 @@ import {
   type TaskSortKey,
 } from "./task-row";
 import type { TaskCardTask } from "./task-card";
+import { compareTaskListValues } from "./task-list-sort";
 import { useHydratedNow } from "@/lib/use-hydrated-now";
 
 const SORT_OPTIONS: { key: TaskSortKey; label: string }[] = [
@@ -78,14 +79,7 @@ export function SortableTaskList({
     return filtered.sort((a, b) => {
       const valA = getTaskSortValue(a, sortKey);
       const valB = getTaskSortValue(b, sortKey);
-      if (typeof valA === "string" && typeof valB === "string") {
-        return sortDir === "asc"
-          ? valA.localeCompare(valB)
-          : valB.localeCompare(valA);
-      }
-      return sortDir === "asc"
-        ? Number(valA) - Number(valB)
-        : Number(valB) - Number(valA);
+      return compareTaskListValues(a, b, valA, valB, sortDir);
     });
   }, [tasks, sortKey, sortDir, filter]);
 

--- a/packages/web/src/components/tasks/task-list-sort.ts
+++ b/packages/web/src/components/tasks/task-list-sort.ts
@@ -1,0 +1,56 @@
+export function compareTaskListValues(
+  a: TaskSortIdentity,
+  b: TaskSortIdentity,
+  valA: string | number,
+  valB: string | number,
+  sortDir: "asc" | "desc",
+): number {
+  const primaryDelta =
+    typeof valA === "string" && typeof valB === "string"
+      ? sortDir === "asc"
+        ? valA.localeCompare(valB)
+        : valB.localeCompare(valA)
+      : sortDir === "asc"
+        ? Number(valA) - Number(valB)
+        : Number(valB) - Number(valA);
+
+  return primaryDelta || compareTaskIdentity(a, b);
+}
+
+interface TaskSortIdentity {
+  assigneeOrganization?: { slug: string } | null;
+  assigneePerson?: { displayName: string; sourceRef?: string | null } | null;
+  description?: string;
+  id: string;
+  roleTitle?: string | null;
+  sourceUrl?: string | null;
+  taskKey?: string | null;
+  title: string;
+}
+
+function compareTaskIdentity(a: TaskSortIdentity, b: TaskSortIdentity) {
+  const stableValuesA = [
+    a.title,
+    a.taskKey ?? "",
+    a.assigneeOrganization?.slug ?? "",
+    a.assigneePerson?.sourceRef ?? a.assigneePerson?.displayName ?? "",
+    a.roleTitle ?? "",
+    a.description ?? "",
+    a.sourceUrl ?? "",
+  ];
+  const stableValuesB = [
+    b.title,
+    b.taskKey ?? "",
+    b.assigneeOrganization?.slug ?? "",
+    b.assigneePerson?.sourceRef ?? b.assigneePerson?.displayName ?? "",
+    b.roleTitle ?? "",
+    b.description ?? "",
+    b.sourceUrl ?? "",
+  ];
+
+  for (let index = 0; index < stableValuesA.length; index += 1) {
+    const delta = stableValuesA[index].localeCompare(stableValuesB[index]);
+    if (delta !== 0) return delta;
+  }
+  return a.id.localeCompare(b.id);
+}

--- a/scripts/smoke-site-apps.mjs
+++ b/scripts/smoke-site-apps.mjs
@@ -13,6 +13,7 @@ import {
   prepareFullPageVisualCapture,
 } from "../packages/web/e2e/utils/visual-settle.mjs";
 import { signInViaApi } from "../packages/web/e2e/utils/auth-api.mjs";
+import { SITE_APP_VISUAL_CAPTURE_VERSION } from "../packages/web/scripts/visual-capture-contract.mjs";
 import { getAuthenticatedSiteAppRoutes } from "./site-app-visual-routes.mjs";
 
 const repoRoot = path.resolve(
@@ -246,7 +247,8 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
     path.join(manifestDirectory, `${appName}.json`),
     `${JSON.stringify(
       {
-        version: 1,
+        version: 2,
+        captureVersion: SITE_APP_VISUAL_CAPTURE_VERSION,
         appName,
         domain: getSiteConfigForVariant(siteVariant).domain,
         routes: screenshotRoutes,


### PR DESCRIPTION
## Summary

- version the web and site-app screenshot capture contracts so incompatible baselines appear as missing instead of false UI changes
- settle scripted slider motion before full-page capture and disable remaining screenshot animations
- make visual fixtures, admin ordering, and task-list tie-breaking deterministic
- mask only generated task IDs while preserving the meaningful `/tasks/` route prefix
- register the task-list state with visual source coverage

## Root cause

PR #230 had no intended UI changes, but screenshots depended on capture timing, generated database IDs, fixture creation dates, and partially ordered query results. The review pipeline also compared screenshots created under different capture behavior as if they were equivalent.

## Impact

Animation and fixture timing should no longer create review noise. A deliberate capture-contract change produces a one-time missing-baseline state instead of a misleading pixel diff.

## Verification

- 15 visual contract and coverage tests passed
- 2 deterministic task-sort tests passed
- War on Disease production build passed
- Trial Abundance Survey production build passed
- 36 War on Disease screenshots captured
- 14 Trial Abundance Survey screenshots captured
- 8 Optimitron search screenshots passed
- 2 Optimitron task-list screenshots passed
- repeat capture comparison: 0 changed routes across 28 reviewed states
- visual source coverage: 4/4 changed UI files
- `git diff --check` passed

The full web and War on Disease typechecks still report pre-existing errors on `main`; none point to the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Admin organization and user lists now use consistent secondary sorting for more predictable results.
  * Task lists now apply stable tie-breaking when multiple tasks share the same sort value.
  * Task-scoped search results display task paths and identifiers more clearly.

* **Reliability**
  * Improved animation handling during visual capture to prevent duplicate scheduling and incomplete screenshots.

* **Testing**
  * Expanded visual regression coverage, capture compatibility checks, and task-list sorting tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->