### PR TITLE
Make tracking reminder MCP tools trustworthy for agent catch-up sessions

### DIFF
--- a/apps/dfda/app/api/v1/tracking-reminders/[id]/route.ts
+++ b/apps/dfda/app/api/v1/tracking-reminders/[id]/route.ts
@@ -1,9 +1,30 @@
-/** REST v1: archive one of the user's tracking reminders. */
-import { upsertTrackingReminderForUser } from "@optimitron/tracking";
+/** REST v1: read or archive one of the user's tracking reminders. */
+import {
+  getTrackingReminderForUser,
+  upsertTrackingReminderForUser,
+} from "@optimitron/tracking";
 import { NextResponse } from "next/server";
 
 import { requireTrackingAuth } from "@/lib/api/require-auth";
 import { trackingErrorResponse } from "@/lib/api/request-helpers";
+
+// GET returns the full reminder, including untruncated instructions; the
+// list endpoint returns the compact shape by default.
+export async function GET(
+  req: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireTrackingAuth(req);
+  if (auth instanceof Response) return auth;
+  try {
+    const { id } = await context.params;
+    return NextResponse.json(
+      await getTrackingReminderForUser({ trackingReminderId: id }, auth.userId),
+    );
+  } catch (error) {
+    return trackingErrorResponse(error, "GET /api/v1/tracking-reminders/[id]");
+  }
+}
 
 // DELETE archives the reminder (active: false). It does not hard-delete:
 // the MCP surface has no hard-delete either, and past notifications and

