### PR TITLE
Send all War on Disease email from one campaign sender identity

### DIFF
--- a/apps/warondisease/lib/email.ts
+++ b/apps/warondisease/lib/email.ts
@@ -17,7 +17,7 @@ import {
   SendOneMoreNudgeEmail,
   VoteConfirmedImpactEmail,
 } from "@/emails/referral-sequence"
-import { getResendClient, getEmailFrom } from "@/lib/email-utils"
+import { getBrandedEmailFrom, getResendClient } from "@/lib/email-utils"
 import { getSiteConfig, getEmail } from "@/lib/site-config"
 import { env } from "@/lib/env"
 import { createLogger } from "@/lib/logger"
@@ -54,7 +54,7 @@ export async function sendDonationThankYouEmail({
     )
 
     const result = await resend.emails.send({
-      from: getEmailFrom(),
+      from: getBrandedEmailFrom(),
       to,
       subject: "Thank you for joining the war on disease! 🎉",
       html: emailHtml,
@@ -114,7 +114,7 @@ export async function sendWeeklyUpdate({
       : "📊 Your Weekly War on Disease Update"
 
     const result = await resend.emails.send({
-      from: getEmailFrom(),
+      from: getBrandedEmailFrom(),
       to,
       subject,
       html: emailHtml,
@@ -164,7 +164,7 @@ export async function sendCampaignPledgeEmail({
     )
 
     const result = await resend.emails.send({
-      from: getEmailFrom(),
+      from: getBrandedEmailFrom(),
       to,
       subject: `Thank you for backing ${campaignTitle}! 🚀`,
       html: emailHtml,
@@ -211,7 +211,7 @@ export async function sendCampaignUpdateEmail({
     )
 
     const result = await resend.emails.send({
-      from: getEmailFrom(),
+      from: getBrandedEmailFrom(),
       to,
       subject: `Update from ${campaignTitle}: ${updateTitle}`,
       html: emailHtml,
@@ -303,7 +303,7 @@ export async function sendPartnerWelcomeEmail({
     )
 
     const result = await resend.emails.send({
-      from: getEmailFrom(),
+      from: getBrandedEmailFrom(),
       to,
       subject: `You're live! Start sharing your ${organizationName} survey`,
       html: emailHtml,
@@ -344,7 +344,7 @@ export async function sendPartnerRejectionEmail({
     )
 
     const result = await resend.emails.send({
-      from: getEmailFrom(),
+      from: getBrandedEmailFrom(),
       to,
       subject: `Update on your partner application for ${organizationName}`,
       html: emailHtml,
@@ -445,7 +445,7 @@ export async function sendReferralMotivationEmail({
       : "⚡ Your time is worth $17M/hour (really)"
 
     const result = await resend.emails.send({
-      from: getEmailFrom(),
+      from: getBrandedEmailFrom(),
       to,
       subject,
       html: emailHtml,
@@ -460,7 +460,7 @@ export async function sendReferralMotivationEmail({
 
 function getWarOnDiseaseFrom(senderName?: string): string {
   const fromAddress = env.EMAIL_FROM_ADDRESS || getEmail()
-  return senderName ? `${senderName} via War on Disease <${fromAddress}>` : getEmailFrom()
+  return senderName ? `${senderName} via War on Disease <${fromAddress}>` : getBrandedEmailFrom()
 }
 
 export async function sendReferralInviteEmail({

--- a/packages/site-kit/src/lib/auth.ts
+++ b/packages/site-kit/src/lib/auth.ts
@@ -8,7 +8,7 @@ import DiscordProvider from "next-auth/providers/discord"
 import EmailProvider from "next-auth/providers/email"
 import { prisma } from "./prisma"
 import { compare, hash } from "bcryptjs"
-import { getEmailFrom } from "./email-utils"
+import { getBrandedEmailFrom } from "./email-utils"
 import { sendSignupConfirmationEmail } from "./email"
 import { SocialPlatform, NotificationType } from "@optimitron/db"
 import { env } from "./env"
@@ -150,7 +150,7 @@ export const authOptions: NextAuthOptions = {
               pass: env.RESEND_API_KEY,
             },
           },
-          from: getEmailFrom(),
+          from: getBrandedEmailFrom(),
           maxAge: 24 * 60 * 60, // Magic links valid for 24 hours
           async sendVerificationRequest({ identifier, url, provider: _provider }) {
             // Extract name from email (local part before @) or use generic greeting

--- a/packages/site-kit/src/lib/email-utils.ts
+++ b/packages/site-kit/src/lib/email-utils.ts
@@ -1,6 +1,7 @@
 import { Resend } from "resend"
 import { EMAIL_CONFIG } from "./constants"
 import { env } from "./env"
+import { getSiteConfig } from "./site-config"
 
 /**
  * Get or create Resend client instance
@@ -23,6 +24,18 @@ export function getEmailFrom(): string {
 
   // If name is provided, use "Name <email>" format, otherwise just email
   return name ? `${name} <${address}>` : address
+}
+
+/**
+ * Get the email "from" using the current site variant's brand identity.
+ *
+ * This is the one place a site's sender name comes from: the variant's
+ * `emailBranding.fromName` in site-config. Prefer this over `getEmailFrom`
+ * for user-facing mail so every email from a site carries the same sender.
+ */
+export function getBrandedEmailFrom(): string {
+  const address = env.EMAIL_FROM_ADDRESS || EMAIL_CONFIG.DEFAULT_FROM_ADDRESS
+  return `${getSiteConfig().emailBranding.fromName} <${address}>`
 }
 
 /**

--- a/packages/site-kit/src/lib/site-config.ts
+++ b/packages/site-kit/src/lib/site-config.ts
@@ -730,7 +730,7 @@ const siteConfigs: Record<SiteVariant, SiteConfig> = {
     },
     legalEntityName: INSTITUTE_FOR_ACCELERATED_MEDICINE,
     emailBranding: {
-      fromName: "International Campaign to End War and Disease",
+      fromName: "The War on Disease",
       primaryColor: "#FF6B9D",
       secondaryColor: "#00D4FF",
       orgName: "The War on Disease",

--- a/packages/site-kit/src/lib/site-config.ts
+++ b/packages/site-kit/src/lib/site-config.ts
@@ -730,7 +730,7 @@ const siteConfigs: Record<SiteVariant, SiteConfig> = {
     },
     legalEntityName: INSTITUTE_FOR_ACCELERATED_MEDICINE,
     emailBranding: {
-      fromName: "DIH Advocacy",
+      fromName: "International Campaign to End War and Disease",
       primaryColor: "#FF6B9D",
       secondaryColor: "#00D4FF",
       orgName: "The War on Disease",


### PR DESCRIPTION
## The problem

Mike's login email arrived from **"DIH Advocacy"**. Tracing it: warondisease email had three sender identities —

1. Magic-link emails: `emailBranding.fromName` in site-config = `"DIH Advocacy"` (stale, pre-rebrand)
2. Seven transactional senders in `apps/warondisease/lib/email.ts`: `getEmailFrom()` → `EMAIL_FROM_NAME` env var, defaulting to `"Decentralized Institutes of Health"`
3. Referral mail: ad-hoc `"Name via War on Disease"`

## The fix

`emailBranding.fromName` (per-variant, in site-config) is now the one place a site's sender identity lives:

- warondisease's `fromName` becomes **"The War on Disease"** — chosen over the full "International Campaign to End War and Disease" because inbox list views cut sender names off at roughly 20–25 characters; the short name displays completely and matches the `orgName` already used inside email bodies. Production mail renders as `The War on Disease <hello@updates.warondisease.org>`.
- New `getBrandedEmailFrom()` in site-kit `email-utils` builds the From header from it.
- Every sender in `apps/warondisease/lib/email.ts` and the site-kit magic-link provider now resolves through that helper. The personalized `"Name via War on Disease"` form is kept, with the branded sender as its fallback.

`getEmailFrom()` (env-based) remains for anything not yet migrated; other variants' senders are unchanged (wishocracy/dfda/etc. would each be a one-line adoption later, but flipping their sender names wasn't asked for).

## Notes for review

- The sender **address** is env-driven (`EMAIL_FROM_ADDRESS`) and already correctly set to `hello@updates.warondisease.org` in production — untouched here.
- No copy/email snapshots embed the sender name (verified by grep); `tsc --noEmit` clean for `@apps/warondisease`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
