### PR TITLE
Remove Accelerated Medicine caveats

### DIFF
--- a/apps/acceleratedmedicine/app/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/page.logged-out.md
@@ -82,7 +82,7 @@
 - $500
 - Per patient in a real pragmatic trial.
 - $929
-- The central estimate used in the pragmatic-trial model.
+- Reference cost per participant.
 - $41K
 - Median cost per participant.
 - 82x
@@ -107,7 +107,7 @@
 - Note: We use the conservative 9.5M figure in our main calculations because single-drug trials are more straightforward. But the combination therapy space shows the true scale of unexplored medicine.
 #### YEARS TO UNIVERSAL TREATMENT COVERAGE
 - Clinical trials are how we discover which treatments work for which diseases. At current trial capacity, we find first effective treatments for only ~15 diseases per year.
-- The reference funding model produces 40.7K pragmatic trials per year. The model projects 185 first treatments per year.
+- Reference funding supports 40.7K pragmatic trials per year and 185 first treatments per year.
 - 36.0
 - Addressing the "Diminishing Returns" Argument
 - Critics argue: "Just funding more trials won't proportionally increase discoveries - we've picked the low-hanging fruit."
@@ -119,23 +119,20 @@
 - 5.
 - 6.
 - Diminishing returns apply to repeated attempts at the same problem. We're proposing to attempt problems we've never tried.
-#### A MODEL, NOT A PROMISE
+#### WHAT MORE TRIAL CAPACITY DELIVERS
 - 40.7K
-- Reference funding divided by the modeled pragmatic-trial cost.
+- Pragmatic trials per year under reference funding.
 - 185
-- Applies the modeled capacity and discovery assumptions.
-- A low-confidence projection with a wide estimated range.
+- First treatments found per year.
+- Time to cover the untreated-disease queue.
 - Treatments exist. Safe compounds exist. Patients are waiting.
 - The missing ingredient is trial capacity. That's a logistics problem, not a scientific frontier.
 ### WHAT PRAGMATIC TRIAL ACCESS AT SCALE COULD PRODUCE
 - 23.4M
 - 12.3x
 - $58.6B
-- THESE ARE PROJECTIONS, NOT OBSERVED RESULTS.
-- Click any number to inspect the formula, estimated range, inputs, and source material. The savings figure covers modeled R&D costs, not all healthcare spending or guaranteed year-one savings.
 ### A DECENTRALIZED FRAMEWORK FOR DRUG ASSESSMENT
 - See what the platonic ideal of healthcare and clinical trials will look like when dFDA frameworks are widely adopted.
-- These are educational interface examples, not medical advice or a promise that every option is available. Treatment decisions stay with patients and licensed clinicians.
 #### How it Works For Patients
 ##### Find the Most Promising Treatment for Your Condition
 - Search for trials based on your condition, location, and preferences.
@@ -324,8 +321,8 @@
 #### THE NEXT DECISION GETS LESS BLIND
 - Public, pooled outcomes reveal what works, what fails, and for whom.
 ### DO SOMETHING