--- a/apps/dfda/app/api/v1/tracking-reminders/route.ts
+++ b/apps/dfda/app/api/v1/tracking-reminders/route.ts
@@ -17,7 +17,7 @@ export async function GET(req: Request) {
   if (auth instanceof Response) return auth;
   try {
     const input = queryInput(new URL(req.url), {
-      booleans: ["includeInactive"],
+      booleans: ["compact", "includeInactive"],
     });
     return NextResponse.json({
       reminders: await listTrackingRemindersForUser(input, auth.userId),

--- a/apps/optimitron/e2e/visual-review-page.spec.ts
+++ b/apps/optimitron/e2e/visual-review-page.spec.ts
@@ -279,7 +279,7 @@ test("Escape preserves always-visible desktop review controls", async ({
   await expect(page.locator("#note-input")).toBeVisible();
 });
 
-test("compatibility routes remain available while filtering", async ({
+test("legacy variant routes remain available while filtering", async ({
   page,
 }, testInfo) => {
   test.skip(testInfo.project.name !== "default");
@@ -297,7 +297,7 @@ test("compatibility routes remain available while filtering", async ({
     'details.rail-group[data-key="compatibility"]',
   );
   await expect(compatibility.locator(":scope > summary")).toHaveText(
-    "Compatibility checks (1)",
+    "Legacy site variants (1)",
   );
   await expect(compatibility).not.toHaveAttribute("open", "");
 

--- a/apps/optimitron/scripts/visual-review-page.mjs
+++ b/apps/optimitron/scripts/visual-review-page.mjs
@@ -1022,12 +1022,12 @@ const CLIENT_JS = `
       if (!list.length) return;
       var hostCount = new Set(list.map(function (r) { return ownerKey(r); })).size;
       var wrap = el("details", {
-        class: "rail-group rail-compat", "data-title": "Compatibility checks",
+        class: "rail-group rail-compat", "data-title": "Legacy site variants",
         "data-total": String(hostCount), "data-key": "compatibility"
       });
       wrap.open = compatibilityOpen;
       wrap.appendChild(el("summary", {
-        class: "rail-group-h", text: "Compatibility checks (" + hostCount + ")"
+        class: "rail-group-h", text: "Legacy site variants (" + hostCount + ")"
       }));
       addOwnerGroups(wrap, list, "legacy-host");
       wrap.addEventListener("toggle", function () {
@@ -2431,7 +2431,7 @@ function renderHeaderHtml(meta, summary, coverage) {
     );
   if (summary.compatibilityRoutes)
     chips.push(
-      `<span class="chip">${escapeHtml(summary.compatibilityRoutes)} compatibility check${Number(summary.compatibilityRoutes) === 1 ? "" : "s"}</span>`,
+      `<span class="chip">${escapeHtml(summary.compatibilityRoutes)} legacy variant route${Number(summary.compatibilityRoutes) === 1 ? "" : "s"}</span>`,
     );
   if (summary.erroredRoutes)
     chips.push(

--- a/apps/optimitron/src/lib/__tests__/mcp-server.test.ts
+++ b/apps/optimitron/src/lib/__tests__/mcp-server.test.ts
@@ -9373,6 +9373,8 @@ describe("MCP server tool dispatch", () => {
       mocks.globalVariableFindFirst.mockResolvedValue(TRACKING_VARIABLE);
       mocks.unitFindFirst.mockResolvedValue(TRACKING_UNIT);
       mocks.nOf1VariableUpsert.mockResolvedValue(NOF1_VARIABLE);
+      // The overdue cross-check queries same-day measurements.
+      mocks.measurementFindMany.mockResolvedValue([]);
     });
 
     it("recordMeasurement writes a measurement upsert keyed on (subjectId, globalVariableId, startTime)", async () => {
@@ -10254,9 +10256,158 @@ describe("MCP server tool dispatch", () => {
 
       expect(result.isError).toBe(true);
       expect(parseToolBody(result).message).toContain(
-        "tracked variable cannot be changed",
+        "tracked variable is fixed at creation",
       );
       expect(mocks.transaction).not.toHaveBeenCalled();
+    });
+
+    it("upsertTrackingReminder changes the recording unit in place via the per-user variable settings", async () => {
+      // #250: the unit is a per-user NOf1Variable setting, not variable
+      // identity, so an ID edit must be able to fix it without recreating
+      // the reminder.
+      const MG_UNIT = {
+        abbreviatedName: "mg",
+        id: "unit-mg",
+        name: "Milligrams",
+        ucumCode: "mg",
+      };
+      mocks.unitFindFirst.mockResolvedValue(MG_UNIT);
+      mocks.trackingReminderFindFirst.mockResolvedValue(
+        EXISTING_TRACKING_REMINDER,
+      );
+      mocks.nOf1VariableUpdate.mockResolvedValue({
+        ...NOF1_VARIABLE,
+        defaultUnitId: "unit-mg",
+      });
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "upsertTrackingReminder",
+        arguments: {
+          trackingReminderId: "reminder-1",
+          unitAbbreviation: "mg",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mocks.nOf1VariableUpdate).toHaveBeenCalledWith({
+        data: { defaultUnitId: "unit-mg" },
+        where: { id: "nof1-1" },
+      });
+      // The canonical GlobalVariable stays untouched.
+      expect(mocks.globalVariableUpdate).not.toHaveBeenCalled();
+      const body = parseToolBody(result) as {
+        result: { unit: { abbreviatedName: string } | null };
+      };
+      expect(body.result.unit?.abbreviatedName).toBe("mg");
+    });
+
+    it("upsertTrackingReminder rejects an unknown unit on an ID edit with no write", async () => {
+      mocks.unitFindFirst.mockResolvedValue(null);
+      mocks.trackingReminderFindFirst.mockResolvedValue(
+        EXISTING_TRACKING_REMINDER,
+      );
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "upsertTrackingReminder",
+        arguments: {
+          trackingReminderId: "reminder-1",
+          unitAbbreviation: "furlongs",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).message).toContain(
+        "Requested unit was not found",
+      );
+      expect(mocks.nOf1VariableUpdate).not.toHaveBeenCalled();
+      expect(mocks.trackingReminderUpdate).not.toHaveBeenCalled();
+    });
+
+    it("getTrackingReminder returns the full reminder with its effective unit", async () => {
+      mocks.trackingReminderFindFirst.mockResolvedValue(
+        EXISTING_TRACKING_REMINDER,
+      );
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "getTrackingReminder",
+        arguments: { trackingReminderId: "reminder-1" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const body = parseToolBody(result) as {
+        reminder: { id: string; instructions: string | null };
+        unit: { abbreviatedName: string } | null;
+      };
+      expect(body.reminder.id).toBe("reminder-1");
+      expect(body.reminder.instructions).toBe("Daily");
+      // Falls back to the canonical variable unit when no per-user unit is set.
+      expect(body.unit?.abbreviatedName).toBe("IU");
+    });
+
+    it("getTrackingReminder hides foreign and missing reminders behind not-found", async () => {
+      mocks.trackingReminderFindFirst.mockResolvedValue(null);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "getTrackingReminder",
+        arguments: { trackingReminderId: "reminder-of-someone-else" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).message).toContain(
+        "TrackingReminder not found",
+      );
+    });
+
+    it("listTrackingReminders defaults to a compact shape and truncates instructions with a pointer", async () => {
+      const longInstructions = "Open the ampoule carefully. ".repeat(20);
+      mocks.trackingReminderFindMany.mockResolvedValue([
+        { ...EXISTING_TRACKING_REMINDER, instructions: longInstructions },
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const compact = await client.callTool({
+        name: "listTrackingReminders",
+        arguments: {},
+      });
+
+      expect(compact.isError).toBeFalsy();
+      const compactBody = parseToolBody(compact) as {
+        reminders: Array<{
+          defaultValue: number | null;
+          globalVariable?: unknown;
+          id: string;
+          instructions: string;
+          name: string;
+          unit: string | null;
+        }>;
+      };
+      expect(compactBody.reminders[0]).toMatchObject({
+        defaultValue: 1,
+        id: "reminder-1",
+        name: "Vitamin D",
+        unit: "IU",
+      });
+      expect(compactBody.reminders[0]!.instructions).toContain(
+        "getTrackingReminder returns the full instructions",
+      );
+      expect(compactBody.reminders[0]!.instructions.length).toBeLessThan(
+        longInstructions.length,
+      );
+      expect(compactBody.reminders[0]!.globalVariable).toBeUndefined();
+
+      const full = await client.callTool({
+        name: "listTrackingReminders",
+        arguments: { compact: false },
+      });
+      const fullBody = parseToolBody(full) as {
+        reminders: Array<{ globalVariable: { name: string }; instructions: string }>;
+      };
+      expect(fullBody.reminders[0]!.instructions).toBe(longInstructions);
+      expect(fullBody.reminders[0]!.globalVariable.name).toBe("Vitamin D");
     });
 
     it("upsertTrackingReminder rejects an invalid reminderStartTime with no write", async () => {
@@ -10429,15 +10580,20 @@ describe("MCP server tool dispatch", () => {
         });
 
         expect(canonical.isError).toBeFalsy();
+        // defaultValue, unit, and fillingType ride along so an agent can
+        // answer without a second listTrackingReminders fetch (#249).
         expect(parseToolBody(canonical)).toEqual({
           dateKey: "2026-08-03",
           notifications: [
             {
+              defaultValue: 1,
               due: "2026-08-03T08:00:00+00:00",
               dueUtc: "2026-08-03T08:00:00.000Z",
+              fillingType: "NONE",
               id: "reminder-1",
               name: "Vitamin D",
               status: "OVERDUE",
+              unit: "IU",
             },
           ],
           timeZone: "UTC",
@@ -10446,11 +10602,14 @@ describe("MCP server tool dispatch", () => {
           dateKey: "2026-08-03",
           reminders: [
             {
+              defaultValue: 1,
               due: "2026-08-03T08:00:00+00:00",
               dueUtc: "2026-08-03T08:00:00.000Z",
+              fillingType: "NONE",
               id: "reminder-1",
               name: "Vitamin D",
               status: "OVERDUE",
+              unit: "IU",
             },
           ],
           timeZone: "UTC",
@@ -10476,7 +10635,7 @@ describe("MCP server tool dispatch", () => {
         const client = await setup("user-1", ALL_SCOPES);
         const result = await client.callTool({
           name: "listTrackingReminderNotifications",
-          arguments: { dateKey: "2026-08-03" },
+          arguments: { compact: false, dateKey: "2026-08-03" },
         });
 
         expect(result.isError).toBeFalsy();
@@ -10522,6 +10681,7 @@ describe("MCP server tool dispatch", () => {
         const result = await client.callTool({
           name: "listTrackingReminderNotifications",
           arguments: {
+            compact: false,
             endDateKey: "2026-08-03",
             startDateKey: "2026-08-02",
             status: "OVERDUE",
@@ -10593,7 +10753,7 @@ describe("MCP server tool dispatch", () => {
       const client = await setup("user-1", ALL_SCOPES);
       const result = await client.callTool({
         name: "listTrackingReminderNotifications",
-        arguments: { dateKey: "2026-08-03", status: "TRACKED" },
+        arguments: { compact: false, dateKey: "2026-08-03", status: "TRACKED" },
       });
 
       expect(result.isError).toBeFalsy();
@@ -10636,7 +10796,7 @@ describe("MCP server tool dispatch", () => {
         const client = await setup("user-1", ALL_SCOPES);
         const before = await client.callTool({
           name: "listTrackingReminderNotifications",
-          arguments: { dateKey: "2026-08-03" },
+          arguments: { compact: false, dateKey: "2026-08-03" },
         });
         expect(parseToolBody(before)).toMatchObject({
           notifications: [
@@ -10657,7 +10817,7 @@ describe("MCP server tool dispatch", () => {
         now.mockReturnValue(new Date("2026-08-03T10:30:00.000Z").getTime());
         const atDeferredTime = await client.callTool({
           name: "listTrackingReminderNotifications",
-          arguments: { dateKey: "2026-08-03" },
+          arguments: { compact: false, dateKey: "2026-08-03" },
         });
         expect(parseToolBody(atDeferredTime)).toMatchObject({
           notifications: [
@@ -10674,7 +10834,7 @@ describe("MCP server tool dispatch", () => {
         now.mockReturnValue(new Date("2026-08-03T10:31:00.000Z").getTime());
         const after = await client.callTool({
           name: "listTrackingReminderNotifications",
-          arguments: { dateKey: "2026-08-03" },
+          arguments: { compact: false, dateKey: "2026-08-03" },
         });
         expect(parseToolBody(after)).toMatchObject({
           notifications: [
@@ -10735,16 +10895,12 @@ describe("MCP server tool dispatch", () => {
         },
       });
 
-      expect(result.isError).toBeFalsy();
-      expect(parseToolBody(result)).toEqual({
-        answeredCount: 0,
-        dateKey: "2026-08-03",
-        failed: [],
-        results: [],
-        // Nothing written, so every scheduled reminder counts as untouched.
-        skippedCount: 1,
-        unknownExceptionIds: ["misheard-reminder"],
-      });
+      // The success-shaped no-op response let an agent report a day as
+      // answered when nothing was written (#248); it is a hard error now.
+      expect(result.isError).toBe(true);
+      expect(parseToolBody(result).message).toContain(
+        "not scheduled for 2026-08-03: misheard-reminder",
+      );
       expect(mocks.transaction).not.toHaveBeenCalled();
       expect(mocks.trackingReminderNotificationCreate).not.toHaveBeenCalled();
       expect(mocks.trackingReminderNotificationUpdate).not.toHaveBeenCalled();
@@ -11555,6 +11711,242 @@ describe("MCP server tool dispatch", () => {
       expect(body.message).toContain("Insufficient scope");
       expect(body.message).toContain("recordMeasurement");
       expect(mocks.measurementUpsert).not.toHaveBeenCalled();
+    });
+
+    // A nightly 22:30 reminder answered at 02:05 the next morning. The old
+    // calendar-today default targeted the new day's still-future occurrence,
+    // leaving yesterday OVERDUE (#248).
+    const NIGHTLY_REMINDER = {
+      createdAt: new Date("2026-08-01T00:00:00.000Z"),
+      defaultValue: 1500,
+      deletedAt: null,
+      globalVariable: TRACKING_VARIABLE,
+      globalVariableId: "gv-vitd",
+      id: "reminder-night",
+      instructions: null,
+      nOf1Variable: { ...NOF1_VARIABLE, subjectId: "subject-1" },
+      nOf1VariableId: "nof1-1",
+      reminderEndTime: null,
+      reminderFrequency: 86_400,
+      reminderStartTime: "22:30",
+      startTrackingDate: null,
+      stopTrackingDate: null,
+      userId: "user-1",
+    };
+
+    it("respondToTrackingReminder without dateKey answers yesterday's unanswered occurrence after midnight", async () => {
+      // 02:05 on 2026-08-19 in Chicago.
+      vi.useFakeTimers({ now: new Date("2026-08-19T07:05:00.000Z"), toFake: ["Date"] });
+      try {
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "America/Chicago" });
+        mocks.trackingReminderFindFirst.mockResolvedValue(NIGHTLY_REMINDER);
+        mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
+        mocks.trackingReminderNotificationCreate.mockImplementation(
+          async ({ data }: { data: Record<string, unknown> }) => ({
+            ...data,
+            id: "notification-1",
+          }),
+        );
+        mocks.measurementUpsert.mockResolvedValue({
+          globalVariableId: "gv-vitd",
+          id: "measurement-1",
+          subjectId: "subject-1",
+          unitId: "unit-iu",
+          value: 1500,
+        });
+        mocks.trackingReminderUpdate.mockResolvedValue({
+          id: "reminder-night",
+        });
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "respondToTrackingReminder",
+          arguments: {
+            status: "TRACKED",
+            trackingReminderId: "reminder-night",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        // The notification lands on Aug 18's 22:30 slot (03:30Z on Aug 19).
+        expect(mocks.trackingReminderNotificationCreate).toHaveBeenCalledWith({
+          data: expect.objectContaining({
+            notifyAt: new Date("2026-08-19T03:30:00.000Z"),
+            status: NotificationStatus.TRACKED,
+          }),
+        });
+        // The measurement anchors to the scheduled slot, not the 02:05 wall
+        // clock, so it counts toward Aug 18.
+        const upsert = mocks.measurementUpsert.mock.calls[0]![0] as {
+          where: { subjectId_globalVariableId_startTime: { startTime: Date } };
+        };
+        expect(
+          upsert.where.subjectId_globalVariableId_startTime.startTime,
+        ).toEqual(new Date("2026-08-19T03:30:00.000Z"));
+        const body = parseToolBody(result) as {
+          result: {
+            answersPastOccurrence?: boolean;
+            dateKey: string;
+            notifyAtLocal: string;
+          };
+        };
+        expect(body.result.dateKey).toBe("2026-08-18");
+        expect(body.result.answersPastOccurrence).toBe(true);
+        expect(body.result.notifyAtLocal).toBe("2026-08-18T22:30:00-05:00");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("respondToTrackingReminder keeps the calendar default when the last occurrence is already answered", async () => {
+      vi.useFakeTimers({ now: new Date("2026-08-19T07:05:00.000Z"), toFake: ["Date"] });
+      try {
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "America/Chicago" });
+        mocks.trackingReminderFindFirst.mockResolvedValue(NIGHTLY_REMINDER);
+        // Yesterday's occurrence is TRACKED, so the walk-back must not
+        // redirect: the caller is answering today (in advance) or correcting.
+        mocks.trackingReminderNotificationFindFirst.mockResolvedValue({
+          id: "notification-yesterday",
+          notifyAt: new Date("2026-08-19T03:30:00.000Z"),
+          status: NotificationStatus.TRACKED,
+          trackedValue: 1500,
+          trackingReminderId: "reminder-night",
+          userId: "user-1",
+        });
+        mocks.trackingReminderNotificationUpdate.mockImplementation(
+          async ({ data }: { data: Record<string, unknown> }) => ({
+            ...data,
+            id: "notification-yesterday",
+          }),
+        );
+        mocks.measurementUpsert.mockResolvedValue({
+          globalVariableId: "gv-vitd",
+          id: "measurement-2",
+          subjectId: "subject-1",
+          unitId: "unit-iu",
+          value: 1500,
+        });
+        mocks.trackingReminderUpdate.mockResolvedValue({
+          id: "reminder-night",
+        });
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "respondToTrackingReminder",
+          arguments: {
+            status: "TRACKED",
+            trackingReminderId: "reminder-night",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const body = parseToolBody(result) as {
+          result: { answersPastOccurrence?: boolean; dateKey: string };
+        };
+        expect(body.result.dateKey).toBe("2026-08-19");
+        expect(body.result.answersPastOccurrence).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("bulk respond without dateKey refuses an after-midnight catch-up and names yesterday", async () => {
+      vi.useFakeTimers({ now: new Date("2026-08-19T07:05:00.000Z"), toFake: ["Date"] });
+      try {
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "America/Chicago" });
+        mocks.trackingReminderFindMany.mockResolvedValue([NIGHTLY_REMINDER]);
+        mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "respondToTrackingReminderNotifications",
+          arguments: { defaultStatus: "TRACKED" },
+        });
+
+        expect(result.isError).toBe(true);
+        const message = parseToolBody(result).message as string;
+        expect(message).toContain("Nothing was written");
+        expect(message).toContain('dateKey: "2026-08-18"');
+        expect(mocks.trackingReminderNotificationCreate).not.toHaveBeenCalled();
+        expect(mocks.measurementUpsert).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("flags an OVERDUE occurrence whose variable already has same-day measurements", async () => {
+      const now = vi
+        .spyOn(Date, "now")
+        .mockReturnValue(new Date("2026-08-03T10:00:00.000Z").getTime());
+      try {
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "UTC" });
+        mocks.trackingReminderFindMany.mockResolvedValue([
+          EXISTING_TRACKING_REMINDER,
+        ]);
+        mocks.trackingReminderNotificationFindMany.mockResolvedValue([]);
+        // Two Vitamin D measurements already exist on the same local day.
+        mocks.measurementFindMany.mockResolvedValue([
+          {
+            globalVariableId: "gv-vitd",
+            startTime: new Date("2026-08-03T08:05:00.000Z"),
+          },
+          {
+            globalVariableId: "gv-vitd",
+            startTime: new Date("2026-08-03T09:00:00.000Z"),
+          },
+        ]);
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "listTrackingReminderNotifications",
+          arguments: { dateKey: "2026-08-03" },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const body = parseToolBody(result) as {
+          notifications: Array<{
+            sameDayMeasurementCount?: number;
+            status: string;
+          }>;
+        };
+        expect(body.notifications[0]).toMatchObject({
+          sameDayMeasurementCount: 2,
+          status: "OVERDUE",
+        });
+      } finally {
+        now.mockRestore();
+      }
+    });
+
+    it("listMeasurements reports startTimeLocal in the user's zone", async () => {
+      mocks.userFindUnique.mockResolvedValue({ timeZone: "America/Chicago" });
+      mocks.measurementFindMany.mockResolvedValue([
+        {
+          globalVariableId: "gv-vitd",
+          id: "measurement-1",
+          // 21:02 on Aug 18 in Chicago; reading the raw UTC value as local
+          // misdated an evening of answers by a day (#248).
+          startTime: new Date("2026-08-19T02:02:09.000Z"),
+          subjectId: "subject-1",
+          value: 2.5,
+        },
+      ]);
+
+      const client = await setup("user-1", ALL_SCOPES);
+      const result = await client.callTool({
+        name: "listMeasurements",
+        arguments: {},
+      });
+
+      expect(result.isError).toBeFalsy();
+      const body = parseToolBody(result) as {
+        measurements: Array<{ startTimeLocal: string }>;
+        timeZone: string;
+      };
+      expect(body.timeZone).toBe("America/Chicago");
+      expect(body.measurements[0]!.startTimeLocal).toBe(
+        "2026-08-18T21:02:09-05:00",
+      );
     });
   });
 });

--- a/apps/optimitron/src/lib/__tests__/mcp-server.test.ts
+++ b/apps/optimitron/src/lib/__tests__/mcp-server.test.ts
@@ -11851,6 +11851,51 @@ describe("MCP server tool dispatch", () => {
       }
     });
 
+    it("respondToTrackingReminder never walks a snooze back to a past occurrence", async () => {
+      // A walked-back SNOOZED would clamp deferUntil at yesterday's day end,
+      // which is already in the past, so the snooze would silently do
+      // nothing. Snoozes stay on calendar today.
+      vi.useFakeTimers({ now: new Date("2026-08-19T07:05:00.000Z"), toFake: ["Date"] });
+      try {
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "America/Chicago" });
+        mocks.trackingReminderFindFirst.mockResolvedValue(NIGHTLY_REMINDER);
+        mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
+        mocks.trackingReminderNotificationCreate.mockImplementation(
+          async ({ data }: { data: Record<string, unknown> }) => ({
+            ...data,
+            id: "notification-1",
+          }),
+        );
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "respondToTrackingReminder",
+          arguments: {
+            snoozeMinutes: 45,
+            status: "SNOOZED",
+            trackingReminderId: "reminder-night",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        // Deferred 45 real minutes into the future, on today's occurrence.
+        expect(mocks.trackingReminderNotificationCreate).toHaveBeenCalledWith({
+          data: expect.objectContaining({
+            notifyAt: new Date("2026-08-19T07:50:00.000Z"),
+            status: NotificationStatus.SNOOZED,
+          }),
+        });
+        const body = parseToolBody(result) as {
+          result: { answersPastOccurrence?: boolean; dateKey: string };
+        };
+        expect(body.result.dateKey).toBe("2026-08-19");
+        expect(body.result.answersPastOccurrence).toBeUndefined();
+        expect(mocks.measurementUpsert).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("respondToTrackingReminder keeps the calendar default for reminders outside their eligibility window", async () => {
       vi.useFakeTimers({ now: new Date("2026-08-19T07:05:00.000Z"), toFake: ["Date"] });
       try {

--- a/apps/optimitron/src/lib/__tests__/mcp-server.test.ts
+++ b/apps/optimitron/src/lib/__tests__/mcp-server.test.ts
@@ -11717,6 +11717,7 @@ describe("MCP server tool dispatch", () => {
     // calendar-today default targeted the new day's still-future occurrence,
     // leaving yesterday OVERDUE (#248).
     const NIGHTLY_REMINDER = {
+      active: true,
       createdAt: new Date("2026-08-01T00:00:00.000Z"),
       defaultValue: 1500,
       deletedAt: null,
@@ -11850,6 +11851,54 @@ describe("MCP server tool dispatch", () => {
       }
     });
 
+    it("respondToTrackingReminder keeps the calendar default for reminders outside their eligibility window", async () => {
+      vi.useFakeTimers({ now: new Date("2026-08-19T07:05:00.000Z"), toFake: ["Date"] });
+      try {
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "America/Chicago" });
+        // Stopped a week+ ago: no day in the walk-back window is eligible,
+        // so an explicit answer targets today, as before the walk-back.
+        mocks.trackingReminderFindFirst.mockResolvedValue({
+          ...NIGHTLY_REMINDER,
+          stopTrackingDate: new Date("2026-08-10T00:00:00.000Z"),
+        });
+        mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
+        mocks.trackingReminderNotificationCreate.mockImplementation(
+          async ({ data }: { data: Record<string, unknown> }) => ({
+            ...data,
+            id: "notification-1",
+          }),
+        );
+        mocks.measurementUpsert.mockResolvedValue({
+          globalVariableId: "gv-vitd",
+          id: "measurement-1",
+          subjectId: "subject-1",
+          unitId: "unit-iu",
+          value: 1500,
+        });
+        mocks.trackingReminderUpdate.mockResolvedValue({
+          id: "reminder-night",
+        });
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "respondToTrackingReminder",
+          arguments: {
+            status: "TRACKED",
+            trackingReminderId: "reminder-night",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const body = parseToolBody(result) as {
+          result: { answersPastOccurrence?: boolean; dateKey: string };
+        };
+        expect(body.result.dateKey).toBe("2026-08-19");
+        expect(body.result.answersPastOccurrence).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("bulk respond without dateKey refuses an after-midnight catch-up and names yesterday", async () => {
       vi.useFakeTimers({ now: new Date("2026-08-19T07:05:00.000Z"), toFake: ["Date"] });
       try {
@@ -11869,6 +11918,93 @@ describe("MCP server tool dispatch", () => {
         expect(message).toContain('dateKey: "2026-08-18"');
         expect(mocks.trackingReminderNotificationCreate).not.toHaveBeenCalled();
         expect(mocks.measurementUpsert).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("bulk respond allows an unambiguous after-midnight answer-in-advance via except", async () => {
+      vi.useFakeTimers({ now: new Date("2026-08-19T07:05:00.000Z"), toFake: ["Date"] });
+      try {
+        // reminder-other is still unanswered for yesterday, but the except
+        // entry names reminder-night, whose yesterday occurrence is TRACKED:
+        // no ambiguity, so the call answers tonight's slot in advance.
+        const otherReminder = {
+          ...NIGHTLY_REMINDER,
+          globalVariable: {
+            ...TRACKING_VARIABLE,
+            id: "gv-magnesium",
+            name: "Magnesium",
+          },
+          globalVariableId: "gv-magnesium",
+          id: "reminder-other",
+        };
+        mocks.userFindUnique.mockResolvedValue({ timeZone: "America/Chicago" });
+        mocks.trackingReminderFindMany.mockResolvedValue([
+          NIGHTLY_REMINDER,
+          otherReminder,
+        ]);
+        mocks.trackingReminderNotificationFindMany.mockImplementation(
+          async ({ where }: { where: { notifyAt: { gte: Date } } }) =>
+            // Yesterday's window: reminder-night is already answered.
+            where.notifyAt.gte.getTime() ===
+            new Date("2026-08-18T05:00:00.000Z").getTime()
+              ? [
+                  {
+                    deletedAt: null,
+                    id: "notification-night-yesterday",
+                    notifyAt: new Date("2026-08-19T03:30:00.000Z"),
+                    status: NotificationStatus.TRACKED,
+                    trackedValue: 1500,
+                    trackingReminderId: "reminder-night",
+                    userId: "user-1",
+                  },
+                ]
+              : [],
+        );
+        mocks.trackingReminderFindFirst.mockResolvedValue(NIGHTLY_REMINDER);
+        mocks.trackingReminderNotificationFindFirst.mockResolvedValue(null);
+        mocks.trackingReminderNotificationCreate.mockImplementation(
+          async ({ data }: { data: Record<string, unknown> }) => ({
+            ...data,
+            id: "notification-tonight",
+          }),
+        );
+        mocks.measurementUpsert.mockResolvedValue({
+          globalVariableId: "gv-vitd",
+          id: "measurement-1",
+          subjectId: "subject-1",
+          unitId: "unit-iu",
+          value: 1500,
+        });
+        mocks.trackingReminderUpdate.mockResolvedValue({
+          id: "reminder-night",
+        });
+
+        const client = await setup("user-1", ALL_SCOPES);
+        const result = await client.callTool({
+          name: "respondToTrackingReminderNotifications",
+          arguments: {
+            except: [
+              { status: "TRACKED", trackingReminderId: "reminder-night" },
+            ],
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(parseToolBody(result)).toMatchObject({
+          answeredCount: 1,
+          results: [
+            { reminderId: "reminder-night", source: "exception" },
+          ],
+        });
+        // The answer lands on tonight's 22:30 slot.
+        expect(mocks.trackingReminderNotificationCreate).toHaveBeenCalledWith({
+          data: expect.objectContaining({
+            notifyAt: new Date("2026-08-20T03:30:00.000Z"),
+            trackingReminderId: "reminder-night",
+          }),
+        });
       } finally {
         vi.useRealTimers();
       }

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -425,7 +425,10 @@ and measurements written by answering a tracking reminder:
 
 An unknown variable name is an error rather than an empty page, so a typo does
 not read as "nothing logged". Pages return `nextCursor`; repeat the same call
-with `cursor` set until it is null.
+with `cursor` set until it is null. Each row carries `startTime` (UTC) and
+`startTimeLocal` (the user's zone, offset attached); report times to the user
+from `startTimeLocal` — reading raw UTC as local misdates late-evening entries
+by a day.
 
 ### Answering Tracking Reminders
 
@@ -444,12 +447,29 @@ whether an old skip meant zero or meant nobody answered.
 `listTrackingReminderNotifications` returns `notifyAtLocal` (compact: `due`) in
 the user's zone with the offset attached, plus the raw UTC instant in
 `notifyAt` (compact: `dueUtc`). `dateKey` and the day boundaries are local.
+The compact shape is the default and carries `defaultValue`, `unit`, and
+`fillingType`, so answering a queue needs no `listTrackingReminders` call;
+pass `compact: false` for full records. An OVERDUE item with
+`sameDayMeasurementCount` already has same-day data for its variable recorded
+outside the notification — verify with `listMeasurements` before answering
+again, or you may duplicate data.
+
+`listTrackingReminders` also defaults to a compact shape with truncated
+instructions; `getTrackingReminder` returns one reminder in full.
+
+`respondToTrackingReminder` without `dateKey` or `trackedAt` answers the
+reminder's most recent unanswered due occurrence within the last 7 days, so an
+after-midnight catch-up resolves yesterday's occurrence instead of
+pre-answering tomorrow's. The response's `notifyAtLocal` shows where the
+answer landed.
 
 `respondToTrackingReminderNotifications` answers several at once. Send only
 `except` entries to answer specific reminders; everything else stays untouched.
 `defaultStatus` is for answering the whole day and reaches only notifications
 that are due and still unanswered. An `except` entry can also correct a response
-already recorded.
+already recorded. The call is all-or-nothing and errors loudly: an `except`
+entry that is not scheduled for the date, or a catch-up aimed at a day with
+nothing due yet, writes nothing and returns directions instead.
 
 `serving`, `servings`, and the UCUM code `{serving}` resolve to the seeded
 `servings` unit. Use servings for simple behavior or adherence tracking. Use a

--- a/packages/tracking/src/core.ts
+++ b/packages/tracking/src/core.ts
@@ -2050,7 +2050,11 @@ export async function respondToTrackingReminderNotificationsForUser(
   // After midnight, "today" flips while the user is still finishing
   // yesterday: every occurrence for the defaulted dateKey is in the future,
   // so a catch-up call either writes nothing or answers tomorrow's slots
-  // while yesterday stays OVERDUE (#248). Refuse with directions instead.
+  // while yesterday stays OVERDUE (#248). Refuse with directions when the
+  // call is ambiguous: the default would write nothing, or an except entry
+  // names a reminder that is still unanswered for yesterday. An except entry
+  // whose reminder has no unanswered yesterday occurrence is an unambiguous
+  // answer-in-advance and proceeds.
   const dateKeyOmitted = input.dateKey == null || input.dateKey === "";
   const nothingDueYetToday = due.notifications.every(
     (item) => item.notifyAt.getTime() > now,
@@ -2064,9 +2068,17 @@ export async function respondToTrackingReminderNotificationsForUser(
         )
       : null;
     if (previous && previous.notifications.length > 0) {
-      throw new Error(
-        `Nothing was written. No notifications are due yet for ${due.dateKey} in ${due.timeZone}, but ${previousDateKey} has ${previous.notifications.length} unanswered. Pass dateKey: "${previousDateKey}" to answer that day, or dateKey: "${due.dateKey}" to answer today's future occurrences in advance.`,
+      const previousUnansweredIds = new Set(
+        previous.notifications.map((item) => item.reminderId),
       );
+      const ambiguous =
+        defaultStatus !== undefined ||
+        [...overrideById.keys()].some((id) => previousUnansweredIds.has(id));
+      if (ambiguous) {
+        throw new Error(
+          `Nothing was written. No notifications are due yet for ${due.dateKey} in ${due.timeZone}, but ${previousDateKey} has ${previous.notifications.length} unanswered. Pass dateKey: "${previousDateKey}" to answer that day, or dateKey: "${due.dateKey}" to answer today's future occurrences in advance.`,
+        );
+      }
     }
   }
 
@@ -2149,21 +2161,35 @@ const MAX_RESPONSE_BACKFILL_DAYS = 7;
 async function mostRecentDueUnansweredDateKey(
   tx: Prisma.TransactionClient,
   reminder: {
+    active: boolean;
     createdAt: Date;
     id: string;
     reminderFrequency: number;
     reminderStartTime: string;
     startTrackingDate: Date | null;
+    stopTrackingDate: Date | null;
   },
   userId: string,
   timeZone: string,
   todayKey: string,
 ) {
+  // An inactive reminder is never listed as due, so implicit catch-up does
+  // not apply; answering it keeps the calendar default.
+  if (!reminder.active) return null;
   const now = Date.now();
   for (let offset = 0; offset <= MAX_RESPONSE_BACKFILL_DAYS; offset += 1) {
     const candidate = offset === 0 ? todayKey : shiftDateKey(todayKey, -offset);
     if (!candidate) return null;
     const { end, start } = dayRange(candidate, timeZone);
+    // Match listDueTrackingRemindersForUser's eligibility window: a day that
+    // starts after stopTrackingDate has no due occurrence. startTrackingDate
+    // is enforced by the occurrence anchor below.
+    if (
+      reminder.stopTrackingDate != null &&
+      reminder.stopTrackingDate < start
+    ) {
+      continue;
+    }
     const occurrence = reminderOccurrenceWithinRange(reminder, {
       dateKey: candidate,
       end,

--- a/packages/tracking/src/core.ts
+++ b/packages/tracking/src/core.ts
@@ -76,6 +76,7 @@ const TRACKING_REMINDER_INCLUDE = {
   globalVariable: { select: TRACKING_VARIABLE_SELECT },
   nOf1Variable: {
     select: {
+      defaultUnit: { select: TRACKING_UNIT_SELECT },
       defaultUnitId: true,
       fillingType: true,
       id: true,
@@ -83,6 +84,27 @@ const TRACKING_REMINDER_INCLUDE = {
     },
   },
 } satisfies Prisma.TrackingReminderInclude;
+
+type TrackingUnitSummary = Prisma.UnitGetPayload<{
+  select: typeof TRACKING_UNIT_SELECT;
+}>;
+
+/**
+ * The unit a reminder answer records in: the user's per-variable preference
+ * when one is set, else the canonical variable default. Responses surface
+ * this because the nested defaultUnitId alone made an honored unit request
+ * look silently dropped (#250).
+ */
+function reminderEffectiveUnit(reminder: {
+  globalVariable?: { defaultUnit?: TrackingUnitSummary | null } | null;
+  nOf1Variable?: { defaultUnit?: TrackingUnitSummary | null } | null;
+}): TrackingUnitSummary | null {
+  return (
+    reminder.nOf1Variable?.defaultUnit ??
+    reminder.globalVariable?.defaultUnit ??
+    null
+  );
+}
 
 const TRACKING_NOTIFICATION_WITH_REMINDER_INCLUDE = {
   trackingReminder: { include: TRACKING_REMINDER_INCLUDE },
@@ -771,20 +793,30 @@ export async function upsertTrackingReminderForUser(
     const immutableVariableFields = [
       "categoryName",
       "combinationOperation",
-      "fillingType",
       "globalVariableId",
-      "unitAbbreviation",
-      "unitId",
-      "unitName",
       "variableName",
     ].filter((fieldName) => fieldName in input);
     if (immutableVariableFields.length > 0) {
       throw new Error(
-        `A reminder's tracked variable cannot be changed. Omit ${immutableVariableFields.join(
+        `A reminder's tracked variable is fixed at creation. Omit ${immutableVariableFields.join(
           ", ",
-        )} when editing by trackingReminderId.`,
+        )} when editing by trackingReminderId. To track a different variable, create a new reminder and set active: false on this one. To change only the recording unit, pass unitAbbreviation, unitId, or unitName.`,
       );
     }
+
+    const unitInput = {
+      unitAbbreviation: optionalString(input.unitAbbreviation),
+      unitId: optionalString(input.unitId),
+      unitName: optionalString(input.unitName),
+    };
+    const hasUnitInput = Boolean(
+      unitInput.unitAbbreviation || unitInput.unitId || unitInput.unitName,
+    );
+    const fillingType = parseEnumInput(
+      FillingType,
+      input.fillingType,
+      "fillingType",
+    );
 
     const update: Prisma.TrackingReminderUpdateInput = {};
     if ("active" in input) {
@@ -846,20 +878,50 @@ export async function upsertTrackingReminderForUser(
         if (!existing) {
           throw new Error(`TrackingReminder not found: ${trackingReminderId}`);
         }
-        if (Object.keys(update).length === 0) {
-          return {
-            reminder: existing,
-            subjectId: existing.nOf1Variable.subjectId,
+
+        // Unit and fillingType are per-user settings on the NOf1Variable,
+        // not part of the reminder's variable identity, so an ID edit may
+        // change them. The canonical GlobalVariable is never touched.
+        let appliedUnit: TrackingUnitSummary | null = null;
+        if (hasUnitInput) {
+          appliedUnit = await resolveTrackingUnit(tx, unitInput);
+          if (!appliedUnit) throw new Error("Requested unit was not found.");
+        }
+        const nOf1Update: Prisma.NOf1VariableUncheckedUpdateInput = {
+          ...(appliedUnit ? { defaultUnitId: appliedUnit.id } : {}),
+          ...(fillingType ? { fillingType } : {}),
+        };
+        if (Object.keys(nOf1Update).length > 0) {
+          await tx.nOf1Variable.update({
+            data: nOf1Update,
+            where: { id: existing.nOf1VariableId },
+          });
+        }
+
+        let reminder =
+          Object.keys(update).length > 0
+            ? await tx.trackingReminder.update({
+                data: update,
+                include: TRACKING_REMINDER_INCLUDE,
+                where: { id: existing.id },
+              })
+            : existing;
+        if (appliedUnit || fillingType) {
+          reminder = {
+            ...reminder,
+            nOf1Variable: {
+              ...reminder.nOf1Variable,
+              ...(appliedUnit
+                ? { defaultUnit: appliedUnit, defaultUnitId: appliedUnit.id }
+                : {}),
+              ...(fillingType ? { fillingType } : {}),
+            },
           };
         }
-        const reminder = await tx.trackingReminder.update({
-          data: update,
-          include: TRACKING_REMINDER_INCLUDE,
-          where: { id: existing.id },
-        });
         return {
           reminder,
           subjectId: reminder.nOf1Variable.subjectId,
+          unit: reminderEffectiveUnit(reminder),
         };
       });
     } catch (error) {
@@ -951,8 +1013,33 @@ export async function upsertTrackingReminderForUser(
         },
       },
     });
-    return { reminder, subjectId: subject.id };
+    return {
+      reminder,
+      subjectId: subject.id,
+      unit: reminderEffectiveUnit(reminder),
+    };
   });
+}
+
+export async function getTrackingReminderForUser(
+  input: Record<string, unknown>,
+  userId: string,
+) {
+  const trackingReminderId = optionalString(input.trackingReminderId);
+  if (!trackingReminderId) {
+    throw new Error(
+      "trackingReminderId is required. Use listTrackingReminders to find it.",
+    );
+  }
+  const prisma = await getPrisma();
+  const reminder = await prisma.trackingReminder.findFirst({
+    include: TRACKING_REMINDER_INCLUDE,
+    where: { deletedAt: null, id: trackingReminderId, userId },
+  });
+  if (!reminder) {
+    throw new Error(`TrackingReminder not found: ${trackingReminderId}`);
+  }
+  return { reminder, unit: reminderEffectiveUnit(reminder) };
 }
 
 export async function listMeasurementsForUser(
@@ -987,6 +1074,13 @@ export async function listMeasurementsForUser(
   const variableName = optionalString(input.variableName);
 
   const prisma = await getPrisma();
+  // Report times in the user's zone alongside UTC: an agent reading raw UTC
+  // startTime as local misdated a whole evening of answers by a day (#248).
+  const user = await prisma.user.findUnique({
+    select: { timeZone: true },
+    where: { id: userId },
+  });
+  const timeZone = user?.timeZone ?? "UTC";
   // Read-only variable lookup: unlike recordMeasurement this must never create
   // a GlobalVariable, and an unknown name is an error rather than an empty page.
   let variable: Prisma.GlobalVariableGetPayload<{
@@ -1043,13 +1137,15 @@ export async function listMeasurementsForUser(
     },
   });
 
-  const measurements = rows.slice(0, limit);
+  const kept = rows.slice(0, limit);
+  const measurements = kept.map((measurement) => ({
+    ...measurement,
+    startTimeLocal: formatZonedIsoString(measurement.startTime, timeZone),
+  }));
   return {
     measurements,
-    nextCursor:
-      rows.length > limit
-        ? (measurements[measurements.length - 1]?.id ?? null)
-        : null,
+    nextCursor: rows.length > limit ? (kept[kept.length - 1]?.id ?? null) : null,
+    timeZone,
     variable,
   };
 }
@@ -1211,12 +1307,24 @@ export async function updateTrackingVariableSettingsForUser(
   });
 }
 
+const INSTRUCTIONS_PREVIEW_LIMIT = 200;
+
+function instructionsPreview(instructions: string | null) {
+  if (
+    instructions == null ||
+    instructions.length <= INSTRUCTIONS_PREVIEW_LIMIT
+  ) {
+    return instructions;
+  }
+  return `${instructions.slice(0, INSTRUCTIONS_PREVIEW_LIMIT)} … [truncated; getTrackingReminder returns the full instructions]`;
+}
+
 export async function listTrackingRemindersForUser(
   input: Record<string, unknown>,
   userId: string,
 ) {
   const prisma = await getPrisma();
-  return prisma.trackingReminder.findMany({
+  const reminders = await prisma.trackingReminder.findMany({
     include: TRACKING_REMINDER_INCLUDE,
     orderBy: [{ active: "desc" }, { reminderStartTime: "asc" }],
     where: {
@@ -1225,6 +1333,24 @@ export async function listTrackingRemindersForUser(
       ...(input.includeInactive === true ? {} : { active: true }),
     },
   });
+  if (input.compact === false) return reminders;
+  // Compact is the default: queue-answering agents need the schedule and the
+  // value/unit, not full instruction text or expanded variable records (#249).
+  return reminders.map((reminder) => ({
+    active: reminder.active,
+    defaultValue: cleanNumber(reminder.defaultValue),
+    fillingType: reminder.nOf1Variable.fillingType,
+    id: reminder.id,
+    instructions: instructionsPreview(reminder.instructions),
+    lastTracked: reminder.lastTracked,
+    name: reminder.globalVariable.name,
+    reminderEndTime: reminder.reminderEndTime,
+    reminderFrequency: reminder.reminderFrequency,
+    reminderStartTime: reminder.reminderStartTime,
+    startTrackingDate: reminder.startTrackingDate,
+    stopTrackingDate: reminder.stopTrackingDate,
+    unit: reminderEffectiveUnit(reminder)?.abbreviatedName ?? null,
+  }));
 }
 
 /** Default snooze length when a caller does not name one. */
@@ -1336,6 +1462,7 @@ export async function listDueTrackingRemindersForUser(
           : snoozeElapsed
             ? NotificationStatus.PENDING
             : status,
+        fillingType: reminder.nOf1Variable.fillingType,
         globalVariable: reminder.globalVariable,
         instructions: reminder.instructions,
         isOverdue,
@@ -1368,6 +1495,7 @@ export async function listDueTrackingRemindersForUser(
         status,
         timeZone,
         trackedValue: cleanNumber(notification?.trackedValue),
+        unit: reminderEffectiveUnit(reminder)?.abbreviatedName ?? null,
         utcOffsetMinutes: getTimeZoneOffsetMinutes(notifyAt, timeZone),
       };
     })
@@ -1397,11 +1525,15 @@ export function toCompactTrackingNotifications(result: {
   dateKey?: string;
   endDateKey?: string;
   notifications: Array<{
+    defaultValue?: number | null;
     derivedStatus: NotificationStatus | TrackingReminderDerivedStatus;
+    fillingType?: FillingType;
     globalVariable: { name: string };
     notifyAt: Date;
     notifyAtLocal: string;
     reminderId: string;
+    sameDayMeasurementCount?: number;
+    unit?: string | null;
   }>;
   startDateKey?: string;
   timeZone: string;
@@ -1411,13 +1543,21 @@ export function toCompactTrackingNotifications(result: {
     ...(result.startDateKey ? { startDateKey: result.startDateKey } : {}),
     ...(result.endDateKey ? { endDateKey: result.endDateKey } : {}),
     notifications: result.notifications.map((notification) => ({
+      // defaultValue and unit ride along so an agent can answer without a
+      // second listTrackingReminders fetch (#249).
+      defaultValue: notification.defaultValue ?? null,
       // `due` is the user's local time so a voice client can read it aloud
       // without converting. `dueUtc` keeps the raw instant for machines.
       due: notification.notifyAtLocal,
       dueUtc: notification.notifyAt,
+      fillingType: notification.fillingType ?? null,
       id: notification.reminderId,
       name: notification.globalVariable.name,
+      ...(notification.sameDayMeasurementCount
+        ? { sameDayMeasurementCount: notification.sameDayMeasurementCount }
+        : {}),
       status: notification.derivedStatus,
+      unit: notification.unit ?? null,
     })),
     timeZone: result.timeZone,
   };
@@ -1464,6 +1604,7 @@ function storedTrackingNotificationToQueueItem(
       : snoozeElapsed
         ? NotificationStatus.PENDING
         : notification.status,
+    fillingType: reminder.nOf1Variable.fillingType,
     globalVariable: reminder.globalVariable,
     instructions: reminder.instructions,
     isOverdue,
@@ -1493,6 +1634,7 @@ function storedTrackingNotificationToQueueItem(
     status: notification.status,
     timeZone,
     trackedValue: cleanNumber(notification.trackedValue),
+    unit: reminderEffectiveUnit(reminder)?.abbreviatedName ?? null,
     utcOffsetMinutes: getTimeZoneOffsetMinutes(notifyAt, timeZone),
   };
 }
@@ -1611,17 +1753,22 @@ export async function listTrackingReminderNotificationsForUser(
     .map((notification) =>
       storedTrackingNotificationToQueueItem(notification, timeZone),
     );
-  const notifications = [
-    ...scheduledNotifications,
-    ...unmatchedStoredNotifications,
-  ]
-    .filter(
-      (notification) =>
-        (!trackingReminderId ||
-          notification.reminderId === trackingReminderId) &&
-        (!status || notification.derivedStatus === status),
-    )
-    .sort((left, right) => left.notifyAt.getTime() - right.notifyAt.getTime());
+  const notifications = await annotateSameDayMeasurements(
+    prisma,
+    [...scheduledNotifications, ...unmatchedStoredNotifications]
+      .filter(
+        (notification) =>
+          (!trackingReminderId ||
+            notification.reminderId === trackingReminderId) &&
+          (!status || notification.derivedStatus === status),
+      )
+      .sort(
+        (left, right) => left.notifyAt.getTime() - right.notifyAt.getTime(),
+      ),
+    userId,
+    timeZone,
+    { end: lastRange.end, start: firstRange.start },
+  );
   const result =
     dateKeys.length === 1
       ? { dateKey: dateKeys[0], notifications, timeZone }
@@ -1631,9 +1778,65 @@ export async function listTrackingReminderNotificationsForUser(
           startDateKey: dateKeys[0],
           timeZone,
         };
-  return input.compact === true
-    ? toCompactTrackingNotifications(result)
-    : result;
+  // Compact is the default so queue-answering clients get the light shape
+  // without knowing to ask; compact: false opts into the full records (#249).
+  return input.compact === false
+    ? result
+    : toCompactTrackingNotifications(result);
+}
+
+/**
+ * Flags OVERDUE occurrences whose variable already has same-local-day
+ * measurements. An unanswered notification says nothing about data recorded
+ * through other paths, which made the overdue queue unverifiable and invited
+ * duplicate re-answers (#248). The flag is diagnostic only; nothing is
+ * auto-resolved.
+ */
+async function annotateSameDayMeasurements<
+  T extends {
+    dateKey: string;
+    globalVariable: { id: string };
+    isOverdue: boolean;
+  },
+>(
+  prisma: TrackingDbClient,
+  notifications: T[],
+  userId: string,
+  timeZone: string,
+  range: { end: Date; start: Date },
+): Promise<Array<T & { sameDayMeasurementCount?: number }>> {
+  const overdue = notifications.filter(
+    (notification) => notification.isOverdue,
+  );
+  if (overdue.length === 0) return notifications;
+  const rows = await prisma.measurement.findMany({
+    select: { globalVariableId: true, startTime: true },
+    where: {
+      deletedAt: null,
+      globalVariableId: {
+        in: [
+          ...new Set(overdue.map((item) => item.globalVariable.id)),
+        ],
+      },
+      startTime: { gte: range.start, lt: range.end },
+      subject: { userId },
+    },
+  });
+  const countByVariableDay = new Map<string, number>();
+  for (const row of rows) {
+    const key = `${row.globalVariableId}|${getZonedDateKey(row.startTime, timeZone)}`;
+    countByVariableDay.set(key, (countByVariableDay.get(key) ?? 0) + 1);
+  }
+  return notifications.map((notification) => {
+    if (!notification.isOverdue) return notification;
+    const count =
+      countByVariableDay.get(
+        `${notification.globalVariable.id}|${notification.dateKey}`,
+      ) ?? 0;
+    return count > 0
+      ? { ...notification, sameDayMeasurementCount: count }
+      : notification;
+  });
 }
 
 async function findOrCreateTrackingNotification(
@@ -1819,15 +2022,14 @@ export async function respondToTrackingReminderNotificationsForUser(
   );
 
   if (unknownExceptionIds.length > 0) {
-    return {
-      answeredCount: 0,
-      dateKey: due.dateKey,
-      failed: [],
-      results: [],
-      // Nothing was written, so every scheduled reminder was left untouched.
-      skippedCount: due.notifications.length,
-      unknownExceptionIds,
-    };
+    // All-or-nothing, and loudly: the previous success-shaped no-op response
+    // let an agent report a whole day as answered when nothing was written
+    // (#248). An error cannot be missed.
+    throw new Error(
+      `Nothing was written. These except entries are not scheduled for ${due.dateKey}: ${unknownExceptionIds.join(
+        ", ",
+      )}. Check the reminder IDs with listTrackingReminderNotifications, or pass the dateKey their occurrences belong to.`,
+    );
   }
 
   // defaultStatus only reaches notifications that are due and still
@@ -1845,7 +2047,31 @@ export async function respondToTrackingReminderNotificationsForUser(
   });
   const skippedCount = due.notifications.length - targets.length;
 
+  // After midnight, "today" flips while the user is still finishing
+  // yesterday: every occurrence for the defaulted dateKey is in the future,
+  // so a catch-up call either writes nothing or answers tomorrow's slots
+  // while yesterday stays OVERDUE (#248). Refuse with directions instead.
+  const dateKeyOmitted = input.dateKey == null || input.dateKey === "";
+  const nothingDueYetToday = due.notifications.every(
+    (item) => item.notifyAt.getTime() > now,
+  );
+  if (dateKeyOmitted && nothingDueYetToday) {
+    const previousDateKey = shiftDateKey(due.dateKey, -1);
+    const previous = previousDateKey
+      ? await listDueTrackingRemindersForUser(
+          { dateKey: previousDateKey },
+          userId,
+        )
+      : null;
+    if (previous && previous.notifications.length > 0) {
+      throw new Error(
+        `Nothing was written. No notifications are due yet for ${due.dateKey} in ${due.timeZone}, but ${previousDateKey} has ${previous.notifications.length} unanswered. Pass dateKey: "${previousDateKey}" to answer that day, or dateKey: "${due.dateKey}" to answer today's future occurrences in advance.`,
+      );
+    }
+  }
+
   const results: Array<{
+    notifyAtLocal: string;
     recordedAsZero: boolean;
     reminderId: string;
     source: "default" | "exception";
@@ -1879,6 +2105,8 @@ export async function respondToTrackingReminderNotificationsForUser(
         userId,
       );
       results.push({
+        // Where the answer landed, so an agent can verify the day it wrote.
+        notifyAtLocal: item.notifyAtLocal,
         recordedAsZero,
         reminderId: item.reminderId,
         source: override ? "exception" : "default",
@@ -1903,6 +2131,64 @@ export async function respondToTrackingReminderNotificationsForUser(
   };
 }
 
+/**
+ * Days respondToTrackingReminder walks back looking for the most recent due
+ * occurrence when the caller names neither dateKey nor trackedAt. Bounds the
+ * per-response lookups; older gaps need an explicit dateKey.
+ */
+const MAX_RESPONSE_BACKFILL_DAYS = 7;
+
+/**
+ * The calendar-today default mis-anchored after-midnight catch-ups: at 02:00
+ * an answer to yesterday's 22:30 reminder landed on today's still-future
+ * occurrence, leaving yesterday OVERDUE (#248). Without an explicit target,
+ * answer the most recent occurrence that is actually due. An already-answered
+ * most-recent occurrence keeps the calendar default so corrections and
+ * answering today in advance behave as before.
+ */
+async function mostRecentDueUnansweredDateKey(
+  tx: Prisma.TransactionClient,
+  reminder: {
+    createdAt: Date;
+    id: string;
+    reminderFrequency: number;
+    reminderStartTime: string;
+    startTrackingDate: Date | null;
+  },
+  userId: string,
+  timeZone: string,
+  todayKey: string,
+) {
+  const now = Date.now();
+  for (let offset = 0; offset <= MAX_RESPONSE_BACKFILL_DAYS; offset += 1) {
+    const candidate = offset === 0 ? todayKey : shiftDateKey(todayKey, -offset);
+    if (!candidate) return null;
+    const { end, start } = dayRange(candidate, timeZone);
+    const occurrence = reminderOccurrenceWithinRange(reminder, {
+      dateKey: candidate,
+      end,
+      start,
+      timeZone,
+    });
+    if (!occurrence || occurrence.getTime() > now) continue;
+    const stored = await tx.trackingReminderNotification.findFirst({
+      select: { status: true },
+      where: {
+        deletedAt: null,
+        notifyAt: { gte: start, lt: end },
+        trackingReminderId: reminder.id,
+        userId,
+      },
+    });
+    const answered =
+      stored != null &&
+      (stored.status === NotificationStatus.TRACKED ||
+        stored.status === NotificationStatus.SKIPPED);
+    return answered ? todayKey : candidate;
+  }
+  return null;
+}
+
 export async function respondToTrackingReminderForUser(
   input: Record<string, unknown>,
   userId: string,
@@ -1918,13 +2204,15 @@ export async function respondToTrackingReminderForUser(
   const snoozeMinutes =
     status === NotificationStatus.SNOOZED ? parseSnoozeMinutes(input) : null;
   const trackedAt = parseOptionalDateValue(input.trackedAt, "trackedAt");
+  const hasExplicitTarget =
+    (input.dateKey != null && input.dateKey !== "") || trackedAt != null;
   const prisma = await getPrisma();
   const user = await prisma.user.findUnique({
     select: { timeZone: true },
     where: { id: userId },
   });
   const timeZone = user?.timeZone ?? "UTC";
-  const dateKey = parseDateKey(
+  const requestedDateKey = parseDateKey(
     input.dateKey,
     getZonedDateKey(trackedAt ?? new Date(), timeZone),
   );
@@ -1939,6 +2227,21 @@ export async function respondToTrackingReminderForUser(
     });
     if (!reminder) {
       throw new Error(`TrackingReminder not found: ${trackingReminderId}`);
+    }
+    let dateKey = requestedDateKey;
+    let answersPastOccurrence = false;
+    if (!hasExplicitTarget) {
+      const resolved = await mostRecentDueUnansweredDateKey(
+        tx,
+        reminder,
+        userId,
+        timeZone,
+        requestedDateKey,
+      );
+      if (resolved && resolved !== requestedDateKey) {
+        dateKey = resolved;
+        answersPastOccurrence = true;
+      }
     }
     const explicitValue = parseOptionalFiniteNumberInput(input, "value");
     if (recordedAsZero) {
@@ -1986,6 +2289,11 @@ export async function respondToTrackingReminderForUser(
       trackingReminderId,
       userId,
     });
+    // A backfilled past occurrence anchors the measurement to its scheduled
+    // slot, matching the bulk tool, so the value lands on the day being
+    // answered instead of the wall-clock day.
+    const measuredAt =
+      trackedAt ?? (answersPastOccurrence ? notifyAt : new Date());
     let measurement = null;
     if (status === NotificationStatus.TRACKED) {
       const value = trackedValue;
@@ -2003,7 +2311,7 @@ export async function respondToTrackingReminderForUser(
         longitude: null,
         note: optionalString(input.note),
         sourceName: optionalString(input.sourceName) ?? "mcp-reminder",
-        startTime: trackedAt ?? new Date(),
+        startTime: measuredAt,
         unitAbbreviation: optionalString(input.unitAbbreviation),
         // Only a caller-named unit is explicit. Leaving unitId unset lets
         // recordTrackingMeasurementWithTx use the user's persisted default
@@ -2017,14 +2325,16 @@ export async function respondToTrackingReminderForUser(
     }
     if (status === NotificationStatus.TRACKED) {
       await tx.trackingReminder.update({
-        data: { lastTracked: trackedAt ?? new Date() },
+        data: { lastTracked: measuredAt },
         where: { id: reminder.id },
       });
     }
     return {
+      ...(answersPastOccurrence ? { answersPastOccurrence: true } : {}),
       dateKey,
       measurement,
       notification,
+      notifyAtLocal: formatZonedIsoString(notifyAt, timeZone),
       recordedAsZero,
       reminderId: reminder.id,
       ...(recordedAsZero

--- a/packages/tracking/src/core.ts
+++ b/packages/tracking/src/core.ts
@@ -2256,7 +2256,11 @@ export async function respondToTrackingReminderForUser(
     }
     let dateKey = requestedDateKey;
     let answersPastOccurrence = false;
-    if (!hasExplicitTarget) {
+    // SNOOZED never walks back: the snooze clamp caps deferUntil at the
+    // target day's end, so a backfilled past day would defer into the past
+    // and the snooze would silently do nothing. Snoozing is a future nudge,
+    // not a backfill; only TRACKED answers target a past occurrence.
+    if (!hasExplicitTarget && status !== NotificationStatus.SNOOZED) {
       const resolved = await mostRecentDueUnansweredDateKey(
         tx,
         reminder,

--- a/packages/tracking/src/handlers.ts
+++ b/packages/tracking/src/handlers.ts
@@ -5,6 +5,7 @@
 // pre-extraction behavior.
 import {
   deleteMeasurementForUser,
+  getTrackingReminderForUser,
   listDueTrackingRemindersForUser,
   listMeasurementsForUser,
   listTrackingReminderNotificationsForUser,
@@ -116,6 +117,15 @@ export async function handleTrackingToolCall({
       return ok({
         reminders: await listTrackingRemindersForUser(a, userId),
       });
+    }
+
+    case "getTrackingReminder": {
+      if (!userId)
+        return authRequired(
+          name,
+          "This tool reads one of your personal tracking reminders.",
+        );
+      return ok(await getTrackingReminderForUser(a, userId));
     }
 
     case "listTrackingReminderNotifications":

--- a/packages/tracking/src/index.ts
+++ b/packages/tracking/src/index.ts
@@ -1,5 +1,6 @@
 export {
   deleteMeasurementForUser,
+  getTrackingReminderForUser,
   listDueTrackingRemindersForUser,
   listMeasurementsForUser,
   listTrackingReminderNotificationsForUser,

--- a/packages/tracking/src/tool-definitions.ts
+++ b/packages/tracking/src/tool-definitions.ts
@@ -55,7 +55,7 @@ export const TRACKING_TOOL_DEFINITIONS = [
   {
     name: "listMeasurements",
     description:
-      "List the authenticated user's own recorded measurements, newest first. Covers everything logged through recordMeasurement or a tracking-reminder response. Filter by globalVariableId or variableName for one variable, or omit both to see every variable. Use this to review logged doses, foods, symptoms, moods, sleep, activity, labs, and vitals, or to check whether a reminder was actually answered.",
+      "List the authenticated user's own recorded measurements, newest first. Covers everything logged through recordMeasurement or a tracking-reminder response. Filter by globalVariableId or variableName for one variable, or omit both to see every variable. Use this to review logged doses, foods, symptoms, moods, sleep, activity, labs, and vitals, or to check whether a reminder was actually answered. Each row carries startTime (UTC) and startTimeLocal (the user's zone): report times to the user from startTimeLocal.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -128,7 +128,7 @@ export const TRACKING_TOOL_DEFINITIONS = [
   {
     name: "upsertTrackingReminder",
     description:
-      "Create or edit a personal tracking reminder for medications, food, symptoms, mood, sleep, activity, labs, or vitals. When creating a new variable, pass categoryName; Food defaults to servings. To edit a reminder in place, first get its ID from listTrackingReminders, then pass trackingReminderId plus only the fields to change. Omit trackingReminderId to create or idempotently update the reminder identified by variable, start time, and frequency. The reminder can later be answered as TRACKED (value 0 for a not-taken day) or SNOOZED.",
+      "Create or edit a personal tracking reminder for medications, food, symptoms, mood, sleep, activity, labs, or vitals. When creating a new variable, pass categoryName; Food defaults to servings. To edit a reminder in place, pass trackingReminderId plus only the fields to change. Omit trackingReminderId to create or idempotently update the reminder identified by variable, start time, and frequency. Unit fields set your personal recording unit for the variable; the canonical variable default is unchanged. The response's top-level unit is the unit answers record in. The reminder can later be answered as TRACKED (value 0 for a not-taken day) or SNOOZED.",
     inputSchema: {
       type: "object" as const,
       anyOf: [
@@ -139,7 +139,7 @@ export const TRACKING_TOOL_DEFINITIONS = [
         trackingReminderId: {
           type: "string",
           description:
-            "Existing reminder ID to edit in place. When present, variable identity fields must be omitted and all other fields are optional patches.",
+            "Existing reminder ID to edit in place. Patchable: active, defaultValue, instructions, reminderStartTime, reminderEndTime, reminderFrequency, startTrackingDate, stopTrackingDate, unit fields, and fillingType. Fixed at creation: the tracked variable (variableName, globalVariableId, categoryName, combinationOperation) — to change it, create a new reminder and set active: false on this one.",
         },
         globalVariableId: { type: "string" },
         variableName: { type: "string" },
@@ -157,7 +157,7 @@ export const TRACKING_TOOL_DEFINITIONS = [
         unitAbbreviation: {
           type: "string",
           description:
-            "Short unit such as mg, IU, servings, count, or 1-5. serving and {serving} are accepted aliases for servings.",
+            "Short unit such as mg, IU, servings, count, or 1-5. serving and {serving} are accepted aliases for servings. Sets your personal recording unit for this variable, on create or on edit.",
         },
         unitName: {
           type: "string",
@@ -197,18 +197,35 @@ export const TRACKING_TOOL_DEFINITIONS = [
   {
     name: "listTrackingReminders",
     description:
-      "List the authenticated user's personal tracking reminders, active by default.",
+      "List the authenticated user's personal tracking reminders, active by default. Returns a compact shape by default: id, name, schedule, defaultValue, recording unit, fillingType, and an instructions preview. Pass compact: false for full records. Use getTrackingReminder for one reminder with full instructions.",
     inputSchema: {
       type: "object" as const,
       properties: {
         includeInactive: { type: "boolean" },
+        compact: {
+          type: "boolean",
+          description:
+            "Defaults to true. Pass false for full records with expanded variable and unit objects and untruncated instructions.",
+        },
       },
+    },
+  },
+  {
+    name: "getTrackingReminder",
+    description:
+      "Get one of the authenticated user's tracking reminders in full, including untruncated instructions, the expanded variable, and the effective recording unit. Use listTrackingReminders to find the ID.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        trackingReminderId: { type: "string" },
+      },
+      required: ["trackingReminderId"],
     },
   },
   {
     name: "listTrackingReminderNotifications",
     description:
-      "List the authenticated user's tracking notification queue for one local day or an inclusive local-date range. A reminder defines a schedule; a notification is one occurrence. Filter by trackingReminderId or effective status, including OVERDUE. Results expose scheduledAt, effective notifyAt, and snoozedUntil so clients can tell exactly how far a snooze moved an occurrence. Set includeCompleted to include recent TRACKED notifications. Times include the user's local zone and the UTC instant. Use compact mode for voice or chat clients.",
+      "List the authenticated user's tracking notification queue for one local day or an inclusive local-date range. A reminder defines a schedule; a notification is one occurrence. Filter by trackingReminderId or effective status, including OVERDUE. The default compact shape carries id (the trackingReminderId to answer with), name, due (local time), status, defaultValue, unit, and fillingType, so an agent can answer without a second lookup. An OVERDUE item with sameDayMeasurementCount already has same-day data for its variable recorded outside this notification: verify with listMeasurements before answering again, or you may duplicate data. Pass compact: false for full records with scheduledAt, effective notifyAt, and snoozedUntil. Set includeCompleted to include recent TRACKED notifications.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -240,7 +257,7 @@ export const TRACKING_TOOL_DEFINITIONS = [
         compact: {
           type: "boolean",
           description:
-            "Return trackingReminderId as id, plus name, due, and status.",
+            "Defaults to true. Pass false for full records including scheduledAt, snooze detail, and instructions.",
         },
         includeCompleted: {
           type: "boolean",
@@ -277,7 +294,7 @@ export const TRACKING_TOOL_DEFINITIONS = [
   {
     name: "respondToTrackingReminderNotifications",
     description:
-      "Answer several tracking reminder notifications in one call. To answer specific reminders, send only except entries and omit defaultStatus; every other reminder stays untouched. Send defaultStatus only when you intend to answer the whole day. An except entry can also correct a response you already recorded. If any exception ID is not scheduled for the date, this tool writes nothing.",
+      "Answer several tracking reminder notifications in one call. To answer specific reminders, send only except entries and omit defaultStatus; every other reminder stays untouched. Send defaultStatus only when you intend to answer the whole day. An except entry can also correct a response you already recorded. All-or-nothing: if any exception ID is not scheduled for the date, the tool writes nothing and returns an error. The call targets one local date; when catching up a past day (for example after midnight), pass that day's dateKey. Each result reports notifyAtLocal, the occurrence the answer landed on: verify it is the day you meant.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -322,7 +339,7 @@ export const TRACKING_TOOL_DEFINITIONS = [
   {
     name: "respondToTrackingReminder",
     description:
-      "Answer a due tracking reminder. TRACKED records a measurement. Record value 0 when the treatment, food, or activity was not taken; those zero days are the baseline that causal analysis needs. SNOOZED defers the notification. Deactivate the reminder when it no longer applies. SKIPPED is retired: it now records a zero and returns a deprecation notice.",
+      "Answer a due tracking reminder. TRACKED records a measurement. Record value 0 when the treatment, food, or activity was not taken; those zero days are the baseline that causal analysis needs. SNOOZED defers the notification. Deactivate the reminder when it no longer applies. SKIPPED is retired: it now records a zero and returns a deprecation notice. When dateKey and trackedAt are omitted, the answer targets the reminder's most recent due occurrence within the last 7 days that is still unanswered — so an after-midnight catch-up resolves yesterday's occurrence, not tomorrow's. The response's notifyAtLocal shows where the answer landed.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -346,10 +363,15 @@ export const TRACKING_TOOL_DEFINITIONS = [
         unitId: { type: "string" },
         unitAbbreviation: { type: "string" },
         unitName: { type: "string" },
-        trackedAt: { type: "string", description: "ISO date/time." },
+        trackedAt: {
+          type: "string",
+          description:
+            "ISO date/time the measurement actually happened. Also anchors the target day when dateKey is omitted.",
+        },
         dateKey: {
           type: "string",
-          description: "Local date in YYYY-MM-DD. Defaults from trackedAt.",
+          description:
+            "Local date in YYYY-MM-DD of the occurrence to answer. Defaults from trackedAt when given, else to the most recent unanswered due occurrence.",
         },
         note: { type: "string" },
         sourceName: { type: "string" },
@@ -365,6 +387,7 @@ export const TRACKING_TOOL_SCOPES = {
   [DELETE_MEASUREMENT_TOOL_NAME]: [McpScope.TASKS_PERSONAL],
   listMeasurements: [McpScope.TASKS_PERSONAL],
   upsertTrackingReminder: [McpScope.TASKS_PERSONAL],
+  getTrackingReminder: [McpScope.TASKS_PERSONAL],
   listTrackingReminders: [McpScope.TASKS_PERSONAL],
   listDueTrackingReminders: [McpScope.TASKS_PERSONAL],
   listTrackingReminderNotifications: [McpScope.TASKS_PERSONAL],


### PR DESCRIPTION
Closes #248, closes #249, closes #250.

## What the investigation found

Production data tells a different story than #248's premise. The Aug 18 overdue list was probably **correct**:

- The "evening symptom ratings recorded just after 2am" were recorded at **9:02pm Aug 18 Chicago** (`2026-08-19T02:02Z`) — the agent read UTC timestamps as local time. Those notifications were resolved correctly at the time.
- Berberine and the other ~30 OVERDUE items had **no measurements at all** until the Aug 19 morning catch-up backfilled them (Berberine's only Aug-18-slot measurement was created `2026-08-19T15:11Z`, after the issue was filed). "The measurements were all there" was an eyeball of ~40 rows against ~86 notifications, misled by UTC display.

So the underlying defects are: agents could not cheaply verify overdue-vs-recorded, UTC-only timestamps invited misreporting, the after-midnight `dateKey` default ("today" flips at midnight) silently mistargets catch-ups, and the batch respond tool returned a success-shaped `{answeredCount: 0, unknownExceptionIds: [...]}` no-op that an agent can miss and report as done.

For #250, the requested `mg` unit was likely **honored** — stored as the per-user unit on `NOf1Variable.defaultUnitId` — but invisible: the response only showed the canonical variable's `count` unit, and the edit path then blocked the "fix" with a dead-end error.

## Changes

**#248 — trustworthy overdue queue**
- `respondToTrackingReminder` without `dateKey`/`trackedAt` answers the most recent **unanswered** due occurrence (≤7 days back) instead of calendar today; backfilled measurements anchor to the scheduled slot, matching the bulk tool. Response reports `notifyAtLocal` and `answersPastOccurrence`. The walk-back applies only to `TRACKED` answers, only to active reminders, and only within the reminder's tracking window.
- `respondToTrackingReminderNotifications` throws on unknown exception IDs (all-or-nothing stays, silence goes) and refuses an after-midnight call without `dateKey` when it is ambiguous: `defaultStatus` present, or an `except` entry naming a reminder still unanswered for yesterday. Unambiguous answer-in-advance `except` entries proceed. Each result carries `notifyAtLocal` so agents can verify where answers landed.
- OVERDUE notifications carry `sameDayMeasurementCount` when the variable already has same-local-day measurements — a duplicate-answer guard. Diagnostic only; nothing is auto-resolved (per the concern in #248 about reconciliation papering over root causes).
- `listMeasurements` returns `startTimeLocal` and `timeZone`.

**#249 — lean payloads**
- Compact is the default on `listTrackingReminderNotifications` and `listTrackingReminders`; `compact: false` opts into full records.
- Compact notification items inline `defaultValue`, `unit`, and `fillingType`, so answering a queue needs no `listTrackingReminders` fetch.
- New `getTrackingReminder` tool (and dfda REST `GET /api/v1/tracking-reminders/[id]`) returns one reminder in full; truncated instruction previews name it in the truncation note.

**#250 — unit changes with a path forward**
- `upsertTrackingReminder` ID edits can change the recording unit and `fillingType` — they are per-user `NOf1Variable` settings, not variable identity. The canonical `GlobalVariable` is never touched.
- The immutable-variable error names the recovery path; the `trackingReminderId` schema description states which fields are patchable and which are fixed.
- Every reminder response surfaces the effective recording `unit`, so an honored unit request no longer reads as silently dropped.

## Review follow-ups

- `6e016af` — bulk guard refined to allow unambiguous answer-in-advance `except` entries; walk-back bounded to active reminders within their tracking window (CodeRabbit findings, both confirmed addressed).
- `d6333ef` — owner-requested rename of the visual review sidebar group "Compatibility checks" → "Legacy site variants" (display strings + e2e assertion only; internal keys unchanged). This is a rendered-text change in the internal visual-review tool itself; it is verified by the exact-text e2e assertion in `visual-review-page.spec.ts` rather than screenshots, since the review tool is not covered by its own screenshot pipeline.
- `993126d` — `SNOOZED` responses never walk back to a past occurrence: the snooze clamp caps `deferUntil` at the target day's end, so a backfilled past day would defer into the past and silently do nothing (claude[bot] review finding).

## Testing

- `apps/optimitron` MCP server suite: **321/321 pass** (12 new tests covering unit edit + unknown-unit rejection, `getTrackingReminder` found/not-found, compact reminder list truncation, after-midnight walk-back + answered-occurrence guard + eligibility-window guard + snooze guard, bulk after-midnight refusal + unambiguous advance answer, `sameDayMeasurementCount`, `startTimeLocal`).
- `apps/dfda` tests: 20/20 pass. `visual-review-page.spec.ts`: 10/10 pass locally. Typechecks clean for `@optimitron/tracking`, `@apps/dfda`, `@optimitron/web`; lint has no errors.
- Full web suite has 20 pre-existing failing files (task-funding/DB integration tests needing live Postgres); verified identical failures on the base commit without this change.

No app page or component UI changed (MCP + REST + the internal visual-review tool label noted above), so no app screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwHkhVc2KBcs8fDFiZDeyi