### PR TITLE
Fix duplicate dFDA ratio unit

### DIFF
--- a/apps/dfda/app/dfda/components/DfdaLandingContent.tsx
+++ b/apps/dfda/app/dfda/components/DfdaLandingContent.tsx
@@ -61,7 +61,7 @@ export function DfdaLandingContent() {
             </h1>
             <p className="text-xl md:text-2xl font-bold mb-8 text-balance">
               A decentralized framework that makes clinical trials{" "}
-              {costReductionFactor}x cheaper,{" "}
+              {costReductionFactor} cheaper,{" "}
               {(DRUG_DISCOVERY_TO_APPROVAL_YEARS.value / 2).toFixed(1)} years
               faster, and saves millions of lives
             </p>
@@ -230,7 +230,7 @@ export function DfdaLandingContent() {
                     <div className="w-2 h-2 bg-primary rounded-full mt-2 flex-shrink-0" />
                     <p className="font-bold">
                       Cost: {pragmaticTrialCostM} per drug (
-                      {costReductionFactor}x cheaper)
+                      {costReductionFactor} cheaper)
                     </p>
                   </div>
                   <div className="flex items-start gap-3">

--- a/apps/dfda/app/page.logged-out.md
+++ b/apps/dfda/app/page.logged-out.md
@@ -15,7 +15,7 @@
 
 - [DFDA](/)
 ## LET'S CREATE THE FDA OF THE FUTURE
-- A decentralized framework that makes clinical trials 82xx cheaper, 7.0 years faster, and saves millions of lives
+- A decentralized framework that makes clinical trials 82x cheaper, 7.0 years faster, and saves millions of lives
 - EXPLORE CONDITIONS:
 - [😞DEPRESSION 332M affected · 10,000 trials](/conditions/depression)
 - [🩺DIABETES 506M affected · 300 trials](/conditions/diabetes-mellitus-type-2)
@@ -49,7 +49,7 @@
 - Automated data from electronic health records
 - Streamlined monitoring (focus on safety)
 - Real-world conditions (actual practice)
-- Cost: $20M per drug (82xx cheaper)
+- Cost: $20M per drug (82x cheaper)
 - Timeline: ~3 months
 ### HOW PRAGMATIC TRIALS WORK
 #### INTEGRATE WITH ROUTINE CARE


### PR DESCRIPTION
## Summary
- remove the redundant literal `x` after the formatted trial cost-reduction ratio
- regenerate the dFDA landing-page copy snapshot

## Copy review
Audience: patients, clinicians, and researchers evaluating the decentralized FDA.
Desired action: trust the quantified case and explore conditions or treatments.
Motivation: trials can be dramatically cheaper and faster.
Old strategic job: lead with the sourced 82x cost-reduction advantage.
Manual/source phrase checked: "82x cost reduction."

Before → After:
- `82xx cheaper` → `82x cheaper` in the hero
- `82xx cheaper` → `82x cheaper` in the pragmatic-trial cost comparison

- [ ] Human copy approval

## Verification
- `pnpm copy dfda --routes=/`
- `pnpm --filter @apps/dfda typecheck`
- focused ESLint on `DfdaLandingContent.tsx`
- desktop and mobile screenshots captured and inspected locally; no layout regression found
- broad `pnpm test:site-app-navigation` currently fails on the pre-existing duplicate `warondisease:door-to-door` visual route on `main`; this branch does not modify that route file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated landing page cost-savings messaging for clearer, more consistent wording.
  * Corrected the “82x cheaper” phrasing in the FDA of the Future and Pragmatic Trials sections.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->