### PR TITLE
Remove pragmatic from spending comparison

### DIFF
--- a/packages/site-kit/src/components/landing/treaty-vote-section.tsx
+++ b/packages/site-kit/src/components/landing/treaty-vote-section.tsx
@@ -515,7 +515,7 @@ export default function TreatyVoteSection({
 
                 <div className="text-base sm:text-lg font-bold text-center mb-4">
                   That&apos;s {militarySpendingPct}% to military and just{" "}
-                  <span className="text-brutal-pink text-xl">{clinicalTrialsSpendingPct}%</span> to pragmatic trials.
+                  <span className="text-brutal-pink text-xl">{clinicalTrialsSpendingPct}%</span> to clinical trials.
                 </div>
 
                 <div className="text-base sm:text-lg font-bold text-center mb-4 p-4 bg-brutal-yellow border-4 border-primary">

--- a/packages/site-kit/src/components/landing/treaty-vote-section.tsx
+++ b/packages/site-kit/src/components/landing/treaty-vote-section.tsx
@@ -510,7 +510,7 @@ export default function TreatyVoteSection({
                   <br className="hidden sm:block" />
                   for every{" "}
                   <br className="hidden sm:block" />
-                  <span className="text-brutal-pink">$1</span> on <span className="text-brutal-pink">PRAGMATIC CLINICAL TRIALS TO CURE DISEASE</span>.
+                  <span className="text-brutal-pink">$1</span> on <span className="text-brutal-pink">CLINICAL TRIALS TO CURE DISEASE</span>.
                 </p>
 
                 <div className="text-base sm:text-lg font-bold text-center mb-4">


### PR DESCRIPTION
## Summary

- Remove “pragmatic” from the spending-ratio punchline and its percentage follow-up.
- Keep the statistic, cure outcome, emphasis, and remaining surrounding copy unchanged.
- Update the shared component used by War on Disease and Trial Abundance Survey surfaces.

## Copy review

Before → After

> $1 on PRAGMATIC CLINICAL TRIALS TO CURE DISEASE.
>
> $1 on CLINICAL TRIALS TO CURE DISEASE.

Before → After

> 0.2% to pragmatic trials.
>
> 0.2% to clinical trials.

- [ ] Copy approved

## Validation

- `pnpm build:app-dependencies`
- `pnpm --filter @apps/warondisease run typecheck`
- `git diff --check`
- Captured and inspected local before/after screenshots at desktop and 390 × 844.
- Desktop emphasis and wrapping remain clean. Mobile uses fewer lines with no clipping or overlap.
- No unrelated visual noise was found.

## Preview pages

- War on Disease vote: https://warondisease-git-feature-remove-pr-95a5a7-mike-p-sinns-projects.vercel.app/vote?logout=1
- War on Disease home: https://warondisease-git-feature-remove-pr-95a5a7-mike-p-sinns-projects.vercel.app/?logout=1
- Trial Abundance Survey: https://trialabundancesurvey-git-feature-r-959684-mike-p-sinns-projects.vercel.app/?logout=1
- Trial Abundance Survey embed: https://trialabundancesurvey-git-feature-r-959684-mike-p-sinns-projects.vercel.app/embed?embed=1&visual=1