### PR TITLE
Reduce unnecessary Vercel and CI builds

### DIFF
--- a/.github/scripts/ci-change-detection.test.mjs
+++ b/.github/scripts/ci-change-detection.test.mjs
@@ -6,10 +6,38 @@ const workflow = readFileSync(
   new URL("../workflows/ci.yml", import.meta.url),
   "utf8",
 );
+const updaterWorkflow = readFileSync(
+  new URL("../workflows/update-pr-branches.yml", import.meta.url),
+  "utf8",
+);
 
 test("detects large pull-request changes from the local git checkout", () => {
   assert.match(
     workflow,
     /- name: Checkout for local change detection[\s\S]*?fetch-depth: 0[\s\S]*?filter: blob:none[\s\S]*?- name: Detect web-impacting changes[\s\S]*?uses: dorny\/paths-filter@v3[\s\S]*?token: ""/u,
   );
+});
+
+test("runs expensive validation only for affected surfaces", () => {
+  assert.match(workflow, /core: \$\{\{[\s\S]*?core_files_changed/u);
+  assert.match(
+    workflow,
+    /core-validate:[\s\S]*?fromJSON\(needs\.changes\.outputs\.core/u,
+  );
+  assert.match(
+    workflow,
+    /web-static-validate:[\s\S]*?fromJSON\(needs\.changes\.outputs\.web/u,
+  );
+  assert.match(
+    workflow,
+    /web-e2e-validate:[\s\S]*?fromJSON\(needs\.changes\.outputs\.web/u,
+  );
+  assert.match(
+    workflow,
+    /sync-preview-managed-data:[\s\S]*?needs: \[changes, web-validate, site-apps-validate\]/u,
+  );
+});
+
+test("refreshes only pull requests that opt in", () => {
+  assert.match(updaterWorkflow, /gh pr list[\s\S]*?--label auto-update/u);
 });

--- a/.github/scripts/ci-change-detection.test.mjs
+++ b/.github/scripts/ci-change-detection.test.mjs
@@ -46,6 +46,21 @@ test("runs expensive validation only for affected surfaces", () => {
   );
 });
 
+test("keeps every real build input inside its validation scope", () => {
+  assert.equal((workflow.match(/- '\.npmrc'/gu) ?? []).length, 3);
+  assert.match(
+    workflow,
+    /web_files_changed:[\s\S]*?'content\/legislation\/\*\*'[\s\S]*?'docs\/canonical-argument-2026-05-20\.md'[\s\S]*?site_apps_changed:/u,
+  );
+});
+
+test("fails the pull-request gate when change detection fails", () => {
+  assert.match(
+    workflow,
+    /pr-validate:[\s\S]*?changes_result="\$\{\{ needs\.changes\.result \}\}"[\s\S]*?\[ "\$changes_result" != "success" \]/u,
+  );
+});
+
 test("refreshes only pull requests that opt in", () => {
   assert.match(updaterWorkflow, /gh pr list[\s\S]*?--label auto-update/u);
 });

--- a/.github/scripts/ci-change-detection.test.mjs
+++ b/.github/scripts/ci-change-detection.test.mjs
@@ -19,6 +19,10 @@ test("detects large pull-request changes from the local git checkout", () => {
 });
 
 test("runs expensive validation only for affected surfaces", () => {
+  assert.match(
+    workflow,
+    /automation-tests:[\s\S]*?fromJSON\(needs\.changes\.outputs\.automation/u,
+  );
   assert.match(workflow, /core: \$\{\{[\s\S]*?core_files_changed/u);
   assert.match(
     workflow,
@@ -35,6 +39,10 @@ test("runs expensive validation only for affected surfaces", () => {
   assert.match(
     workflow,
     /sync-preview-managed-data:[\s\S]*?needs: \[changes, web-validate, site-apps-validate\]/u,
+  );
+  assert.match(
+    workflow,
+    /pr-validate:[\s\S]*?- automation-tests[\s\S]*?automation_result/u,
   );
 });
 

--- a/.github/scripts/vercel-app-build-scope.mjs
+++ b/.github/scripts/vercel-app-build-scope.mjs
@@ -21,10 +21,7 @@ const globalBuildFiles = new Set([
   "tsconfig.base.json",
 ]);
 const appExtraBuildPaths = Object.freeze({
-  optimitron: [
-    "content/",
-    "docs/canonical-argument-2026-05-20.md",
-  ],
+  optimitron: ["content/", "docs/canonical-argument-2026-05-20.md"],
 });
 const appIgnoredBuildPaths = Object.freeze({
   optimitron: [
@@ -105,19 +102,72 @@ export function ensureVercelDiffBase(
 
   for (const remote of fetchRemotes) {
     try {
+      execFile("git", ["fetch", "--no-tags", "--depth=1", remote, diffBase], {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+    } catch {
+      continue;
+    }
+    if (hasGitCommit(diffBase, root, execFile)) return diffBase;
+  }
+
+  return null;
+}
+
+export function ensureVercelProductionDiffBase({
+  root = repoRoot,
+  execFile = execFileSync,
+  fetchRemotes = getVercelGitFetchRemotes(process.env, root),
+  currentBranch = String(process.env.VERCEL_GIT_COMMIT_REF ?? "").trim(),
+  productionBranch = "main",
+  fetchDepth = 100,
+} = {}) {
+  if (!currentBranch || currentBranch === productionBranch) return null;
+
+  const localMergeBase = resolveProductionMergeBase(
+    root,
+    execFile,
+    productionBranch,
+  );
+  if (localMergeBase) return localMergeBase;
+
+  for (const remote of fetchRemotes) {
+    try {
       execFile(
         "git",
-        ["fetch", "--no-tags", "--depth=1", remote, diffBase],
+        ["fetch", "--no-tags", `--depth=${fetchDepth}`, remote, currentBranch],
         {
           cwd: root,
           encoding: "utf8",
           stdio: ["ignore", "ignore", "pipe"],
         },
       );
+      execFile(
+        "git",
+        [
+          "fetch",
+          "--no-tags",
+          `--depth=${fetchDepth}`,
+          remote,
+          productionBranch,
+        ],
+        {
+          cwd: root,
+          encoding: "utf8",
+          stdio: ["ignore", "ignore", "pipe"],
+        },
+      );
+      const mergeBase = execFile("git", ["merge-base", "HEAD", "FETCH_HEAD"], {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (/^[0-9a-f]{40}$/iu.test(mergeBase)) return mergeBase;
     } catch {
       continue;
     }
-    if (hasGitCommit(diffBase, root, execFile)) return diffBase;
   }
 
   return null;
@@ -176,11 +226,15 @@ function hasGitCommit(ref, root, execFile) {
   }
 }
 
-function resolveProductionMergeBase() {
-  for (const ref of ["origin/main", "main"]) {
+function resolveProductionMergeBase(
+  root = repoRoot,
+  execFile = execFileSync,
+  productionBranch = "main",
+) {
+  for (const ref of [`origin/${productionBranch}`, productionBranch]) {
     try {
-      const sha = execFileSync("git", ["merge-base", "HEAD", ref], {
-        cwd: repoRoot,
+      const sha = execFile("git", ["merge-base", "HEAD", ref], {
+        cwd: root,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
       }).trim();

--- a/.github/scripts/vercel-app-build-scope.test.mjs
+++ b/.github/scripts/vercel-app-build-scope.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   ensureVercelDiffBase,
+  ensureVercelProductionDiffBase,
   getVercelAppBuildMatches,
   getVercelDiffBase,
   getVercelGitFetchRemotes,
@@ -37,9 +38,7 @@ test("matches each app and its transitive workspace dependencies", () => {
     ["packages/survey-embed/src/index.ts"],
   );
   assert.deepEqual(
-    getVercelAppBuildMatches("curedao", [
-      "packages/survey-embed/src/index.ts",
-    ]),
+    getVercelAppBuildMatches("curedao", ["packages/survey-embed/src/index.ts"]),
     [],
   );
 });
@@ -51,10 +50,7 @@ test("keeps Optimitron content inputs without treating it as the default app", (
       "docs/canonical-argument-2026-05-20.md",
       "apps/warondisease/app/page.tsx",
     ]),
-    [
-      "content/legislation/example.md",
-      "docs/canonical-argument-2026-05-20.md",
-    ],
+    ["content/legislation/example.md", "docs/canonical-argument-2026-05-20.md"],
   );
 });
 
@@ -110,10 +106,7 @@ test("compares with the last successful deployment when Vercel provides it", () 
     "abcdef1234567890abcdef1234567890abcdef12",
   );
   assert.equal(
-    getVercelDiffBase(
-      { VERCEL_GIT_PREVIOUS_SHA: "not-a-sha" },
-      () => null,
-    ),
+    getVercelDiffBase({ VERCEL_GIT_PREVIOUS_SHA: "not-a-sha" }, () => null),
     null,
   );
 });
@@ -187,4 +180,51 @@ test("builds safely when a missing Vercel diff base cannot be fetched", () => {
     }),
     null,
   );
+});
+
+test("fetches main to scope a branch's first Vercel deployment", () => {
+  const mergeBase = "1234567890abcdef1234567890abcdef12345678";
+  let fetched = false;
+  const calls = [];
+  const execFile = (_command, args) => {
+    calls.push(args);
+    if (args[0] === "fetch") {
+      fetched = true;
+      return "";
+    }
+    if (args[0] === "merge-base" && fetched) return mergeBase;
+    throw new Error("missing production ref");
+  };
+
+  assert.equal(
+    ensureVercelProductionDiffBase({
+      root: "/repo",
+      execFile,
+      fetchRemotes: ["origin"],
+      currentBranch: "feature/example",
+    }),
+    mergeBase,
+  );
+  assert.deepEqual(calls, [
+    ["merge-base", "HEAD", "origin/main"],
+    ["merge-base", "HEAD", "main"],
+    ["fetch", "--no-tags", "--depth=100", "origin", "feature/example"],
+    ["fetch", "--no-tags", "--depth=100", "origin", "main"],
+    ["merge-base", "HEAD", "FETCH_HEAD"],
+  ]);
+});
+
+test("does not compare a production deployment with its own HEAD", () => {
+  let called = false;
+  assert.equal(
+    ensureVercelProductionDiffBase({
+      currentBranch: "main",
+      execFile: () => {
+        called = true;
+        return "";
+      },
+    }),
+    null,
+  );
+  assert.equal(called, false);
 });

--- a/.github/scripts/vercel-app-projects.mjs
+++ b/.github/scripts/vercel-app-projects.mjs
@@ -76,15 +76,32 @@ export function getProjectPatch(current, desired) {
     enableAffectedProjectsDeployments: true,
     framework: "nextjs",
     nodeVersion: "24.x",
+    productionDeploymentsFastLane: true,
     rootDirectory: desired.rootDirectory,
     sourceFilesOutsideRootDirectory: true,
   };
-  return Object.fromEntries(
+  const patch = Object.fromEntries(
     Object.entries(expected).filter(([key, value]) => {
       const currentValue = current?.[key] ?? current?.settings?.[key];
       return currentValue !== value;
     }),
   );
+  const currentResourceConfig =
+    current?.resourceConfig ?? current?.settings?.resourceConfig ?? {};
+  const expectedResourceConfig = {
+    buildMachineSelection: "fixed",
+    buildMachineType: "standard",
+    elasticConcurrencyEnabled: false,
+  };
+  const resourceConfigPatch = Object.fromEntries(
+    Object.entries(expectedResourceConfig).filter(
+      ([key, value]) => currentResourceConfig[key] !== value,
+    ),
+  );
+  if (Object.keys(resourceConfigPatch).length > 0) {
+    patch.resourceConfig = resourceConfigPatch;
+  }
+  return patch;
 }
 
 export function getGitLinkProblem(current) {

--- a/.github/scripts/vercel-app-projects.test.mjs
+++ b/.github/scripts/vercel-app-projects.test.mjs
@@ -153,6 +153,12 @@ test("repairs only deployment settings that drift", () => {
         enableAffectedProjectsDeployments: false,
         framework: "nextjs",
         nodeVersion: "20.x",
+        productionDeploymentsFastLane: false,
+        resourceConfig: {
+          buildMachineSelection: "auto",
+          buildMachineType: "turbo",
+          elasticConcurrencyEnabled: true,
+        },
         rootDirectory: desired.rootDirectory,
         sourceFilesOutsideRootDirectory: false,
       },
@@ -161,6 +167,12 @@ test("repairs only deployment settings that drift", () => {
     {
       enableAffectedProjectsDeployments: true,
       nodeVersion: "24.x",
+      productionDeploymentsFastLane: true,
+      resourceConfig: {
+        buildMachineSelection: "fixed",
+        buildMachineType: "standard",
+        elasticConcurrencyEnabled: false,
+      },
       sourceFilesOutsideRootDirectory: true,
     },
   );
@@ -172,6 +184,12 @@ test("repairs only deployment settings that drift", () => {
           enableAffectedProjectsDeployments: true,
           framework: "nextjs",
           nodeVersion: "24.x",
+          productionDeploymentsFastLane: true,
+          resourceConfig: {
+            buildMachineSelection: "fixed",
+            buildMachineType: "standard",
+            elasticConcurrencyEnabled: false,
+          },
           rootDirectory: desired.rootDirectory,
           sourceFilesOutsideRootDirectory: true,
         },

--- a/.github/scripts/vercel-ignore-build.mjs
+++ b/.github/scripts/vercel-ignore-build.mjs
@@ -1,18 +1,25 @@
 import { execFileSync } from "node:child_process";
 import {
   ensureVercelDiffBase,
+  ensureVercelProductionDiffBase,
   getVercelAppBuildMatches,
   getVercelDiffBase,
 } from "./vercel-app-build-scope.mjs";
 
 const appName = process.argv[2] ?? "optimitron";
-const requestedDiffBase = getVercelDiffBase();
-const diffBase = ensureVercelDiffBase(requestedDiffBase);
+const requestedDiffBase = getVercelDiffBase(process.env, () => null);
+const diffBase = requestedDiffBase
+  ? ensureVercelDiffBase(requestedDiffBase)
+  : ensureVercelProductionDiffBase();
 const comparisonLabel = diffBase ?? "the full tracked tree";
 
 if (requestedDiffBase && !diffBase) {
   console.warn(
     `Could not load Vercel diff base ${requestedDiffBase}; building ${appName} to avoid an unsafe skip.`,
+  );
+} else if (!requestedDiffBase && !diffBase) {
+  console.warn(
+    `Could not load the production merge base; building ${appName} to avoid an unsafe skip.`,
   );
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      automation: ${{ steps.manual.outputs.automation_files_changed || steps.main.outputs.automation_files_changed || steps.filter.outputs.automation_files_changed }}
       core: ${{ steps.manual.outputs.core_files_changed || steps.main.outputs.core_files_changed || steps.filter.outputs.core_files_changed }}
       web: ${{ steps.manual.outputs.web_files_changed || steps.main.outputs.web_files_changed || steps.filter.outputs.web_files_changed }}
       web_files_changed: ${{ steps.manual.outputs.web_files_changed || steps.main.outputs.web_files_changed || steps.filter.outputs.web_files_changed }}
@@ -33,6 +34,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         shell: bash
         run: |
+          echo "automation_files_changed=true" >> "$GITHUB_OUTPUT"
           echo "core_files_changed=true" >> "$GITHUB_OUTPUT"
           echo "web_files_changed=true" >> "$GITHUB_OUTPUT"
           echo "site_apps_changed=true" >> "$GITHUB_OUTPUT"
@@ -43,6 +45,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         shell: bash
         run: |
+          echo "automation_files_changed=true" >> "$GITHUB_OUTPUT"
           echo "core_files_changed=true" >> "$GITHUB_OUTPUT"
           echo "web_files_changed=true" >> "$GITHUB_OUTPUT"
           echo "site_apps_changed=true" >> "$GITHUB_OUTPUT"
@@ -105,6 +108,16 @@ jobs:
           # Local git diff avoids REST pagination and rate limits on large moves.
           token: ""
           filters: |
+            automation_files_changed:
+              - '.github/workflows/**'
+              - '.github/scripts/**'
+              - 'scripts/app-preview-urls.mjs'
+              - 'scripts/app-preview-urls.test.mjs'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+              - 'apps/*/package.json'
+              - 'apps/*/vercel.json'
+              - 'packages/*/package.json'
             core_files_changed:
               - '.github/workflows/ci.yml'
               - 'package.json'
@@ -118,7 +131,6 @@ jobs:
             web_files_changed:
               - '.github/workflows/ci.yml'
               - '.github/workflows/smoke-deploy.yml'
-              - '.github/scripts/**'
               - 'package.json'
               - 'package-lock.json'
               - 'pnpm-lock.yaml'
@@ -187,6 +199,27 @@ jobs:
           node-version: 22
       - name: Scan tracked files for private-information leaks
         run: node scripts/leak-scan.mjs
+
+  automation-tests:
+    name: automation-tests
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+      fromJSON(needs.changes.outputs.automation || 'false') == true)
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Test GitHub and Vercel automation
+        run: node --test .github/scripts/ci-change-detection.test.mjs .github/scripts/generate-pr-preview-links.test.mjs .github/scripts/preview-managed-data-filter.test.mjs .github/scripts/preview-smoke-scope.test.mjs .github/scripts/preview-neon-branch.test.mjs .github/scripts/preview-masking-workflow-order.test.mjs .github/scripts/preview-masking-demo-user.test.mjs .github/scripts/preview-masking-managed-triggers.test.mjs .github/scripts/preview-masking-private-execution.test.mjs .github/scripts/preview-deploy-smoke.test.mjs .github/scripts/smoke-deploy-demo-login.test.mjs .github/scripts/vercel-app-build-scope.test.mjs .github/scripts/vercel-app-projects.test.mjs scripts/app-preview-urls.test.mjs
 
   core-validate:
     name: core-validate
@@ -561,9 +594,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Run GitHub automation script tests
-        run: node --test .github/scripts/ci-change-detection.test.mjs .github/scripts/generate-pr-preview-links.test.mjs .github/scripts/preview-managed-data-filter.test.mjs .github/scripts/preview-smoke-scope.test.mjs .github/scripts/preview-neon-branch.test.mjs .github/scripts/preview-masking-workflow-order.test.mjs .github/scripts/preview-masking-demo-user.test.mjs .github/scripts/preview-masking-managed-triggers.test.mjs .github/scripts/preview-masking-private-execution.test.mjs .github/scripts/preview-deploy-smoke.test.mjs .github/scripts/smoke-deploy-demo-login.test.mjs .github/scripts/vercel-app-build-scope.test.mjs .github/scripts/vercel-app-projects.test.mjs scripts/app-preview-urls.test.mjs
 
       - name: Apply database migrations
         run: pnpm db:deploy
@@ -1493,6 +1523,7 @@ jobs:
     name: pr-validate
     if: always() && github.event_name == 'pull_request'
     needs:
+      - automation-tests
       - changes
       - web-visual-review
     runs-on: ubuntu-latest
@@ -1501,8 +1532,14 @@ jobs:
       - name: Verify pull request review evidence
         shell: bash
         run: |
+          automation_result="${{ needs.automation-tests.result }}"
+          automation_required="${{ fromJSON(needs.changes.outputs.automation || 'false') }}"
           visual_result="${{ needs.web-visual-review.result }}"
           visual_required="${{ github.event_name == 'pull_request' && (fromJSON(needs.changes.outputs.web || 'false') == true || fromJSON(needs.changes.outputs.site_apps || 'false') == true) }}"
+          echo "automation-tests: $automation_result (required: $automation_required)"
+          if [ "$automation_required" = "true" ] && [ "$automation_result" != "success" ]; then
+            exit 1
+          fi
           echo "web-visual-review: $visual_result (required: $visual_required)"
           if [ "$visual_required" = "true" ] && [ "$visual_result" != "success" ]; then
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      core: ${{ steps.manual.outputs.core_files_changed || steps.main.outputs.core_files_changed || steps.filter.outputs.core_files_changed }}
       web: ${{ steps.manual.outputs.web_files_changed || steps.main.outputs.web_files_changed || steps.filter.outputs.web_files_changed }}
       web_files_changed: ${{ steps.manual.outputs.web_files_changed || steps.main.outputs.web_files_changed || steps.filter.outputs.web_files_changed }}
       site_apps: ${{ steps.manual.outputs.site_apps_changed || steps.main.outputs.site_apps_changed || steps.filter.outputs.site_apps_changed }}
@@ -32,6 +33,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         shell: bash
         run: |
+          echo "core_files_changed=true" >> "$GITHUB_OUTPUT"
           echo "web_files_changed=true" >> "$GITHUB_OUTPUT"
           echo "site_apps_changed=true" >> "$GITHUB_OUTPUT"
           echo "web_deploy=true" >> "$GITHUB_OUTPUT"
@@ -41,6 +43,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         shell: bash
         run: |
+          echo "core_files_changed=true" >> "$GITHUB_OUTPUT"
           echo "web_files_changed=true" >> "$GITHUB_OUTPUT"
           echo "site_apps_changed=true" >> "$GITHUB_OUTPUT"
 
@@ -102,8 +105,19 @@ jobs:
           # Local git diff avoids REST pagination and rate limits on large moves.
           token: ""
           filters: |
+            core_files_changed:
+              - '.github/workflows/ci.yml'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'eslint.config.mjs'
+              - 'tsconfig*.json'
+              - 'vitest*.ts'
+              - 'scripts/**'
+              - 'packages/**'
             web_files_changed:
-              - '.github/workflows/**'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/smoke-deploy.yml'
               - '.github/scripts/**'
               - 'package.json'
               - 'package-lock.json'
@@ -176,7 +190,11 @@ jobs:
 
   core-validate:
     name: core-validate
-    if: github.event_name != 'push'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+      fromJSON(needs.changes.outputs.core || 'false') == true)
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -247,10 +265,7 @@ jobs:
     # Gates all apps/* site packages (shared @optimitron/db schema).
     # Typecheck every app; unit-test apps with vitest unit suites; WoD DB smoke.
     # apps/optimitron keeps its own e2e/deploy smoke — not replaced here.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: ${{ fromJSON(needs.changes.outputs.site_apps || 'false') == true }}
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -500,7 +515,8 @@ jobs:
 
   web-static-validate:
     name: web-static-validate
-    if: github.event_name != 'push' || github.ref == 'refs/heads/main'
+    if: ${{ fromJSON(needs.changes.outputs.web || 'false') == true }}
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -547,7 +563,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run GitHub automation script tests
-        run: node --test .github/scripts/generate-pr-preview-links.test.mjs .github/scripts/preview-managed-data-filter.test.mjs .github/scripts/preview-smoke-scope.test.mjs .github/scripts/preview-neon-branch.test.mjs .github/scripts/preview-masking-workflow-order.test.mjs .github/scripts/preview-masking-demo-user.test.mjs .github/scripts/preview-masking-managed-triggers.test.mjs .github/scripts/preview-masking-private-execution.test.mjs .github/scripts/preview-deploy-smoke.test.mjs .github/scripts/smoke-deploy-demo-login.test.mjs .github/scripts/vercel-app-build-scope.test.mjs .github/scripts/vercel-app-projects.test.mjs scripts/app-preview-urls.test.mjs
+        run: node --test .github/scripts/ci-change-detection.test.mjs .github/scripts/generate-pr-preview-links.test.mjs .github/scripts/preview-managed-data-filter.test.mjs .github/scripts/preview-smoke-scope.test.mjs .github/scripts/preview-neon-branch.test.mjs .github/scripts/preview-masking-workflow-order.test.mjs .github/scripts/preview-masking-demo-user.test.mjs .github/scripts/preview-masking-managed-triggers.test.mjs .github/scripts/preview-masking-private-execution.test.mjs .github/scripts/preview-deploy-smoke.test.mjs .github/scripts/smoke-deploy-demo-login.test.mjs .github/scripts/vercel-app-build-scope.test.mjs .github/scripts/vercel-app-projects.test.mjs scripts/app-preview-urls.test.mjs
 
       - name: Apply database migrations
         run: pnpm db:deploy
@@ -571,7 +587,7 @@ jobs:
 
   web-e2e-validate:
     name: web-e2e-validate
-    if: github.event_name != 'push' || github.ref == 'refs/heads/main'
+    if: ${{ fromJSON(needs.changes.outputs.web || 'false') == true }}
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -789,7 +805,7 @@ jobs:
 
   web-visual-review:
     name: web-visual-review
-    if: ${{ always() && github.event_name == 'pull_request' && (fromJSON(needs.changes.outputs.web || 'false') == true || fromJSON(needs.changes.outputs.site_apps || 'false') == true) && needs.web-e2e-validate.result == 'success' && (fromJSON(needs.changes.outputs.site_apps || 'false') != true || needs.site-apps-build.result == 'success') }}
+    if: ${{ always() && github.event_name == 'pull_request' && (fromJSON(needs.changes.outputs.web || 'false') == true || fromJSON(needs.changes.outputs.site_apps || 'false') == true) && (fromJSON(needs.changes.outputs.web || 'false') != true || needs.web-e2e-validate.result == 'success') && (fromJSON(needs.changes.outputs.site_apps || 'false') != true || needs.site-apps-build.result == 'success') }}
     needs:
       - changes
       - site-apps-build
@@ -1496,6 +1512,7 @@ jobs:
     name: web-validate
     if: always() && (github.event_name != 'push' || github.ref == 'refs/heads/main')
     needs:
+      - changes
       - web-static-validate
       - web-e2e-validate
     runs-on: ubuntu-latest
@@ -1504,8 +1521,13 @@ jobs:
       - name: Verify web validation lanes passed
         shell: bash
         run: |
+          web_required="${{ fromJSON(needs.changes.outputs.web || 'false') }}"
           static_result="${{ needs.web-static-validate.result }}"
           e2e_result="${{ needs.web-e2e-validate.result }}"
+          if [ "$web_required" != "true" ]; then
+            echo "No web-impacting changes; web validation was skipped."
+            exit 0
+          fi
           echo "web-static-validate: $static_result"
           echo "web-e2e-validate: $e2e_result"
           if [ "$static_result" != "success" ] || [ "$e2e_result" != "success" ]; then
@@ -1514,8 +1536,14 @@ jobs:
 
   sync-preview-managed-data:
     name: sync-preview-managed-data
-    if: github.event_name == 'pull_request'
-    needs: web-validate
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      (fromJSON(needs.changes.outputs.web || 'false') == true ||
+      fromJSON(needs.changes.outputs.site_apps || 'false') == true) &&
+      needs.web-validate.result == 'success' &&
+      needs.site-apps-validate.result == 'success'
+    needs: [changes, web-validate, site-apps-validate]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
               - 'packages/*/package.json'
             core_files_changed:
               - '.github/workflows/ci.yml'
+              - '.npmrc'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -131,6 +132,7 @@ jobs:
             web_files_changed:
               - '.github/workflows/ci.yml'
               - '.github/workflows/smoke-deploy.yml'
+              - '.npmrc'
               - 'package.json'
               - 'package-lock.json'
               - 'pnpm-lock.yaml'
@@ -159,6 +161,8 @@ jobs:
               - 'packages/db/prisma/**'
               - 'packages/db/src/managed-data/**'
               - 'apps/optimitron/**'
+              - 'content/legislation/**'
+              - 'docs/canonical-argument-2026-05-20.md'
             site_apps_changed:
               - 'apps/acceleratedmedicine/**'
               - 'apps/curedao/**'
@@ -177,6 +181,7 @@ jobs:
               - 'scripts/site-app-navigation.test.ts'
               - 'scripts/site-app-visual-routes.mjs'
               - 'scripts/smoke-site-apps.mjs'
+              - '.npmrc'
               - 'package.json'
               - 'pnpm-workspace.yaml'
               - 'pnpm-lock.yaml'
@@ -1532,6 +1537,11 @@ jobs:
       - name: Verify pull request review evidence
         shell: bash
         run: |
+          changes_result="${{ needs.changes.result }}"
+          if [ "$changes_result" != "success" ]; then
+            echo "::error::Change detection result: $changes_result"
+            exit 1
+          fi
           automation_result="${{ needs.automation-tests.result }}"
           automation_required="${{ fromJSON(needs.changes.outputs.automation || 'false') }}"
           visual_result="${{ needs.web-visual-review.result }}"

--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -1,9 +1,7 @@
 name: Update PR branches
 
-# Whenever main moves (a merge landed), bring every open, behind, conflict-free
-# PR branch up to date so the next merge never waits on a manual "Update
-# branch" click. PRs with conflicts are skipped (they need a human anyway) and
-# listed in the job summary.
+# Whenever main moves, refresh only open PRs labeled `auto-update`. This avoids
+# rebuilding every active PR and every Vercel app after an unrelated merge.
 
 on:
   push:
@@ -62,6 +60,7 @@ jobs:
           # state — which is exactly the case a human ends up clicking by hand.
           repo_owner="${REPO%%/*}"
           if ! rows=$(gh pr list --repo "$REPO" --state open --base main \
+              --label auto-update \
               --json number,headRefName,isDraft,headRepositoryOwner \
               --jq '.[] | select(.isDraft | not) | "\(.number):\(.headRepositoryOwner.login):\(.headRefName)"'); then
             echo "::error::gh pr list failed; aborting instead of silently treating a discovery outage as \"no PRs to update\""

--- a/apps/DEPLOYMENT.md
+++ b/apps/DEPLOYMENT.md
@@ -37,6 +37,11 @@ which projects need a preview or production deployment. Root configuration and
 lockfile changes can still affect every project. Every app disables deployment
 from `gh-pages` because that branch contains generated visual-review files.
 
+All projects use Standard build machines with on-demand concurrency disabled.
+Builds share the included queue, prioritize production, and skip stale queued
+commits when a newer commit reaches the same branch. The project reconciler
+repairs drift from these settings.
+
 Vercel treats changes outside the pnpm workspace as global. Each app therefore
 uses the same dependency-aware ignore script to reject documentation, review
 automation, and unrelated app changes before build CPU starts. App source,

--- a/apps/DEPLOYMENT.md
+++ b/apps/DEPLOYMENT.md
@@ -49,9 +49,9 @@ transitive workspace dependencies, and root dependency files still build. The
 script compares against the last successful deployment, so multi-commit pushes
 cannot hide an earlier app change. App tests, browser fixtures, screenshots,
 and Optimitron's current visual-review assembler do not trigger app deployment.
-On a branch's first deployment, the script compares with `main` or treats the
-full tracked tree as changed. It can overbuild once, but it cannot skip an
-earlier unpreviewed change.
+On a branch's first deployment, the script fetches `main` and uses the merge
+base. It treats the full tracked tree as changed only when it cannot load that
+base, so a Git outage can overbuild but cannot cause an unsafe skip.
 
 GitHub Actions also builds and captures every relevant app for pull request
 visual review. This local fixture-based review is broader than the live Vercel


### PR DESCRIPTION
## Summary

- keep all seven Vercel app projects on fixed Standard machines with paid on-demand concurrency disabled and production builds prioritized
- update open PR branches only when they carry the `auto-update` label
- run core, web, site-app, and preview-database CI lanes only when their affected paths change
- scope a branch's first Vercel deployment against the merge base with `main` instead of treating the whole monorepo as changed
- fail closed when change detection fails and preserve validation for traced campaign content and package-manager configuration

## Cost impact

The live Vercel settings were updated before this PR: all seven projects now report on-demand concurrency disabled, production fast lane enabled, and affected-project deployments enabled. This PR makes that state durable in the reconciler.

From August 1 through August 21, Vercel reports $17.01 of Build CPU effective cost and $0.512 billed after credits. The seven apps in this repository account for $16.70 of that effective cost.

A recent full-fanout PR commit used 21.9 total build-minutes across the seven apps. At the former Standard on-demand rate of $0.014/minute, that commit cost about $0.31 before credits; three pushes would cost about $0.92. With the new settings, Standard builds use the included queue rather than paid on-demand concurrency.

The final PR commit produced seven passing Vercel checks through the Ignored Build Step. Each project cloned and evaluated the diff, then canceled before dependency installation or application build because no deployable inputs changed.

## Validation

- `node --test` for all 78 GitHub automation, deployment-scope, preview-data, and Vercel project helper tests
- real depth-1 clone proof that the first-deployment helper fetches branch history and resolves the merge base with `main`
- YAML parse for both changed workflows
- Prettier check for all changed files
- `git diff --check`
- live Vercel project audit for all seven projects
- all four review threads addressed or explicitly dismissed as non-functional

No user-facing UI changed, so no screenshot review is required.