### PR TITLE
Add Right to Trial volunteer path

### DIFF
--- a/apps/acceleratedmedicine/app/contact/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/contact/page.logged-out.md
@@ -2,23 +2,46 @@
 
 ## Metadata
 
-- Page title: Institute for Accelerated Medicine
-- Meta description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Page title: Volunteer for Right to Trial | Institute for Accelerated Medicine
+- Meta description: Help bring Right to Trial to every patient. Patients, clinicians, researchers, and public educators can volunteer in any state.
 - Canonical: https://acceleratedmedicine.org/contact
 - Open Graph title: Institute for Accelerated Medicine
-- Open Graph description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Open Graph description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Open Graph image: https://acceleratedmedicine.org/assets/acceleratedmedicine/iam-og-1200x630.png
 - Twitter title: Institute for Accelerated Medicine
-- Twitter description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Twitter description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 
 ## Visible Page Copy
 
 - [INSTITUTE FOR ACCELERATED MEDICINE](/)
-## CONTACT IAM
-- Send your question, correction, partnership idea, or media request. A human will read it.
-- [EMAIL HELLO@ACCELERATEDMEDICINE.ORG](mailto:hello@acceleratedmedicine.org?subject=Institute%20for%20Accelerated%20Medicine%20question)
+- VOLUNTEER
+## HELP EVERY PATIENT GET THE RIGHT TO TRIAL.
+- Every patient should be able to join a pragmatic clinical trial for the most promising treatments. Every result should help the next patient. You can help make that normal.
+- [FIND MY PART](#volunteer-form)
+### THERE IS USEFUL WORK FOR EVERY KIND OF HUMAN.
+#### PATIENTS AND CAREGIVERS
+- Tell the story only you can tell. Show what another real option could mean when approved treatments are not enough.
+#### CLINICIANS
+- Help make access safe, practical, and real for the patients and professionals who will use it.
+#### RESEARCHERS
+- Help turn each treatment into comparable evidence that improves the next patient’s decision.
+#### ORGANIZERS AND COMMUNICATORS
+- Find the local humans, answer the real questions, and bring Right to Trial to your state.
+### TELL US WHERE YOU WANT TO HELP.
+- Give us one minute. Tell us your state, your role, and the part you would love to take on.
+- YOUR NAME
+- YOUR STATE Choose a state Alabama Alaska Arizona Arkansas California Colorado Connecticut Delaware Florida Georgia Hawaii Idaho Illinois Indiana Iowa Kansas Kentucky Louisiana Maine Maryland Massachusetts Michigan Minnesota Mississippi Missouri Montana Nebraska Nevada New Hampshire New Jersey New Mexico New York North Carolina North Dakota Ohio Oklahoma Oregon Pennsylvania Rhode Island South Carolina South Dakota Tennessee Texas Utah Vermont Virginia Washington West Virginia Wisconsin Wyoming
+- YOUR ROLE Patient or caregiver Clinician Researcher Public educator or organizer Other
+- WHAT WOULD YOU LOVE TO HELP MAKE HAPPEN? (optional)
+- EMAIL
+- Send me occasional updates about Right to Trial in my state.
+- I WANT TO HELP
+- We’ll use your email to reply and send the updates you request.
+### PREFER EMAIL?
+- The form is the fastest path. If your idea does not fit it, send it directly.
+- [EMAIL HELLO@ACCELERATEDMEDICINE.ORG](mailto:hello@acceleratedmedicine.org?subject=Right%20to%20Trial%20volunteer)
 - MISSION: TOTAL DISEASE ERADICATION
-#### RIGHT TO TRY
+#### RIGHT TO TRIAL
 - [MONTANA MODEL](/montana)
 - [MISSOURI](/states/missouri)
 - [YOUR STATE](/#state-support)

--- a/apps/acceleratedmedicine/app/contact/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/contact/page.logged-out.md
@@ -17,7 +17,7 @@
 - VOLUNTEER
 ## HELP EVERY PATIENT GET THE RIGHT TO TRIAL.
 - Every patient should be able to join a pragmatic clinical trial for the most promising treatments. Every result should help the next patient. You can help make that normal.
-- [FIND MY PART](#volunteer-form)
+- [FIND MY PART](#tell-us-where-you-want-to-help)
 ### THERE IS USEFUL WORK FOR EVERY KIND OF HUMAN.
 #### PATIENTS AND CAREGIVERS
 - Tell the story only you can tell. Show what another real option could mean when approved treatments are not enough.
@@ -36,7 +36,7 @@
 - EMAIL
 - Send me occasional updates about Right to Trial in my state.
 - I WANT TO HELP
-- We’ll use your email to reply and send the updates you request.
+- We’ll use your email for your confirmation, our reply, and any updates you request.
 ### PREFER EMAIL?
 - The form is the fastest path. If your idea does not fit it, send it directly.
 - [EMAIL HELLO@ACCELERATEDMEDICINE.ORG](mailto:hello@acceleratedmedicine.org?subject=Right%20to%20Trial%20volunteer)

--- a/apps/acceleratedmedicine/app/contact/page.tsx
+++ b/apps/acceleratedmedicine/app/contact/page.tsx
@@ -1,7 +1,140 @@
+import {
+  ArrowDown,
+  HeartPulse,
+  Mail,
+  Microscope,
+  Stethoscope,
+  Users,
+} from "lucide-react";
 import type { Metadata } from "next";
 
+import Layout from "@/components/layout";
+import { RightToTrySupportForm } from "@/components/right-to-try-support-form";
+import { Card } from "@optimitron/neobrutalist-ui/ui/card";
+import { Container } from "@optimitron/neobrutalist-ui/ui/container";
+import { SectionContainer } from "@optimitron/neobrutalist-ui/ui/section-container";
+
 export const metadata: Metadata = {
+  title: "Volunteer for Right to Trial | Institute for Accelerated Medicine",
+  description:
+    "Help bring Right to Trial to every patient. Patients, clinicians, researchers, and public educators can volunteer in any state.",
   alternates: { canonical: "https://acceleratedmedicine.org/contact" },
 };
 
-export { default } from "@optimitron/site-kit/components/contact-page";
+const roles = [
+  {
+    icon: HeartPulse,
+    title: "Patients and caregivers",
+    text: "Tell the story only you can tell. Show what another real option could mean when approved treatments are not enough.",
+    color: "bg-brutal-pink",
+  },
+  {
+    icon: Stethoscope,
+    title: "Clinicians",
+    text: "Help make access safe, practical, and real for the patients and professionals who will use it.",
+    color: "bg-brutal-yellow",
+  },
+  {
+    icon: Microscope,
+    title: "Researchers",
+    text: "Help turn each treatment into comparable evidence that improves the next patient’s decision.",
+    color: "bg-brutal-cyan",
+  },
+  {
+    icon: Users,
+    title: "Organizers and communicators",
+    text: "Find the local humans, answer the real questions, and bring Right to Trial to your state.",
+    color: "bg-background",
+  },
+] as const;
+
+export default function VolunteerPage() {
+  return (
+    <Layout>
+      <SectionContainer
+        bgColor="background"
+        borderPosition="bottom"
+        className="py-24 sm:py-28 lg:py-32"
+      >
+        <Container size="lg" className="text-center">
+          <p className="inline-block rotate-[-1deg] border-4 border-primary bg-brutal-cyan px-4 py-2 font-black uppercase shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+            Volunteer
+          </p>
+          <h1 className="mx-auto mt-6 max-w-6xl text-5xl font-black uppercase leading-[0.9] tracking-tighter sm:text-6xl md:text-7xl lg:text-8xl">
+            Help every patient get the Right to Trial.
+          </h1>
+          <p className="mx-auto mt-7 max-w-4xl text-lg font-bold sm:text-xl md:text-2xl">
+            Every patient should be able to join a pragmatic clinical trial for
+            the most promising treatments. Every result should help the next
+            patient. You can help make that normal.
+          </p>
+          <a
+            className="mt-9 inline-flex items-center gap-2 border-4 border-primary bg-brutal-pink px-7 py-4 text-xl font-black uppercase shadow-[7px_7px_0px_0px_rgba(0,0,0,1)] transition-all hover:-translate-x-1 hover:-translate-y-1 hover:shadow-[11px_11px_0px_0px_rgba(0,0,0,1)]"
+            href="#volunteer-form"
+          >
+            Find my part <ArrowDown className="h-6 w-6" strokeWidth={3} />
+          </a>
+        </Container>
+      </SectionContainer>
+
+      <SectionContainer bgColor="pink" borderPosition="bottom">
+        <Container>
+          <h2 className="mx-auto max-w-5xl text-center text-4xl font-black uppercase leading-none tracking-tighter text-brutal-pink-foreground sm:text-5xl md:text-6xl lg:text-7xl">
+            There is useful work for every kind of human.
+          </h2>
+          <div className="mt-12 grid gap-6 md:grid-cols-2">
+            {roles.map(({ icon: Icon, title, text, color }) => (
+              <Card
+                key={title}
+                className={`${color} gap-4 rounded-none border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}
+              >
+                <Icon className="h-12 w-12" strokeWidth={3} />
+                <h3 className="text-2xl font-black uppercase">{title}</h3>
+                <p className="text-lg font-bold">{text}</p>
+              </Card>
+            ))}
+          </div>
+        </Container>
+      </SectionContainer>
+
+      <SectionContainer
+        id="volunteer-form"
+        bgColor="cyan"
+        borderPosition="bottom"
+        className="scroll-mt-24"
+      >
+        <Container size="lg">
+          <div className="mx-auto mb-10 max-w-4xl text-center">
+            <h2 className="text-4xl font-black uppercase leading-none tracking-tighter sm:text-5xl md:text-6xl lg:text-7xl">
+              Tell us where you want to help.
+            </h2>
+            <p className="mx-auto mt-5 max-w-3xl text-lg font-bold sm:text-xl">
+              Give us one minute. Tell us your state, your role, and the part
+              you would love to take on.
+            </p>
+          </div>
+          <RightToTrySupportForm variant="volunteer" />
+        </Container>
+      </SectionContainer>
+
+      <SectionContainer bgColor="yellow" borderPosition="none">
+        <Container size="md" className="text-center">
+          <Mail className="mx-auto h-14 w-14" strokeWidth={3} />
+          <h2 className="mt-4 text-3xl font-black uppercase sm:text-4xl">
+            Prefer email?
+          </h2>
+          <p className="mx-auto mt-3 max-w-2xl text-lg font-bold">
+            The form is the fastest path. If your idea does not fit it, send it
+            directly.
+          </p>
+          <a
+            className="mt-6 inline-block border-4 border-primary bg-background px-7 py-4 text-lg font-black uppercase shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] transition-all hover:-translate-x-1 hover:-translate-y-1 hover:shadow-[10px_10px_0px_0px_rgba(0,0,0,1)]"
+            href="mailto:hello@acceleratedmedicine.org?subject=Right%20to%20Trial%20volunteer"
+          >
+            Email hello@acceleratedmedicine.org
+          </a>
+        </Container>
+      </SectionContainer>
+    </Layout>
+  );
+}

--- a/apps/acceleratedmedicine/app/contact/page.tsx
+++ b/apps/acceleratedmedicine/app/contact/page.tsx
@@ -70,7 +70,7 @@ export default function VolunteerPage() {
           </p>
           <a
             className="mt-9 inline-flex items-center gap-2 border-4 border-primary bg-brutal-pink px-7 py-4 text-xl font-black uppercase shadow-[7px_7px_0px_0px_rgba(0,0,0,1)] transition-all hover:-translate-x-1 hover:-translate-y-1 hover:shadow-[11px_11px_0px_0px_rgba(0,0,0,1)]"
-            href="#volunteer-form"
+            href="#tell-us-where-you-want-to-help"
           >
             Find my part <ArrowDown className="h-6 w-6" strokeWidth={3} />
           </a>
@@ -98,7 +98,7 @@ export default function VolunteerPage() {
       </SectionContainer>
 
       <SectionContainer
-        id="volunteer-form"
+        id="tell-us-where-you-want-to-help"
         bgColor="cyan"
         borderPosition="bottom"
         className="scroll-mt-24"

--- a/apps/acceleratedmedicine/app/donate/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/donate/page.logged-out.md
@@ -3,13 +3,13 @@
 ## Metadata
 
 - Page title: Institute for Accelerated Medicine
-- Meta description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Meta description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Canonical: https://acceleratedmedicine.org
 - Open Graph title: Institute for Accelerated Medicine
-- Open Graph description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Open Graph description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Open Graph image: https://acceleratedmedicine.org/assets/acceleratedmedicine/iam-og-1200x630.png
 - Twitter title: Institute for Accelerated Medicine
-- Twitter description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Twitter description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 
 ## Visible Page Copy
 
@@ -47,7 +47,7 @@
 #### INFRASTRUCTURE
 - Maintain secure tools for standardized outcome collection, anonymization, aggregation, analysis, and public treatment rankings.
 - MISSION: TOTAL DISEASE ERADICATION
-#### RIGHT TO TRY
+#### RIGHT TO TRIAL
 - [MONTANA MODEL](/montana)
 - [MISSOURI](/states/missouri)
 - [YOUR STATE](/#state-support)

--- a/apps/acceleratedmedicine/app/faq/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/faq/page.logged-out.md
@@ -3,13 +3,13 @@
 ## Metadata
 
 - Page title: Institute for Accelerated Medicine
-- Meta description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Meta description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Canonical: https://acceleratedmedicine.org/faq
 - Open Graph title: Institute for Accelerated Medicine
-- Open Graph description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Open Graph description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Open Graph image: https://acceleratedmedicine.org/assets/acceleratedmedicine/iam-og-1200x630.png
 - Twitter title: Institute for Accelerated Medicine
-- Twitter description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Twitter description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 
 ## Visible Page Copy
 

--- a/apps/acceleratedmedicine/app/model-act/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/model-act/page.logged-out.md
@@ -2,20 +2,20 @@
 
 ## Metadata
 
-- Page title: Universal Right to Try Model Framework
+- Page title: Right to Trial Model Framework
 - Meta description: An educational framework for state patient access, licensed experimental treatment centers, informed consent, oversight, and useful outcome evidence.
 - Canonical: https://acceleratedmedicine.org/model-act
-- Open Graph title: Universal Right to Try Model Framework
+- Open Graph title: Right to Trial Model Framework
 - Open Graph description: An educational framework for state patient access, licensed experimental treatment centers, informed consent, oversight, and useful outcome evidence.
 - Open Graph image: https://acceleratedmedicine.org/assets/acceleratedmedicine/iam-og-1200x630.png
-- Twitter title: Universal Right to Try Model Framework
+- Twitter title: Right to Trial Model Framework
 - Twitter description: An educational framework for state patient access, licensed experimental treatment centers, informed consent, oversight, and useful outcome evidence.
 
 ## Visible Page Copy
 
 - [INSTITUTE FOR ACCELERATED MEDICINE](/)
-## A MODEL FRAMEWORK STATES CAN ACTUALLY DISCUSS.
-- Start with Montana's enacted licensing framework. Keep the patient safeguards. Add comparable outcomes so wider access also produces better evidence.
+## A RIGHT TO TRIAL FRAMEWORK FOR EVERY STATE.
+- Start with Montana's enacted licensing framework. Add pragmatic trials and comparable outcomes. Give every patient another option and make every result useful to the next patient.
 - 01
 ### PATIENT ELIGIBILITY
 - Let an informed adult consider an experimental treatment after the patient and treating clinician evaluate approved options.
@@ -38,9 +38,9 @@
 - The framework above is an educational outline. Montana's enrolled bill and final rules provide the official enacted language, definitions, licensing structure, and implementation detail.
 - [OPEN SB 535](https://docs.legmt.gov/download-ticket?ticketId=404bf910-6276-4d4a-b3d3-56b7cac4b5f9)
 - [READ THE MONTANA GUIDE](/montana)
-- BUILD THE STATE MAP FROM REAL HUMANS
-### SHOULD YOUR STATE CONSIDER UNIVERSAL RIGHT TO TRY?
-- Tell us where you live, how you see the proposal, and what role you could play. The Institute will use the responses to choose the next state education pages, clinician briefings, and public events.
+- BRING RIGHT TO TRIAL TO EVERY STATE
+### SHOULD EVERY PATIENT IN YOUR STATE HAVE THE RIGHT TO TRIAL?
+- Tell us where you live and what role you can play. Your response helps the Institute build the next state page, clinician briefing, and public event.
 - YOUR STATE Choose a state Alabama Alaska Arizona Arkansas California Colorado Connecticut Delaware Florida Georgia Hawaii Idaho Illinois Indiana Iowa Kansas Kentucky Louisiana Maine Maryland Massachusetts Michigan Minnesota Mississippi Missouri Montana Nebraska Nevada New Hampshire New Jersey New Mexico New York North Carolina North Dakota Ohio Oklahoma Oregon Pennsylvania Rhode Island South Carolina South Dakota Tennessee Texas Utah Vermont Virginia Washington West Virginia Wisconsin Wyoming
 - YOUR ROLE Patient or caregiver Clinician Researcher Public educator or organizer Other
 - YES
@@ -48,11 +48,11 @@
 - NO
 - WHY DOES THIS MATTER TO YOU? (optional)
 - EMAIL (optional)
-- Send me occasional updates about Universal Right to Try education in my state.
+- Send me occasional updates about Right to Trial in my state.
 - RECORD MY STATE RESPONSE
 - If you provide an email, we will send a confirmation. We will not sell or rent it.
 - MISSION: TOTAL DISEASE ERADICATION
-#### RIGHT TO TRY
+#### RIGHT TO TRIAL
 - [MONTANA MODEL](/montana)
 - [MISSOURI](/states/missouri)
 - [YOUR STATE](/#state-support)

--- a/apps/acceleratedmedicine/app/model-act/page.tsx
+++ b/apps/acceleratedmedicine/app/model-act/page.tsx
@@ -22,12 +22,12 @@ import { StateSupportSection } from "@/components/landing/right-to-try-sections"
 import { RIGHT_TO_TRY_SOURCES } from "@/lib/right-to-try";
 
 export const metadata: Metadata = {
-  title: "Universal Right to Try Model Framework",
+  title: "Right to Trial Model Framework",
   description:
     "An educational framework for state patient access, licensed experimental treatment centers, informed consent, oversight, and useful outcome evidence.",
   alternates: { canonical: "https://acceleratedmedicine.org/model-act" },
   openGraph: {
-    title: "Universal Right to Try Model Framework",
+    title: "Right to Trial Model Framework",
     description:
       "An educational framework for state patient access, licensed experimental treatment centers, informed consent, oversight, and useful outcome evidence.",
     images: [
@@ -42,7 +42,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Universal Right to Try Model Framework",
+    title: "Right to Trial Model Framework",
     description:
       "An educational framework for state patient access, licensed experimental treatment centers, informed consent, oversight, and useful outcome evidence.",
     images: [
@@ -93,16 +93,20 @@ export default function ModelActPage() {
 
   return (
     <Layout>
-      <SectionContainer bgColor="yellow" borderPosition="bottom" className="py-24 sm:py-28">
+      <SectionContainer
+        bgColor="yellow"
+        borderPosition="bottom"
+        className="py-24 sm:py-28"
+      >
         <Container size="lg" className="text-center">
           <FileText className="mx-auto h-16 w-16" strokeWidth={3} />
           <h1 className="mt-5 text-5xl font-black uppercase leading-[0.9] tracking-tighter sm:text-6xl md:text-7xl lg:text-8xl">
-            A model framework states can actually discuss.
+            A Right to Trial framework for every state.
           </h1>
           <p className="mx-auto mt-7 max-w-4xl text-lg font-bold sm:text-xl md:text-2xl">
-            Start with Montana&apos;s enacted licensing framework. Keep the
-            patient safeguards. Add comparable outcomes so wider access also
-            produces better evidence.
+            Start with Montana&apos;s enacted licensing framework. Add pragmatic
+            trials and comparable outcomes. Give every patient another option
+            and make every result useful to the next patient.
           </p>
         </Container>
       </SectionContainer>
@@ -111,7 +115,10 @@ export default function ModelActPage() {
         <Container>
           <div className="grid gap-7 md:grid-cols-2 lg:grid-cols-3">
             {parts.map(({ icon: Icon, number, title, text }, index) => (
-              <Card key={title} className={`${index === 5 ? "bg-brutal-cyan" : index % 2 === 0 ? "bg-brutal-pink" : "bg-brutal-yellow"} gap-4 rounded-none border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}>
+              <Card
+                key={title}
+                className={`${index === 5 ? "bg-brutal-cyan" : index % 2 === 0 ? "bg-brutal-pink" : "bg-brutal-yellow"} gap-4 rounded-none border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}
+              >
                 <div className="flex items-center justify-between gap-3">
                   <Icon className="h-12 w-12" strokeWidth={3} />
                   <span className="text-4xl font-black">{number}</span>
@@ -125,22 +132,37 @@ export default function ModelActPage() {
       </SectionContainer>
 
       <SectionContainer bgColor="pink" borderPosition="bottom">
-        <Container size="lg" className="text-center text-brutal-pink-foreground">
+        <Container
+          size="lg"
+          className="text-center text-brutal-pink-foreground"
+        >
           <h2 className="text-5xl font-black uppercase leading-none tracking-tighter sm:text-6xl md:text-7xl">
             Use enacted text as the starting point.
           </h2>
           <p className="mx-auto mt-6 max-w-3xl text-lg font-bold sm:text-xl">
-            The framework above is an educational outline. Montana&apos;s enrolled
-            bill and final rules provide the official enacted language,
+            The framework above is an educational outline. Montana&apos;s
+            enrolled bill and final rules provide the official enacted language,
             definitions, licensing structure, and implementation detail.
           </p>
           <div className="mt-8 flex flex-col justify-center gap-4 sm:flex-row">
-            <Button asChild size="lg" className="rounded-none border-4 border-primary bg-brutal-yellow px-7 py-6 text-base font-black uppercase text-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
-              <a href={RIGHT_TO_TRY_SOURCES.montanaSb535} rel="noreferrer" target="_blank">
+            <Button
+              asChild
+              size="lg"
+              className="rounded-none border-4 border-primary bg-brutal-yellow px-7 py-6 text-base font-black uppercase text-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]"
+            >
+              <a
+                href={RIGHT_TO_TRY_SOURCES.montanaSb535}
+                rel="noreferrer"
+                target="_blank"
+              >
                 Open SB 535 <ExternalLink className="h-5 w-5" />
               </a>
             </Button>
-            <Button asChild size="lg" className="rounded-none border-4 border-primary bg-background px-7 py-6 text-base font-black uppercase text-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
+            <Button
+              asChild
+              size="lg"
+              className="rounded-none border-4 border-primary bg-background px-7 py-6 text-base font-black uppercase text-foreground shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]"
+            >
               <Link href="/montana">
                 Read the Montana guide <ArrowRight className="h-5 w-5" />
               </Link>

--- a/apps/acceleratedmedicine/app/montana/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/montana/page.logged-out.md
@@ -20,7 +20,7 @@
 - [READ ENROLLED SB 535](https://docs.legmt.gov/download-ticket?ticketId=404bf910-6276-4d4a-b3d3-56b7cac4b5f9)
 - AN ENACTED STATE PRECEDENT
 ### MONTANA ALREADY MOVED THE LINE.
-- Universal Right to Try is no longer a white-paper idea. Montana enacted a broader, regulated access framework and completed the rules needed to license experimental treatment centers.
+- Montana's Universal Right to Try law is enacted, regulated, and ready for licensed experimental treatment centers. The precedent exists. Right to Trial carries it forward.
 - 2015
 #### RIGHT TO TRY BEGINS
 - Montana creates an initial access path for eligible patients.
@@ -56,9 +56,9 @@
 - [FINAL 2026 RULES](https://dphhs.mt.gov/assets/rules/2026-427-Adp-Arm.pdf)
 - [CURRENT MONTANA CODE](https://mca.legmt.gov/bills/mca/title_0500/chapter_0120/part_0010/sections_index.html)
 - [TREATMENT CENTER LICENSING](https://dphhs.mt.gov/oig/licensure/healthcarefacilitylicensure/lbfacilityapplications/lbexperimentaltreatmentcenters)
-- BUILD THE STATE MAP FROM REAL HUMANS
-### SHOULD YOUR STATE CONSIDER UNIVERSAL RIGHT TO TRY?
-- Tell us where you live, how you see the proposal, and what role you could play. The Institute will use the responses to choose the next state education pages, clinician briefings, and public events.
+- BRING RIGHT TO TRIAL TO EVERY STATE
+### SHOULD EVERY PATIENT IN YOUR STATE HAVE THE RIGHT TO TRIAL?
+- Tell us where you live and what role you can play. Your response helps the Institute build the next state page, clinician briefing, and public event.
 - YOUR STATE Choose a state Alabama Alaska Arizona Arkansas California Colorado Connecticut Delaware Florida Georgia Hawaii Idaho Illinois Indiana Iowa Kansas Kentucky Louisiana Maine Maryland Massachusetts Michigan Minnesota Mississippi Missouri Montana Nebraska Nevada New Hampshire New Jersey New Mexico New York North Carolina North Dakota Ohio Oklahoma Oregon Pennsylvania Rhode Island South Carolina South Dakota Tennessee Texas Utah Vermont Virginia Washington West Virginia Wisconsin Wyoming
 - YOUR ROLE Patient or caregiver Clinician Researcher Public educator or organizer Other
 - YES
@@ -66,11 +66,11 @@
 - NO
 - WHY DOES THIS MATTER TO YOU? (optional)
 - EMAIL (optional)
-- Send me occasional updates about Universal Right to Try education in my state.
+- Send me occasional updates about Right to Trial in my state.
 - RECORD MY STATE RESPONSE
 - If you provide an email, we will send a confirmation. We will not sell or rent it.
 - MISSION: TOTAL DISEASE ERADICATION
-#### RIGHT TO TRY
+#### RIGHT TO TRIAL
 - [MONTANA MODEL](/montana)
 - [MISSOURI](/states/missouri)
 - [YOUR STATE](/#state-support)

--- a/apps/acceleratedmedicine/app/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/page.logged-out.md
@@ -3,28 +3,28 @@
 ## Metadata
 
 - Page title: Institute for Accelerated Medicine
-- Meta description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Meta description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Canonical: https://acceleratedmedicine.org
 - Open Graph title: Institute for Accelerated Medicine
-- Open Graph description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Open Graph description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Open Graph image: https://acceleratedmedicine.org/assets/acceleratedmedicine/iam-og-1200x630.png
 - Twitter title: Institute for Accelerated Medicine
-- Twitter description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Twitter description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 
 ## Visible Page Copy
 
 - [INSTITUTE FOR ACCELERATED MEDICINE](/)
-- UNIVERSAL RIGHT TO TRY
-## THE RIGHT TO TRY SHOULD NOT DEPEND ON YOUR ZIP CODE.
-- Montana created a broader path for patients and licensed clinicians to consider experimental treatments after evaluating approved options. The Institute is helping every state understand the model—and helping every patient's outcome become evidence for the next patient.
-- [SEE WHAT THE LAW DOES](/montana)
-- [BRING IT TO MY STATE](#state-support)
+- RIGHT TO TRIAL
+## EVERY PATIENT HAS THE RIGHT TO TRIAL.
+- Every patient should be able to join a pragmatic clinical trial for the most promising treatments. Every result should help the next patient. Montana opened the door. Now every state can turn access into evidence.
+- [SEE MONTANA'S PRECEDENT](/montana)
+- [BRING RIGHT TO TRIAL TO MY STATE](#state-support)
 - MONTANA
 - SB 535
 - Signed in 2025. Final rules effective in 2026. Experimental treatment center applications are available now.
 - AN ENACTED STATE PRECEDENT
 ### MONTANA ALREADY MOVED THE LINE.
-- Universal Right to Try is no longer a white-paper idea. Montana enacted a broader, regulated access framework and completed the rules needed to license experimental treatment centers.
+- Montana's Universal Right to Try law is enacted, regulated, and ready for licensed experimental treatment centers. The precedent exists. Right to Trial carries it forward.
 - 2015
 #### RIGHT TO TRY BEGINS
 - Montana creates an initial access path for eligible patients.
@@ -39,7 +39,7 @@
 - Final rules take effect and Montana publishes the experimental treatment center application.
 - Read the official [enrolled SB 535](https://docs.legmt.gov/download-ticket?ticketId=404bf910-6276-4d4a-b3d3-56b7cac4b5f9), [final rules](https://dphhs.mt.gov/assets/rules/2026-427-Adp-Arm.pdf), and [licensing page](https://dphhs.mt.gov/oig/licensure/healthcarefacilitylicensure/lbfacilityapplications/lbexperimentaltreatmentcenters).
 ### OPEN THE DOOR. THEN LEARN FROM EVERY PERSON WHO WALKS THROUGH IT.
-- The law creates access, licensing, consent, and oversight. The Institute's decentralized FDA model adds standardized outcomes, pooled evidence, and faster learning.
+- Montana created a licensed path to treatment. Right to Trial adds pragmatic trials, standardized outcomes, and shared evidence so each patient can help the next one.
 - BEFORE
 #### A NARROW EXCEPTION
 - Eligibility can depend on a narrow diagnosis or federal pathway.
@@ -50,8 +50,7 @@
 - Licensed centers operate under state rules and inspection.
 - Patients review approved options with a treating clinician.
 - Consent, safety, records, and professional oversight are explicit.
-- INSTITUTE MODEL
-#### ACCESS THAT LEARNS
+#### EVERY PATIENT BECOMES EVIDENCE
 - Use standard outcome measures before and after treatment.
 - Pool comparable results across patients and centers.
 - Publish useful treatment evidence for the next decision.
@@ -64,9 +63,9 @@
 - A licensed center and qualified professionals provide care, maintain records, and meet safety rules.
 #### MAKE THE OUTCOME USEFUL
 - Standard measures turn one person's result into comparable evidence for future patients and clinicians.
-- BUILD THE STATE MAP FROM REAL HUMANS
-### SHOULD YOUR STATE CONSIDER UNIVERSAL RIGHT TO TRY?
-- Tell us where you live, how you see the proposal, and what role you could play. The Institute will use the responses to choose the next state education pages, clinician briefings, and public events.
+- BRING RIGHT TO TRIAL TO EVERY STATE
+### SHOULD EVERY PATIENT IN YOUR STATE HAVE THE RIGHT TO TRIAL?
+- Tell us where you live and what role you can play. Your response helps the Institute build the next state page, clinician briefing, and public event.
 - YOUR STATE Choose a state Alabama Alaska Arizona Arkansas California Colorado Connecticut Delaware Florida Georgia Hawaii Idaho Illinois Indiana Iowa Kansas Kentucky Louisiana Maine Maryland Massachusetts Michigan Minnesota Mississippi Missouri Montana Nebraska Nevada New Hampshire New Jersey New Mexico New York North Carolina North Dakota Ohio Oklahoma Oregon Pennsylvania Rhode Island South Carolina South Dakota Tennessee Texas Utah Vermont Virginia Washington West Virginia Wisconsin Wyoming
 - YOUR ROLE Patient or caregiver Clinician Researcher Public educator or organizer Other
 - YES
@@ -74,11 +73,11 @@
 - NO
 - WHY DOES THIS MATTER TO YOU? (optional)
 - EMAIL (optional)
-- Send me occasional updates about Universal Right to Try education in my state.
+- Send me occasional updates about Right to Trial in my state.
 - RECORD MY STATE RESPONSE
 - If you provide an email, we will send a confirmation. We will not sell or rent it.
 ### MONTANA PROVED A PATH. MISSOURI IS THE NEXT ACTIVE STATE.
-- Pick any state to record local interest. This map tracks the Institute's education work: enacted precedent, active education, and where we are still listening.
+- Pick any state and put it on the map. Montana is the enacted precedent. Missouri is active now. Every other state can be next.
 - ENACTED PRECEDENT
 - ACTIVE EDUCATION
 - LISTENING
@@ -438,15 +437,14 @@
 - [RESEARCHERS MAKE EVERY OUTCOME COMPARABLE Help define the small, standard outcome set that turns treatment access into cumulative evidence. CONTINUE](/research)
 - [PUBLIC EDUCATORS BUILD A USEFUL STATE PAGE Collect local questions, identify credible speakers, and explain the model without slogans or fog. CONTINUE](/contact)
 - NEXT ACTIVE STATE: MISSOURI
-### HELP MISSOURI BUILD A RESPONSIBLE VERSION.
-- The Institute is collecting patient priorities, clinician safeguards, research standards, and public questions before a Missouri proposal is finalized.
+### HELP MISSOURI LEAD THE NEXT RIGHT TO TRIAL STATE.
+- Patients, clinicians, researchers, and public educators can build a Missouri model where access creates evidence and every outcome helps the next patient.
 - [OPEN THE MISSOURI PAGE](/states/missouri)
 ### 💀 DEATH CLOCK
-### ONE STATE PROVED IT CAN MOVE. WHICH STATE IS NEXT?
+### MONTANA OPENED THE DOOR. BRING RIGHT TO TRIAL TO YOUR STATE.
 - [RECORD MY STATE](#state-support)
 - [READ THE MODEL FRAMEWORK](/model-act)
 - MISSION: TOTAL DISEASE ERADICATION
-#### RIGHT TO TRY
 - [MONTANA MODEL](/montana)
 - [MISSOURI](/states/missouri)
 - [YOUR STATE](/#state-support)

--- a/apps/acceleratedmedicine/app/privacy/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/privacy/page.logged-out.md
@@ -3,13 +3,13 @@
 ## Metadata
 
 - Page title: Institute for Accelerated Medicine
-- Meta description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Meta description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Canonical: https://acceleratedmedicine.org/privacy
 - Open Graph title: Institute for Accelerated Medicine
-- Open Graph description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Open Graph description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Open Graph image: https://acceleratedmedicine.org/assets/acceleratedmedicine/iam-og-1200x630.png
 - Twitter title: Institute for Accelerated Medicine
-- Twitter description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Twitter description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 
 ## Visible Page Copy
 
@@ -55,7 +55,7 @@
 - Email: hello@acceleratedmedicine.org
 - Website: AcceleratedMedicine.org
 - MISSION: TOTAL DISEASE ERADICATION
-#### RIGHT TO TRY
+#### RIGHT TO TRIAL
 - [MONTANA MODEL](/montana)
 - [MISSOURI](/states/missouri)
 - [YOUR STATE](/#state-support)

--- a/apps/acceleratedmedicine/app/states/[state]/page.tsx
+++ b/apps/acceleratedmedicine/app/states/[state]/page.tsx
@@ -16,7 +16,9 @@ export function generateStaticParams() {
   ).map((campaign) => ({ state: campaign.slug }));
 }
 
-export async function generateMetadata({ params }: StatePageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: StatePageProps): Promise<Metadata> {
   const { state } = await params;
   if (state === "montana") return {};
 
@@ -24,7 +26,7 @@ export async function generateMetadata({ params }: StatePageProps): Promise<Meta
   if (!campaign) return {};
 
   return {
-    title: `${campaign.name} Universal Right to Try`,
+    title: `${campaign.name} Right to Trial`,
     description: campaign.summary,
     alternates: {
       canonical: `https://acceleratedmedicine.org/states/${campaign.slug}`,

--- a/apps/acceleratedmedicine/app/states/missouri/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/states/missouri/page.logged-out.md
@@ -2,21 +2,21 @@
 
 ## Metadata
 
-- Page title: Missouri Universal Right to Try
-- Meta description: Missouri patients, clinicians, researchers, and public educators can help shape a responsible Universal Right to Try proposal.
+- Page title: Missouri Right to Trial
+- Meta description: Help bring Right to Trial to every Missouri patient through pragmatic clinical trials and shared outcome evidence.
 - Canonical: https://acceleratedmedicine.org/states/missouri
 - Open Graph title: Institute for Accelerated Medicine
-- Open Graph description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Open Graph description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Open Graph image: https://acceleratedmedicine.org/assets/acceleratedmedicine/iam-og-1200x630.png
 - Twitter title: Institute for Accelerated Medicine
-- Twitter description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Twitter description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 
 ## Visible Page Copy
 
 - [INSTITUTE FOR ACCELERATED MEDICINE](/)
 - ACTIVE EDUCATION
-## MISSOURI CAN BUILD THE NEXT STATE MODEL.
-- The Institute is assembling patients, clinicians, researchers, and public educators around a responsible Missouri proposal.
+## MISSOURI CAN BRING RIGHT TO TRIAL TO EVERY PATIENT.
+- Patients, clinicians, researchers, and public educators can build a Missouri model where access creates evidence for the next patient.
 - [ADD MY RESPONSE](#state-support)
 ### WHAT THE MISSOURI PAGE IS BUILDING NOW
 #### PATIENT QUESTIONS
@@ -25,12 +25,12 @@
 - Who can explain responsible supervision, consent, monitoring, and comparable outcomes?
 #### STATE-SPECIFIC EDUCATION
 - How does the Montana precedent fit the state's current law, agencies, facilities, and public questions?
-### THE PROPOSAL COMES AFTER THE LISTENING.
-- There is no bill number on this page because the Missouri proposal is still being built. The Institute is starting with Montana's enacted framework, then gathering local patient, clinical, research, and implementation priorities.
-- [REVIEW THE STARTING FRAMEWORK](/model-act)
-- BUILD THE STATE MAP FROM REAL HUMANS
-### SHOULD YOUR STATE CONSIDER UNIVERSAL RIGHT TO TRY?
-- Tell us where you live, how you see the proposal, and what role you could play. The Institute will use the responses to choose the next state education pages, clinician briefings, and public events.
+### MISSOURI CAN GIVE EVERY PATIENT THE RIGHT TO TRIAL.
+- Montana showed that a state can open a broader, licensed path. Missouri can go further by making pragmatic trials and shared outcomes part of the path from day one.
+- [SEE THE RIGHT TO TRIAL FRAMEWORK](/model-act)
+- BRING RIGHT TO TRIAL TO EVERY STATE
+### SHOULD EVERY PATIENT IN YOUR STATE HAVE THE RIGHT TO TRIAL?
+- Tell us where you live and what role you can play. Your response helps the Institute build the next state page, clinician briefing, and public event.
 - YOUR STATE Choose a state Alabama Alaska Arizona Arkansas California Colorado Connecticut Delaware Florida Georgia Hawaii Idaho Illinois Indiana Iowa Kansas Kentucky Louisiana Maine Maryland Massachusetts Michigan Minnesota Mississippi Missouri Montana Nebraska Nevada New Hampshire New Jersey New Mexico New York North Carolina North Dakota Ohio Oklahoma Oregon Pennsylvania Rhode Island South Carolina South Dakota Tennessee Texas Utah Vermont Virginia Washington West Virginia Wisconsin Wyoming
 - YOUR ROLE Patient or caregiver Clinician Researcher Public educator or organizer Other
 - YES
@@ -38,11 +38,11 @@
 - NO
 - WHY DOES THIS MATTER TO YOU? (optional)
 - EMAIL (optional)
-- Send me occasional updates about Universal Right to Try education in my state.
+- Send me occasional updates about Right to Trial in my state.
 - RECORD MY STATE RESPONSE
 - If you provide an email, we will send a confirmation. We will not sell or rent it.
 - MISSION: TOTAL DISEASE ERADICATION
-#### RIGHT TO TRY
+#### RIGHT TO TRIAL
 - [MONTANA MODEL](/montana)
 - [MISSOURI](/states/missouri)
 - [YOUR STATE](/#state-support)

--- a/apps/acceleratedmedicine/app/states/missouri/page.tsx
+++ b/apps/acceleratedmedicine/app/states/missouri/page.tsx
@@ -4,9 +4,9 @@ import { StateCampaignPage } from "@/components/state-campaign-page";
 import { getStateCampaign } from "@/lib/right-to-try";
 
 export const metadata: Metadata = {
-  title: "Missouri Universal Right to Try",
+  title: "Missouri Right to Trial",
   description:
-    "Missouri patients, clinicians, researchers, and public educators can help shape a responsible Universal Right to Try proposal.",
+    "Help bring Right to Trial to every Missouri patient through pragmatic clinical trials and shared outcome evidence.",
   alternates: {
     canonical: "https://acceleratedmedicine.org/states/missouri",
   },

--- a/apps/acceleratedmedicine/app/terms/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/terms/page.logged-out.md
@@ -3,13 +3,13 @@
 ## Metadata
 
 - Page title: Institute for Accelerated Medicine
-- Meta description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Meta description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Canonical: https://acceleratedmedicine.org/terms
 - Open Graph title: Institute for Accelerated Medicine
-- Open Graph description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Open Graph description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Open Graph image: https://acceleratedmedicine.org/assets/acceleratedmedicine/iam-og-1200x630.png
 - Twitter title: Institute for Accelerated Medicine
-- Twitter description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Twitter description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 
 ## Visible Page Copy
 
@@ -45,7 +45,7 @@
 - Email: hello@acceleratedmedicine.org
 - Website: AcceleratedMedicine.org
 - MISSION: TOTAL DISEASE ERADICATION
-#### RIGHT TO TRY
+#### RIGHT TO TRIAL
 - [MONTANA MODEL](/montana)
 - [MISSOURI](/states/missouri)
 - [YOUR STATE](/#state-support)

--- a/apps/acceleratedmedicine/app/the-plan/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/the-plan/page.logged-out.md
@@ -3,13 +3,13 @@
 ## Metadata
 
 - Page title: Institute for Accelerated Medicine
-- Meta description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Meta description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Canonical: https://acceleratedmedicine.org
 - Open Graph title: Institute for Accelerated Medicine
-- Open Graph description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Open Graph description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 - Open Graph image: https://acceleratedmedicine.org/assets/acceleratedmedicine/iam-og-1200x630.png
 - Twitter title: Institute for Accelerated Medicine
-- Twitter description: Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.
+- Twitter description: Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.
 
 ## Visible Page Copy
 
@@ -154,7 +154,7 @@
 - [DONATE](/donate)
 - [BROWSE THE FIELD MANUAL](https://manual.warondisease.org?utm_source=the_plan_footer&utm_medium=web&utm_campaign=cross_site)
 - MISSION: TOTAL DISEASE ERADICATION
-#### RIGHT TO TRY
+#### RIGHT TO TRIAL
 - [MONTANA MODEL](/montana)
 - [MISSOURI](/states/missouri)
 - [YOUR STATE](/#state-support)

--- a/apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx
+++ b/apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx
@@ -33,7 +33,13 @@ import type { StateCampaignStage, SupporterRole } from "@/lib/right-to-try";
 const buttonShadow =
   "rounded-none border-4 border-primary px-7 py-6 text-base font-black uppercase shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] transition-all hover:-translate-x-1 hover:-translate-y-1 hover:shadow-[10px_10px_0px_0px_rgba(0,0,0,1)]";
 
-function SourceLink({ href, children }: { href: string; children: React.ReactNode }) {
+function SourceLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
   return (
     <a
       className="inline-flex items-center gap-1 font-black underline decoration-2 underline-offset-4 hover:text-brutal-pink"
@@ -57,27 +63,36 @@ export function UniversalRightToTryHero() {
         <div className="grid items-center gap-10 lg:grid-cols-[1.35fr_0.65fr]">
           <div>
             <p className="mb-5 inline-block rotate-[-1deg] border-4 border-primary bg-brutal-cyan px-4 py-2 text-sm font-black uppercase shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] sm:text-base">
-              Universal Right to Try
+              Right to Trial
             </p>
             <h1 className="text-5xl font-black uppercase leading-[0.9] tracking-tighter sm:text-6xl md:text-7xl lg:text-8xl">
-              The right to try should not depend on your zip code.
+              Every patient has the Right to Trial.
             </h1>
             <p className="mt-7 max-w-4xl text-lg font-bold sm:text-xl md:text-2xl">
-              Montana created a broader path for patients and licensed
-              clinicians to consider experimental treatments after evaluating
-              approved options. The Institute is helping every state understand
-              the model—and helping every patient&apos;s outcome become evidence
-              for the next patient.
+              Every patient should be able to join a pragmatic clinical trial
+              for the most promising treatments. Every result should help the
+              next patient. Montana opened the door. Now every state can turn
+              access into evidence.
             </p>
             <div className="mt-8 flex flex-col gap-4 sm:flex-row">
-              <Button asChild size="lg" className={`${buttonShadow} bg-brutal-pink`}>
+              <Button
+                asChild
+                size="lg"
+                className={`${buttonShadow} bg-brutal-pink`}
+              >
                 <Link href="/montana">
-                  See what the law does <ArrowRight className="h-5 w-5" />
+                  See Montana&apos;s precedent{" "}
+                  <ArrowRight className="h-5 w-5" />
                 </Link>
               </Button>
-              <Button asChild size="lg" className={`${buttonShadow} bg-brutal-yellow`}>
+              <Button
+                asChild
+                size="lg"
+                className={`${buttonShadow} bg-brutal-yellow`}
+              >
                 <a href="#state-support">
-                  Bring it to my state <MapPin className="h-5 w-5" />
+                  Bring Right to Trial to my state{" "}
+                  <MapPin className="h-5 w-5" />
                 </a>
               </Button>
             </div>
@@ -87,7 +102,9 @@ export function UniversalRightToTryHero() {
             <div className="rotate-2 border-4 border-primary bg-brutal-yellow p-7 shadow-[12px_12px_0px_0px_rgba(0,0,0,1)]">
               <Landmark className="h-16 w-16" strokeWidth={3} />
               <p className="mt-5 text-lg font-black uppercase">Montana</p>
-              <p className="text-6xl font-black uppercase leading-none">SB 535</p>
+              <p className="text-6xl font-black uppercase leading-none">
+                SB 535
+              </p>
               <p className="mt-4 text-lg font-bold">
                 Signed in 2025. Final rules effective in 2026. Experimental
                 treatment center applications are available now.
@@ -125,7 +142,11 @@ export function MontanaProofSection() {
   ];
 
   return (
-    <SectionContainer id="montana-proof" bgColor="yellow" borderPosition="bottom">
+    <SectionContainer
+      id="montana-proof"
+      bgColor="yellow"
+      borderPosition="bottom"
+    >
       <Container>
         <div className="mx-auto max-w-4xl text-center">
           <p className="font-black uppercase">An enacted state precedent</p>
@@ -133,9 +154,9 @@ export function MontanaProofSection() {
             Montana already moved the line.
           </h2>
           <p className="mx-auto mt-5 max-w-3xl text-lg font-bold sm:text-xl">
-            Universal Right to Try is no longer a white-paper idea. Montana
-            enacted a broader, regulated access framework and completed the
-            rules needed to license experimental treatment centers.
+            Montana&apos;s Universal Right to Try law is enacted, regulated, and
+            ready for licensed experimental treatment centers. The precedent
+            exists. Right to Trial carries it forward.
           </p>
         </div>
 
@@ -146,7 +167,9 @@ export function MontanaProofSection() {
               className={`${index === 2 ? "bg-brutal-pink" : index === 3 ? "bg-brutal-cyan" : "bg-background"} gap-3 rounded-none border-4 border-primary p-5 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]`}
             >
               <p className="text-4xl font-black">{milestone.year}</p>
-              <h3 className="text-xl font-black uppercase">{milestone.title}</h3>
+              <h3 className="text-xl font-black uppercase">
+                {milestone.title}
+              </h3>
               <p className="font-bold">{milestone.text}</p>
             </Card>
           ))}
@@ -154,9 +177,18 @@ export function MontanaProofSection() {
 
         <p className="mt-10 text-center font-bold">
           Read the official{" "}
-          <SourceLink href={RIGHT_TO_TRY_SOURCES.montanaSb535}>enrolled SB 535</SourceLink>,{" "}
-          <SourceLink href={RIGHT_TO_TRY_SOURCES.montanaRules}>final rules</SourceLink>, and{" "}
-          <SourceLink href={RIGHT_TO_TRY_SOURCES.montanaLicensing}>licensing page</SourceLink>.
+          <SourceLink href={RIGHT_TO_TRY_SOURCES.montanaSb535}>
+            enrolled SB 535
+          </SourceLink>
+          ,{" "}
+          <SourceLink href={RIGHT_TO_TRY_SOURCES.montanaRules}>
+            final rules
+          </SourceLink>
+          , and{" "}
+          <SourceLink href={RIGHT_TO_TRY_SOURCES.montanaLicensing}>
+            licensing page
+          </SourceLink>
+          .
         </p>
       </Container>
     </SectionContainer>
@@ -189,8 +221,8 @@ export function RightToTryEvolutionSection() {
     },
     {
       icon: Database,
-      label: "Institute model",
-      title: "Access that learns",
+      label: "Right to Trial",
+      title: "Every patient becomes evidence",
       bullets: [
         "Use standard outcome measures before and after treatment.",
         "Pool comparable results across patients and centers.",
@@ -208,38 +240,48 @@ export function RightToTryEvolutionSection() {
             Open the door. Then learn from every person who walks through it.
           </h2>
           <p className="mx-auto mt-6 max-w-3xl text-lg font-bold sm:text-xl">
-            The law creates access, licensing, consent, and oversight. The
-            Institute&apos;s decentralized FDA model adds standardized outcomes,
-            pooled evidence, and faster learning.
+            Montana created a licensed path to treatment. Right to Trial adds
+            pragmatic trials, standardized outcomes, and shared evidence so each
+            patient can help the next one.
           </p>
         </div>
 
         <div className="mt-12 grid gap-7 lg:grid-cols-3">
-          {columns.map(({ icon: Icon, label, title, bullets, color }, index) => (
-            <div key={label} className="relative">
-              <Card
-                className={`${color} h-full gap-4 rounded-none border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}
-              >
-                <div className="flex items-center justify-between gap-3">
-                  <Icon className="h-12 w-12" strokeWidth={3} />
-                  <span className="text-5xl font-black">{index + 1}</span>
-                </div>
-                <p className="font-black uppercase">{label}</p>
-                <h3 className="text-3xl font-black uppercase leading-none">{title}</h3>
-                <ul className="space-y-3 font-bold">
-                  {bullets.map((bullet) => (
-                    <li key={bullet} className="flex gap-2">
-                      <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0" strokeWidth={3} />
-                      <span>{bullet}</span>
-                    </li>
-                  ))}
-                </ul>
-              </Card>
-              {index < columns.length - 1 ? (
-                <ArrowRight className="absolute -right-6 top-1/2 z-10 hidden h-10 w-10 -translate-y-1/2 rounded-full border-4 border-primary bg-brutal-yellow p-1 lg:block" strokeWidth={3} />
-              ) : null}
-            </div>
-          ))}
+          {columns.map(
+            ({ icon: Icon, label, title, bullets, color }, index) => (
+              <div key={label} className="relative">
+                <Card
+                  className={`${color} h-full gap-4 rounded-none border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <Icon className="h-12 w-12" strokeWidth={3} />
+                    <span className="text-5xl font-black">{index + 1}</span>
+                  </div>
+                  <p className="font-black uppercase">{label}</p>
+                  <h3 className="text-3xl font-black uppercase leading-none">
+                    {title}
+                  </h3>
+                  <ul className="space-y-3 font-bold">
+                    {bullets.map((bullet) => (
+                      <li key={bullet} className="flex gap-2">
+                        <CheckCircle2
+                          className="mt-0.5 h-5 w-5 shrink-0"
+                          strokeWidth={3}
+                        />
+                        <span>{bullet}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Card>
+                {index < columns.length - 1 ? (
+                  <ArrowRight
+                    className="absolute -right-6 top-1/2 z-10 hidden h-10 w-10 -translate-y-1/2 rounded-full border-4 border-primary bg-brutal-yellow p-1 lg:block"
+                    strokeWidth={3}
+                  />
+                ) : null}
+              </div>
+            ),
+          )}
         </div>
       </Container>
     </SectionContainer>
@@ -312,17 +354,22 @@ export function StateSupportSection({
     >
       <Container size="lg">
         <div className="mx-auto mb-10 max-w-4xl text-center">
-          <p className="font-black uppercase">Build the state map from real humans</p>
+          <p className="font-black uppercase">
+            Bring Right to Trial to every state
+          </p>
           <h2 className="mt-2 text-4xl font-black uppercase leading-none tracking-tighter sm:text-5xl md:text-6xl lg:text-7xl">
-            Should your state consider Universal Right to Try?
+            Should every patient in your state have the Right to Trial?
           </h2>
           <p className="mx-auto mt-5 max-w-3xl text-lg font-bold sm:text-xl">
-            Tell us where you live, how you see the proposal, and what role you
-            could play. The Institute will use the responses to choose the next
-            state education pages, clinician briefings, and public events.
+            Tell us where you live and what role you can play. Your response
+            helps the Institute build the next state page, clinician briefing,
+            and public event.
           </p>
         </div>
-        <RightToTrySupportForm initialRole={initialRole} initialState={initialState} />
+        <RightToTrySupportForm
+          initialRole={initialRole}
+          initialState={initialState}
+        />
       </Container>
     </SectionContainer>
   );
@@ -343,16 +390,21 @@ export function StateCampaignMapSection() {
             Montana proved a path. Missouri is the next active state.
           </h2>
           <p className="mx-auto mt-5 max-w-3xl text-lg font-bold sm:text-xl">
-            Pick any state to record local interest. This map tracks the
-            Institute&apos;s education work: enacted precedent, active education,
-            and where we are still listening.
+            Pick any state and put it on the map. Montana is the enacted
+            precedent. Missouri is active now. Every other state can be next.
           </p>
         </div>
 
         <div className="mt-8 flex flex-wrap justify-center gap-3 font-black uppercase">
-          <span className="border-4 border-primary bg-brutal-green px-3 py-2">Enacted precedent</span>
-          <span className="border-4 border-primary bg-brutal-pink px-3 py-2">Active education</span>
-          <span className="border-4 border-primary bg-background px-3 py-2">Listening</span>
+          <span className="border-4 border-primary bg-brutal-green px-3 py-2">
+            Enacted precedent
+          </span>
+          <span className="border-4 border-primary bg-brutal-pink px-3 py-2">
+            Active education
+          </span>
+          <span className="border-4 border-primary bg-background px-3 py-2">
+            Listening
+          </span>
         </div>
 
         <div className="mt-8 grid grid-cols-5 gap-2 sm:grid-cols-10">
@@ -426,7 +478,9 @@ export function RoleActionSection() {
                 <p className="font-black uppercase">{role}</p>
                 <Icon className="h-12 w-12" strokeWidth={3} />
               </div>
-              <h3 className="mt-5 text-3xl font-black uppercase leading-none">{action}</h3>
+              <h3 className="mt-5 text-3xl font-black uppercase leading-none">
+                {action}
+              </h3>
               <p className="mt-4 font-bold">{text}</p>
               <span className="mt-auto flex items-center gap-2 pt-6 font-black uppercase">
                 Continue <ArrowRight className="h-5 w-5" />
@@ -445,14 +499,18 @@ export function MissouriCampaignSection() {
       <Container size="lg" className="text-center text-brutal-pink-foreground">
         <p className="font-black uppercase">Next active state: Missouri</p>
         <h2 className="mt-3 text-5xl font-black uppercase leading-none tracking-tighter sm:text-6xl md:text-7xl">
-          Help Missouri build a responsible version.
+          Help Missouri lead the next Right to Trial state.
         </h2>
         <p className="mx-auto mt-6 max-w-3xl text-lg font-bold sm:text-xl">
-          The Institute is collecting patient priorities, clinician safeguards,
-          research standards, and public questions before a Missouri proposal
-          is finalized.
+          Patients, clinicians, researchers, and public educators can build a
+          Missouri model where access creates evidence and every outcome helps
+          the next patient.
         </p>
-        <Button asChild size="lg" className={`${buttonShadow} mt-8 bg-brutal-yellow text-foreground`}>
+        <Button
+          asChild
+          size="lg"
+          className={`${buttonShadow} mt-8 bg-brutal-yellow text-foreground`}
+        >
           <Link href="/states/missouri">
             Open the Missouri page <ArrowRight className="h-5 w-5" />
           </Link>
@@ -468,10 +526,14 @@ export function UniversalRightToTryFinalCTA() {
       <Container size="lg" className="text-center">
         <Share2 className="mx-auto h-16 w-16" strokeWidth={3} />
         <h2 className="mt-5 text-5xl font-black uppercase leading-none tracking-tighter sm:text-6xl md:text-7xl">
-          One state proved it can move. Which state is next?
+          Montana opened the door. Bring Right to Trial to your state.
         </h2>
         <div className="mt-8 flex flex-col justify-center gap-4 sm:flex-row">
-          <Button asChild size="lg" className={`${buttonShadow} bg-brutal-pink`}>
+          <Button
+            asChild
+            size="lg"
+            className={`${buttonShadow} bg-brutal-pink`}
+          >
             <a href="#state-support">
               Record my state <MapPin className="h-5 w-5" />
             </a>

--- a/apps/acceleratedmedicine/components/right-to-try-support-form.tsx
+++ b/apps/acceleratedmedicine/components/right-to-try-support-form.tsx
@@ -269,7 +269,7 @@ export function RightToTrySupportForm({
 
       <p className="mt-4 text-center text-sm font-bold">
         {variant === "volunteer"
-          ? "We’ll use your email to reply and send the updates you request."
+          ? "We’ll use your email for your confirmation, our reply, and any updates you request."
           : "If you provide an email, we will send a confirmation. We will not sell or rent it."}
       </p>
 

--- a/apps/acceleratedmedicine/components/right-to-try-support-form.tsx
+++ b/apps/acceleratedmedicine/components/right-to-try-support-form.tsx
@@ -47,14 +47,15 @@ export function RightToTrySupportForm({
         body: JSON.stringify({
           submissionKey: submissionKey.current,
           intent: variant,
-          name: formData.get("name"),
           state: formData.get("state"),
-          position: formData.get("position"),
           role: formData.get("role"),
           email: formData.get("email"),
           story: formData.get("story"),
           updates: formData.get("updates") === "on",
           companyWebsite: formData.get("companyWebsite"),
+          ...(variant === "volunteer"
+            ? { name: formData.get("name") }
+            : { position: formData.get("position") }),
         }),
       });
       const body = (await response.json()) as {

--- a/apps/acceleratedmedicine/components/right-to-try-support-form.tsx
+++ b/apps/acceleratedmedicine/components/right-to-try-support-form.tsx
@@ -10,6 +10,7 @@ import type { SupporterRole } from "@/lib/right-to-try";
 interface RightToTrySupportFormProps {
   initialRole?: SupporterRole;
   initialState?: string;
+  variant?: "state-support" | "volunteer";
 }
 
 type SubmissionState =
@@ -24,6 +25,7 @@ const inputClassName =
 export function RightToTrySupportForm({
   initialRole = "patient-or-caregiver",
   initialState = "",
+  variant = "state-support",
 }: RightToTrySupportFormProps) {
   const [submission, setSubmission] = useState<SubmissionState>({
     status: "idle",
@@ -44,6 +46,8 @@ export function RightToTrySupportForm({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           submissionKey: submissionKey.current,
+          intent: variant,
+          name: formData.get("name"),
           state: formData.get("state"),
           position: formData.get("position"),
           role: formData.get("role"),
@@ -86,12 +90,18 @@ export function RightToTrySupportForm({
       >
         <Check className="mx-auto h-14 w-14" strokeWidth={4} />
         <h3 className="mt-3 text-3xl font-black uppercase">
-          Your response is recorded.
+          {variant === "volunteer"
+            ? "You’re in."
+            : "Your response is recorded."}
         </h3>
         <p className="mx-auto mt-3 max-w-xl text-lg font-bold">
-          {submission.sentConfirmation
-            ? "Check your inbox for a copy and the Montana and model-framework links."
-            : "Thank you. Your state is now part of the Institute's education map."}
+          {variant === "volunteer"
+            ? submission.sentConfirmation
+              ? "Check your inbox for ways to start helping right now."
+              : "Thank you. We saved your offer to help bring Right to Trial to every patient."
+            : submission.sentConfirmation
+              ? "Check your inbox for a copy and the Montana and model-framework links."
+              : "Thank you. Your state is now part of the Institute's education map."}
         </p>
       </div>
     );
@@ -102,6 +112,20 @@ export function RightToTrySupportForm({
       className="border-4 border-primary bg-brutal-yellow p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8"
       onSubmit={handleSubmit}
     >
+      {variant === "volunteer" ? (
+        <label className="mb-6 block font-black uppercase">
+          <span className="mb-2 block">Your name</span>
+          <input
+            autoComplete="name"
+            className={inputClassName}
+            maxLength={120}
+            name="name"
+            placeholder="Your name"
+            required
+          />
+        </label>
+      ) : null}
+
       <div className="grid gap-6 md:grid-cols-2">
         <label className="block font-black uppercase">
           <span className="mb-2 flex items-center gap-2">
@@ -126,64 +150,82 @@ export function RightToTrySupportForm({
 
         <label className="block font-black uppercase">
           <span className="mb-2 block">Your role</span>
-          <select className={inputClassName} defaultValue={initialRole} name="role" required>
+          <select
+            className={inputClassName}
+            defaultValue={initialRole}
+            name="role"
+            required
+          >
             <option value="patient-or-caregiver">Patient or caregiver</option>
             <option value="clinician">Clinician</option>
             <option value="researcher">Researcher</option>
-            <option value="public-educator">Public educator or organizer</option>
+            <option value="public-educator">
+              Public educator or organizer
+            </option>
             <option value="other">Other</option>
           </select>
         </label>
       </div>
 
-      <fieldset className="mt-7">
-        <legend className="font-black uppercase">
-          Should your state consider this model?
-        </legend>
-        <div className="mt-3 grid gap-3 sm:grid-cols-3">
-          {[
-            ["yes", "Yes"],
-            ["unsure", "Show me more"],
-            ["no", "No"],
-          ].map(([value, label]) => (
-            <label
-              key={value}
-              className="cursor-pointer border-4 border-primary bg-background p-4 text-center text-lg font-black uppercase shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] has-[:checked]:-translate-x-0.5 has-[:checked]:-translate-y-0.5 has-[:checked]:bg-brutal-cyan has-[:checked]:shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]"
-            >
-              <input
-                className="mr-2 h-4 w-4 accent-black"
-                defaultChecked={value === "yes"}
-                name="position"
-                type="radio"
-                value={value}
-              />
-              {label}
-            </label>
-          ))}
-        </div>
-      </fieldset>
+      {variant === "state-support" ? (
+        <fieldset className="mt-7">
+          <legend className="font-black uppercase">
+            Should every patient in your state have the Right to Trial?
+          </legend>
+          <div className="mt-3 grid gap-3 sm:grid-cols-3">
+            {[
+              ["yes", "Yes"],
+              ["unsure", "Show me more"],
+              ["no", "No"],
+            ].map(([value, label]) => (
+              <label
+                key={value}
+                className="cursor-pointer border-4 border-primary bg-background p-4 text-center text-lg font-black uppercase shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] has-[:checked]:-translate-x-0.5 has-[:checked]:-translate-y-0.5 has-[:checked]:bg-brutal-cyan has-[:checked]:shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]"
+              >
+                <input
+                  className="mr-2 h-4 w-4 accent-black"
+                  defaultChecked={value === "yes"}
+                  name="position"
+                  type="radio"
+                  value={value}
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+      ) : null}
 
       <label className="mt-7 block font-black uppercase">
-        Why does this matter to you? <span className="normal-case">(optional)</span>
+        {variant === "volunteer"
+          ? "What would you love to help make happen?"
+          : "Why does this matter to you?"}{" "}
+        <span className="normal-case">(optional)</span>
         <textarea
           className={`${inputClassName} mt-2 min-h-32 resize-y`}
           maxLength={2000}
           name="story"
-          placeholder="A sentence is enough."
+          placeholder={
+            variant === "volunteer"
+              ? "Share a skill, a connection, or the part you want to take on."
+              : "A sentence is enough."
+          }
         />
       </label>
 
       <label className="mt-7 block font-black uppercase">
         <span className="mb-2 flex items-center gap-2">
           <Mail className="h-5 w-5" strokeWidth={3} /> Email{" "}
-          <span className="normal-case">(optional)</span>
+          {variant === "state-support" ? (
+            <span className="normal-case">(optional)</span>
+          ) : null}
         </span>
         <input
           autoComplete="email"
           className={inputClassName}
           name="email"
           placeholder="you@example.com"
-          required={wantsUpdates}
+          required={variant === "volunteer" || wantsUpdates}
           type="email"
         />
       </label>
@@ -196,8 +238,7 @@ export function RightToTrySupportForm({
           onChange={(event) => setWantsUpdates(event.target.checked)}
           type="checkbox"
         />
-        Send me occasional updates about Universal Right to Try education in my
-        state.
+        Send me occasional updates about Right to Trial in my state.
       </label>
 
       <div aria-hidden="true" className="hidden">
@@ -218,14 +259,17 @@ export function RightToTrySupportForm({
           <>
             <Loader2 className="h-6 w-6 animate-spin" /> Recording
           </>
+        ) : variant === "volunteer" ? (
+          "I want to help"
         ) : (
           "Record my state response"
         )}
       </button>
 
       <p className="mt-4 text-center text-sm font-bold">
-        If you provide an email, we will send a confirmation. We will not sell
-        or rent it.
+        {variant === "volunteer"
+          ? "We’ll use your email to reply and send the updates you request."
+          : "If you provide an email, we will send a confirmation. We will not sell or rent it."}
       </p>
 
       {submission.status === "error" ? (

--- a/apps/acceleratedmedicine/components/state-campaign-page.tsx
+++ b/apps/acceleratedmedicine/components/state-campaign-page.tsx
@@ -1,4 +1,10 @@
-import { ArrowRight, BookOpen, MapPin, MessageSquareText, Users } from "lucide-react";
+import {
+  ArrowRight,
+  BookOpen,
+  MapPin,
+  MessageSquareText,
+  Users,
+} from "lucide-react";
 import Link from "next/link";
 
 import { Button } from "@optimitron/neobrutalist-ui/ui/button";
@@ -22,9 +28,15 @@ export function StateCampaignPage({
 
   return (
     <Layout>
-      <SectionContainer bgColor="background" borderPosition="bottom" className="py-24 sm:py-28">
+      <SectionContainer
+        bgColor="background"
+        borderPosition="bottom"
+        className="py-24 sm:py-28"
+      >
         <Container size="lg" className="text-center">
-          <p className={`mx-auto inline-block rotate-[-1deg] border-4 border-primary ${stageColor} px-4 py-2 font-black uppercase shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]`}>
+          <p
+            className={`mx-auto inline-block rotate-[-1deg] border-4 border-primary ${stageColor} px-4 py-2 font-black uppercase shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]`}
+          >
             {campaign.stageLabel}
           </p>
           <h1 className="mt-7 text-5xl font-black uppercase leading-[0.9] tracking-tighter sm:text-6xl md:text-7xl lg:text-8xl">
@@ -33,7 +45,11 @@ export function StateCampaignPage({
           <p className="mx-auto mt-7 max-w-4xl text-lg font-bold sm:text-xl md:text-2xl">
             {campaign.summary}
           </p>
-          <Button asChild size="lg" className="mt-8 rounded-none border-4 border-primary bg-brutal-yellow px-7 py-6 text-base font-black uppercase shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
+          <Button
+            asChild
+            size="lg"
+            className="mt-8 rounded-none border-4 border-primary bg-brutal-yellow px-7 py-6 text-base font-black uppercase shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]"
+          >
             <a href="#state-support">
               Add my response <MapPin className="h-5 w-5" />
             </a>
@@ -41,7 +57,10 @@ export function StateCampaignPage({
         </Container>
       </SectionContainer>
 
-      <SectionContainer bgColor={isMissouri ? "yellow" : "pink"} borderPosition="bottom">
+      <SectionContainer
+        bgColor={isMissouri ? "yellow" : "pink"}
+        borderPosition="bottom"
+      >
         <Container>
           <h2 className="text-center text-4xl font-black uppercase leading-none tracking-tighter sm:text-5xl md:text-6xl">
             {isMissouri
@@ -66,7 +85,10 @@ export function StateCampaignPage({
                 text: "How does the Montana precedent fit the state's current law, agencies, facilities, and public questions?",
               },
             ].map(({ icon: Icon, title, text }, index) => (
-              <Card key={title} className={`${index === 1 ? "bg-brutal-cyan" : "bg-background"} gap-4 rounded-none border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}>
+              <Card
+                key={title}
+                className={`${index === 1 ? "bg-brutal-cyan" : "bg-background"} gap-4 rounded-none border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}
+              >
                 <Icon className="h-12 w-12" strokeWidth={3} />
                 <h3 className="text-2xl font-black uppercase">{title}</h3>
                 <p className="font-bold">{text}</p>
@@ -80,24 +102,31 @@ export function StateCampaignPage({
         <SectionContainer bgColor="cyan" borderPosition="bottom">
           <Container size="lg" className="text-center">
             <h2 className="text-5xl font-black uppercase leading-none tracking-tighter sm:text-6xl md:text-7xl">
-              The proposal comes after the listening.
+              Missouri can give every patient the Right to Trial.
             </h2>
             <p className="mx-auto mt-6 max-w-3xl text-lg font-bold sm:text-xl">
-              There is no bill number on this page because the Missouri proposal
-              is still being built. The Institute is starting with Montana&apos;s
-              enacted framework, then gathering local patient, clinical,
-              research, and implementation priorities.
+              Montana showed that a state can open a broader, licensed path.
+              Missouri can go further by making pragmatic trials and shared
+              outcomes part of the path from day one.
             </p>
-            <Button asChild size="lg" className="mt-8 rounded-none border-4 border-primary bg-brutal-yellow px-7 py-6 text-base font-black uppercase shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
+            <Button
+              asChild
+              size="lg"
+              className="mt-8 rounded-none border-4 border-primary bg-brutal-yellow px-7 py-6 text-base font-black uppercase shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]"
+            >
               <Link href="/model-act">
-                Review the starting framework <ArrowRight className="h-5 w-5" />
+                See the Right to Trial framework{" "}
+                <ArrowRight className="h-5 w-5" />
               </Link>
             </Button>
           </Container>
         </SectionContainer>
       ) : null}
 
-      <StateSupportSection initialRole={initialRole} initialState={campaign.name} />
+      <StateSupportSection
+        initialRole={initialRole}
+        initialState={campaign.name}
+      />
     </Layout>
   );
 }

--- a/apps/acceleratedmedicine/lib/right-to-try-support-store.ts
+++ b/apps/acceleratedmedicine/lib/right-to-try-support-store.ts
@@ -15,7 +15,7 @@ import { US_STATES } from "@/lib/right-to-try";
 import type { RightToTrySupportInput } from "@/lib/right-to-try-support";
 
 const FORM_SOURCE_KEY = "acceleratedmedicine:universal-right-to-try-support";
-const FORM_TITLE = "Universal Right to Try state support";
+const FORM_TITLE = "Right to Trial participation";
 const SUBMISSION_WINDOW_MS = 10 * 60 * 1000;
 const SUBMISSIONS_PER_WINDOW = 5;
 
@@ -28,6 +28,19 @@ export class RightToTryRateLimitError extends Error {
 
 const formFields = [
   {
+    key: "intent",
+    prompt: "How this person wants to participate",
+    type: FormFieldType.SINGLE_SELECT,
+    required: true,
+    optionsJson: ["state-support", "volunteer"],
+  },
+  {
+    key: "name",
+    prompt: "Your name",
+    type: FormFieldType.SHORT_TEXT,
+    required: false,
+  },
+  {
     key: "state",
     prompt: "Your state",
     type: FormFieldType.SINGLE_SELECT,
@@ -36,9 +49,9 @@ const formFields = [
   },
   {
     key: "position",
-    prompt: "Should your state consider this model?",
+    prompt: "Should every patient in your state have the Right to Trial?",
     type: FormFieldType.SINGLE_SELECT,
-    required: true,
+    required: false,
     optionsJson: ["yes", "unsure", "no"],
   },
   {
@@ -68,7 +81,7 @@ const formFields = [
   },
   {
     key: "updates",
-    prompt: "Send occasional Universal Right to Try education updates",
+    prompt: "Send occasional Right to Trial updates",
     type: FormFieldType.BOOLEAN,
     required: true,
   },
@@ -166,8 +179,10 @@ export async function storeRightToTrySupport(
   const { user } = await upsertWishoniaUser(prisma);
   const revision = await getCurrentFormRevision(user.id);
   const values: Record<string, boolean | string> = {
+    intent: input.intent,
+    name: input.name || "",
     state: input.state,
-    position: input.position,
+    position: input.position || "",
     role: input.role,
     story: input.story || "",
     email: input.email || "",

--- a/apps/acceleratedmedicine/lib/right-to-try-support.ts
+++ b/apps/acceleratedmedicine/lib/right-to-try-support.ts
@@ -4,38 +4,48 @@ import { z } from "zod";
 import { SUPPORTER_ROLES, US_STATES } from "@/lib/right-to-try";
 import { storeRightToTrySupport } from "@/lib/right-to-try-support-store";
 
-const stateNames = US_STATES.map(([name]) => name) as [
-  string,
-  ...string[],
-];
+const stateNames = US_STATES.map(([name]) => name) as [string, ...string[]];
 
 export const supportPositionSchema = z.enum(["yes", "unsure", "no"]);
 export const supporterRoleSchema = z.enum(SUPPORTER_ROLES);
 
-export const rightToTrySupportSchema = z.object({
+const participationFields = z.object({
   submissionKey: z.string().uuid(),
   state: z.enum(stateNames),
-  position: supportPositionSchema,
   role: supporterRoleSchema,
   email: z.string().trim().email().max(320).optional().or(z.literal("")),
   story: z.string().trim().max(2000).optional().or(z.literal("")),
   updates: z.boolean().default(false),
   companyWebsite: z.string().max(500).optional().default(""),
-}).superRefine((input, context) => {
-  if (input.updates && !input.email) {
-    context.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Enter an email address to receive updates.",
-      path: ["email"],
-    });
-  }
 });
 
-export type RightToTrySupportInput = z.infer<
-  typeof rightToTrySupportSchema
->;
+export const rightToTrySupportSchema = z
+  .discriminatedUnion("intent", [
+    participationFields.extend({
+      intent: z.literal("state-support"),
+      name: z.string().trim().max(120).optional().or(z.literal("")),
+      position: supportPositionSchema,
+    }),
+    participationFields.extend({
+      intent: z.literal("volunteer"),
+      name: z.string().trim().min(1).max(120),
+      email: z.string().trim().email().max(320),
+      position: supportPositionSchema.optional(),
+    }),
+  ])
+  .superRefine((input, context) => {
+    if (input.updates && !input.email) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Enter an email address to receive updates.",
+        path: ["email"],
+      });
+    }
+  });
 
-const positionLabels: Record<RightToTrySupportInput["position"], string> = {
+export type RightToTrySupportInput = z.infer<typeof rightToTrySupportSchema>;
+
+const positionLabels: Record<z.infer<typeof supportPositionSchema>, string> = {
   yes: "Supports the proposal",
   unsure: "Wants more information",
   no: "Does not support the proposal",
@@ -58,10 +68,43 @@ function escapeHtml(value: string): string {
     .replaceAll("'", "&#039;");
 }
 
+function statePageUrl(state: string): string {
+  if (state === "Montana") {
+    return "https://acceleratedmedicine.org/montana";
+  }
+  return `https://acceleratedmedicine.org/states/${state.toLowerCase().replaceAll(" ", "-")}`;
+}
+
 export function buildSupportNotification(input: RightToTrySupportInput) {
   const email = input.email || "Not provided";
   const story = input.story || "Not provided";
-  const subject = `[Right to Try] ${input.state}: ${positionLabels[input.position]}`;
+  if (input.intent === "volunteer") {
+    const subject = `[Right to Trial volunteer] ${input.state}: ${roleLabels[input.role]}`;
+    const text = [
+      `Name: ${input.name}`,
+      `State: ${input.state}`,
+      `Role: ${roleLabels[input.role]}`,
+      `Email: ${email}`,
+      `Requested updates: ${input.updates ? "Yes" : "No"}`,
+      "",
+      "What they want to help make happen:",
+      story,
+    ].join("\n");
+    const html = `
+      <h1>Right to Trial volunteer</h1>
+      <p><strong>Name:</strong> ${escapeHtml(input.name)}</p>
+      <p><strong>State:</strong> ${escapeHtml(input.state)}</p>
+      <p><strong>Role:</strong> ${escapeHtml(roleLabels[input.role])}</p>
+      <p><strong>Email:</strong> ${escapeHtml(email)}</p>
+      <p><strong>Requested updates:</strong> ${input.updates ? "Yes" : "No"}</p>
+      <h2>What they want to help make happen</h2>
+      <p>${escapeHtml(story).replaceAll("\n", "<br>")}</p>
+    `.trim();
+
+    return { html, subject, text };
+  }
+
+  const subject = `[Right to Trial] ${input.state}: ${positionLabels[input.position]}`;
   const text = [
     `State: ${input.state}`,
     `Position: ${positionLabels[input.position]}`,
@@ -73,7 +116,7 @@ export function buildSupportNotification(input: RightToTrySupportInput) {
     story,
   ].join("\n");
   const html = `
-    <h1>Universal Right to Try response</h1>
+    <h1>Right to Trial response</h1>
     <p><strong>State:</strong> ${escapeHtml(input.state)}</p>
     <p><strong>Position:</strong> ${escapeHtml(positionLabels[input.position])}</p>
     <p><strong>Role:</strong> ${escapeHtml(roleLabels[input.role])}</p>
@@ -87,12 +130,42 @@ export function buildSupportNotification(input: RightToTrySupportInput) {
 }
 
 export function buildSupportConfirmation(input: RightToTrySupportInput) {
+  if (input.intent === "volunteer") {
+    const name = escapeHtml(input.name);
+    const stateUrl = statePageUrl(input.state);
+    const subject = "You’re on the Right to Trial team";
+    const text = [
+      `Thank you, ${input.name}.`,
+      "",
+      "You offered something humanity needs: your time. Right to Trial means every patient can join a pragmatic clinical trial for the most promising treatments, and every result helps the next patient.",
+      "",
+      "See the Montana precedent: https://acceleratedmedicine.org/montana",
+      "Review the model framework: https://acceleratedmedicine.org/model-act",
+      `Open your state page: ${stateUrl}`,
+      "",
+      "Institute for Accelerated Medicine",
+      "A DBA of the Accelerated Medicine Foundation",
+    ].join("\n");
+    const html = `
+      <main style="font-family:Arial,sans-serif;line-height:1.6;max-width:640px;margin:auto;padding:24px">
+        <h1 style="text-transform:uppercase">Thank you, ${name}.</h1>
+        <p>You offered something humanity needs: your time. Right to Trial means every patient can join a pragmatic clinical trial for the most promising treatments, and every result helps the next patient.</p>
+        <p><a href="https://acceleratedmedicine.org/montana">See the Montana precedent</a></p>
+        <p><a href="https://acceleratedmedicine.org/model-act">Review the model framework</a></p>
+        <p><a href="${stateUrl}">Open your state page</a></p>
+        <p><strong>Institute for Accelerated Medicine</strong><br>A DBA of the Accelerated Medicine Foundation</p>
+      </main>
+    `.trim();
+
+    return { html, subject, text };
+  }
+
   const state = escapeHtml(input.state);
-  const subject = `We recorded your ${input.state} Right to Try response`;
+  const subject = `We recorded your ${input.state} Right to Trial response`;
   const text = [
     `Your ${input.state} response has been recorded.`,
     "",
-    "Montana has already shown that a broader, licensed treatment path can become law. Your response helps the Institute decide where public education is most useful next.",
+    "Montana has already shown that a broader, licensed treatment path can become law. Your response helps the Institute bring Right to Trial education to every state.",
     "",
     "See the Montana precedent: https://acceleratedmedicine.org/montana",
     "Review the model framework: https://acceleratedmedicine.org/model-act",
@@ -103,7 +176,7 @@ export function buildSupportConfirmation(input: RightToTrySupportInput) {
   const html = `
     <main style="font-family:Arial,sans-serif;line-height:1.6;max-width:640px;margin:auto;padding:24px">
       <h1 style="text-transform:uppercase">Your ${state} response is recorded.</h1>
-      <p>Montana has already shown that a broader, licensed treatment path can become law. Your response helps the Institute decide where public education is most useful next.</p>
+      <p>Montana has already shown that a broader, licensed treatment path can become law. Your response helps the Institute bring Right to Trial education to every state.</p>
       <p><a href="https://acceleratedmedicine.org/montana">See the Montana precedent</a></p>
       <p><a href="https://acceleratedmedicine.org/model-act">Review the model framework</a></p>
       <p><strong>Institute for Accelerated Medicine</strong><br>A DBA of the Accelerated Medicine Foundation</p>

--- a/apps/acceleratedmedicine/lib/right-to-try.ts
+++ b/apps/acceleratedmedicine/lib/right-to-try.ts
@@ -114,9 +114,9 @@ export const STATE_CAMPAIGNS: StateCampaign[] = US_STATES.map(
         slug,
         stage: "active",
         stageLabel: "Active education",
-        headline: "Missouri can build the next state model.",
+        headline: "Missouri can bring Right to Trial to every patient.",
         summary:
-          "The Institute is assembling patients, clinicians, researchers, and public educators around a responsible Missouri proposal.",
+          "Patients, clinicians, researchers, and public educators can build a Missouri model where access creates evidence for the next patient.",
       };
     }
 
@@ -126,9 +126,9 @@ export const STATE_CAMPAIGNS: StateCampaign[] = US_STATES.map(
       slug,
       stage: "listening",
       stageLabel: "Listening for support",
-      headline: `Should ${name} build a Universal Right to Try path?`,
+      headline: `Should every patient in ${name} have the Right to Trial?`,
       summary:
-        "Tell the Institute which people and organizations want a state education page and a serious local conversation.",
+        "Put your state on the map and help bring pragmatic trials, shared outcomes, and more treatment options to every patient.",
     };
   },
 );
@@ -138,7 +138,5 @@ export function getStateCampaign(slug: string): StateCampaign | undefined {
 }
 
 export function stateCampaignHref(campaign: StateCampaign): string {
-  return campaign.name === "Montana"
-    ? "/montana"
-    : `/states/${campaign.slug}`;
+  return campaign.name === "Montana" ? "/montana" : `/states/${campaign.slug}`;
 }

--- a/apps/acceleratedmedicine/tests/unit/right-to-try-support-form.test.tsx
+++ b/apps/acceleratedmedicine/tests/unit/right-to-try-support-form.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RightToTrySupportForm } from "../../components/right-to-try-support-form";
+
+const submissionKey = "f938e396-c1db-41cb-8f8c-abb33d2d67ae";
+
+function successfulFetch() {
+  return vi.fn(async () =>
+    Response.json({ ok: true, sentConfirmation: false }),
+  );
+}
+
+describe("Right to Trial browser form payloads", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("omits the inactive volunteer name from a state response", async () => {
+    const fetchMock = successfulFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(submissionKey);
+    render(<RightToTrySupportForm initialState="Missouri" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Record my state response" }),
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const body = JSON.parse(
+      String(fetchMock.mock.calls[0]?.[1]?.body),
+    ) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      intent: "state-support",
+      position: "yes",
+      state: "Missouri",
+    });
+    expect(body).not.toHaveProperty("name");
+  });
+
+  it("omits the inactive state position from a volunteer offer", async () => {
+    const fetchMock = successfulFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(submissionKey);
+    render(
+      <RightToTrySupportForm initialState="Missouri" variant="volunteer" />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Your name"), {
+      target: { value: "Ada Patient" },
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "ada@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "I want to help" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const body = JSON.parse(
+      String(fetchMock.mock.calls[0]?.[1]?.body),
+    ) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      email: "ada@example.com",
+      intent: "volunteer",
+      name: "Ada Patient",
+      state: "Missouri",
+    });
+    expect(body).not.toHaveProperty("position");
+  });
+});

--- a/apps/acceleratedmedicine/tests/unit/right-to-try-support-route.test.ts
+++ b/apps/acceleratedmedicine/tests/unit/right-to-try-support-route.test.ts
@@ -5,6 +5,8 @@ import { RightToTryRateLimitError } from "../../lib/right-to-try-support-store";
 
 const validResponse = {
   submissionKey: "f938e396-c1db-41cb-8f8c-abb33d2d67ae",
+  intent: "state-support",
+  name: "",
   state: "Missouri",
   position: "yes",
   role: "patient-or-caregiver",
@@ -15,11 +17,14 @@ const validResponse = {
 };
 
 function makeRequest(body: unknown) {
-  return new Request("https://acceleratedmedicine.org/api/right-to-try-support", {
-    body: JSON.stringify(body),
-    headers: { "content-type": "application/json" },
-    method: "POST",
-  });
+  return new Request(
+    "https://acceleratedmedicine.org/api/right-to-try-support",
+    {
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    },
+  );
 }
 
 const clientKeyForRequest = () => "0".repeat(64);
@@ -48,7 +53,9 @@ describe("Right to Try support POST", () => {
   });
 
   it("returns 503 when durable storage fails", async () => {
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     const post = createPostHandler({
       clientKeyForRequest,
       submit: async () => {

--- a/apps/acceleratedmedicine/tests/unit/right-to-try-support.test.ts
+++ b/apps/acceleratedmedicine/tests/unit/right-to-try-support.test.ts
@@ -11,6 +11,7 @@ import {
 } from "vitest";
 
 import {
+  buildSupportConfirmation,
   buildSupportNotification,
   sendRightToTrySupport,
 } from "../../lib/right-to-try-support";
@@ -22,6 +23,8 @@ let previousResendApiKey: string | undefined;
 
 const validResponse = {
   submissionKey: "f938e396-c1db-41cb-8f8c-abb33d2d67ae",
+  intent: "state-support" as const,
+  name: "",
   state: "Missouri",
   position: "yes" as const,
   role: "patient-or-caregiver" as const,
@@ -38,7 +41,7 @@ const server = setupServer(
   }),
 );
 
-describe("Universal Right to Try support submission", () => {
+describe("Right to Trial participation submission", () => {
   const store = vi.fn(async () => ({ submissionId: "submission_1" }));
   const submissionOptions = {
     clientKey: "0".repeat(64),
@@ -85,13 +88,45 @@ describe("Universal Right to Try support submission", () => {
         from: "Institute for Accelerated Medicine <no-reply@updates.dfda.earth>",
         to: "hello@acceleratedmedicine.org",
         reply_to: "patient@example.com",
-        subject: "[Right to Try] Missouri: Supports the proposal",
+        subject: "[Right to Trial] Missouri: Supports the proposal",
       }),
     );
     expect(sentMessages[1]).toEqual(
       expect.objectContaining({
         to: "patient@example.com",
-        subject: "We recorded your Missouri Right to Try response",
+        subject: "We recorded your Missouri Right to Trial response",
+      }),
+    );
+  });
+
+  it("records a volunteer offer and sends both volunteer emails", async () => {
+    await expect(
+      sendRightToTrySupport(
+        {
+          ...validResponse,
+          intent: "volunteer",
+          name: "Ada Patient",
+          position: undefined,
+          role: "researcher",
+          story: "I can help define common outcomes.",
+        },
+        submissionOptions,
+      ),
+    ).resolves.toEqual({ sentConfirmation: true });
+
+    expect(store).toHaveBeenCalledOnce();
+    expect(sentMessages).toHaveLength(2);
+    expect(sentMessages[0]).toEqual(
+      expect.objectContaining({
+        reply_to: "patient@example.com",
+        subject: "[Right to Trial volunteer] Missouri: Researcher",
+        to: "hello@acceleratedmedicine.org",
+      }),
+    );
+    expect(sentMessages[1]).toEqual(
+      expect.objectContaining({
+        subject: "You’re on the Right to Trial team",
+        to: "patient@example.com",
       }),
     );
   });
@@ -106,6 +141,21 @@ describe("Universal Right to Try support submission", () => {
       "&lt;script&gt;alert(&#039;nope&#039;)&lt;/script&gt;",
     );
     expect(notification.html).not.toContain("<script>");
+  });
+
+  it("uses the canonical Montana page in volunteer confirmations", () => {
+    const confirmation = buildSupportConfirmation({
+      ...validResponse,
+      intent: "volunteer",
+      name: "Ada Patient",
+      position: undefined,
+      state: "Montana",
+    });
+
+    expect(confirmation.text).toContain(
+      "Open your state page: https://acceleratedmedicine.org/montana",
+    );
+    expect(confirmation.text).not.toContain("/states/montana");
   });
 
   it("does not deliver honeypot submissions", async () => {
@@ -180,9 +230,27 @@ describe("Universal Right to Try support submission", () => {
     expect(store).not.toHaveBeenCalled();
   });
 
+  it("requires an email address for volunteer offers", async () => {
+    await expect(
+      sendRightToTrySupport(
+        {
+          ...validResponse,
+          email: "",
+          intent: "volunteer",
+          name: "Ada Patient",
+          position: undefined,
+        },
+        submissionOptions,
+      ),
+    ).rejects.toThrow();
+    expect(store).not.toHaveBeenCalled();
+  });
+
   it("keeps the stored response when email delivery is not configured", async () => {
     const apiKey = process.env.RESEND_API_KEY;
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     delete process.env.RESEND_API_KEY;
 
     try {

--- a/packages/site-kit/src/lib/nav-items.ts
+++ b/packages/site-kit/src/lib/nav-items.ts
@@ -168,8 +168,7 @@ export const NAV_ITEMS_MAP = {
     id: "rightToTryMissouri",
     label: "Missouri",
     path: ROUTES.missouri,
-    description:
-      "Follow the Missouri education campaign for a Universal Right to Try law.",
+    description: "Help bring Right to Trial to every Missouri patient.",
     emoji: "⭐",
     canonicalVariant: VARIANTS.ACCELERATED_MEDICINE,
     allowedVariants: [VARIANTS.ACCELERATED_MEDICINE],
@@ -183,8 +182,7 @@ export const NAV_ITEMS_MAP = {
     id: "rightToTryStates",
     label: "Your State",
     path: `${ROUTES.home}#state-support`,
-    description:
-      "Record support for Universal Right to Try education in your state.",
+    description: "Put your state on the Right to Trial map.",
     emoji: "🗺️",
     isHashLink: true,
     requiresScrollHandler: true,
@@ -197,12 +195,12 @@ export const NAV_ITEMS_MAP = {
     label: "Model Act",
     path: ROUTES.modelAct,
     description:
-      "Review the core parts of a responsible Universal Right to Try framework.",
+      "See how every patient can join a pragmatic trial and every result can help the next patient.",
     emoji: "📄",
     canonicalVariant: VARIANTS.ACCELERATED_MEDICINE,
     allowedVariants: [VARIANTS.ACCELERATED_MEDICINE],
     keywords: [
-      "Universal Right to Try model act",
+      "Right to Trial model act",
       "patient access legislation",
       "experimental treatment licensing",
     ],

--- a/packages/site-kit/src/lib/site-config.ts
+++ b/packages/site-kit/src/lib/site-config.ts
@@ -1332,7 +1332,7 @@ const siteConfigs: Record<SiteVariant, SiteConfig> = {
   // ============================================================================
   // acceleratedmedicine.org - INSTITUTE FOR ACCELERATED MEDICINE
   // ============================================================================
-  // Purpose: Universal Right to Try education, pragmatic trials, and public evidence
+  // Purpose: Right to Trial education, pragmatic trials, and public evidence
   // Audience: Patients, caregivers, clinicians, researchers, and state educators
   // Goal: Measure support, explain the Montana precedent, and equip state campaigns
   // CANONICAL FOR: /donate (all other variants redirect here for donations)
@@ -1340,7 +1340,7 @@ const siteConfigs: Record<SiteVariant, SiteConfig> = {
     name: "IAM",
     title: "Institute for Accelerated Medicine",
     description:
-      "Universal Right to Try education for every state, with pragmatic clinical trials and public outcome data that help the next patient.",
+      "Right to Trial for every patient, with pragmatic clinical trials and public outcomes that help the next patient.",
     domains: ["acceleratedmedicine.org", "www.acceleratedmedicine.org"],
     baseUrl: "https://acceleratedmedicine.org",
     domain: "acceleratedmedicine.org",
@@ -1407,7 +1407,7 @@ const siteConfigs: Record<SiteVariant, SiteConfig> = {
     footerSections: [
       {
         id: "right-to-try",
-        label: "RIGHT TO TRY",
+        label: "RIGHT TO TRIAL",
         items: [
           "rightToTryMontana",
           "rightToTryMissouri",

--- a/scripts/smoke-site-apps.mjs
+++ b/scripts/smoke-site-apps.mjs
@@ -252,6 +252,13 @@ function getScreenshotRoutes(appName, siteVariant) {
   if (siteVariant === VARIANTS.ACCELERATED_MEDICINE) {
     const rightToTryRouteFiles = new Map([
       [
+        "/contact",
+        [
+          "apps/acceleratedmedicine/app/contact/page.tsx",
+          "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
+        ],
+      ],
+      [
         "/montana",
         [
           "apps/acceleratedmedicine/app/montana/page.tsx",


### PR DESCRIPTION
## Outcome

The Institute now presents the aspirational Right to Trial ideal directly: every patient should be able to join a pragmatic clinical trial for the most promising treatments, and every result should help the next patient.

The Volunteer page is now an invitation instead of a generic contact page. It includes a one-minute volunteer form and keeps direct email as a fallback.

## Copy review

Before → After

- “Universal Right to Try” as the Institute-wide campaign name → “Right to Trial” for the Institute’s broader ideal.
- “The right to try should not depend on your zip code.” → “Every patient has the Right to Trial.”
- “Send your question... A human will read it.” → “Help every patient get the Right to Trial.”
- Email-only contact → state, role, email, and volunteer-interest form with confirmation email.

Montana’s enacted law keeps its official “Universal Right to Try” name.

## Data and email

- Reuses the existing Form, FormRevision, FormSubmission, and FormResponse storage path.
- Records whether the submission is state support or a volunteer offer.
- Sends the Institute a structured volunteer notification.
- Sends the volunteer a confirmation with Montana, framework, and state links.
- Keeps email available below the form for unusual requests.

## Validation

- 19 focused unit tests passed, including both browser-form payload variants.
- Accelerated Medicine typecheck and lint passed.
- Accelerated Medicine production build passed.
- 26 desktop/mobile screenshots captured and inspected locally.
- Visual-review coverage is complete for all 11 changed UI source files.
- No horizontal overflow, overlap, missing content, or broken responsive layout found.

## Review routes

- /?logout=1
- /contact?logout=1
- /states/missouri?logout=1
- /model-act?logout=1

## Human copy approval

- [ ] The Right to Trial promise is strong enough.
- [ ] The Volunteer page feels friendly and inspiring.
- [ ] The form asks for the right amount of information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a volunteer recruitment page with role descriptions, contact details, and a volunteer signup form.
  - Signup forms now support both volunteer participation and state-support responses, with tailored fields and confirmation messaging.
- **Content Updates**
  - Rebranded public messaging from “Universal Right to Try” to “Right to Trial” across landing, state, model framework, donation, FAQ, and policy pages.
  - Updated Missouri and Montana campaign copy to emphasize pragmatic trials, patient access, and shared outcomes.
- **Navigation**
  - Refreshed menu descriptions and footer labels to match the Right to Trial initiative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->