### PR TITLE
Capture every site-app page in the visual review and gate site-app UI changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,7 @@ jobs:
               - 'scripts/site-app-navigation.test.ts'
               - 'scripts/site-app-visual-routes.mjs'
               - 'scripts/smoke-site-apps.mjs'
+              - 'apps/optimitron/scripts/visual-capture-contract.mjs'
               - '.npmrc'
               - 'package.json'
               - 'pnpm-workspace.yaml'

--- a/apps/optimitron/scripts/visual-capture-contract.mjs
+++ b/apps/optimitron/scripts/visual-capture-contract.mjs
@@ -2,6 +2,17 @@ export const LEGACY_VISUAL_CAPTURE_VERSION = 1;
 export const VISUAL_CAPTURE_VERSION = 3;
 export const SITE_APP_VISUAL_CAPTURE_VERSION = 4;
 
+/** Standalone site apps whose captures ride the visual review. Must match the
+ * app matrix in scripts/smoke-site-apps.mjs and .github/workflows/ci.yml. */
+export const SITE_APP_NAMES = Object.freeze([
+  "warondisease",
+  "dfda",
+  "wishocracy",
+  "trialabundancesurvey",
+  "curedao",
+  "acceleratedmedicine",
+]);
+
 export function getVisualCaptureVersion(value) {
   return value &&
     typeof value === "object" &&

--- a/apps/optimitron/scripts/visual-review-coverage.mjs
+++ b/apps/optimitron/scripts/visual-review-coverage.mjs
@@ -111,9 +111,11 @@ function isSiteAppServerOnlyJsx(appRelative) {
     /^app\/(?:.*\/)?(?:apple-icon|icon|opengraph-image|twitter-image)\.(?:jsx|tsx)$/i.test(
       appRelative,
     ) ||
-    // Error, loading, and not-found boundaries only render in exceptional
-    // states the screenshot smoke cannot reach deterministically.
-    /^app\/(?:.*\/)?(?:error|global-error|loading|not-found)\.(?:jsx|tsx)$/i.test(
+    // Error and loading boundaries only render in exceptional or transient
+    // states the screenshot smoke cannot reach deterministically. Not-found
+    // boundaries stay in the gate: an unknown URL renders them on demand,
+    // and each app registers a not-found capture.
+    /^app\/(?:.*\/)?(?:error|global-error|loading)\.(?:jsx|tsx)$/i.test(
       appRelative,
     )
   );

--- a/apps/optimitron/scripts/visual-review-coverage.mjs
+++ b/apps/optimitron/scripts/visual-review-coverage.mjs
@@ -1,8 +1,10 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { SITE_APP_NAMES } from "./visual-capture-contract.mjs";
 
 const WEB_PREFIX = "apps/optimitron/";
+const SITE_APP_PREFIXES = SITE_APP_NAMES.map((appName) => `apps/${appName}/`);
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -92,27 +94,71 @@ function isServerOnlyJsx(webRelative) {
   );
 }
 
+function getSiteAppRelativePath(normalized) {
+  for (const prefix of SITE_APP_PREFIXES) {
+    if (normalized.startsWith(prefix)) {
+      return normalized.slice(prefix.length);
+    }
+  }
+  return null;
+}
+
+function isSiteAppServerOnlyJsx(appRelative) {
+  return (
+    /^app\/api\//.test(appRelative) ||
+    /^emails\//.test(appRelative) ||
+    /\.email\.(?:jsx|tsx)$/i.test(appRelative) ||
+    /^app\/(?:.*\/)?(?:apple-icon|icon|opengraph-image|twitter-image)\.(?:jsx|tsx)$/i.test(
+      appRelative,
+    ) ||
+    // Error, loading, and not-found boundaries only render in exceptional
+    // states the screenshot smoke cannot reach deterministically.
+    /^app\/(?:.*\/)?(?:error|global-error|loading|not-found)\.(?:jsx|tsx)$/i.test(
+      appRelative,
+    )
+  );
+}
+
 /** Rendered web source that requires a registered screenshot state when changed. */
 export function isVisualUiSourceFile(filePath) {
   const normalized = normalizeRepoPath(filePath);
-  if (!normalized.startsWith(WEB_PREFIX) || isTestOrStory(normalized)) {
+  if (isTestOrStory(normalized)) {
     return false;
   }
 
-  const webRelative = normalized.slice(WEB_PREFIX.length);
+  if (normalized.startsWith(WEB_PREFIX)) {
+    const webRelative = normalized.slice(WEB_PREFIX.length);
+    if (
+      /^src\/.*\.(?:jsx|tsx)$/i.test(webRelative) &&
+      !isServerOnlyJsx(webRelative)
+    ) {
+      return true;
+    }
+    if (/^src\/.*\.css$/.test(webRelative)) {
+      return true;
+    }
+    if (
+      /^public\/.*\.(?:avif|gif|ico|jpe?g|png|svg|webp)$/i.test(webRelative)
+    ) {
+      return true;
+    }
+    return /^(?:postcss|tailwind)\.config\.[cm]?[jt]s$/.test(webRelative);
+  }
+
+  const appRelative = getSiteAppRelativePath(normalized);
+  if (appRelative === null) {
+    return false;
+  }
   if (
-    /^src\/.*\.(?:jsx|tsx)$/i.test(webRelative) &&
-    !isServerOnlyJsx(webRelative)
+    /^(?:app|components)\/.*\.(?:jsx|tsx)$/i.test(appRelative) &&
+    !isSiteAppServerOnlyJsx(appRelative)
   ) {
     return true;
   }
-  if (/^src\/.*\.css$/.test(webRelative)) {
+  if (/^(?:app|components)\/.*\.css$/.test(appRelative)) {
     return true;
   }
-  if (/^public\/.*\.(?:avif|gif|ico|jpe?g|png|svg|webp)$/i.test(webRelative)) {
-    return true;
-  }
-  return /^(?:postcss|tailwind)\.config\.[cm]?[jt]s$/.test(webRelative);
+  return /^public\/.*\.(?:avif|gif|ico|jpe?g|png|svg|webp)$/i.test(appRelative);
 }
 
 /**

--- a/apps/optimitron/scripts/visual-review-coverage.test.mjs
+++ b/apps/optimitron/scripts/visual-review-coverage.test.mjs
@@ -128,6 +128,36 @@ test("excludes tests, stories, email renderers, and server-only JSX", () => {
   );
 });
 
+test("classifies site-app UI sources with their server-only exclusions", () => {
+  const included = [
+    "apps/warondisease/app/vote/page.tsx",
+    "apps/warondisease/app/layout.tsx",
+    "apps/warondisease/components/sharing/campaign-qr-code.tsx",
+    "apps/dfda/app/conditions/[conditionSlug]/page.tsx",
+    "apps/warondisease/app/globals.css",
+    "apps/acceleratedmedicine/public/images/hero.png",
+  ];
+  for (const filePath of included) {
+    assert.equal(isVisualUiSourceFile(filePath), true, filePath);
+  }
+
+  const excluded = [
+    "apps/warondisease/app/api/og/route.tsx",
+    "apps/warondisease/emails/referral-invitation.tsx",
+    "apps/warondisease/app/opengraph-image.tsx",
+    "apps/warondisease/app/not-found.tsx",
+    "apps/warondisease/app/global-error.tsx",
+    "apps/warondisease/app/soldiers/loading.tsx",
+    "apps/warondisease/lib/treaty-votes.server.ts",
+    "apps/warondisease/components/shared/ParameterValue.test.tsx",
+    // Only apps enrolled in the site-app capture matrix are gated.
+    "apps/courtofhumanity/app/page.tsx",
+  ];
+  for (const filePath of excluded) {
+    assert.equal(isVisualUiSourceFile(filePath), false, filePath);
+  }
+});
+
 test("keeps stylesheet, public image, and styling config coverage", () => {
   const included = [
     "apps/optimitron/src/app/globals.css",

--- a/apps/optimitron/scripts/visual-review-coverage.test.mjs
+++ b/apps/optimitron/scripts/visual-review-coverage.test.mjs
@@ -136,6 +136,10 @@ test("classifies site-app UI sources with their server-only exclusions", () => {
     "apps/dfda/app/conditions/[conditionSlug]/page.tsx",
     "apps/warondisease/app/globals.css",
     "apps/acceleratedmedicine/public/images/hero.png",
+    // Not-found boundaries render deterministically via any unknown URL, so
+    // each app registers a 404 capture and the files stay in the gate.
+    "apps/warondisease/app/not-found.tsx",
+    "apps/warondisease/app/survey/[slug]/not-found.tsx",
   ];
   for (const filePath of included) {
     assert.equal(isVisualUiSourceFile(filePath), true, filePath);
@@ -145,7 +149,6 @@ test("classifies site-app UI sources with their server-only exclusions", () => {
     "apps/warondisease/app/api/og/route.tsx",
     "apps/warondisease/emails/referral-invitation.tsx",
     "apps/warondisease/app/opengraph-image.tsx",
-    "apps/warondisease/app/not-found.tsx",
     "apps/warondisease/app/global-error.tsx",
     "apps/warondisease/app/soldiers/loading.tsx",
     "apps/warondisease/lib/treaty-votes.server.ts",

--- a/packages/db/scripts/seed-site-app-visual-fixtures.ts
+++ b/packages/db/scripts/seed-site-app-visual-fixtures.ts
@@ -80,6 +80,12 @@ try {
       where: { id: user.id },
       data: { isAdmin: true },
     }),
+    // The managed seed keeps the demo person private. The /u/demo capture
+    // needs the public-profile rendering, so this local-only fixture flips it.
+    prisma.person.update({
+      where: { id: user.personId },
+      data: { isPublic: true },
+    }),
     prisma.referendumVote.upsert({
       where: {
         referendumId_personId: {

--- a/scripts/site-app-navigation.test.ts
+++ b/scripts/site-app-navigation.test.ts
@@ -82,6 +82,90 @@ test("every internal site-app navigation route has a Next.js page", async (t) =>
   }
 });
 
+test("declared public site-app routes are valid", async () => {
+  const { publicSiteAppRoutes } = await import("./site-app-visual-routes.mjs");
+
+  const routeNames = new Set<string>();
+  for (const [appName, routes] of Object.entries(publicSiteAppRoutes)) {
+    assert.ok(routes.length > 0, `${appName} must declare at least one public route`);
+    for (const route of routes) {
+      assert.ok(
+        !route.authenticated,
+        `${appName}:${route.routeName} is authenticated; declare it in authenticatedSiteAppRoutes instead`,
+      );
+      assert.ok(route.routePath.startsWith("/"), `${appName}:${route.routeName} must use an absolute route path`);
+      assert.ok(route.sourcePage, `${appName}:${route.routeName} must name its source page`);
+      assert.ok(route.covers.includes(route.sourcePage), `${appName}:${route.routeName} must cover its source page`);
+      assert.ok(
+        existsSync(path.join(repoRoot, route.sourcePage)),
+        `${appName}:${route.routeName} references missing page ${route.sourcePage}`,
+      );
+      assert.ok(
+        !isAuthenticatedPage(path.join(repoRoot, route.sourcePage)),
+        `${appName}:${route.routeName} source page has an auth guard; declare it in authenticatedSiteAppRoutes instead`,
+      );
+
+      const uniqueRouteName = `${appName}:${route.routeName}`;
+      assert.ok(!routeNames.has(uniqueRouteName), `Duplicate visual route ${uniqueRouteName}`);
+      routeNames.add(uniqueRouteName);
+    }
+  }
+});
+
+test("every site-app page is captured by the visual review or has a documented exemption", async (t) => {
+  const {
+    authenticatedSiteAppRouteExemptions,
+    getSiteAppScreenshotRoutes,
+    publicSiteAppRouteExemptions,
+  } = await import("./site-app-visual-routes.mjs");
+  const { VARIANTS } = await import(
+    "../packages/site-kit/src/lib/site-config.ts"
+  );
+  const apps = [
+    ["warondisease", VARIANTS.WAR_ON_DISEASE],
+    ["dfda", VARIANTS.DFDA],
+    ["wishocracy", VARIANTS.WISHOCRACY],
+    ["trialabundancesurvey", VARIANTS.SURVEY],
+    ["curedao", VARIANTS.CUREDAO],
+    ["acceleratedmedicine", VARIANTS.ACCELERATED_MEDICINE],
+  ] as const;
+
+  const exemptPages = new Set<string>();
+  for (const exemption of [
+    ...authenticatedSiteAppRouteExemptions,
+    ...publicSiteAppRouteExemptions,
+  ]) {
+    assert.ok(exemption.reason?.trim(), `${exemption.sourcePage} needs an exemption reason`);
+    assert.ok(
+      existsSync(path.join(repoRoot, exemption.sourcePage)),
+      `Exemption references missing page ${exemption.sourcePage}`,
+    );
+    exemptPages.add(exemption.sourcePage);
+  }
+
+  for (const [appName, siteVariant] of apps) {
+    await t.test(appName, () => {
+      const capturedPages = new Set(
+        getSiteAppScreenshotRoutes(appName, siteVariant).map(
+          (route) => route.sourcePage,
+        ),
+      );
+      const missing = listPageFiles(path.join(repoRoot, "apps", appName, "app"))
+        .map((filePath) => normalizePath(path.relative(repoRoot, filePath)))
+        .filter(
+          (filePath) =>
+            !capturedPages.has(filePath) && !exemptPages.has(filePath),
+        )
+        .sort();
+      assert.deepEqual(
+        missing,
+        [],
+        `${appName} pages are missing from the visual review. Add each to publicSiteAppRoutes or authenticatedSiteAppRoutes in scripts/site-app-visual-routes.mjs, or exempt it with a reason:\n${missing.join("\n")}`,
+      );
+    });
+  }
+});
+
 test("every authenticated site-app page has visual coverage or a documented exemption", async () => {
   const {
     authenticatedSiteAppRouteExemptions,

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -293,6 +293,22 @@ export const publicSiteAppRoutes = Object.freeze({
       routePath: "/auth/verify-request",
       sourcePage: "apps/warondisease/app/auth/verify-request/page.tsx",
     },
+    {
+      covers: ["apps/warondisease/app/not-found.tsx"],
+      expectNotFound: true,
+      label: "Page not found",
+      routeName: "not-found",
+      routePath: "/this-page-does-not-exist",
+      sourcePage: "apps/warondisease/app/not-found.tsx",
+    },
+    {
+      covers: ["apps/warondisease/app/survey/[slug]/not-found.tsx"],
+      expectNotFound: true,
+      label: "Survey not found",
+      routeName: "survey-not-found",
+      routePath: "/survey/this-org-does-not-exist",
+      sourcePage: "apps/warondisease/app/survey/[slug]/not-found.tsx",
+    },
   ],
   dfda: [
     {
@@ -326,6 +342,14 @@ export const publicSiteAppRoutes = Object.freeze({
       routePath: "/auth/signin",
       sourcePage: "apps/dfda/app/auth/signin/page.tsx",
     },
+    {
+      covers: ["apps/dfda/app/not-found.tsx"],
+      expectNotFound: true,
+      label: "Page not found",
+      routeName: "not-found",
+      routePath: "/this-page-does-not-exist",
+      sourcePage: "apps/dfda/app/not-found.tsx",
+    },
   ],
   wishocracy: [
     {
@@ -342,6 +366,14 @@ export const publicSiteAppRoutes = Object.freeze({
       routePath: "/auth/signin",
       sourcePage: "apps/wishocracy/app/auth/signin/page.tsx",
     },
+    {
+      covers: ["apps/wishocracy/app/not-found.tsx"],
+      expectNotFound: true,
+      label: "Page not found",
+      routeName: "not-found",
+      routePath: "/this-page-does-not-exist",
+      sourcePage: "apps/wishocracy/app/not-found.tsx",
+    },
   ],
   trialabundancesurvey: [
     {
@@ -357,6 +389,34 @@ export const publicSiteAppRoutes = Object.freeze({
       routeName: "auth-signin",
       routePath: "/auth/signin",
       sourcePage: "apps/trialabundancesurvey/app/auth/signin/page.tsx",
+    },
+    {
+      covers: ["apps/trialabundancesurvey/app/not-found.tsx"],
+      expectNotFound: true,
+      label: "Page not found",
+      routeName: "not-found",
+      routePath: "/this-page-does-not-exist",
+      sourcePage: "apps/trialabundancesurvey/app/not-found.tsx",
+    },
+  ],
+  curedao: [
+    {
+      covers: ["apps/curedao/app/not-found.tsx"],
+      expectNotFound: true,
+      label: "Page not found",
+      routeName: "not-found",
+      routePath: "/this-page-does-not-exist",
+      sourcePage: "apps/curedao/app/not-found.tsx",
+    },
+  ],
+  acceleratedmedicine: [
+    {
+      covers: ["apps/acceleratedmedicine/app/not-found.tsx"],
+      expectNotFound: true,
+      label: "Page not found",
+      routeName: "not-found",
+      routePath: "/this-page-does-not-exist",
+      sourcePage: "apps/acceleratedmedicine/app/not-found.tsx",
     },
   ],
 });

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -1,3 +1,63 @@
+import {
+  getInternalNavigationRoutesForVariant,
+  VARIANTS,
+} from "../packages/site-kit/src/lib/site-config.ts";
+
+const campaignPlanPageFile =
+  "packages/site-kit/src/components/campaign-plan-page.tsx";
+const dfdaHowItWorksFiles = [
+  "packages/site-kit/src/components/how-it-works/DfdaUserWorkflows.tsx",
+  "packages/site-kit/src/components/how-it-works/HowItWorksStep.tsx",
+  "packages/site-kit/src/components/how-it-works/OutcomeLabelPreview.tsx",
+  "packages/site-kit/src/components/how-it-works/PatientHowItWorks.tsx",
+  "packages/site-kit/src/components/how-it-works/PatientSteps.tsx",
+  "packages/site-kit/src/components/how-it-works/ProviderHowItWorks.tsx",
+  "packages/site-kit/src/components/how-it-works/ProviderSteps.tsx",
+  "packages/site-kit/src/components/how-it-works/ResearchPartnerHowItWorks.tsx",
+  "packages/site-kit/src/components/how-it-works/ResearchPartnerStep.tsx",
+  "packages/site-kit/src/components/how-it-works/ResearchPartnerSteps.tsx",
+  "packages/site-kit/src/components/how-it-works/provider-steps/Step1ReviewPatientMatches.tsx",
+  "packages/site-kit/src/components/how-it-works/provider-steps/Step2AssignIntervention.tsx",
+  "packages/site-kit/src/components/how-it-works/provider-steps/Step3MonitorProgress.tsx",
+  "packages/site-kit/src/components/how-it-works/steps/Step1FindTrials.tsx",
+  "packages/site-kit/src/components/how-it-works/steps/Step2ViewOutcomeLabels.tsx",
+  "packages/site-kit/src/components/how-it-works/steps/Step3JoinTrial.tsx",
+  "packages/site-kit/src/components/how-it-works/steps/Step4CoordinateCare.tsx",
+  "packages/site-kit/src/components/how-it-works/steps/Step5TrackData.tsx",
+  "packages/site-kit/src/components/how-it-works/steps/Step6GainInsights.tsx",
+  "packages/site-kit/src/components/how-it-works/steps/Step7FDAiAgent.tsx",
+];
+const campaignHomeSharedFiles = [
+  "packages/site-kit/src/components/campaign-home-page.tsx",
+  "packages/site-kit/src/components/landing/decentralized-fda-section.tsx",
+  "packages/site-kit/src/components/landing/final-cta.tsx",
+  "packages/site-kit/src/components/landing/societal-benefits-concise.tsx",
+  "packages/site-kit/src/lib/site-config.ts",
+  ...dfdaHowItWorksFiles,
+];
+
+function getCampaignHomeFiles(appName) {
+  if (appName === "acceleratedmedicine") {
+    return [
+      "apps/acceleratedmedicine/app/page.tsx",
+      "apps/acceleratedmedicine/components/landing/medical-freedom-sections.tsx",
+      "apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx",
+      "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
+      "apps/acceleratedmedicine/lib/right-to-try.ts",
+      "apps/acceleratedmedicine/lib/right-to-trial-impact.ts",
+      "packages/site-kit/src/components/landing/problem-statement.tsx",
+      "packages/site-kit/src/components/landing/SystemProblemsSection.tsx",
+      "packages/site-kit/src/components/landing/bottleneck-proof-section.tsx",
+      "packages/site-kit/src/components/landing/decentralized-fda-section.tsx",
+      "packages/site-kit/src/components/landing/death-clock.tsx",
+      "packages/site-kit/src/lib/site-config.ts",
+      ...dfdaHowItWorksFiles,
+    ];
+  }
+
+  return [`apps/${appName}/app/page.tsx`, ...campaignHomeSharedFiles];
+}
+
 const warOnDiseaseDashboardFiles = [
   "packages/site-kit/src/components/dashboard/DashboardClient.tsx",
   "packages/site-kit/src/components/dashboard/StatsOverview.tsx",
@@ -144,6 +204,453 @@ export const authenticatedSiteAppRouteExemptions = Object.freeze([
   },
 ]);
 
+/**
+ * Logged-out pages that the site navigation does not link, so the nav-derived
+ * screenshot set never reaches them. Every entry is captured in both visual
+ * projects, exactly like the nav routes.
+ */
+export const publicSiteAppRoutes = Object.freeze({
+  warondisease: [
+    {
+      covers: [
+        "apps/warondisease/app/vote/page.tsx",
+        "packages/site-kit/src/components/landing/treaty-vote-section.tsx",
+      ],
+      label: "Treaty vote",
+      routeName: "vote",
+      routePath: "/vote",
+      sourcePage: "apps/warondisease/app/vote/page.tsx",
+    },
+    {
+      covers: [
+        "apps/warondisease/app/treaty/page.tsx",
+        "packages/site-kit/src/components/landing/TreatySignatureBox.tsx",
+      ],
+      label: "Treaty text and signature",
+      routeName: "treaty",
+      routePath: "/treaty",
+      sourcePage: "apps/warondisease/app/treaty/page.tsx",
+    },
+    {
+      covers: [
+        "apps/warondisease/app/soldiers/page.tsx",
+        "apps/warondisease/app/soldiers/soldiers-leaderboard.tsx",
+      ],
+      label: "Soldiers leaderboard",
+      routeName: "soldiers",
+      routePath: "/soldiers",
+      sourcePage: "apps/warondisease/app/soldiers/page.tsx",
+    },
+    {
+      covers: ["apps/warondisease/app/survey/demo/page.tsx"],
+      label: "Survey embed demo",
+      routeName: "survey-demo",
+      routePath: "/survey/demo",
+      sourcePage: "apps/warondisease/app/survey/demo/page.tsx",
+    },
+    {
+      covers: [
+        "apps/warondisease/app/survey/[slug]/page.tsx",
+        "apps/warondisease/app/survey/[slug]/layout.tsx",
+      ],
+      label: "Partner institute survey",
+      routeName: "survey-organization",
+      routePath: "/survey/institute-for-accelerated-medicine",
+      sourcePage: "apps/warondisease/app/survey/[slug]/page.tsx",
+    },
+    {
+      covers: ["apps/warondisease/app/u/[username]/page.tsx"],
+      label: "Public user profile",
+      routeName: "user-profile",
+      routePath: "/u/demo",
+      sourcePage: "apps/warondisease/app/u/[username]/page.tsx",
+    },
+    {
+      covers: ["apps/warondisease/app/institutes/success/page.tsx"],
+      label: "Institute signup success",
+      routeName: "institutes-success",
+      routePath: "/institutes/success?slug=institute-for-accelerated-medicine",
+      sourcePage: "apps/warondisease/app/institutes/success/page.tsx",
+    },
+    {
+      covers: ["apps/warondisease/app/auth/signin/page.tsx"],
+      label: "Sign in",
+      routeName: "auth-signin",
+      routePath: "/auth/signin",
+      sourcePage: "apps/warondisease/app/auth/signin/page.tsx",
+    },
+    {
+      covers: ["apps/warondisease/app/auth/error/page.tsx"],
+      label: "Auth error",
+      routeName: "auth-error",
+      routePath: "/auth/error?error=Verification",
+      sourcePage: "apps/warondisease/app/auth/error/page.tsx",
+    },
+    {
+      covers: ["apps/warondisease/app/auth/verify-request/page.tsx"],
+      label: "Check your email",
+      routeName: "auth-verify-request",
+      routePath: "/auth/verify-request",
+      sourcePage: "apps/warondisease/app/auth/verify-request/page.tsx",
+    },
+  ],
+  dfda: [
+    {
+      covers: ["apps/dfda/app/contact/page.tsx"],
+      label: "Contact",
+      routeName: "contact",
+      routePath: "/contact",
+      sourcePage: "apps/dfda/app/contact/page.tsx",
+    },
+    {
+      covers: [
+        "apps/dfda/app/conditions/[conditionSlug]/page.tsx",
+        "apps/dfda/components/condition/TreatmentRankings.tsx",
+      ],
+      label: "Condition detail",
+      routeName: "condition-detail",
+      routePath: "/conditions/endometriosis",
+      sourcePage: "apps/dfda/app/conditions/[conditionSlug]/page.tsx",
+    },
+    {
+      covers: ["apps/dfda/app/treatments/[treatmentSlug]/page.tsx"],
+      label: "Treatment detail",
+      routeName: "treatment-detail",
+      routePath: "/treatments/laparoscopic-excision-surgery",
+      sourcePage: "apps/dfda/app/treatments/[treatmentSlug]/page.tsx",
+    },
+    {
+      covers: ["apps/dfda/app/auth/signin/page.tsx"],
+      label: "Sign in",
+      routeName: "auth-signin",
+      routePath: "/auth/signin",
+      sourcePage: "apps/dfda/app/auth/signin/page.tsx",
+    },
+  ],
+  wishocracy: [
+    {
+      covers: ["apps/wishocracy/app/contact/page.tsx"],
+      label: "Contact",
+      routeName: "contact",
+      routePath: "/contact",
+      sourcePage: "apps/wishocracy/app/contact/page.tsx",
+    },
+    {
+      covers: ["apps/wishocracy/app/auth/signin/page.tsx"],
+      label: "Sign in",
+      routeName: "auth-signin",
+      routePath: "/auth/signin",
+      sourcePage: "apps/wishocracy/app/auth/signin/page.tsx",
+    },
+  ],
+  trialabundancesurvey: [
+    {
+      covers: ["apps/trialabundancesurvey/app/contact/page.tsx"],
+      label: "Contact",
+      routeName: "contact",
+      routePath: "/contact",
+      sourcePage: "apps/trialabundancesurvey/app/contact/page.tsx",
+    },
+    {
+      covers: ["apps/trialabundancesurvey/app/auth/signin/page.tsx"],
+      label: "Sign in",
+      routeName: "auth-signin",
+      routePath: "/auth/signin",
+      sourcePage: "apps/trialabundancesurvey/app/auth/signin/page.tsx",
+    },
+  ],
+});
+
+export const publicSiteAppRouteExemptions = Object.freeze([
+  {
+    reason:
+      "The success content requires a live Stripe checkout session; without one the page can only render its error card.",
+    sourcePage: "apps/warondisease/app/donate/success/page.tsx",
+  },
+  {
+    reason:
+      "Transitional processing page that immediately redirects to sign-in or the dashboard; it has no stable visual state.",
+    sourcePage: "apps/warondisease/app/auth/complete-signup/page.tsx",
+  },
+  {
+    reason:
+      "Renders the same DfdaLandingContent as the captured home route.",
+    sourcePage: "apps/dfda/app/dfda/page.tsx",
+  },
+  {
+    reason:
+      "Fetches live clinicaltrials.gov data at request time, so there is no deterministic capture fixture.",
+    sourcePage:
+      "apps/dfda/app/conditions/[conditionSlug]/treatments/[treatmentSlug]/page.tsx",
+  },
+  {
+    reason:
+      "Shared auth scaffolding; this app captures /auth/signin and warondisease captures the full auth set.",
+    sourcePage: "apps/dfda/app/auth/error/page.tsx",
+  },
+  {
+    reason:
+      "Shared auth scaffolding; this app captures /auth/signin and warondisease captures the full auth set.",
+    sourcePage: "apps/dfda/app/auth/verify-request/page.tsx",
+  },
+  {
+    reason:
+      "Shared auth scaffolding; this app captures /auth/signin and warondisease captures the full auth set.",
+    sourcePage: "apps/dfda/app/auth/complete-signup/page.tsx",
+  },
+  {
+    reason:
+      "Shared auth scaffolding; this app captures /auth/signin and warondisease captures the full auth set.",
+    sourcePage: "apps/wishocracy/app/auth/error/page.tsx",
+  },
+  {
+    reason:
+      "Shared auth scaffolding; this app captures /auth/signin and warondisease captures the full auth set.",
+    sourcePage: "apps/wishocracy/app/auth/verify-request/page.tsx",
+  },
+  {
+    reason:
+      "Shared auth scaffolding; this app captures /auth/signin and warondisease captures the full auth set.",
+    sourcePage: "apps/wishocracy/app/auth/complete-signup/page.tsx",
+  },
+  {
+    reason:
+      "Shared auth scaffolding; this app captures /auth/signin and warondisease captures the full auth set.",
+    sourcePage: "apps/trialabundancesurvey/app/auth/error/page.tsx",
+  },
+  {
+    reason:
+      "Shared auth scaffolding; this app captures /auth/signin and warondisease captures the full auth set.",
+    sourcePage: "apps/trialabundancesurvey/app/auth/verify-request/page.tsx",
+  },
+  {
+    reason:
+      "Shared auth scaffolding; this app captures /auth/signin and warondisease captures the full auth set.",
+    sourcePage: "apps/trialabundancesurvey/app/auth/complete-signup/page.tsx",
+  },
+  {
+    reason:
+      "The success content requires a live Stripe checkout session; without one the page can only render its error card.",
+    sourcePage: "apps/acceleratedmedicine/app/donate/success/page.tsx",
+  },
+]);
+
 export function getAuthenticatedSiteAppRoutes(appName) {
   return authenticatedSiteAppRoutes[appName] ?? [];
+}
+
+export function getPublicSiteAppRoutes(appName) {
+  return publicSiteAppRoutes[appName] ?? [];
+}
+
+/**
+ * Map a captured route path to the Next.js page file that renders it.
+ * Dynamic routes cannot be derived this way, so their declarations carry an
+ * explicit sourcePage instead.
+ */
+export function getSourcePageForRoutePath(appName, routePath) {
+  const [withoutHash] = String(routePath).split("#", 1);
+  const [pathname] = withoutHash.split("?", 1);
+  const segments = pathname.replace(/^\/+|\/+$/g, "");
+  return segments
+    ? `apps/${appName}/app/${segments}/page.tsx`
+    : `apps/${appName}/app/page.tsx`;
+}
+
+/**
+ * The full screenshot set for one site app: every nav-linked page, the
+ * hand-registered extra states, and the declared public and authenticated
+ * routes above.
+ */
+export function getSiteAppScreenshotRoutes(appName, siteVariant) {
+  const isCampaignHome =
+    siteVariant === VARIANTS.WAR_ON_DISEASE ||
+    siteVariant === VARIANTS.CUREDAO ||
+    siteVariant === VARIANTS.ACCELERATED_MEDICINE;
+  const campaignHomeFiles = getCampaignHomeFiles(appName);
+  const routes = getInternalNavigationRoutesForVariant(siteVariant).map(
+    ({ label, path: routePath }) => ({
+      label,
+      ...(isCampaignHome && routePath === "/"
+        ? { covers: campaignHomeFiles }
+        : {}),
+      routeName:
+        routePath === "/"
+          ? "home"
+          : routePath
+              .replace(/^\/+|\/+$/g, "")
+              .replaceAll("/", "-")
+              .replace(/[^a-z0-9-]+/gi, "-")
+              .toLowerCase(),
+      routePath,
+    }),
+  );
+
+  if (siteVariant === VARIANTS.WAR_ON_DISEASE) {
+    routes.push({
+      label: "Home footer",
+      routeName: "home-footer",
+      routePath: "/",
+      captureSelector: "footer",
+      covers: campaignHomeFiles,
+    });
+    const planRoute = routes.find(({ routePath }) => routePath === "/the-plan");
+    if (planRoute) {
+      planRoute.covers = [campaignPlanPageFile];
+    } else {
+      routes.push({
+        label: "Shared campaign plan",
+        routeName: "the-plan",
+        routePath: "/the-plan",
+        covers: [campaignPlanPageFile],
+      });
+    }
+  }
+
+  if (siteVariant === VARIANTS.DFDA) {
+    const landingRoute = routes.find(({ routePath }) => routePath === "/");
+    if (landingRoute) {
+      landingRoute.covers = [
+        "apps/dfda/app/dfda/components/DfdaLandingContent.tsx",
+        ...dfdaHowItWorksFiles,
+      ];
+    }
+  }
+
+  if (siteVariant === VARIANTS.ACCELERATED_MEDICINE) {
+    const rightToTryRouteFiles = new Map([
+      [
+        "/impact",
+        [
+          "apps/acceleratedmedicine/app/impact/page.tsx",
+          "apps/acceleratedmedicine/components/impact/right-to-trial-impact-explorer.tsx",
+          "apps/acceleratedmedicine/lib/right-to-trial-impact.ts",
+          "packages/site-kit/src/components/landing/decentralized-fda-section.tsx",
+          "packages/site-kit/src/components/how-it-works/DfdaUserWorkflows.tsx",
+        ],
+      ],
+      [
+        "/contact",
+        [
+          "apps/acceleratedmedicine/app/contact/page.tsx",
+          "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
+        ],
+      ],
+      [
+        "/montana",
+        [
+          "apps/acceleratedmedicine/app/montana/page.tsx",
+          "apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx",
+          "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
+          "apps/acceleratedmedicine/lib/right-to-try.ts",
+        ],
+      ],
+      [
+        "/model-act",
+        [
+          "apps/acceleratedmedicine/app/model-act/page.tsx",
+          "apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx",
+          "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
+        ],
+      ],
+      [
+        "/states/missouri",
+        [
+          "apps/acceleratedmedicine/app/states/missouri/page.tsx",
+          "apps/acceleratedmedicine/components/state-campaign-page.tsx",
+          "apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx",
+          "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
+          "apps/acceleratedmedicine/lib/right-to-try.ts",
+        ],
+      ],
+    ]);
+    for (const route of routes) {
+      const covers = rightToTryRouteFiles.get(route.routePath);
+      if (covers) route.covers = covers;
+    }
+    routes.push({
+      label: "State education template",
+      routeName: "states-alabama",
+      routePath: "/states/alabama",
+      covers: [
+        "apps/acceleratedmedicine/app/states/[state]/page.tsx",
+        "apps/acceleratedmedicine/components/state-campaign-page.tsx",
+        "apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx",
+        "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
+        "apps/acceleratedmedicine/lib/right-to-try.ts",
+      ],
+      sourcePage: "apps/acceleratedmedicine/app/states/[state]/page.tsx",
+    });
+    routes.push({
+      label: "Missouri clinician response",
+      routeName: "states-missouri-clinician",
+      routePath: "/states/missouri?role=clinician#state-support",
+      covers: [
+        "apps/acceleratedmedicine/app/states/missouri/page.tsx",
+        "apps/acceleratedmedicine/components/state-campaign-page.tsx",
+        "apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx",
+        "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
+      ],
+      sourcePage: "apps/acceleratedmedicine/app/states/[state]/page.tsx",
+    });
+    const planRoute = routes.find(({ routePath }) => routePath === "/the-plan");
+    if (planRoute) {
+      planRoute.covers = [campaignPlanPageFile];
+    } else {
+      routes.push({
+        label: "Legacy campaign plan",
+        routeName: "the-plan",
+        routePath: "/the-plan",
+        covers: [campaignPlanPageFile],
+      });
+    }
+    routes.push({
+      label: "Legacy About redirect",
+      routeName: "about-redirect",
+      routePath: "/about",
+    });
+  }
+
+  if (siteVariant === VARIANTS.SURVEY) {
+    routes.push({
+      label: "Partner embed",
+      routeName: "embed",
+      routePath: "/embed?embed=1&visual=1",
+    });
+  }
+
+  const screenshotRoutes = [
+    ...routes,
+    ...getPublicSiteAppRoutes(appName),
+    ...getAuthenticatedSiteAppRoutes(appName),
+  ].map((route) => {
+    const sourcePage =
+      route.sourcePage ?? getSourcePageForRoutePath(appName, route.routePath);
+    // A capture always exercises its own page file, and the home capture
+    // additionally exercises the root layout, so those files never need a
+    // hand-maintained covers entry.
+    const covers = [
+      ...new Set([
+        ...(route.covers ?? []),
+        sourcePage,
+        ...(route.routeName === "home"
+          ? [
+              `apps/${appName}/app/layout.tsx`,
+              `apps/${appName}/app/globals.css`,
+            ]
+          : []),
+      ]),
+    ];
+    return { ...route, covers, sourcePage };
+  });
+  const routeNames = new Set();
+  for (const route of screenshotRoutes) {
+    if (routeNames.has(route.routeName)) {
+      throw new Error(
+        `@apps/${appName}: duplicate screenshot route name ${route.routeName}`,
+      );
+    }
+    routeNames.add(route.routeName);
+  }
+  return screenshotRoutes;
 }

--- a/scripts/smoke-site-apps.mjs
+++ b/scripts/smoke-site-apps.mjs
@@ -4,7 +4,6 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  getInternalNavigationRoutesForVariant,
   getSiteConfigForVariant,
   VARIANTS,
 } from "../packages/site-kit/src/lib/site-config.ts";
@@ -16,7 +15,7 @@ import {
 import { freezeClock } from "../apps/optimitron/e2e/helpers/freeze-clock.mjs";
 import { signInViaApi } from "../apps/optimitron/e2e/utils/auth-api.mjs";
 import { SITE_APP_VISUAL_CAPTURE_VERSION } from "../apps/optimitron/scripts/visual-capture-contract.mjs";
-import { getAuthenticatedSiteAppRoutes } from "./site-app-visual-routes.mjs";
+import { getSiteAppScreenshotRoutes } from "./site-app-visual-routes.mjs";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -48,61 +47,6 @@ const screenshotRootInput = process.env.SITE_APP_SCREENSHOT_ROOT?.trim();
 const screenshotRoot = screenshotRootInput
   ? path.resolve(repoRoot, screenshotRootInput)
   : undefined;
-const campaignPlanPageFile =
-  "packages/site-kit/src/components/campaign-plan-page.tsx";
-const dfdaHowItWorksFiles = [
-  "packages/site-kit/src/components/how-it-works/DfdaUserWorkflows.tsx",
-  "packages/site-kit/src/components/how-it-works/HowItWorksStep.tsx",
-  "packages/site-kit/src/components/how-it-works/OutcomeLabelPreview.tsx",
-  "packages/site-kit/src/components/how-it-works/PatientHowItWorks.tsx",
-  "packages/site-kit/src/components/how-it-works/PatientSteps.tsx",
-  "packages/site-kit/src/components/how-it-works/ProviderHowItWorks.tsx",
-  "packages/site-kit/src/components/how-it-works/ProviderSteps.tsx",
-  "packages/site-kit/src/components/how-it-works/ResearchPartnerHowItWorks.tsx",
-  "packages/site-kit/src/components/how-it-works/ResearchPartnerStep.tsx",
-  "packages/site-kit/src/components/how-it-works/ResearchPartnerSteps.tsx",
-  "packages/site-kit/src/components/how-it-works/provider-steps/Step1ReviewPatientMatches.tsx",
-  "packages/site-kit/src/components/how-it-works/provider-steps/Step2AssignIntervention.tsx",
-  "packages/site-kit/src/components/how-it-works/provider-steps/Step3MonitorProgress.tsx",
-  "packages/site-kit/src/components/how-it-works/steps/Step1FindTrials.tsx",
-  "packages/site-kit/src/components/how-it-works/steps/Step2ViewOutcomeLabels.tsx",
-  "packages/site-kit/src/components/how-it-works/steps/Step3JoinTrial.tsx",
-  "packages/site-kit/src/components/how-it-works/steps/Step4CoordinateCare.tsx",
-  "packages/site-kit/src/components/how-it-works/steps/Step5TrackData.tsx",
-  "packages/site-kit/src/components/how-it-works/steps/Step6GainInsights.tsx",
-  "packages/site-kit/src/components/how-it-works/steps/Step7FDAiAgent.tsx",
-];
-const campaignHomeSharedFiles = [
-  "packages/site-kit/src/components/campaign-home-page.tsx",
-  "packages/site-kit/src/components/landing/decentralized-fda-section.tsx",
-  "packages/site-kit/src/components/landing/final-cta.tsx",
-  "packages/site-kit/src/components/landing/societal-benefits-concise.tsx",
-  "packages/site-kit/src/lib/site-config.ts",
-  ...dfdaHowItWorksFiles,
-];
-
-function getCampaignHomeFiles(appName) {
-  if (appName === "acceleratedmedicine") {
-    return [
-      "apps/acceleratedmedicine/app/page.tsx",
-      "apps/acceleratedmedicine/components/landing/medical-freedom-sections.tsx",
-      "apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx",
-      "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
-      "apps/acceleratedmedicine/lib/right-to-try.ts",
-      "apps/acceleratedmedicine/lib/right-to-trial-impact.ts",
-      "packages/site-kit/src/components/landing/problem-statement.tsx",
-      "packages/site-kit/src/components/landing/SystemProblemsSection.tsx",
-      "packages/site-kit/src/components/landing/bottleneck-proof-section.tsx",
-      "packages/site-kit/src/components/landing/decentralized-fda-section.tsx",
-      "packages/site-kit/src/components/landing/death-clock.tsx",
-      "packages/site-kit/src/lib/site-config.ts",
-      ...dfdaHowItWorksFiles,
-    ];
-  }
-
-  return [`apps/${appName}/app/page.tsx`, ...campaignHomeSharedFiles];
-}
-
 const requestedApps = process.argv.slice(2);
 const unknownApps = requestedApps.filter(
   (requestedApp) => !apps.some(([appName]) => appName === requestedApp),
@@ -195,183 +139,12 @@ async function verifyWarOnDiseaseHome(baseUrl) {
   }
 }
 
-function getScreenshotRoutes(appName, siteVariant) {
-  const isCampaignHome =
-    siteVariant === VARIANTS.WAR_ON_DISEASE ||
-    siteVariant === VARIANTS.CUREDAO ||
-    siteVariant === VARIANTS.ACCELERATED_MEDICINE;
-  const campaignHomeFiles = getCampaignHomeFiles(appName);
-  const routes = getInternalNavigationRoutesForVariant(siteVariant).map(
-    ({ label, path: routePath }) => ({
-      label,
-      ...(isCampaignHome && routePath === "/"
-        ? { covers: campaignHomeFiles }
-        : {}),
-      routeName:
-        routePath === "/"
-          ? "home"
-          : routePath
-              .replace(/^\/+|\/+$/g, "")
-              .replaceAll("/", "-")
-              .replace(/[^a-z0-9-]+/gi, "-")
-              .toLowerCase(),
-      routePath,
-    }),
-  );
-
-  if (siteVariant === VARIANTS.WAR_ON_DISEASE) {
-    routes.push({
-      label: "Home footer",
-      routeName: "home-footer",
-      routePath: "/",
-      captureSelector: "footer",
-      covers: campaignHomeFiles,
-    });
-    const planRoute = routes.find(({ routePath }) => routePath === "/the-plan");
-    if (planRoute) {
-      planRoute.covers = [campaignPlanPageFile];
-    } else {
-      routes.push({
-        label: "Shared campaign plan",
-        routeName: "the-plan",
-        routePath: "/the-plan",
-        covers: [campaignPlanPageFile],
-      });
-    }
-  }
-
-  if (siteVariant === VARIANTS.DFDA) {
-    const landingRoute = routes.find(({ routePath }) => routePath === "/");
-    if (landingRoute) {
-      landingRoute.covers = [
-        "apps/dfda/app/dfda/components/DfdaLandingContent.tsx",
-        ...dfdaHowItWorksFiles,
-      ];
-    }
-  }
-
-  if (siteVariant === VARIANTS.ACCELERATED_MEDICINE) {
-    const rightToTryRouteFiles = new Map([
-      [
-        "/impact",
-        [
-          "apps/acceleratedmedicine/app/impact/page.tsx",
-          "apps/acceleratedmedicine/components/impact/right-to-trial-impact-explorer.tsx",
-          "apps/acceleratedmedicine/lib/right-to-trial-impact.ts",
-          "packages/site-kit/src/components/landing/decentralized-fda-section.tsx",
-          "packages/site-kit/src/components/how-it-works/DfdaUserWorkflows.tsx",
-        ],
-      ],
-      [
-        "/contact",
-        [
-          "apps/acceleratedmedicine/app/contact/page.tsx",
-          "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
-        ],
-      ],
-      [
-        "/montana",
-        [
-          "apps/acceleratedmedicine/app/montana/page.tsx",
-          "apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx",
-          "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
-          "apps/acceleratedmedicine/lib/right-to-try.ts",
-        ],
-      ],
-      [
-        "/model-act",
-        [
-          "apps/acceleratedmedicine/app/model-act/page.tsx",
-          "apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx",
-          "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
-        ],
-      ],
-      [
-        "/states/missouri",
-        [
-          "apps/acceleratedmedicine/app/states/missouri/page.tsx",
-          "apps/acceleratedmedicine/components/state-campaign-page.tsx",
-          "apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx",
-          "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
-          "apps/acceleratedmedicine/lib/right-to-try.ts",
-        ],
-      ],
-    ]);
-    for (const route of routes) {
-      const covers = rightToTryRouteFiles.get(route.routePath);
-      if (covers) route.covers = covers;
-    }
-    routes.push({
-      label: "State education template",
-      routeName: "states-alabama",
-      routePath: "/states/alabama",
-      covers: [
-        "apps/acceleratedmedicine/app/states/[state]/page.tsx",
-        "apps/acceleratedmedicine/components/state-campaign-page.tsx",
-        "apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx",
-        "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
-        "apps/acceleratedmedicine/lib/right-to-try.ts",
-      ],
-    });
-    routes.push({
-      label: "Missouri clinician response",
-      routeName: "states-missouri-clinician",
-      routePath: "/states/missouri?role=clinician#state-support",
-      covers: [
-        "apps/acceleratedmedicine/app/states/missouri/page.tsx",
-        "apps/acceleratedmedicine/components/state-campaign-page.tsx",
-        "apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx",
-        "apps/acceleratedmedicine/components/right-to-try-support-form.tsx",
-      ],
-    });
-    const planRoute = routes.find(({ routePath }) => routePath === "/the-plan");
-    if (planRoute) {
-      planRoute.covers = [campaignPlanPageFile];
-    } else {
-      routes.push({
-        label: "Legacy campaign plan",
-        routeName: "the-plan",
-        routePath: "/the-plan",
-        covers: [campaignPlanPageFile],
-      });
-    }
-    routes.push({
-      label: "Legacy About redirect",
-      routeName: "about-redirect",
-      routePath: "/about",
-    });
-  }
-
-  if (siteVariant === VARIANTS.SURVEY) {
-    routes.push({
-      label: "Partner embed",
-      routeName: "embed",
-      routePath: "/embed?embed=1&visual=1",
-    });
-  }
-
-  const screenshotRoutes = [
-    ...routes,
-    ...getAuthenticatedSiteAppRoutes(appName),
-  ];
-  const routeNames = new Set();
-  for (const route of screenshotRoutes) {
-    if (routeNames.has(route.routeName)) {
-      throw new Error(
-        `@apps/${appName}: duplicate screenshot route name ${route.routeName}`,
-      );
-    }
-    routeNames.add(route.routeName);
-  }
-  return screenshotRoutes;
-}
-
 async function captureScreenshots(appName, siteVariant, baseUrl) {
   if (!screenshotRoot) {
     return;
   }
 
-  const screenshotRoutes = getScreenshotRoutes(appName, siteVariant);
+  const screenshotRoutes = getSiteAppScreenshotRoutes(appName, siteVariant);
   const requireFromWeb = createRequire(
     path.join(repoRoot, "apps", "optimitron", "package.json"),
   );

--- a/scripts/smoke-site-apps.mjs
+++ b/scripts/smoke-site-apps.mjs
@@ -205,6 +205,7 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
 
           for (const {
             authenticated,
+            expectNotFound,
             routeName,
             routePath,
             captureSelector,
@@ -221,9 +222,13 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
               timeout: 30_000,
               waitUntil: "load",
             });
-            if (!response || response.status() >= 400) {
+            const status = response?.status() ?? 0;
+            const statusIsExpected = expectNotFound
+              ? status === 404
+              : status >= 200 && status < 400;
+            if (!response || !statusIsExpected) {
               throw new Error(
-                `${url} returned HTTP ${response?.status() ?? "unknown"}`,
+                `${url} returned HTTP ${response?.status() ?? "unknown"}${expectNotFound ? " (expected 404)" : ""}`,
               );
             }
             if (authenticated) {


### PR DESCRIPTION
## What this fixes

The visual preview only screenshotted **nav-linked pages plus declared authenticated routes**, and the coverage gate only watched `apps/optimitron/**`. Result: `/vote` — the campaign's #1 conversion surface — `/treaty`, `/soldiers`, `/u/[username]`, the survey pages, and every auth/success state never appeared in any PR's visual review, while the manifest still reported `coverage.complete: true`. (Found while auditing the PR #276 preview, which ships 8 more pages that would have been invisible for the same reason.)

## The three changes

**1. Declare the nav-orphaned public pages** (`scripts/site-app-visual-routes.mjs`)

New `publicSiteAppRoutes` registry, mirroring the existing authenticated one. Warondisease gains 10 captures: `/vote`, `/treaty`, `/soldiers`, `/survey/demo`, `/survey/institute-for-accelerated-medicine`, `/u/demo`, `/institutes/success?slug=…`, `/auth/signin`, `/auth/error?error=Verification`, `/auth/verify-request`. dfda gains `/contact`, `/conditions/endometriosis`, `/treatments/laparoscopic-excision-surgery`, `/auth/signin`; wishocracy and trialabundancesurvey gain `/contact` + `/auth/signin`. Full matrix: **55 → 83 captured routes**.

Pages with no deterministic capture get documented exemptions instead of silence: Stripe success pages (need a live checkout session), `auth/complete-signup` (transitional redirect), dfda's `/dfda` (duplicate of home content), the nested condition/treatment page (live clinicaltrials.gov fetch), and the auth-scaffolding clones in non-warondisease apps.

**2. Page-inventory audit** (`scripts/site-app-navigation.test.ts`, runs in the existing `site-apps-static-validate` job)

Enumerates `apps/<app>/app/**/page.tsx` for all six apps and fails CI when a page is neither captured nor exempted. Adding a page without registering a screenshot is now a red build, not a silent gap.

**3. Site-app files join the coverage gate** (`apps/optimitron/scripts/visual-review-coverage.mjs`)

`isVisualUiSourceFile` now treats site-app `app/`, `components/`, stylesheets, and public images as UI source (api routes, emails, og-images, and error/loading boundaries excluded), so a changed site-app file must map to a captured route exactly like optimitron files. Every capture automatically covers its own page file and the home capture covers the root layout, so routine page edits are auto-covered.

Supporting changes: `getScreenshotRoutes` moved from `smoke-site-apps.mjs` into `site-app-visual-routes.mjs` (one route set shared by smoke + audit); the CI-local visual fixture seed flips the demo person public so `/u/demo` captures the real profile UI; `visual-capture-contract.mjs` exports `SITE_APP_NAMES` and joins the `site_apps_changed` filter.

## Verification

- `pnpm test:site-app-navigation`: 16/16 pass — the inventory audit proves every page in all six apps is captured or exempted.
- `node --test` on the optimitron script suites: 19/19 pass, including new site-app classification cases.
- Local end-to-end: built `@apps/warondisease` and ran the capture smoke — all 28 routes × 2 viewports captured, exit 0. Screenshots inspected locally (not uploaded): `/vote`, `/treaty`, `/soldiers`, `/survey/*`, `/institutes/success`, and the auth pages all render correctly; `/u/demo` shows the private-profile state locally because the fixture seed was deliberately not run against the dev database.

## Predicted irritations

- The first CI run captures ~28 new route screenshots as "baseline missing → new"; the review page will be long this once.
- Future PRs touching a site-app component now block until the file appears in some route's `covers` — that's the point, but it's a new speed bump.
- PR #276 adds 8 more warondisease pages; after this merges, its branch must add them to `publicSiteAppRoutes` (or exempt them) to pass the new audit — a small follow-up commit I can push there.
- `/auth/error` renders in a different visual style (gradient card) than the rest of the site — pre-existing, now visible in review for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded visual capture coverage across supported standalone site applications, including pages, components, styles, images, and public routes.
  * Added support for validating expected not-found pages during site smoke checks.
  * Enabled demo profile pages to render publicly in visual captures.

* **Bug Fixes**
  * Improved route coverage validation to identify missing or incorrectly configured site pages.

* **Tests**
  * Added checks for public access, route completeness, exclusions, and duplicate screenshot routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->