-- [OPTION 1: LEARN INSPECT THE EVIDENCE See the observed trial costs, source studies, and model assumptions. CONTINUE](#evidence)
-- [OPTION 2: CHECK CHALLENGE THE MODEL Open every estimate. Check its inputs. Decide whether the benefits survive your assumptions. CONTINUE](#model)
+- [OPTION 1: LEARN INSPECT THE EVIDENCE See the observed trial costs, source studies, and calculation inputs. CONTINUE](#evidence)
+- [OPTION 2: CHECK CHECK THE MATH Open every number. Check its inputs. Decide whether the benefits survive your assumptions. CONTINUE](#model)
 - [OPTION 3: SUPPORT FUND THE RESEARCH Support a 501(c)(3) working to make treatment evidence faster, cheaper, and public. CONTINUE](/donate)
 ### 💀 DEATH CLOCK
 - [READ THE EVIDENCE](#evidence)

--- a/apps/acceleratedmedicine/app/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/page.logged-out.md
@@ -119,7 +119,7 @@
 - 5.
 - 6.
 - Diminishing returns apply to repeated attempts at the same problem. We're proposing to attempt problems we've never tried.
-#### WHAT MORE TRIAL CAPACITY DELIVERS
+#### WHAT MORE TRIAL CAPACITY COULD PRODUCE
 - 40.7K
 - Pragmatic trials per year under reference funding.
 - 185

--- a/apps/acceleratedmedicine/app/page.tsx
+++ b/apps/acceleratedmedicine/app/page.tsx
@@ -32,7 +32,7 @@ export default function HomePage() {
       <PragmaticTrialEvidenceSection />
       <BottleneckProofSection scenario="medical-freedom" />
       <ModeledBenefitsSection />
-      <DecentralizedFDASection />
+      <DecentralizedFDASection showDisclaimer={false} />
       <PatientImpactSection />
       <EducationCallToAction />
       <DeathClock message="while safe treatments remain untested and willing patients remain excluded" />

--- a/apps/acceleratedmedicine/components/landing/medical-freedom-sections.tsx
+++ b/apps/acceleratedmedicine/components/landing/medical-freedom-sections.tsx
@@ -281,10 +281,7 @@ export function MedicalFreedomAccessSection() {
           </h3>
           <p className="max-w-3xl text-lg font-bold sm:text-xl">
             There are about{" "}
-            <EvidenceNumber
-              param={RARE_DISEASES_COUNT_GLOBAL}
-              precision={0}
-            />{" "}
+            <EvidenceNumber param={RARE_DISEASES_COUNT_GLOBAL} precision={0} />{" "}
             rare diseases. Roughly{" "}
             <EvidenceNumber
               param={DISEASES_WITHOUT_EFFECTIVE_TREATMENT}
@@ -351,11 +348,9 @@ export function PragmaticTrialEvidenceSection() {
               <EvidenceNumber param={DFDA_PRAGMATIC_TRIAL_COST_PER_PATIENT} />
             </div>
             <div className="text-lg font-black uppercase">
-              Conservative estimate
+              Pragmatic-trial cost
             </div>
-            <p className="font-bold">
-              The central estimate used in the pragmatic-trial model.
-            </p>
+            <p className="font-bold">Reference cost per participant.</p>
           </Card>
 
           <Card className="gap-3 rounded-none border-4 border-primary bg-primary p-6 text-center text-primary-foreground shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
@@ -386,7 +381,7 @@ export function PragmaticTrialEvidenceSection() {
                 precision={1}
               />
             </div>
-            <div className="font-black uppercase">Conservative model</div>
+            <div className="font-black uppercase">Reference cost ratio</div>
           </div>
           <div>
             <div className="text-4xl font-black text-brutal-pink">
@@ -395,7 +390,7 @@ export function PragmaticTrialEvidenceSection() {
                 precision={1}
               />
             </div>
-            <div className="font-black uppercase">Lower modeled cost</div>
+            <div className="font-black uppercase">Lower trial cost</div>
           </div>
         </div>
       </Container>
@@ -431,25 +426,27 @@ export function ModeledBenefitsSection() {
     },
     {
       param: DFDA_TRIAL_CAPACITY_MULTIPLIER,
-      label: "Modeled trial-capacity increase",
+      label: "Trial-capacity increase",
       color: "bg-background",
       precision: 1,
     },
     {
       param: DFDA_NET_SAVINGS_RD_ONLY_ANNUAL,
-      label: "Modeled annual net R&D savings",
+      label: "Annual net R&D savings",
       color: "bg-brutal-yellow",
       precision: 1,
     },
   ];
 
   return (
-    <SectionContainer id="model" bgColor="cyan" borderPosition="bottom">
+    <SectionContainer
+      id="model"
+      bgColor="cyan"
+      borderPosition="bottom"
+      className="scroll-mt-[121px]"
+    >
       <Container>
         <div className="mx-auto mb-12 max-w-5xl text-center">
-          <div className="mb-4 inline-block border-4 border-primary bg-background px-4 py-2 text-sm font-black uppercase shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
-            Modeled reference-funding scenario
-          </div>
           <h2 className="text-4xl font-black uppercase tracking-tighter sm:text-5xl md:text-6xl lg:text-7xl">
             What pragmatic trial access at scale could produce
           </h2>
@@ -465,23 +462,8 @@ export function ModeledBenefitsSection() {
                 <EvidenceNumber param={stat.param} precision={stat.precision} />
               </div>
               <div className="font-black uppercase">{stat.label}</div>
-              <div className="mx-auto border-2 border-primary bg-background px-2 py-1 text-xs font-black uppercase">
-                Modeled estimate
-              </div>
             </Card>
           ))}
-        </div>
-
-        <div className="mt-10 border-4 border-primary bg-primary p-6 text-center text-primary-foreground shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-          <BarChart3 className="mx-auto mb-3 h-10 w-10 text-brutal-yellow" />
-          <p className="text-lg font-black uppercase sm:text-xl">
-            These are projections, not observed results.
-          </p>
-          <p className="mx-auto mt-2 max-w-3xl font-bold">
-            Click any number to inspect the formula, estimated range, inputs,
-            and source material. The savings figure covers modeled R&amp;D costs,
-            not all healthcare spending or guaranteed year-one savings.
-          </p>
         </div>
       </Container>
     </SectionContainer>
@@ -542,15 +524,15 @@ export function EducationCallToAction() {
       href: "#evidence",
       eyebrow: "Option 1: Learn",
       title: "Inspect the evidence",
-      text: "See the observed trial costs, source studies, and model assumptions.",
+      text: "See the observed trial costs, source studies, and calculation inputs.",
       color: "bg-brutal-cyan",
       icon: BookOpen,
     },
     {
       href: "#model",
       eyebrow: "Option 2: Check",
-      title: "Challenge the model",
-      text: "Open every estimate. Check its inputs. Decide whether the benefits survive your assumptions.",
+      title: "Check the math",
+      text: "Open every number. Check its inputs. Decide whether the benefits survive your assumptions.",
       color: "bg-brutal-yellow",
       icon: BarChart3,
     },

--- a/packages/site-kit/src/components/landing/bottleneck-proof-section.tsx
+++ b/packages/site-kit/src/components/landing/bottleneck-proof-section.tsx
@@ -424,16 +424,16 @@ export function BottleneckProofSection({
             {scenario === "medical-freedom" ? (
               <div>
                 <div className="text-lg font-black uppercase mb-4">
-                  Reference Pragmatic-Trial Capacity Model
+                  Reference Pragmatic-Trial Capacity
                 </div>
                 <p className="font-bold mb-4">
-                  The reference funding model produces{" "}
+                  Reference funding supports{" "}
                   <ParameterValue
                     param={DFDA_TRIALS_PER_YEAR_CAPACITY}
                     format={{ precision: 1 }}
                     className="text-brutal-cyan font-black"
                   />{" "}
-                  pragmatic trials per year. The model projects{" "}
+                  pragmatic trials per year and{" "}
                   <ParameterValue
                     param={DFDA_FIRST_TREATMENTS_PER_YEAR}
                     className="text-brutal-cyan font-black"
@@ -449,12 +449,12 @@ export function BottleneckProofSection({
                     Years
                   </div>
                   <div className="text-sm font-bold">
-                    Modeled time to cover the untreated-disease queue
+                    Time to cover the untreated-disease queue
                   </div>
                   <div className="text-xs text-foreground/70 mt-1">
-                    {referenceTrials.toLocaleString()} trials produce a modeled{" "}
-                    {referenceTreatments} first treatments per year; modeled
-                    queue time rounds to {referenceQueueYears} years.
+                    {referenceTrials.toLocaleString()} trials produce{" "}
+                    {referenceTreatments} first treatments per year and cover
+                    the queue in {referenceQueueYears} years.
                   </div>
                 </div>
               </div>
@@ -622,7 +622,7 @@ export function BottleneckProofSection({
         <Card className="bg-brutal-pink border-4 border-primary p-4 sm:p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
           <h3 className="text-2xl font-black uppercase text-center mb-6 text-brutal-pink-foreground">
             {scenario === "medical-freedom"
-              ? "A Model, Not A Promise"
+              ? "What More Trial Capacity Delivers"
               : "Two Possible Futures"}
           </h3>
 
@@ -637,18 +637,16 @@ export function BottleneckProofSection({
                 </div>
                 <div className="font-black uppercase">Trials/year</div>
                 <p className="text-sm font-bold mt-2">
-                  Reference funding divided by the modeled pragmatic-trial cost.
+                  Pragmatic trials per year under reference funding.
                 </p>
               </div>
               <div className="bg-brutal-yellow border-4 border-primary p-5 text-center text-foreground">
                 <div className="text-3xl font-black mb-2">
-                  <ParameterValue
-                    param={DFDA_FIRST_TREATMENTS_PER_YEAR}
-                  />
+                  <ParameterValue param={DFDA_FIRST_TREATMENTS_PER_YEAR} />
                 </div>
                 <div className="font-black uppercase">Treatments/year</div>
                 <p className="text-sm font-bold mt-2">
-                  Applies the modeled capacity and discovery assumptions.
+                  First treatments found per year.
                 </p>
               </div>
               <div className="bg-brutal-cyan border-4 border-primary p-5 text-center text-foreground">
@@ -660,7 +658,7 @@ export function BottleneckProofSection({
                 </div>
                 <div className="font-black uppercase">Years</div>
                 <p className="text-sm font-bold mt-2">
-                  A low-confidence projection with a wide estimated range.
+                  Time to cover the untreated-disease queue.
                 </p>
               </div>
             </div>

--- a/packages/site-kit/src/components/landing/bottleneck-proof-section.tsx
+++ b/packages/site-kit/src/components/landing/bottleneck-proof-section.tsx
@@ -622,7 +622,7 @@ export function BottleneckProofSection({
         <Card className="bg-brutal-pink border-4 border-primary p-4 sm:p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
           <h3 className="text-2xl font-black uppercase text-center mb-6 text-brutal-pink-foreground">
             {scenario === "medical-freedom"
-              ? "What More Trial Capacity Delivers"
+              ? "What More Trial Capacity Could Produce"
               : "Two Possible Futures"}
           </h3>
 

--- a/packages/site-kit/src/components/landing/decentralized-fda-section.tsx
+++ b/packages/site-kit/src/components/landing/decentralized-fda-section.tsx
@@ -2,13 +2,20 @@ import { Container } from "@optimitron/neobrutalist-ui/ui/container";
 import { SectionContainer } from "@optimitron/neobrutalist-ui/ui/section-container";
 import { DfdaUserWorkflows } from "../how-it-works/DfdaUserWorkflows";
 
-export default function DecentralizedFDASection() {
+interface DecentralizedFDASectionProps {
+  showDisclaimer?: boolean;
+}
+
+export default function DecentralizedFDASection({
+  showDisclaimer = true,
+}: DecentralizedFDASectionProps) {
   return (
     <SectionContainer
       id="decentralized-fda-section"
       bgColor="cyan"
       borderPosition="bottom"
       padding="lg"
+      className="scroll-mt-[121px]"
     >
       <Container>
         <div className="mx-auto max-w-5xl text-center">
@@ -21,13 +28,15 @@ export default function DecentralizedFDASection() {
           </p>
         </div>
 
-        <div className="mt-12 border-4 border-primary bg-primary p-5 text-center text-primary-foreground shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-          <p className="font-bold">
-            These are educational interface examples, not medical advice or a
-            promise that every option is available. Treatment decisions stay
-            with patients and licensed clinicians.
-          </p>
-        </div>
+        {showDisclaimer && (
+          <div className="mt-12 border-4 border-primary bg-primary p-5 text-center text-primary-foreground shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+            <p className="font-bold">
+              These are educational interface examples, not medical advice or a
+              promise that every option is available. Treatment decisions stay
+              with patients and licensed clinicians.
+            </p>
+          </div>
+        )}
 
         <DfdaUserWorkflows />
       </Container>

--- a/packages/site-kit/src/lib/site-config.ts
+++ b/packages/site-kit/src/lib/site-config.ts
@@ -150,6 +150,7 @@ import {
 const logger = createLogger("site-config");
 const INSTITUTE_FOR_ACCELERATED_MEDICINE = "Institute for Accelerated Medicine";
 const IAM_501C3_FOOTER_NOTICE = `${INSTITUTE_FOR_ACCELERATED_MEDICINE} is a 501(c)(3) nonprofit. EIN: 41-2555651. Donations are tax-deductible.`;
+const ACCELERATED_MEDICINE_FOOTER_NOTICE = `${INSTITUTE_FOR_ACCELERATED_MEDICINE} is a DBA for the Accelerated Medicine Foundation. The Accelerated Medicine Foundation is a 501(c)(3) nonprofit. EIN: 41-2555651. Donations are tax-deductible.`;
 
 // ===== INTERFACES =====
 
@@ -1447,7 +1448,7 @@ const siteConfigs: Record<SiteVariant, SiteConfig> = {
     },
     legalItems: ["privacy", "terms"],
     copyrightText: "© 2025 Institute for Accelerated Medicine | CC BY-NC 4.0",
-    footerComplianceNotice: IAM_501C3_FOOTER_NOTICE,
+    footerComplianceNotice: ACCELERATED_MEDICINE_FOOTER_NOTICE,
     faq: ACCELERATED_MEDICINE_FAQ,
 
     // Image generation prompts


### PR DESCRIPTION
## Outcome

Accelerated Medicine now presents its trial-capacity numbers and dFDA workflows without repeated caveat labels or disclaimer boxes.

## User story

As a patient, clinician, or research supporter, I want to see the quantified case directly so I can understand the benefit and inspect the sources without the page repeatedly apologizing for its own calculations.

## Copy review

- **Removed:** `Modeled reference-funding scenario`
- **Removed:** `Modeled estimate` from every metric card
- **Before → After:** `A model, not a promise` → `What more trial capacity could produce`
- **Removed:** `These are projections, not observed results.` and the savings disclaimer
- **Removed:** the educational-interface / medical-advice disclaimer from Accelerated Medicine
- **Before → After:** `Challenge the model` → `Check the math`
- **New:** `Institute for Accelerated Medicine is a DBA for the Accelerated Medicine Foundation.`
- Quantitative values, ranges, formulas, and source popovers remain unchanged.

## Visual review

Captured and inspected Accelerated Medicine desktop and mobile before/after screenshots locally, including the footer. The metric grid is tighter, the dFDA examples begin sooner, and anchored headings now clear the sticky header.

- [Accelerated Medicine home](https://acceleratedmedicine-git-feature-re-a4b92e-mike-p-sinns-projects.vercel.app/?logout=1)

## Verification

- `pnpm --filter @apps/acceleratedmedicine run typecheck`
- `pnpm --filter @apps/acceleratedmedicine run lint`
- `pnpm --filter @apps/acceleratedmedicine run test:unit` — 4 passed
- `pnpm --filter @apps/curedao run typecheck`
- `pnpm build:app-dependencies`
- `pnpm --filter @apps/warondisease run typecheck`
- `pnpm copy acceleratedmedicine --routes=/`
- focused ESLint, Prettier, and `git diff --check`

## Human copy approval

- [ ] The direct presentation is stronger than the removed caveats.
- [ ] The remaining source and uncertainty popovers provide enough substantiation.
- [ ] The DBA and nonprofit footer wording is accurate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated medical-freedom landing-page messaging with clearer reference figures for trial costs, treatment capacity, and queue-clearing timelines.
  * Revised calls to action to encourage visitors to inspect observed costs and check the math.
  * Condensed rare-disease evidence and cost-related content.

* **Accessibility & Presentation**
  * Improved navigation to relevant landing-page sections.
  * Removed selected explanatory disclaimers and model-oriented labels from the presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->