### PR TITLE
Improve Trial Abundance survey and research evidence

### DIFF
--- a/apps/trialabundancesurvey/app/research/page.logged-out.md
+++ b/apps/trialabundancesurvey/app/research/page.logged-out.md
@@ -21,10 +21,13 @@
 - Pragmatic clinical trials test treatments in real-world healthcare settings using existing medical records and routine care, rather than creating expensive artificial research environments.
 - The landmark RECOVERY trial at Oxford University demonstrated this approach at scale. Embedded in routine NHS care, it enrolled 40,000+ patients across 176 hospitals and produced three actionable treatment results within 100 days.
 - It recruited its first patient on March 19, 2020, and announced the dexamethasone mortality result 89 days later. The result is estimated to have saved over 1 million lives.
-- RECOVERY cost about [$500](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) per patient, compared with a $41,413 median for pivotal drug trials—about [82.0x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html). A separate review of 64 embedded trials found a $97 median. These studies show the cost potential; they do not set one price for every pragmatic trial.
+- RECOVERY cost about [$500](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) per patient, compared with a $41,413 median for pivotal drug trials—about [82.0x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html). A separate review of 64 embedded trials found a $97 median.
 ### TIMELINE COMPRESSION
-- At the current rate of ~15 diseases per year receiving a first effective treatment, finding treatments for all ~6,650 currently untreatable diseases would take an estimated [443](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years.
-- At the modeled funding level of about [$22B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) per year, scaling pragmatic trials would increase clinical trial capacity by [12.3x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html), compressing that timeline to approximately [36](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years.
+- CURRENT PACE
+- [443](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) YEARS
+- EXPANDED TRIAL CAPACITY
+- [36](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) YEARS
+- [12.3x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) more trial capacity at [$22B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) per year
 ### KEY FINDINGS
 - [82.0x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
 - About $500 per RECOVERY participant versus a $41,413 pivotal-trial median.
@@ -33,10 +36,11 @@
 - RECOVERY's identification of dexamethasone as an effective treatment saved over 1 million lives globally.
 - March 19 to June 16, 2020; RECOVERY produced three actionable results within 100 days.
 ### PUBLIC SPENDING GAP
+- MILITARY SPENDING
+- $2.718T
+- CLINICAL TRIAL SPENDING
 - [$4.5B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
 - [604:1](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html)
-- This is a government-to-government comparison. No complete global accounting exists, so the $4.5 billion trial figure is our estimate; its range is $3B–$6B.
-- Including private trial spending raises the denominator to about [$60B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) and lowers the ratio to about [45:1](https://manual.WarOnDisease.org/knowledge/strategy/earth-optimization-prize.html).
 ### WHY CAN'T EVERY DOCTOR OFFER A TRIAL?
 - Pragmatic trials are legal. Doctors can generally prescribe approved drugs off-label, but a systematic study adds research duties: an IND unless exempt, IRB review, consent, privacy approval, safety reporting, contracts, data systems, and an accountable sponsor. Insurance may cover routine care without paying for the research work.
 - Universal access needs reusable protocols, central review, proportionate rules for minimal-risk comparisons, reliable funding, interoperable records, and a shared trial network to handle monitoring, reporting, and liability.
@@ -45,8 +49,11 @@
 ### WHAT COULD A GLOBAL MAJORITY CHANGE?
 - [4.08B](https://manual.WarOnDisease.org/knowledge/solution/dih.html)
 - A verified majority could make private preferences common knowledge and create an election-scale mandate for trial access and funding reform.
-- Verified preferences → public mandate → access and funding reform → more physician-embedded trials → faster evidence → earlier treatment → less disease
-- The survey would not change law by itself. Patients and physicians must participate; health systems must embed trials; researchers must publish; foundations and insurers must fund; developers must supply treatments; and politicians and governments must act.
+- 🗳️VERIFIED PREFERENCES→
+- 📣PUBLIC MANDATE→
+- 🏛️ACCESS + FUNDING REFORM→
+- 🩺MORE TRIALS + FASTER EVIDENCE→
+- ❤️EARLIER TREATMENT + LESS DISEASE
 ### SOURCES
 - [Oxford RECOVERY](https://www.ndm.ox.ac.uk/covid-19/covid-research/drug-trials-recovery) — design, enrollment, dates, results, and NHS integration.
 - [Pivotal trial costs](https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/) and [embedded pragmatic trial costs](https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/).

--- a/apps/trialabundancesurvey/app/research/page.logged-out.md
+++ b/apps/trialabundancesurvey/app/research/page.logged-out.md
@@ -15,27 +15,132 @@
 
 - [GLOBAL CLINICAL TRIAL ABUNDANCE SURVEY](/)
 - [Go to Dashboard](/dashboard)
-## CLINICAL TRIAL EVIDENCE &DATA SOURCES
-- Peer-reviewed evidence on pragmatic clinical trials and the assumptions behind the survey's capacity model.
-### WHAT ARE PRAGMATIC TRIALS?
-- Pragmatic clinical trials test treatments in real-world healthcare settings using existing medical records and routine care, rather than creating expensive artificial research environments.
-- The landmark RECOVERY trial at Oxford University demonstrated this approach at scale: it enrolled 40,000+ patients across 176 NHS hospitals, identified effective COVID-19 treatments months ahead of traditional trials, and did so at [82.0x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) lower cost per patient.
-- RECOVERY is estimated to have saved over 1 million lives worldwide by rapidly identifying that dexamethasone reduces COVID mortality by one-third.
-### TIMELINE COMPRESSION
-- At the current rate of ~15 diseases per year receiving a first effective treatment, finding treatments for all ~6,650 currently untreatable diseases would take an estimated [443](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years.
-- At the modeled funding level of about [$22B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) per year, scaling pragmatic trials would increase clinical trial capacity by [12.3x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html), compressing that timeline to approximately [36](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years.
-### KEY FINDINGS
-- [82.0x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
-- Pragmatic trials cost a fraction of traditional trials by using existing healthcare infrastructure.
+- INDEPENDENT RESEARCH INITIATIVE
+## EVIDENCE BEHIND THE TRIAL ABUNDANCE SURVEY
+- The three-question survey stays brief. This page separates observed evidence from estimates, model projections, and a coordination hypothesis about what verified public preferences could change.
+### HOW TO READ THE CLAIMS
+- The label on each claim matters. A published observation is not the same thing as an estimated global denominator, a model output, or a forecast about collective action.
+#### OBSERVED EVIDENCE
+- Dates, trial results, designs, and study findings reported by the cited institutions or papers.
+#### ESTIMATE
+- A best current approximation used where no complete global accounting exists.
+#### MODEL PROJECTION
+- A calculated scenario that depends on explicit inputs and assumptions.
+#### COORDINATION HYPOTHESIS
+- A plausible pathway to test, not an observed survey result or an automatic policy effect.
+- OBSERVED INPUT + MODEL ESTIMATE
+### GOVERNMENT SPENDING CONTEXT
+- The survey's allocation question compares two categories of government spending. It does not compare military spending with all public and private medical research.
+#### OBSERVED: MILITARY SPENDING
+- [$2.718T](https://www.sipri.org/publications/2025/sipri-fact-sheets/trends-world-military-expenditure-2024)
+- SIPRI's estimate of world military expenditure in 2024.
+#### ESTIMATE: GOVERNMENT TRIALS
+- [$4.5B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- Current annual model estimate; uncertainty range $3B–$6B.
+#### CALCULATED SHARE
+- 0.166%
+- $4.5 billion as a share of SIPRI's $2.718 trillion estimate.
+#### CALCULATED RATIO
+- [604:1](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html)
+- About $604 in military spending for every $1 in government clinical-trial spending.
+#### WHAT THE DENOMINATOR DOES—AND DOES NOT—MEAN
+- This is explicitly a government-to-government comparison: global military expenditure versus estimated government spending on interventional clinical trials.
+- No authoritative organization publishes a complete global accounting of government spending on interventional trials across every country. The [$4.5B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) denominator is therefore an estimate, not an observed world total. The current model uses a $3B–$6B uncertainty range.
+- Including private pharmaceutical trial spending and other non-government funding produces a substantially smaller comparison. The current all-trials estimate is [$60B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html), which yields about [45:1](https://manual.WarOnDisease.org/knowledge/strategy/earth-optimization-prize.html). That broader ratio answers a different question from the survey's public-budget comparison.
+### WHAT RECOVERY DEMONSTRATED
+- RECOVERY used a simple adaptive design embedded in routine NHS care. Existing clinical workflows and routinely collected data reduced additional burden while preserving randomized comparisons.
+#### FIRST PATIENT
+- 19 MAR 2020
+- Oxford reports that RECOVERY recruited its first patient nine days after the protocol was drafted.
+#### DEXAMETHASONE RESULT
+- 16 JUN 2020
+- The trial announced the first treatment shown to reduce COVID-19 mortality.
+#### ELAPSED TIME
+- 89 DAYS
+- Calendar days from the first recruited patient to the dexamethasone announcement.
+#### FIRST 100 DAYS
+- 3 TREATMENTS
+- Actionable results for hydroxychloroquine, dexamethasone, and lopinavir-ritonavir.
+- COST EVIDENCE
+#### LARGE POTENTIAL, NOT ONE UNIVERSAL MULTIPLIER
+##### RECOVERY ESTIMATE
+- [$500](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- Approximate per-participant estimate for one unusually streamlined emergency platform trial.
+##### PIVOTAL APPROVAL TRIALS
+- [$41,413](https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/)
+- Peer-reviewed median estimate per participant across 225 pivotal trials supporting drug approvals.
+##### EMBEDDED PRAGMATIC TRIALS
+- [$97](https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/)
+- Median research cost per randomized participant among 64 trials with available cost data.
+- Dividing the pivotal-trial median by the RECOVERY estimate produces the familiar approximately [82.0x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) comparison. It is a RECOVERY-versus-pivotal-trial comparison, not a guaranteed saving for every pragmatic trial. The studies cover heterogeneous interventions, health systems, accounting methods, and trial designs. Together they show major cost potential, not a universal multiplier.
+- Sources: Oxford's [RECOVERY account](https://www.ndm.ox.ac.uk/covid-19/covid-research/drug-trials-recovery), the [pivotal-trial cost study](https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/), and the [embedded pragmatic-trial review](https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/).
+- MODEL PROJECTION—NOT AN OBSERVED OUTCOME
+### HOW THE CAPACITY SCENARIO IS BUILT
+- The model uses a deliberately conservative pragmatic-trial cost input rather than treating RECOVERY's emergency result as universally reproducible. Its outputs change when the inputs change.
+#### CENTRAL COST INPUT
+- [$929](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- Per participant, with an uncertainty interval informed by embedded-trial evidence and more complex trials.
+#### PROJECTED CAPACITY
 - [12.3x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
-- At the model's [$22B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) annual funding level, scaling pragmatic trials compresses the disease eradication timeline from [443](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years to [36](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years.
-- RECOVERY's identification of dexamethasone as an effective treatment saved over 1 million lives globally.
-- Pragmatic designs deliver actionable results in months, while traditional trials can take 5-10 years.
-### SOURCES
-- RECOVERY Trial — Horby, P. et al. (2021). Dexamethasone in Hospitalized Patients with Covid-19. New England Journal of Medicine, 384(8), 693-704.
-- Trial Cost Analysis — Martin, L. et al. (2017). How much do clinical trials cost? Nature Reviews Drug Discovery, 16(6), 381-382.
-- Pragmatic Trial Design — Ford, I. & Norrie, J. (2016). Pragmatic Trials. New England Journal of Medicine, 375(5), 454-463.
-- RECOVERY Impact — Wellcome Trust (2022). The RECOVERY trial: one of the most important clinical trials ever run.
+- Scenario output at the model's trial-funding level, not an observed global expansion.
+#### PROJECTED QUEUE
+- [443](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) → [36](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years
+- Modeled treatment-research queue under current versus expanded capacity assumptions.
+- COORDINATION HYPOTHESIS—NOT AN OBSERVED SURVEY RESULT
+### WHAT COULD A GLOBAL MAJORITY CHANGE?
+- A verified majority would not enact a law by itself. It could create an election-scale public mandate and coordination event that institutions can respond to independently.
+- 51%
+- [4.08B](https://manual.WarOnDisease.org/knowledge/solution/dih.html)
+- PEOPLE AT THE CURRENT CHECKED-IN POPULATION INPUT
+- The current global-population parameter is [8B](https://manual.WarOnDisease.org/knowledge/solution/dih.html). Multiplying it by 51% gives 4.08 billion people—about 4.1 billion. As the population input rises above 8.2 billion, the same rule is about 4.2 billion; the target is calculated instead of frozen to a stale headcount.
+- Public verification could reduce pluralistic ignorance: people may privately support a reform while incorrectly believing that most others do not. Country-level, auditable results could make dispersed preferences common knowledge and give decision-makers a visible mandate to answer.
+#### PLAUSIBLE INDEPENDENT RESPONSES
+##### PATIENTS
+- Ask about eligible trials, contribute outcomes, and identify unanswered treatment questions.
+##### PHYSICIANS
+- Offer eligible patients trial participation through routine care.
+##### HEALTH SYSTEMS
+- Embed randomization and outcome collection in clinical workflows and records.
+##### RESEARCHERS
+- Publish reusable protocols, interoperable measures, and transparent analyses.
+##### FOUNDATIONS
+- Fund shared trial infrastructure and questions that lack commercial incentives.
+##### INSURERS
+- Support routine-care trial participation and evidence generation for covered treatments.
+##### TREATMENT DEVELOPERS
+- Supply interventions and support comparative studies, including low-margin uses.
+##### POLITICIANS
+- Propose access, funding, privacy, and interoperability reforms.
+##### GOVERNMENTS
+- Fund public trial networks and coordinate standards across borders.
+#### THE HYPOTHESIZED CAUSAL CHAIN
+- 1 VERIFIED PREFERENCES→
+- 2 COMMON KNOWLEDGE AND POLITICAL MANDATE→
+- 3 TRIAL-ACCESS AND FUNDING REFORMS→
+- 4 MORE PHYSICIAN-EMBEDDED PRAGMATIC TRIALS→
+- 5 FASTER EVIDENCE→
+- 6 EARLIER ADOPTION OF EFFECTIVE TREATMENTS→
+- 7 REDUCED DISEASE BURDEN
+- Survey responses do not automatically enact laws, fund trials, establish causation, or eradicate disease. Each arrow requires institutions and people to act, and the effects must be measured.
+- CONDITIONS FOR CREDIBILITY
+#### A MAJORITY CLAIM MUST EARN TRUST
+- ■One verified response per person
+- ■Transparent methodology
+- ■Country-level results
+- ■Representative-sample reporting kept separate from self-selected participation
+- ■Clear translations
+- ■Published recruitment sources
+- ■Protection of respondent privacy
+- ■Concrete follow-up paths for patients, physicians, organizations, funders, and governments
+- SOURCE TRAIL
+### READ THE UNDERLYING EVIDENCE
+- Parameter values on this page open their own source and calculation details. These are the primary institutional and peer-reviewed sources for the central observed claims.
+- [SIPRI: WORLD MILITARY EXPENDITURE, 2024 Observed military-spending input.](https://www.sipri.org/publications/2025/sipri-fact-sheets/trends-world-military-expenditure-2024)
+- [OXFORD: RECOVERY TRIAL First patient, dexamethasone date, and NHS embedding.](https://www.ndm.ox.ac.uk/covid-19/covid-research/drug-trials-recovery)
+- [OXFORD: THREE RESULTS WITHIN 100 DAYS Institutional account of the trial's rapid results.](https://www.ndph.ox.ac.uk/news/recovery-trial-celebrates-two-year-anniversary-of-life-saving-dexamethasone-result)
+- [PIVOTAL TRIAL COST STUDY Peer-reviewed $41,413 median cost per participant.](https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/)
+- [EMBEDDED PRAGMATIC TRIAL REVIEW Peer-reviewed review reporting a $97 median among 64 trials.](https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/)
+- [RECOVERY COST ESTIMATE Source behind the approximate $500 model parameter.](https://manhattan.institute/article/slow-costly-clinical-trials-drag-down-biomedical-breakthroughs)
 ### TAKE THE SURVEY
 - [TAKE THE SURVEY](/#vote)
 - AN INDEPENDENT RESEARCH INITIATIVE

--- a/apps/trialabundancesurvey/app/research/page.logged-out.md
+++ b/apps/trialabundancesurvey/app/research/page.logged-out.md
@@ -16,42 +16,43 @@
 - [GLOBAL CLINICAL TRIAL ABUNDANCE SURVEY](/)
 - [Go to Dashboard](/dashboard)
 ## CLINICAL TRIAL EVIDENCE &DATA SOURCES
-- Peer-reviewed evidence on pragmatic clinical trials and the assumptions behind the survey's capacity model.
+- Peer-reviewed evidence and the numbers behind the survey's treatment timeline and funding model.
 ### WHAT ARE PRAGMATIC TRIALS?
 - Pragmatic clinical trials test treatments in real-world healthcare settings using existing medical records and routine care, rather than creating expensive artificial research environments.
-- The landmark RECOVERY trial at Oxford University demonstrated this approach at scale. Embedded in routine NHS care, it enrolled 40,000+ patients across 176 hospitals and produced three actionable treatment results within 100 days.
+- The landmark RECOVERY trial at Oxford University demonstrated this approach at scale. Embedded in routine NHS care, it enrolled 40,000+ patients across 176 hospitals and produced three treatment findings within 100 days.
 - It recruited its first patient on March 19, 2020, and announced the dexamethasone mortality result 89 days later. The result is estimated to have saved over 1 million lives.
 - RECOVERY cost about [$500](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) per patient, compared with a $41,413 median for pivotal drug trials—about [82.0x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html). A separate review of 64 embedded trials found a $97 median.
-### TIMELINE COMPRESSION
-- CURRENT PACE
+### DISEASE ERADICATION TIMELINE
+- About [6,650](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) rare diseases have no FDA-approved treatment. About [15](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) diseases get their first effective treatment each year. At that rate, clearing today's treatment backlog takes [443](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years.
+- TODAY'S TREATMENT RATE
 - [443](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) YEARS
-- EXPANDED TRIAL CAPACITY
+- WITH [12.3x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) TRIAL CAPACITY
 - [36](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) YEARS
-- [12.3x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) more trial capacity at [$22B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) per year
+- [$22B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) per year funds [12.3x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) as many patient trial slots.
 ### KEY FINDINGS
 - [82.0x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
 - About $500 per RECOVERY participant versus a $41,413 pivotal-trial median.
 - [12.3x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
-- At the model's [$22B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) annual funding level, scaling pragmatic trials compresses the disease eradication timeline from [443](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years to [36](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years.
+- [$22B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) per year funds [12.3x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) as many patient trial slots, cutting the disease eradication timeline from [443](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years to [36](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years.
 - RECOVERY's identification of dexamethasone as an effective treatment saved over 1 million lives globally.
-- March 19 to June 16, 2020; RECOVERY produced three actionable results within 100 days.
+- March 19 to June 16, 2020; RECOVERY produced three treatment findings within 100 days.
 ### PUBLIC SPENDING GAP
-- MILITARY SPENDING
+- ANNUAL WEAPONS AND MILITARY SPENDING
 - $2.718T
-- CLINICAL TRIAL SPENDING
+- ANNUAL PUBLICLY FUNDED CLINICAL TRIAL SPENDING
 - [$4.5B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
 - [604:1](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html)
 ### WHY CAN'T EVERY DOCTOR OFFER A TRIAL?
-- Pragmatic trials are legal. Doctors can generally prescribe approved drugs off-label, but a systematic study adds research duties: an IND unless exempt, IRB review, consent, privacy approval, safety reporting, contracts, data systems, and an accountable sponsor. Insurance may cover routine care without paying for the research work.
-- Universal access needs reusable protocols, central review, proportionate rules for minimal-risk comparisons, reliable funding, interoperable records, and a shared trial network to handle monitoring, reporting, and liability.
-#### RIGHT TO TRY IS NARROWER
+- Pragmatic trials are legal. Doctors can generally prescribe approved drugs off-label, but a systematic study adds research duties: an FDA investigational new drug application unless exempt, ethics review, consent, privacy approval, safety reporting, contracts, data systems, and a research sponsor. Insurance may cover routine care without paying for the research work.
+- Universal access needs reusable study plans, central ethics review, simpler rules for low-risk comparisons, reliable funding, connected health records, and a shared trial network to handle monitoring, reporting, and liability.
+#### RIGHT TO TRY DOES NOT CREATE TRIALS
 - Federal Right to Try covers some patients with life-threatening conditions who cannot join a relevant trial. Montana's 2025 SB 535 also created licensed experimental-treatment centers; final rules took effect July 25, 2026. These laws expand treatment access, but they do not require treatment supply, payment, trial enrollment, randomization, or useful comparative evidence.
 ### WHAT COULD A GLOBAL MAJORITY CHANGE?
 - [4.08B](https://manual.WarOnDisease.org/knowledge/solution/dih.html)
-- A verified majority could make private preferences common knowledge and create an election-scale mandate for trial access and funding reform.
-- 🗳️VERIFIED PREFERENCES→
+- If 51% of people publicly verify their support, governments can see an election-scale mandate for laws and public funding that let patients join trials through their physicians.
+- 🗳️VERIFIED PUBLIC SUPPORT→
 - 📣PUBLIC MANDATE→
-- 🏛️ACCESS + FUNDING REFORM→
+- 🏛️TRIAL ACCESS LAWS + PUBLIC FUNDING→
 - 🩺MORE TRIALS + FASTER EVIDENCE→
 - ❤️EARLIER TREATMENT + LESS DISEASE
 ### SOURCES

--- a/apps/trialabundancesurvey/app/research/page.logged-out.md
+++ b/apps/trialabundancesurvey/app/research/page.logged-out.md
@@ -74,6 +74,43 @@
 - Median research cost per randomized participant among 64 trials with available cost data.
 - Dividing the pivotal-trial median by the RECOVERY estimate produces the familiar approximately [82.0x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) comparison. It is a RECOVERY-versus-pivotal-trial comparison, not a guaranteed saving for every pragmatic trial. The studies cover heterogeneous interventions, health systems, accounting methods, and trial designs. Together they show major cost potential, not a universal multiplier.
 - Sources: Oxford's [RECOVERY account](https://www.ndm.ox.ac.uk/covid-19/covid-research/drug-trials-recovery), the [pivotal-trial cost study](https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/), and the [embedded pragmatic-trial review](https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/).
+- CURRENT LEGAL AND OPERATIONAL CONSTRAINTS
+### WHY DOESN'T EVERY DOCTOR OFFER A PRAGMATIC TRIAL?
+- Pragmatic trials are not categorically illegal. The difficulty is that a physician's treatment decision becomes research—and often regulated research—when a protocol systematically assigns care and collects data to produce generalizable evidence. That change adds duties that an ordinary clinic usually cannot absorb alone.
+#### TREATMENT IS NOT A TRIAL
+- FDA says clinicians generally may prescribe an approved drug off-label when medically appropriate. Randomization and systematic evidence generation still require a research protocol and accountable sponsor.
+#### IND-EXEMPT IS NOT OVERSIGHT-FREE
+- A study of a marketed drug can avoid an IND only when every 21 CFR 312.2(b)(1) condition is met. IRB review and informed consent still apply; riskier or unapproved uses need another FDA pathway.
+#### CONSENT AND DATA ARE RISK-DEPENDENT
+- The Common Rule and HIPAA allow documented waivers in qualifying minimal-risk research. An IRB or Privacy Board must still assess and document the study, privacy safeguards, and practicability.
+#### COVERAGE IS INCOMPLETE
+- Medicare covers routine costs in qualifying trials, but not every investigational intervention or research-only service. Other coverage, site contracts, and unrecovered clinic work remain variable.
+- A review of embedded pragmatic trials identified research governance, processes incompatible with clinical operations, and unrecoverable costs as recurring barriers. Protections for consent, safety, and privacy remain necessary; the policy question is how to make oversight proportionate and reusable.
+- POLICY DESIGN TARGETS—NOT CURRENT RIGHTS
+#### WHAT UNIVERSAL ACCESS WOULD REQUIRE
+##### PATIENT ACCESS
+- TODAY: No universal right to be screened, enrolled, or supplied an intervention.
+- POSSIBLE TARGET: A portable right to be informed and considered for eligible trials—not a right to demand an unsafe or unavailable treatment.
+##### PROPORTIONATE REVIEW
+- TODAY: IND, IRB, consent, privacy, and local-site determinations can be repeated or inconsistent.
+- POSSIBLE TARGET: Clear pathways for minimal-risk marketed-treatment comparisons, shared protocols, central review, and tiered consent.
+##### PAYMENT
+- TODAY: Routine care may be covered while research-only work, infrastructure, or the intervention is not.
+- POSSIBLE TARGET: Reliable routine-care coverage plus public or shared research funding. Any patient-funded option needs equity and consent safeguards.
+##### CLINIC WORKFLOW
+- TODAY: Site contracts, staff training, fragmented records, manual reporting, and unrecovered physician time block participation.
+- POSSIBLE TARGET: Reusable agreements, interoperable records, funded clinician time, and automated eligibility, safety, and outcome reporting.
+##### ACCOUNTABILITY
+- TODAY: A clinician cannot safely become sponsor, data center, monitor, and regulator for every study.
+- POSSIBLE TARGET: A shared trial network that preserves independent review, privacy, adverse-event monitoring, public registration, results reporting, and clear liability.
+- ADJACENT LEGAL EXPERIMENT
+#### RIGHT TO TRY IS NOT RIGHT TO TRIAL
+- Right-to-try and expanded-access laws primarily govern treatment with an investigational product outside a clinical trial. Their purpose is access for an individual patient, not randomization or the production of reliable comparative evidence.
+##### FEDERAL RIGHT TO TRY, 2018
+- The federal pathway is limited to a patient with a life-threatening condition who exhausted approved options and cannot participate in a relevant trial. It does not require FDA or IRB review of an individual request, and it does not require a manufacturer to provide the drug.
+##### MONTANA SB 535, 2025
+- Montana created licensed experimental-treatment centers for interventions that completed phase 1 and either remain under FDA-approved investigation or meet a state-defined documented-safety route. Patients must evaluate approved options, receive a provider recommendation, and consent. Final center-licensing rules took effect July 25, 2026.
+- Montana permits payment arrangements but does not require a manufacturer, facility, insurer, or government program to provide or pay for treatment. The law is therefore a live experiment in treatment access and financing—not a universal right to join a pragmatic trial, a replacement for federal research rules, or a guarantee that useful comparative evidence will result.
 - MODEL PROJECTION—NOT AN OBSERVED OUTCOME
 ### HOW THE CAPACITY SCENARIO IS BUILT
 - The model uses a deliberately conservative pragmatic-trial cost input rather than treating RECOVERY's emergency result as universally reproducible. Its outputs change when the inputs change.
@@ -141,6 +178,14 @@
 - [PIVOTAL TRIAL COST STUDY Peer-reviewed $41,413 median cost per participant.](https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/)
 - [EMBEDDED PRAGMATIC TRIAL REVIEW Peer-reviewed review reporting a $97 median among 64 trials.](https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/)
 - [RECOVERY COST ESTIMATE Source behind the approximate $500 model parameter.](https://manhattan.institute/article/slow-costly-clinical-trials-drag-down-biomedical-breakthroughs)
+- [FDA: OFF-LABEL USE OF APPROVED DRUGS What clinicians may prescribe in ordinary medical practice.](https://www.fda.gov/understanding-unapproved-use-approved-drugs-label)
+- [FDA: IND EXEMPTION CRITERIA Conditions for studies of lawfully marketed drugs.](https://www.fda.gov/drugs/investigational-new-drug-ind-application/ind-application-procedures-exemptions-ind-requirements)
+- [HHS: COMMON RULE IRB and informed-consent protections for covered research.](https://www.hhs.gov/ohrp/regulations-and-policy/regulations/45-cfr-46/index.html)
+- [HHS: HIPAA AND RESEARCH Authorization and documented waiver routes for protected health information.](https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/research/index.html)
+- [CMS: ROUTINE COSTS IN CLINICAL TRIALS What Medicare covers in qualifying trials and what it excludes.](https://www.cms.gov/medicare-coverage-database/view/ncd.aspx?NCDId=1&NCDver=3)
+- [FDA: FEDERAL RIGHT TO TRY Eligibility, manufacturer discretion, and the treatment-access pathway.](https://www.fda.gov/patients/learn-about-expanded-access-and-other-treatment-options/right-try)
+- [MONTANA SB 535, CHAPTER 621 The 2025 law establishing experimental-treatment centers.](https://archive.legmt.gov/content/Sessions/69th/Contractor_index/CH0621.pdf)
+- [MONTANA: EXPERIMENTAL-TREATMENT CENTERS Current licensing applications, statutes, and rules.](https://dphhs.mt.gov/oig/licensure/healthcarefacilitylicensure/lbfacilityapplications/lbexperimentaltreatmentcenters)
 ### TAKE THE SURVEY
 - [TAKE THE SURVEY](/#vote)
 - AN INDEPENDENT RESEARCH INITIATIVE

--- a/apps/trialabundancesurvey/app/research/page.logged-out.md
+++ b/apps/trialabundancesurvey/app/research/page.logged-out.md
@@ -15,177 +15,44 @@
 
 - [GLOBAL CLINICAL TRIAL ABUNDANCE SURVEY](/)
 - [Go to Dashboard](/dashboard)
-- INDEPENDENT RESEARCH INITIATIVE
-## EVIDENCE BEHIND THE TRIAL ABUNDANCE SURVEY
-- The three-question survey stays brief. This page separates observed evidence from estimates, model projections, and a coordination hypothesis about what verified public preferences could change.
-### HOW TO READ THE CLAIMS
-- The label on each claim matters. A published observation is not the same thing as an estimated global denominator, a model output, or a forecast about collective action.
-#### OBSERVED EVIDENCE
-- Dates, trial results, designs, and study findings reported by the cited institutions or papers.
-#### ESTIMATE
-- A best current approximation used where no complete global accounting exists.
-#### MODEL PROJECTION
-- A calculated scenario that depends on explicit inputs and assumptions.
-#### COORDINATION HYPOTHESIS
-- A plausible pathway to test, not an observed survey result or an automatic policy effect.
-- OBSERVED INPUT + MODEL ESTIMATE
-### GOVERNMENT SPENDING CONTEXT
-- The survey's allocation question compares two categories of government spending. It does not compare military spending with all public and private medical research.
-#### OBSERVED: MILITARY SPENDING
-- [$2.718T](https://www.sipri.org/publications/2025/sipri-fact-sheets/trends-world-military-expenditure-2024)
-- SIPRI's estimate of world military expenditure in 2024.
-#### ESTIMATE: GOVERNMENT TRIALS
-- [$4.5B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
-- Current annual model estimate; uncertainty range $3B–$6B.
-#### CALCULATED SHARE
-- 0.166%
-- $4.5 billion as a share of SIPRI's $2.718 trillion estimate.
-#### CALCULATED RATIO
-- [604:1](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html)
-- About $604 in military spending for every $1 in government clinical-trial spending.
-#### WHAT THE DENOMINATOR DOES—AND DOES NOT—MEAN
-- This is explicitly a government-to-government comparison: global military expenditure versus estimated government spending on interventional clinical trials.
-- No authoritative organization publishes a complete global accounting of government spending on interventional trials across every country. The [$4.5B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) denominator is therefore an estimate, not an observed world total. The current model uses a $3B–$6B uncertainty range.
-- Including private pharmaceutical trial spending and other non-government funding produces a substantially smaller comparison. The current all-trials estimate is [$60B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html), which yields about [45:1](https://manual.WarOnDisease.org/knowledge/strategy/earth-optimization-prize.html). That broader ratio answers a different question from the survey's public-budget comparison.
-### WHAT RECOVERY DEMONSTRATED
-- RECOVERY used a simple adaptive design embedded in routine NHS care. Existing clinical workflows and routinely collected data reduced additional burden while preserving randomized comparisons.
-#### FIRST PATIENT
-- 19 MAR 2020
-- Oxford reports that RECOVERY recruited its first patient nine days after the protocol was drafted.
-#### DEXAMETHASONE RESULT
-- 16 JUN 2020
-- The trial announced the first treatment shown to reduce COVID-19 mortality.
-#### ELAPSED TIME
-- 89 DAYS
-- Calendar days from the first recruited patient to the dexamethasone announcement.
-#### FIRST 100 DAYS
-- 3 TREATMENTS
-- Actionable results for hydroxychloroquine, dexamethasone, and lopinavir-ritonavir.
-- COST EVIDENCE
-#### LARGE POTENTIAL, NOT ONE UNIVERSAL MULTIPLIER
-##### RECOVERY ESTIMATE
-- [$500](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
-- Approximate per-participant estimate for one unusually streamlined emergency platform trial.
-##### PIVOTAL APPROVAL TRIALS
-- [$41,413](https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/)
-- Peer-reviewed median estimate per participant across 225 pivotal trials supporting drug approvals.
-##### EMBEDDED PRAGMATIC TRIALS
-- [$97](https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/)
-- Median research cost per randomized participant among 64 trials with available cost data.
-- Dividing the pivotal-trial median by the RECOVERY estimate produces the familiar approximately [82.0x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) comparison. It is a RECOVERY-versus-pivotal-trial comparison, not a guaranteed saving for every pragmatic trial. The studies cover heterogeneous interventions, health systems, accounting methods, and trial designs. Together they show major cost potential, not a universal multiplier.
-- Sources: Oxford's [RECOVERY account](https://www.ndm.ox.ac.uk/covid-19/covid-research/drug-trials-recovery), the [pivotal-trial cost study](https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/), and the [embedded pragmatic-trial review](https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/).
-- CURRENT LEGAL AND OPERATIONAL CONSTRAINTS
-### WHY DOESN'T EVERY DOCTOR OFFER A PRAGMATIC TRIAL?
-- Pragmatic trials are not categorically illegal. The difficulty is that a physician's treatment decision becomes research—and often regulated research—when a protocol systematically assigns care and collects data to produce generalizable evidence. That change adds duties that an ordinary clinic usually cannot absorb alone.
-#### TREATMENT IS NOT A TRIAL
-- FDA says clinicians generally may prescribe an approved drug off-label when medically appropriate. Randomization and systematic evidence generation still require a research protocol and accountable sponsor.
-#### IND-EXEMPT IS NOT OVERSIGHT-FREE
-- A study of a marketed drug can avoid an IND only when every 21 CFR 312.2(b)(1) condition is met. IRB review and informed consent still apply; riskier or unapproved uses need another FDA pathway.
-#### CONSENT AND DATA ARE RISK-DEPENDENT
-- The Common Rule and HIPAA allow documented waivers in qualifying minimal-risk research. An IRB or Privacy Board must still assess and document the study, privacy safeguards, and practicability.
-#### COVERAGE IS INCOMPLETE
-- Medicare covers routine costs in qualifying trials, but not every investigational intervention or research-only service. Other coverage, site contracts, and unrecovered clinic work remain variable.
-- A review of embedded pragmatic trials identified research governance, processes incompatible with clinical operations, and unrecoverable costs as recurring barriers. Protections for consent, safety, and privacy remain necessary; the policy question is how to make oversight proportionate and reusable.
-- POLICY DESIGN TARGETS—NOT CURRENT RIGHTS
-#### WHAT UNIVERSAL ACCESS WOULD REQUIRE
-##### PATIENT ACCESS
-- TODAY: No universal right to be screened, enrolled, or supplied an intervention.
-- POSSIBLE TARGET: A portable right to be informed and considered for eligible trials—not a right to demand an unsafe or unavailable treatment.
-##### PROPORTIONATE REVIEW
-- TODAY: IND, IRB, consent, privacy, and local-site determinations can be repeated or inconsistent.
-- POSSIBLE TARGET: Clear pathways for minimal-risk marketed-treatment comparisons, shared protocols, central review, and tiered consent.
-##### PAYMENT
-- TODAY: Routine care may be covered while research-only work, infrastructure, or the intervention is not.
-- POSSIBLE TARGET: Reliable routine-care coverage plus public or shared research funding. Any patient-funded option needs equity and consent safeguards.
-##### CLINIC WORKFLOW
-- TODAY: Site contracts, staff training, fragmented records, manual reporting, and unrecovered physician time block participation.
-- POSSIBLE TARGET: Reusable agreements, interoperable records, funded clinician time, and automated eligibility, safety, and outcome reporting.
-##### ACCOUNTABILITY
-- TODAY: A clinician cannot safely become sponsor, data center, monitor, and regulator for every study.
-- POSSIBLE TARGET: A shared trial network that preserves independent review, privacy, adverse-event monitoring, public registration, results reporting, and clear liability.
-- ADJACENT LEGAL EXPERIMENT
-#### RIGHT TO TRY IS NOT RIGHT TO TRIAL
-- Right-to-try and expanded-access laws primarily govern treatment with an investigational product outside a clinical trial. Their purpose is access for an individual patient, not randomization or the production of reliable comparative evidence.
-##### FEDERAL RIGHT TO TRY, 2018
-- The federal pathway is limited to a patient with a life-threatening condition who exhausted approved options and cannot participate in a relevant trial. It does not require FDA or IRB review of an individual request, and it does not require a manufacturer to provide the drug.
-##### MONTANA SB 535, 2025
-- Montana created licensed experimental-treatment centers for interventions that completed phase 1 and either remain under FDA-approved investigation or meet a state-defined documented-safety route. Patients must evaluate approved options, receive a provider recommendation, and consent. Final center-licensing rules took effect July 25, 2026.
-- Montana permits payment arrangements but does not require a manufacturer, facility, insurer, or government program to provide or pay for treatment. The law is therefore a live experiment in treatment access and financing—not a universal right to join a pragmatic trial, a replacement for federal research rules, or a guarantee that useful comparative evidence will result.
-- MODEL PROJECTION—NOT AN OBSERVED OUTCOME
-### HOW THE CAPACITY SCENARIO IS BUILT
-- The model uses a deliberately conservative pragmatic-trial cost input rather than treating RECOVERY's emergency result as universally reproducible. Its outputs change when the inputs change.
-#### CENTRAL COST INPUT
-- [$929](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
-- Per participant, with an uncertainty interval informed by embedded-trial evidence and more complex trials.
-#### PROJECTED CAPACITY
+## CLINICAL TRIAL EVIDENCE &DATA SOURCES
+- Peer-reviewed evidence on pragmatic clinical trials and the assumptions behind the survey's capacity model.
+### WHAT ARE PRAGMATIC TRIALS?
+- Pragmatic clinical trials test treatments in real-world healthcare settings using existing medical records and routine care, rather than creating expensive artificial research environments.
+- The landmark RECOVERY trial at Oxford University demonstrated this approach at scale. Embedded in routine NHS care, it enrolled 40,000+ patients across 176 hospitals and produced three actionable treatment results within 100 days.
+- It recruited its first patient on March 19, 2020, and announced the dexamethasone mortality result 89 days later. The result is estimated to have saved over 1 million lives.
+- RECOVERY cost about [$500](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) per patient, compared with a $41,413 median for pivotal drug trials—about [82.0x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html). A separate review of 64 embedded trials found a $97 median. These studies show the cost potential; they do not set one price for every pragmatic trial.
+### TIMELINE COMPRESSION
+- At the current rate of ~15 diseases per year receiving a first effective treatment, finding treatments for all ~6,650 currently untreatable diseases would take an estimated [443](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years.
+- At the modeled funding level of about [$22B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) per year, scaling pragmatic trials would increase clinical trial capacity by [12.3x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html), compressing that timeline to approximately [36](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years.
+### KEY FINDINGS
+- [82.0x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- About $500 per RECOVERY participant versus a $41,413 pivotal-trial median.
 - [12.3x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
-- Scenario output at the model's trial-funding level, not an observed global expansion.
-#### PROJECTED QUEUE
-- [443](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) → [36](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years
-- Modeled treatment-research queue under current versus expanded capacity assumptions.
-- COORDINATION HYPOTHESIS—NOT AN OBSERVED SURVEY RESULT
+- At the model's [$22B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) annual funding level, scaling pragmatic trials compresses the disease eradication timeline from [443](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years to [36](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) years.
+- RECOVERY's identification of dexamethasone as an effective treatment saved over 1 million lives globally.
+- March 19 to June 16, 2020; RECOVERY produced three actionable results within 100 days.
+### PUBLIC SPENDING GAP
+- [$4.5B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- [604:1](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html)
+- This is a government-to-government comparison. No complete global accounting exists, so the $4.5 billion trial figure is our estimate; its range is $3B–$6B.
+- Including private trial spending raises the denominator to about [$60B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) and lowers the ratio to about [45:1](https://manual.WarOnDisease.org/knowledge/strategy/earth-optimization-prize.html).
+### WHY CAN'T EVERY DOCTOR OFFER A TRIAL?
+- Pragmatic trials are legal. Doctors can generally prescribe approved drugs off-label, but a systematic study adds research duties: an IND unless exempt, IRB review, consent, privacy approval, safety reporting, contracts, data systems, and an accountable sponsor. Insurance may cover routine care without paying for the research work.
+- Universal access needs reusable protocols, central review, proportionate rules for minimal-risk comparisons, reliable funding, interoperable records, and a shared trial network to handle monitoring, reporting, and liability.
+#### RIGHT TO TRY IS NARROWER
+- Federal Right to Try covers some patients with life-threatening conditions who cannot join a relevant trial. Montana's 2025 SB 535 also created licensed experimental-treatment centers; final rules took effect July 25, 2026. These laws expand treatment access, but they do not require treatment supply, payment, trial enrollment, randomization, or useful comparative evidence.
 ### WHAT COULD A GLOBAL MAJORITY CHANGE?
-- A verified majority would not enact a law by itself. It could create an election-scale public mandate and coordination event that institutions can respond to independently.
-- 51%
 - [4.08B](https://manual.WarOnDisease.org/knowledge/solution/dih.html)
-- PEOPLE AT THE CURRENT CHECKED-IN POPULATION INPUT
-- The current global-population parameter is [8B](https://manual.WarOnDisease.org/knowledge/solution/dih.html). Multiplying it by 51% gives 4.08 billion people—about 4.1 billion. As the population input rises above 8.2 billion, the same rule is about 4.2 billion; the target is calculated instead of frozen to a stale headcount.
-- Public verification could reduce pluralistic ignorance: people may privately support a reform while incorrectly believing that most others do not. Country-level, auditable results could make dispersed preferences common knowledge and give decision-makers a visible mandate to answer.
-#### PLAUSIBLE INDEPENDENT RESPONSES
-##### PATIENTS
-- Ask about eligible trials, contribute outcomes, and identify unanswered treatment questions.
-##### PHYSICIANS
-- Offer eligible patients trial participation through routine care.
-##### HEALTH SYSTEMS
-- Embed randomization and outcome collection in clinical workflows and records.
-##### RESEARCHERS
-- Publish reusable protocols, interoperable measures, and transparent analyses.
-##### FOUNDATIONS
-- Fund shared trial infrastructure and questions that lack commercial incentives.
-##### INSURERS
-- Support routine-care trial participation and evidence generation for covered treatments.
-##### TREATMENT DEVELOPERS
-- Supply interventions and support comparative studies, including low-margin uses.
-##### POLITICIANS
-- Propose access, funding, privacy, and interoperability reforms.
-##### GOVERNMENTS
-- Fund public trial networks and coordinate standards across borders.
-#### THE HYPOTHESIZED CAUSAL CHAIN
-- 1 VERIFIED PREFERENCES→
-- 2 COMMON KNOWLEDGE AND POLITICAL MANDATE→
-- 3 TRIAL-ACCESS AND FUNDING REFORMS→
-- 4 MORE PHYSICIAN-EMBEDDED PRAGMATIC TRIALS→
-- 5 FASTER EVIDENCE→
-- 6 EARLIER ADOPTION OF EFFECTIVE TREATMENTS→
-- 7 REDUCED DISEASE BURDEN
-- Survey responses do not automatically enact laws, fund trials, establish causation, or eradicate disease. Each arrow requires institutions and people to act, and the effects must be measured.
-- CONDITIONS FOR CREDIBILITY
-#### A MAJORITY CLAIM MUST EARN TRUST
-- ■One verified response per person
-- ■Transparent methodology
-- ■Country-level results
-- ■Representative-sample reporting kept separate from self-selected participation
-- ■Clear translations
-- ■Published recruitment sources
-- ■Protection of respondent privacy
-- ■Concrete follow-up paths for patients, physicians, organizations, funders, and governments
-- SOURCE TRAIL
-### READ THE UNDERLYING EVIDENCE
-- Parameter values on this page open their own source and calculation details. These are the primary institutional and peer-reviewed sources for the central observed claims.
-- [SIPRI: WORLD MILITARY EXPENDITURE, 2024 Observed military-spending input.](https://www.sipri.org/publications/2025/sipri-fact-sheets/trends-world-military-expenditure-2024)
-- [OXFORD: RECOVERY TRIAL First patient, dexamethasone date, and NHS embedding.](https://www.ndm.ox.ac.uk/covid-19/covid-research/drug-trials-recovery)
-- [OXFORD: THREE RESULTS WITHIN 100 DAYS Institutional account of the trial's rapid results.](https://www.ndph.ox.ac.uk/news/recovery-trial-celebrates-two-year-anniversary-of-life-saving-dexamethasone-result)
-- [PIVOTAL TRIAL COST STUDY Peer-reviewed $41,413 median cost per participant.](https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/)
-- [EMBEDDED PRAGMATIC TRIAL REVIEW Peer-reviewed review reporting a $97 median among 64 trials.](https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/)
-- [RECOVERY COST ESTIMATE Source behind the approximate $500 model parameter.](https://manhattan.institute/article/slow-costly-clinical-trials-drag-down-biomedical-breakthroughs)
-- [FDA: OFF-LABEL USE OF APPROVED DRUGS What clinicians may prescribe in ordinary medical practice.](https://www.fda.gov/understanding-unapproved-use-approved-drugs-label)
-- [FDA: IND EXEMPTION CRITERIA Conditions for studies of lawfully marketed drugs.](https://www.fda.gov/drugs/investigational-new-drug-ind-application/ind-application-procedures-exemptions-ind-requirements)
-- [HHS: COMMON RULE IRB and informed-consent protections for covered research.](https://www.hhs.gov/ohrp/regulations-and-policy/regulations/45-cfr-46/index.html)
-- [HHS: HIPAA AND RESEARCH Authorization and documented waiver routes for protected health information.](https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/research/index.html)
-- [CMS: ROUTINE COSTS IN CLINICAL TRIALS What Medicare covers in qualifying trials and what it excludes.](https://www.cms.gov/medicare-coverage-database/view/ncd.aspx?NCDId=1&NCDver=3)
-- [FDA: FEDERAL RIGHT TO TRY Eligibility, manufacturer discretion, and the treatment-access pathway.](https://www.fda.gov/patients/learn-about-expanded-access-and-other-treatment-options/right-try)
-- [MONTANA SB 535, CHAPTER 621 The 2025 law establishing experimental-treatment centers.](https://archive.legmt.gov/content/Sessions/69th/Contractor_index/CH0621.pdf)
-- [MONTANA: EXPERIMENTAL-TREATMENT CENTERS Current licensing applications, statutes, and rules.](https://dphhs.mt.gov/oig/licensure/healthcarefacilitylicensure/lbfacilityapplications/lbexperimentaltreatmentcenters)
+- A verified majority could make private preferences common knowledge and create an election-scale mandate for trial access and funding reform.
+- Verified preferences → public mandate → access and funding reform → more physician-embedded trials → faster evidence → earlier treatment → less disease
+- The survey would not change law by itself. Patients and physicians must participate; health systems must embed trials; researchers must publish; foundations and insurers must fund; developers must supply treatments; and politicians and governments must act.
+### SOURCES
+- [Oxford RECOVERY](https://www.ndm.ox.ac.uk/covid-19/covid-research/drug-trials-recovery) — design, enrollment, dates, results, and NHS integration.
+- [Pivotal trial costs](https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/) and [embedded pragmatic trial costs](https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/).
+- [SIPRI military spending](https://www.sipri.org/publications/2025/sipri-fact-sheets/trends-world-military-expenditure-2024) — the $2.718 trillion 2024 estimate.
+- [FDA IND rules](https://www.fda.gov/drugs/investigational-new-drug-ind-application/ind-application-procedures-exemptions-ind-requirements), [Common Rule](https://www.hhs.gov/ohrp/regulations-and-policy/regulations/45-cfr-46/index.html), [HIPAA research rules](https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/research/index.html), and [Medicare trial coverage](https://www.cms.gov/medicare-coverage-database/view/ncd.aspx?NCDId=1&NCDver=3).
+- [Federal Right to Try](https://www.fda.gov/patients/learn-about-expanded-access-and-other-treatment-options/right-try) and [Montana SB 535](https://archive.legmt.gov/content/Sessions/69th/Contractor_index/CH0621.pdf).
 ### TAKE THE SURVEY
 - [TAKE THE SURVEY](/#vote)
 - AN INDEPENDENT RESEARCH INITIATIVE

--- a/packages/site-kit/src/components/landing/timeline-scrolly.tsx
+++ b/packages/site-kit/src/components/landing/timeline-scrolly.tsx
@@ -60,11 +60,13 @@ export function TimelineScrolly({ userAge, onAgeChange }: TimelineScrollyProps) 
   const [dfdaComplete, setDfdaComplete] = useState(false)
   const timelineRef = useRef<HTMLDivElement>(null)
   const statusQuoRef = useRef<HTMLDivElement>(null)
+  const visualCaptureRef = useRef(false)
 
 
   // Scroll handler to update year counter
   useEffect(() => {
     const handleScroll = () => {
+      if (visualCaptureRef.current) return
       if (!statusQuoRef.current || !timelineRef.current) return
 
       const statusQuoRect = statusQuoRef.current.getBoundingClientRect()
@@ -82,6 +84,7 @@ export function TimelineScrolly({ userAge, onAgeChange }: TimelineScrollyProps) 
     }
 
     const completeVisualCapture = () => {
+      visualCaptureRef.current = true
       setCurrentYear(queueYears)
       setDfdaComplete(true)
     }

--- a/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
+++ b/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
@@ -382,6 +382,7 @@ export default function TrialAbundanceSurveySection({
           height: 32px;
           background: black;
           border: 4px solid black;
+          border-radius: 0;
           cursor: pointer;
           box-shadow: 2px 2px 0px 0px rgba(0, 0, 0, 1);
         }

--- a/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
+++ b/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
@@ -4,12 +4,6 @@ import {
   TRIAL_ABUNDANCE_REFERENDUM_QUESTION,
   TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_QUESTION,
 } from "@optimitron/db/constants"
-import {
-  DFDA_QUEUE_CLEARANCE_YEARS,
-  DFDA_TRIAL_CAPACITY_MULTIPLIER,
-  MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO,
-  STATUS_QUO_QUEUE_CLEARANCE_YEARS,
-} from "@optimitron/data/parameters"
 import { Button } from "@optimitron/neobrutalist-ui/ui/button"
 import { Card } from "@optimitron/neobrutalist-ui/ui/card"
 import { Container } from "@optimitron/neobrutalist-ui/ui/container"
@@ -28,11 +22,7 @@ import { syncPendingTrialAbundanceResponse } from "../../lib/trial-abundance-sur
 import { buildUserReferralUrl, getBaseUrl } from "../../lib/url"
 import { AuthForm } from "../auth/AuthForm"
 import { ReferralLinkCard } from "../shared/ReferralLinkCard"
-import { ParameterValue } from "../shared/ParameterValue"
 import { PragmaticTrialsDialog } from "./PragmaticTrialsDialog"
-
-const ratio = MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO.value
-const formattedRatio = `$${Math.round(ratio)}`
 
 type SurveyStage =
   | "patient-access"
@@ -68,10 +58,6 @@ function getInitialStage(
   if (visualState === "allocation") return "allocation"
   if (visualState === "complete") return "complete"
   return "patient-access"
-}
-
-function formatAnswer(answer: TrialAbundanceAnswer | null) {
-  return answer === "ABSTAIN" ? "NOT SURE" : answer
 }
 
 function celebrateResponse() {
@@ -112,9 +98,6 @@ export default function TrialAbundanceSurveySection({
   const [userHasDragged, setUserHasDragged] = useState(
     disableIntroAnimation || isVisualCapture,
   )
-  const [syncState, setSyncState] = useState<
-    "idle" | "saving" | "saved" | "local"
-  >(visualState === "complete" ? "local" : "idle")
   const completionRef = useRef<HTMLDivElement>(null)
   const hasRetriedSync = useRef(false)
 
@@ -134,7 +117,6 @@ export default function TrialAbundanceSurveySection({
     setSelfFundedAccessAnswer(pending.selfFundedAccessAnswer)
     setStage("complete")
     setUserHasDragged(true)
-    setSyncState("local")
   }, [isVisualCapture])
 
   useEffect(() => {
@@ -149,10 +131,7 @@ export default function TrialAbundanceSurveySection({
     }
 
     hasRetriedSync.current = true
-    setSyncState("saving")
-    void syncPendingTrialAbundanceResponse(session).then((saved) => {
-      setSyncState(saved ? "saved" : "local")
-    })
+    void syncPendingTrialAbundanceResponse(session)
   }, [isVisualCapture, session, status])
 
   const clinicalTrialsAllocation = 100 - militaryAllocation
@@ -213,7 +192,6 @@ export default function TrialAbundanceSurveySection({
       timestamp: new Date().toISOString(),
     }
     storage.setPendingTrialAbundanceResponse(response)
-    setSyncState("local")
 
     window.setTimeout(() => {
       completionRef.current?.scrollIntoView({
@@ -223,9 +201,7 @@ export default function TrialAbundanceSurveySection({
     }, 350)
 
     if (status === "authenticated" && session) {
-      setSyncState("saving")
-      const saved = await syncPendingTrialAbundanceResponse(session)
-      setSyncState(saved ? "saved" : "local")
+      await syncPendingTrialAbundanceResponse(session)
     }
   }
 
@@ -365,34 +341,6 @@ export default function TrialAbundanceSurveySection({
 
         {stage === "complete" ? (
           <div ref={completionRef} className="space-y-8">
-            <SurveyCard>
-              <p className="text-sm font-black uppercase text-brutal-pink">
-                Response complete
-              </p>
-              <h2 className="text-3xl font-black uppercase sm:text-4xl">
-                Thank you
-              </h2>
-              <div className="space-y-2 text-lg font-bold">
-                <p>Patient access: {formatAnswer(patientAccessAnswer)}.</p>
-                <p>
-                  Patient-funded access: {formatAnswer(selfFundedAccessAnswer)}.
-                </p>
-                <p>
-                  Allocation: {militaryAllocation}% to military and weapons and{" "}
-                  {clinicalTrialsAllocation}% to pragmatic clinical trials.
-                </p>
-              </div>
-              <p className="font-bold text-muted-foreground">
-                {syncState === "saved"
-                  ? "Your verified response is saved."
-                  : syncState === "saving"
-                    ? "Saving your verified response..."
-                    : "Your response is saved on this device. Verify below to store it with your account."}
-              </p>
-            </SurveyCard>
-
-            <RealityCheck />
-
             {status === "authenticated" && session?.user ? (
               <ReferralLinkCard
                 referralLink={shareUrl}
@@ -426,6 +374,28 @@ export default function TrialAbundanceSurveySection({
           </div>
         ) : null}
       </Container>
+
+      <style jsx>{`
+        .slider-brutal::-webkit-slider-thumb {
+          appearance: none;
+          width: 32px;
+          height: 32px;
+          background: black;
+          border: 4px solid black;
+          cursor: pointer;
+          box-shadow: 2px 2px 0px 0px rgba(0, 0, 0, 1);
+        }
+
+        .slider-brutal::-moz-range-thumb {
+          width: 32px;
+          height: 32px;
+          background: black;
+          border: 4px solid black;
+          cursor: pointer;
+          box-shadow: 2px 2px 0px 0px rgba(0, 0, 0, 1);
+          border-radius: 0;
+        }
+      `}</style>
     </SectionContainer>
   )
 }
@@ -515,41 +485,5 @@ function AllocationDisplay({
         </div>
       </div>
     </div>
-  )
-}
-
-function RealityCheck() {
-  return (
-    <Card className="mx-auto max-w-3xl border-4 border-primary bg-brutal-yellow p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8">
-      <h2 className="mb-4 text-2xl font-black uppercase">After you answer</h2>
-      <p className="mb-4 text-lg font-bold">
-        Governments spend about{" "}
-        <span className="text-brutal-pink">{formattedRatio}</span> on military
-        systems for every <span className="text-brutal-pink">$1</span> on
-        government-funded clinical trials.
-      </p>
-      <p className="font-bold">
-        The current model estimates that a 1% reallocation could increase trial
-        capacity by{" "}
-        <ParameterValue
-          param={DFDA_TRIAL_CAPACITY_MULTIPLIER}
-          format={{ precision: 1 }}
-          className="font-black text-brutal-pink"
-        />
-        , reducing the modeled treatment-research queue from{" "}
-        <ParameterValue
-          param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
-          format={{ precision: 0 }}
-          className="font-black text-brutal-pink"
-        />{" "}
-        years to{" "}
-        <ParameterValue
-          param={DFDA_QUEUE_CLEARANCE_YEARS}
-          format={{ precision: 0 }}
-          className="font-black text-brutal-pink"
-        />{" "}
-        years.
-      </p>
-    </Card>
   )
 }

--- a/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
+++ b/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
@@ -214,13 +214,17 @@ export default function TrialAbundanceSurveySection({
       className="pb-24"
     >
       <Container>
-        <h1 className="mb-3 text-center text-3xl font-black uppercase sm:text-4xl md:text-6xl">
-          Trial <span className="text-brutal-pink">Abundance</span> Survey
-        </h1>
-        <p className="mx-auto mb-10 max-w-2xl text-center text-base font-bold sm:text-lg">
-          Three questions about patient access, who may fund trial
-          participation, and public priorities.
-        </p>
+        {stage === "patient-access" ? (
+          <>
+            <h1 className="mb-3 text-center text-3xl font-black uppercase sm:text-4xl md:text-6xl">
+              Trial <span className="text-brutal-pink">Abundance</span> Survey
+            </h1>
+            <p className="mx-auto mb-10 max-w-2xl text-center text-base font-bold sm:text-lg">
+              Three questions about patient access, who may fund trial
+              participation, and public priorities.
+            </p>
+          </>
+        ) : null}
 
         <AnimatePresence mode="wait">
           {stage === "patient-access" ? (

--- a/packages/site-kit/src/components/research-page.tsx
+++ b/packages/site-kit/src/components/research-page.tsx
@@ -24,6 +24,7 @@ import {
   DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_SUFFERING_HOURS,
   DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_YEARS,
   DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL,
+  DISEASES_WITHOUT_EFFECTIVE_TREATMENT,
   GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL,
   GLOBAL_MILITARY_SPENDING_ANNUAL_2024,
   GLOBAL_POPULATION_2024,
@@ -73,9 +74,9 @@ const surveyMajorityTarget: Parameter = {
   stdError: undefined,
 }
 const coordinationFlow = [
-  { emoji: "🗳️", label: "Verified preferences", color: "bg-background" },
+  { emoji: "🗳️", label: "Verified public support", color: "bg-background" },
   { emoji: "📣", label: "Public mandate", color: "bg-brutal-cyan" },
-  { emoji: "🏛️", label: "Access + funding reform", color: "bg-brutal-yellow" },
+  { emoji: "🏛️", label: "Trial access laws + public funding", color: "bg-brutal-yellow" },
   { emoji: "🩺", label: "More trials + faster evidence", color: "bg-background" },
   { emoji: "❤️", label: "Earlier treatment + less disease", color: "bg-brutal-cyan" },
 ] as const
@@ -273,8 +274,7 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                 <span className="text-brutal-cyan">DATA SOURCES</span>
               </h1>
               <p className="text-lg sm:text-xl font-bold text-center max-w-2xl mx-auto">
-                Peer-reviewed evidence on pragmatic clinical trials and the assumptions behind the survey&apos;s
-                capacity model.
+                Peer-reviewed evidence and the numbers behind the survey&apos;s treatment timeline and funding model.
               </p>
             </Container>
           </SectionContainer>
@@ -297,8 +297,8 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                     The landmark{" "}
                     <span className="font-black text-brutal-pink">RECOVERY trial</span> at Oxford
                     University demonstrated this approach at scale. Embedded in routine NHS care, it
-                    enrolled 40,000+ patients across 176 hospitals and produced three actionable
-                    treatment results within 100 days.
+                    enrolled 40,000+ patients across 176 hospitals and produced three treatment findings
+                    within 100 days.
                   </p>
                   <p>
                     It recruited its first patient on March 19, 2020, and announced the dexamethasone
@@ -315,17 +315,39 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
               </Card>
 
               <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8 pt-8">
-                TIMELINE <span className="text-brutal-pink">COMPRESSION</span>
+                DISEASE ERADICATION <span className="text-brutal-pink">TIMELINE</span>
               </h2>
               <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-brutal-yellow">
+                <p className="mb-8 text-lg font-bold leading-relaxed">
+                  About{" "}
+                  <ParameterValue
+                    param={DISEASES_WITHOUT_EFFECTIVE_TREATMENT}
+                    valueOverride="6,650"
+                    className="font-black"
+                  />{" "}
+                  rare diseases have no FDA-approved treatment. About{" "}
+                  <ParameterValue
+                    param={NEW_DISEASE_FIRST_TREATMENTS_PER_YEAR}
+                    valueOverride="15"
+                    className="font-black"
+                  />{" "}
+                  diseases get their first effective treatment each year. At that rate, clearing today&apos;s
+                  treatment backlog takes{" "}
+                  <ParameterValue
+                    param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
+                    format={{ precision: 0 }}
+                    className="font-black"
+                  />{" "}
+                  years.
+                </p>
                 <div
-                  aria-label={`Modeled timeline falls from ${Math.round(STATUS_QUO_QUEUE_CLEARANCE_YEARS.value)} years to ${Math.round(DFDA_QUEUE_CLEARANCE_YEARS.value)} years`}
+                  aria-label={`Disease eradication timeline falls from ${Math.round(STATUS_QUO_QUEUE_CLEARANCE_YEARS.value)} years to ${Math.round(DFDA_QUEUE_CLEARANCE_YEARS.value)} years`}
                   className="space-y-6"
                   role="group"
                 >
                   <div>
                     <div className="mb-2 flex items-end justify-between gap-4 font-black uppercase">
-                      <span>Current pace</span>
+                      <span>Today&apos;s treatment rate</span>
                       <span className="text-3xl">
                         <ParameterValue param={STATUS_QUO_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} /> years
                       </span>
@@ -336,7 +358,10 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                   </div>
                   <div>
                     <div className="mb-2 flex items-end justify-between gap-4 font-black uppercase">
-                      <span>Expanded trial capacity</span>
+                      <span>
+                        With <ParameterValue param={DFDA_TRIAL_CAPACITY_MULTIPLIER} format={{ precision: 1 }} /> trial
+                        capacity
+                      </span>
                       <span className="text-3xl text-brutal-pink">
                         <ParameterValue param={DFDA_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} /> years
                       </span>
@@ -349,8 +374,9 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                     </div>
                   </div>
                   <p className="text-base font-bold text-center">
-                    <ParameterValue param={DFDA_TRIAL_CAPACITY_MULTIPLIER} format={{ precision: 1 }} /> more trial
-                    capacity at <ParameterValue param={DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL} /> per year
+                    <ParameterValue param={DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL} /> per year funds{" "}
+                    <ParameterValue param={DFDA_TRIAL_CAPACITY_MULTIPLIER} format={{ precision: 1 }} /> as many
+                    patient trial slots.
                   </p>
                 </div>
               </Card>
@@ -371,12 +397,12 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                     stat: (
                       <ParameterValue param={DFDA_TRIAL_CAPACITY_MULTIPLIER} format={{ precision: 1 }} />
                     ),
-                    label: "CAPACITY INCREASE",
+                    label: "PATIENT TRIAL CAPACITY",
                     detail: (
                       <>
-                        At the model&apos;s{" "}
-                        <ParameterValue param={DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL} /> annual funding level,
-                        scaling pragmatic trials compresses the disease eradication timeline from{" "}
+                        <ParameterValue param={DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL} /> per year funds{" "}
+                        <ParameterValue param={DFDA_TRIAL_CAPACITY_MULTIPLIER} format={{ precision: 1 }} /> as many
+                        patient trial slots, cutting the disease eradication timeline from{" "}
                         <ParameterValue param={STATUS_QUO_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} />{" "}
                         years to{" "}
                         <ParameterValue param={DFDA_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} /> years.
@@ -393,9 +419,9 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                   },
                   {
                     stat: "89 DAYS",
-                    label: "FIRST PATIENT TO RESULT",
+                    label: "89 DAYS TO A TREATMENT RESULT",
                     detail:
-                      "March 19 to June 16, 2020; RECOVERY produced three actionable results within 100 days.",
+                      "March 19 to June 16, 2020; RECOVERY produced three treatment findings within 100 days.",
                     color: "bg-brutal-cyan",
                   },
                 ].map((item, i) => (
@@ -415,13 +441,13 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
               </h2>
               <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-brutal-yellow">
                 <div
-                  aria-label="Annual military spending is $2.718 trillion versus $4.5 billion in government clinical trial spending"
+                  aria-label="Annual weapons and military spending is $2.718 trillion versus $4.5 billion in publicly funded clinical trial spending"
                   className="space-y-6"
                   role="group"
                 >
                   <div>
                     <div className="mb-2 flex items-end justify-between gap-4 font-black uppercase">
-                      <span>Military spending</span>
+                      <span>Annual weapons and military spending</span>
                       <span className="text-3xl">$2.718T</span>
                     </div>
                     <div className="h-12 border-4 border-primary bg-background">
@@ -430,7 +456,7 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                   </div>
                   <div>
                     <div className="mb-2 flex items-end justify-between gap-4 font-black uppercase">
-                      <span>Clinical trial spending</span>
+                      <span>Annual publicly funded clinical trial spending</span>
                       <span className="text-3xl text-brutal-pink">
                         <ParameterValue
                           param={GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL}
@@ -449,13 +475,13 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                 <div className="mt-8 grid gap-4 text-center sm:grid-cols-2">
                   <div className="border-4 border-primary bg-background p-4">
                     <div className="text-3xl font-black">{governmentTrialShareOfMilitarySpending.toFixed(3)}%</div>
-                    <div className="text-sm font-black uppercase">Trial share of military spending</div>
+                    <div className="text-sm font-black uppercase">Trial share of weapons and military spending</div>
                   </div>
                   <div className="border-4 border-primary bg-background p-4">
                     <div className="text-3xl font-black">
                       <ParameterValue param={MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO} format={{ precision: 0 }} />
                     </div>
-                    <div className="text-sm font-black uppercase">Military dollars per trial dollar</div>
+                    <div className="text-sm font-black uppercase">Weapons and military dollars per public trial dollar</div>
                   </div>
                 </div>
               </Card>
@@ -467,19 +493,20 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                 <div className="space-y-5 text-lg leading-relaxed">
                   <p>
                     Pragmatic trials are legal. Doctors can generally prescribe approved drugs off-label,
-                    but a systematic study adds research duties: an IND unless exempt, IRB review, consent,
-                    privacy approval, safety reporting, contracts, data systems, and an accountable sponsor.
-                    Insurance may cover routine care without paying for the research work.
+                    but a systematic study adds research duties: an FDA investigational new drug application
+                    unless exempt, ethics review, consent, privacy approval, safety reporting, contracts, data
+                    systems, and a research sponsor. Insurance may cover routine care without paying for the
+                    research work.
                   </p>
                   <p>
-                    Universal access needs reusable protocols, central review, proportionate rules for
-                    minimal-risk comparisons, reliable funding, interoperable records, and a shared trial
-                    network to handle monitoring, reporting, and liability.
+                    Universal access needs reusable study plans, central ethics review, simpler rules for
+                    low-risk comparisons, reliable funding, connected health records, and a shared trial network
+                    to handle monitoring, reporting, and liability.
                   </p>
                 </div>
               </Card>
               <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-brutal-cyan">
-                <h3 className="text-2xl font-black uppercase mb-3">Right to try is narrower</h3>
+                <h3 className="text-2xl font-black uppercase mb-3">Right to Try does not create trials</h3>
                 <p className="text-base font-bold leading-relaxed">
                   Federal Right to Try covers some patients with life-threatening conditions who cannot
                   join a relevant trial. Montana&apos;s 2025 SB 535 also created licensed experimental-treatment
@@ -506,8 +533,8 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                   </div>
                   <div className="text-base font-bold leading-relaxed">
                     <p>
-                      A verified majority could make private preferences common knowledge and create an
-                      election-scale mandate for trial access and funding reform.
+                      If 51% of people publicly verify their support, governments can see an election-scale
+                      mandate for laws and public funding that let patients join trials through their physicians.
                     </p>
                   </div>
                 </div>

--- a/packages/site-kit/src/components/research-page.tsx
+++ b/packages/site-kit/src/components/research-page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next"
 import Link from "next/link"
-import type { ReactNode } from "react"
 
 import Layout from "./layout"
 import { ParameterValue } from "./shared/ParameterValue"
@@ -51,61 +50,21 @@ const queueStatusQuo = formatParameter(STATUS_QUO_QUEUE_CLEARANCE_YEARS)
 const queueCompressed = formatParameter(DFDA_QUEUE_CLEARANCE_YEARS)
 const livesSaved = formatParameter(DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_LIVES_SAVED)
 const trialCapacityMultiplier = formatParameter(DFDA_TRIAL_CAPACITY_MULTIPLIER, { precision: 1 })
-
-const SIPRI_2024_MILITARY_SPENDING_USD = 2_718_000_000_000
-const SURVEY_MAJORITY_SHARE = 0.51
-const GOVERNMENT_TRIAL_SHARE_OF_MILITARY_PCT =
-  (GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.value / SIPRI_2024_MILITARY_SPENDING_USD) * 100
-const RECOVERY_DAYS_TO_DEXAMETHASONE = Math.round(
-  (Date.UTC(2020, 5, 16) - Date.UTC(2020, 2, 19)) / (24 * 60 * 60 * 1000)
-)
+const governmentTrialSpendingRange = GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.confidenceInterval
+  ?.map((value) => formatParameter({ ...GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL, value }))
+  .join("–")
+const governmentTrialShareOfMilitarySpending =
+  (GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.value / 2_718_000_000_000) * 100
 const surveyMajorityTarget: Parameter = {
   ...GLOBAL_POPULATION_2024,
-  value: GLOBAL_POPULATION_2024.value * SURVEY_MAJORITY_SHARE,
+  value: GLOBAL_POPULATION_2024.value * 0.51,
   parameterName: "SURVEY_MAJORITY_RESPONSE_TARGET",
-  displayName: "51% global response threshold",
-  description: "Current global-population parameter multiplied by 51%.",
+  displayName: "51% of the current global population",
   sourceType: "calculated",
   formula: "GLOBAL_POPULATION_2024 × 51%",
   inputs: ["GLOBAL_POPULATION_2024"],
   computeExpr: "GLOBAL_POPULATION_2024 * 0.51",
 }
-const pivotalTrialMedianCostPerParticipant: Parameter = {
-  ...TRADITIONAL_PHASE3_COST_PER_PATIENT,
-  value: 41_413,
-  parameterName: "PIVOTAL_TRIAL_MEDIAN_COST_PER_PARTICIPANT",
-  displayName: "Pivotal trial median cost per participant",
-  description:
-    "Median estimated cost per enrolled participant across 225 pivotal trials supporting US drug approvals from 2015 through 2017.",
-  sourceRef: undefined,
-  sourceUrl: "https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/",
-  calculationsUrl: undefined,
-  manualPageUrl: undefined,
-  manualPageTitle: undefined,
-  confidenceInterval: undefined,
-}
-const embeddedPragmaticTrialMedianCostPerParticipant: Parameter = {
-  ...DFDA_PRAGMATIC_TRIAL_COST_PER_PATIENT,
-  value: 97,
-  parameterName: "EMBEDDED_PRAGMATIC_TRIAL_MEDIAN_COST_PER_PARTICIPANT",
-  displayName: "Embedded pragmatic trial median cost per participant",
-  description:
-    "Median research cost per randomized participant among 64 embedded pragmatic trials with available cost data.",
-  sourceRef: undefined,
-  sourceUrl: "https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/",
-  calculationsUrl: undefined,
-  manualPageUrl: undefined,
-  manualPageTitle: undefined,
-  confidenceInterval: undefined,
-}
-const governmentTrialSpendingRange = GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.confidenceInterval
-  ?.map((value) =>
-    formatParameter({
-      ...GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL,
-      value,
-    })
-  )
-  .join("–")
 
 const headlineStats: StatCardProps[] = [
   {
@@ -286,8 +245,309 @@ export function generateSurveyResearchMetadata(): Metadata {
 }
 
 export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
+
+  // Survey variant: concise evidence page in the survey's original style.
   if (variant === "survey") {
-    return <SurveyResearchPage />
+    return (
+      <Layout>
+        <div className="min-h-screen bg-background">
+          {/* Neutral Hero */}
+          <SectionContainer bgColor="foreground" borderPosition="bottom" padding="lg">
+            <Container size="md">
+              <h1 className="text-4xl sm:text-5xl md:text-6xl font-black uppercase text-center mb-6">
+                CLINICAL TRIAL EVIDENCE &<br />
+                <span className="text-brutal-cyan">DATA SOURCES</span>
+              </h1>
+              <p className="text-lg sm:text-xl font-bold text-center max-w-2xl mx-auto">
+                Peer-reviewed evidence on pragmatic clinical trials and the assumptions behind the survey&apos;s
+                capacity model.
+              </p>
+            </Container>
+          </SectionContainer>
+
+          {/* Pragmatic Trials Evidence */}
+          <SectionContainer bgColor="background" borderPosition="none" padding="lg">
+            <Container size="md" className="space-y-8">
+              <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8">
+                WHAT ARE <span className="text-brutal-pink">PRAGMATIC TRIALS?</span>
+              </h2>
+              <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                <div className="space-y-6 text-lg leading-relaxed">
+                  <p>
+                    Pragmatic clinical trials test treatments in{" "}
+                    <span className="font-black">real-world healthcare settings</span> using existing
+                    medical records and routine care, rather than creating expensive artificial research
+                    environments.
+                  </p>
+                  <p>
+                    The landmark{" "}
+                    <span className="font-black text-brutal-pink">RECOVERY trial</span> at Oxford
+                    University demonstrated this approach at scale. Embedded in routine NHS care, it
+                    enrolled 40,000+ patients across 176 hospitals and produced three actionable
+                    treatment results within 100 days.
+                  </p>
+                  <p>
+                    It recruited its first patient on March 19, 2020, and announced the dexamethasone
+                    mortality result <span className="font-black">89 days later</span>. The result is
+                    estimated to have saved over <span className="font-black">1 million lives</span>.
+                  </p>
+                  <p>
+                    RECOVERY cost about <ParameterValue param={RECOVERY_TRIAL_COST_PER_PATIENT} /> per
+                    patient, compared with a $41,413 median for pivotal drug trials—about{" "}
+                    <ParameterValue param={RECOVERY_TRIAL_COST_REDUCTION_FACTOR} className="font-black" />.
+                    A separate review of 64 embedded trials found a $97 median. These studies show the
+                    cost potential; they do not set one price for every pragmatic trial.
+                  </p>
+                </div>
+              </Card>
+
+              <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8 pt-8">
+                TIMELINE <span className="text-brutal-pink">COMPRESSION</span>
+              </h2>
+              <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-brutal-yellow">
+                <div className="space-y-4 text-lg leading-relaxed">
+                  <p>
+                    At the current rate of ~15 diseases per year receiving a first effective treatment,
+                    finding treatments for all ~6,650 currently untreatable diseases would take an
+                    estimated{" "}
+                    <ParameterValue
+                      param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
+                      format={{ precision: 0 }}
+                      className="font-black"
+                    />{" "}
+                    <span className="font-black">years</span>.
+                  </p>
+                  <p>
+                    At the modeled funding level of about{" "}
+                    <ParameterValue param={DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL} className="font-black" />{" "}
+                    per year, scaling pragmatic trials would increase clinical trial capacity by{" "}
+                    <ParameterValue
+                      param={DFDA_TRIAL_CAPACITY_MULTIPLIER}
+                      format={{ precision: 1 }}
+                      className="font-black text-brutal-pink"
+                    />, compressing that timeline to approximately{" "}
+                    <ParameterValue
+                      param={DFDA_QUEUE_CLEARANCE_YEARS}
+                      format={{ precision: 0 }}
+                      className="font-black text-brutal-pink"
+                    />{" "}
+                    <span className="font-black text-brutal-pink">years</span>.
+                  </p>
+                </div>
+              </Card>
+
+              <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8 pt-8">
+                KEY <span className="text-brutal-pink">FINDINGS</span>
+              </h2>
+              <div className="grid md:grid-cols-2 gap-6">
+                {[
+                  {
+                    stat: <ParameterValue param={RECOVERY_TRIAL_COST_REDUCTION_FACTOR} />,
+                    label: "RECOVERY COST COMPARISON",
+                    detail:
+                      "About $500 per RECOVERY participant versus a $41,413 pivotal-trial median.",
+                    color: "bg-brutal-cyan",
+                  },
+                  {
+                    stat: (
+                      <ParameterValue param={DFDA_TRIAL_CAPACITY_MULTIPLIER} format={{ precision: 1 }} />
+                    ),
+                    label: "CAPACITY INCREASE",
+                    detail: (
+                      <>
+                        At the model&apos;s{" "}
+                        <ParameterValue param={DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL} /> annual funding level,
+                        scaling pragmatic trials compresses the disease eradication timeline from{" "}
+                        <ParameterValue param={STATUS_QUO_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} />{" "}
+                        years to{" "}
+                        <ParameterValue param={DFDA_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} /> years.
+                      </>
+                    ),
+                    color: "bg-brutal-yellow",
+                  },
+                  {
+                    stat: "1M+",
+                    label: "LIVES SAVED (RECOVERY)",
+                    detail:
+                      "RECOVERY's identification of dexamethasone as an effective treatment saved over 1 million lives globally.",
+                    color: "bg-brutal-pink",
+                  },
+                  {
+                    stat: "89 DAYS",
+                    label: "FIRST PATIENT TO RESULT",
+                    detail:
+                      "March 19 to June 16, 2020; RECOVERY produced three actionable results within 100 days.",
+                    color: "bg-brutal-cyan",
+                  },
+                ].map((item, i) => (
+                  <Card
+                    key={i}
+                    className={`${item.color} border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}
+                  >
+                    <div className="text-3xl sm:text-4xl font-black mb-1">{item.stat}</div>
+                    <div className="text-sm font-black uppercase mb-3">{item.label}</div>
+                    <p className="text-sm font-bold">{item.detail}</p>
+                  </Card>
+                ))}
+              </div>
+
+              <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8 pt-8">
+                PUBLIC SPENDING <span className="text-brutal-pink">GAP</span>
+              </h2>
+              <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-brutal-yellow">
+                <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4 text-center mb-6">
+                  <div>
+                    <div className="text-3xl font-black">$2.718T</div>
+                    <div className="text-sm font-black uppercase">2024 military spending</div>
+                  </div>
+                  <div>
+                    <div className="text-3xl font-black">
+                      <ParameterValue param={GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL} valueOverride="$4.5B" />
+                    </div>
+                    <div className="text-sm font-black uppercase">Government trial estimate</div>
+                  </div>
+                  <div>
+                    <div className="text-3xl font-black">{governmentTrialShareOfMilitarySpending.toFixed(3)}%</div>
+                    <div className="text-sm font-black uppercase">Trial share</div>
+                  </div>
+                  <div>
+                    <div className="text-3xl font-black">
+                      <ParameterValue param={MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO} format={{ precision: 0 }} />
+                    </div>
+                    <div className="text-sm font-black uppercase">Military dollars per $1</div>
+                  </div>
+                </div>
+                <div className="space-y-3 text-base font-bold leading-relaxed">
+                  <p>
+                    This is a government-to-government comparison. No complete global accounting exists,
+                    so the $4.5 billion trial figure is our estimate; its range is {governmentTrialSpendingRange}.
+                  </p>
+                  <p>
+                    Including private trial spending raises the denominator to about{" "}
+                    <ParameterValue param={GLOBAL_CLINICAL_TRIALS_SPENDING_ANNUAL} /> and lowers the ratio to about{" "}
+                    <ParameterValue param={MILITARY_TO_CLINICAL_TRIALS_SPENDING_RATIO} format={{ precision: 0 }} />.
+                  </p>
+                </div>
+              </Card>
+
+              <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8 pt-8">
+                WHY CAN&apos;T EVERY DOCTOR <span className="text-brutal-pink">OFFER A TRIAL?</span>
+              </h2>
+              <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                <div className="space-y-5 text-lg leading-relaxed">
+                  <p>
+                    Pragmatic trials are legal. Doctors can generally prescribe approved drugs off-label,
+                    but a systematic study adds research duties: an IND unless exempt, IRB review, consent,
+                    privacy approval, safety reporting, contracts, data systems, and an accountable sponsor.
+                    Insurance may cover routine care without paying for the research work.
+                  </p>
+                  <p>
+                    Universal access needs reusable protocols, central review, proportionate rules for
+                    minimal-risk comparisons, reliable funding, interoperable records, and a shared trial
+                    network to handle monitoring, reporting, and liability.
+                  </p>
+                </div>
+              </Card>
+              <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-brutal-cyan">
+                <h3 className="text-2xl font-black uppercase mb-3">Right to try is narrower</h3>
+                <p className="text-base font-bold leading-relaxed">
+                  Federal Right to Try covers some patients with life-threatening conditions who cannot
+                  join a relevant trial. Montana&apos;s 2025 SB 535 also created licensed experimental-treatment
+                  centers; final rules took effect July 25, 2026. These laws expand treatment access, but
+                  they do not require treatment supply, payment, trial enrollment, randomization, or useful
+                  comparative evidence.
+                </p>
+              </Card>
+
+              <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8 pt-8">
+                WHAT COULD A <span className="text-brutal-pink">GLOBAL MAJORITY</span> CHANGE?
+              </h2>
+              <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-brutal-pink">
+                <div className="grid gap-6 md:grid-cols-[0.35fr_1fr] md:items-center">
+                  <div className="text-center">
+                    <div className="text-6xl font-black">51%</div>
+                    <div className="text-lg font-black">
+                      <ParameterValue param={surveyMajorityTarget} valueOverride="4.08B" /> people
+                    </div>
+                  </div>
+                  <div className="space-y-4 text-base font-bold leading-relaxed">
+                    <p>
+                      A verified majority could make private preferences common knowledge and create an
+                      election-scale mandate for trial access and funding reform.
+                    </p>
+                    <p className="font-black">
+                      Verified preferences → public mandate → access and funding reform → more physician-embedded
+                      trials → faster evidence → earlier treatment → less disease
+                    </p>
+                    <p>
+                      The survey would not change law by itself. Patients and physicians must participate;
+                      health systems must embed trials; researchers must publish; foundations and insurers
+                      must fund; developers must supply treatments; and politicians and governments must act.
+                    </p>
+                  </div>
+                </div>
+              </Card>
+              <Card className="p-6 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-brutal-yellow text-sm font-bold leading-relaxed">
+                A credible majority requires one verified response per person, transparent methods,
+                country results, separate representative and self-selected samples, clear translations,
+                published recruitment sources, respondent privacy, and concrete follow-up paths.
+              </Card>
+
+              <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8 pt-8">
+                <span className="text-brutal-pink">SOURCES</span>
+              </h2>
+              <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                <ul className="space-y-4 text-base leading-relaxed">
+                  <li>
+                    <a className="font-black underline" href="https://www.ndm.ox.ac.uk/covid-19/covid-research/drug-trials-recovery" target="_blank" rel="noopener noreferrer">Oxford RECOVERY</a>
+                    {" — "}design, enrollment, dates, results, and NHS integration.
+                  </li>
+                  <li>
+                    <a className="font-black underline" href="https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/" target="_blank" rel="noopener noreferrer">Pivotal trial costs</a>
+                    {" and "}
+                    <a className="font-black underline" href="https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/" target="_blank" rel="noopener noreferrer">embedded pragmatic trial costs</a>.
+                  </li>
+                  <li>
+                    <a className="font-black underline" href="https://www.sipri.org/publications/2025/sipri-fact-sheets/trends-world-military-expenditure-2024" target="_blank" rel="noopener noreferrer">SIPRI military spending</a>
+                    {" — "}the $2.718 trillion 2024 estimate.
+                  </li>
+                  <li>
+                    <a className="font-black underline" href="https://www.fda.gov/drugs/investigational-new-drug-ind-application/ind-application-procedures-exemptions-ind-requirements" target="_blank" rel="noopener noreferrer">FDA IND rules</a>,{" "}
+                    <a className="font-black underline" href="https://www.hhs.gov/ohrp/regulations-and-policy/regulations/45-cfr-46/index.html" target="_blank" rel="noopener noreferrer">Common Rule</a>,{" "}
+                    <a className="font-black underline" href="https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/research/index.html" target="_blank" rel="noopener noreferrer">HIPAA research rules</a>, and{" "}
+                    <a className="font-black underline" href="https://www.cms.gov/medicare-coverage-database/view/ncd.aspx?NCDId=1&NCDver=3" target="_blank" rel="noopener noreferrer">Medicare trial coverage</a>.
+                  </li>
+                  <li>
+                    <a className="font-black underline" href="https://www.fda.gov/patients/learn-about-expanded-access-and-other-treatment-options/right-try" target="_blank" rel="noopener noreferrer">Federal Right to Try</a>
+                    {" and "}
+                    <a className="font-black underline" href="https://archive.legmt.gov/content/Sessions/69th/Contractor_index/CH0621.pdf" target="_blank" rel="noopener noreferrer">Montana SB 535</a>.
+                  </li>
+                </ul>
+              </Card>
+            </Container>
+          </SectionContainer>
+
+          {/* CTA */}
+          <CTASection
+            bgColor="yellow"
+            heading={
+              <>
+                TAKE THE
+                <br />
+                <span className="text-foreground">SURVEY</span>
+              </>
+            }
+          >
+            <Button
+              asChild
+              className="h-14 bg-foreground text-background border-4 border-foreground hover:bg-background hover:text-foreground px-8 sm:px-12 text-lg font-black uppercase"
+            >
+              <Link href="/#vote">Take the survey</Link>
+            </Button>
+          </CTASection>
+        </div>
+      </Layout>
+    )
   }
 
   return (
@@ -499,756 +759,6 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
         </SectionContainer>
       </div>
     </Layout>
-  )
-}
-
-function SurveyResearchPage() {
-  const coordinationActors = [
-    ["Patients", "Ask about eligible trials, contribute outcomes, and identify unanswered treatment questions."],
-    ["Physicians", "Offer eligible patients trial participation through routine care."],
-    ["Health systems", "Embed randomization and outcome collection in clinical workflows and records."],
-    ["Researchers", "Publish reusable protocols, interoperable measures, and transparent analyses."],
-    ["Foundations", "Fund shared trial infrastructure and questions that lack commercial incentives."],
-    ["Insurers", "Support routine-care trial participation and evidence generation for covered treatments."],
-    ["Treatment developers", "Supply interventions and support comparative studies, including low-margin uses."],
-    ["Politicians", "Propose access, funding, privacy, and interoperability reforms."],
-    ["Governments", "Fund public trial networks and coordinate standards across borders."],
-  ]
-  const coordinationConditions = [
-    "One verified response per person",
-    "Transparent methodology",
-    "Country-level results",
-    "Representative-sample reporting kept separate from self-selected participation",
-    "Clear translations",
-    "Published recruitment sources",
-    "Protection of respondent privacy",
-    "Concrete follow-up paths for patients, physicians, organizations, funders, and governments",
-  ]
-  const coordinationChain = [
-    "Verified preferences",
-    "Common knowledge and political mandate",
-    "Trial-access and funding reforms",
-    "More physician-embedded pragmatic trials",
-    "Faster evidence",
-    "Earlier adoption of effective treatments",
-    "Reduced disease burden",
-  ]
-
-  return (
-    <Layout>
-      <div className="min-h-screen bg-background">
-        <SectionContainer bgColor="foreground" borderPosition="bottom" padding="lg">
-          <Container size="xl">
-            <div className="mx-auto max-w-5xl text-center text-background">
-              <p className="mb-4 text-sm font-black uppercase tracking-[0.2em] text-brutal-cyan">
-                Independent research initiative
-              </p>
-              <h1 className="mb-6 text-4xl font-black uppercase leading-none sm:text-5xl md:text-6xl">
-                Evidence behind the
-                <br />
-                <span className="text-brutal-pink">Trial Abundance Survey</span>
-              </h1>
-              <p className="mx-auto max-w-3xl text-lg font-bold sm:text-xl">
-                The three-question survey stays brief. This page separates observed evidence from estimates, model
-                projections, and a coordination hypothesis about what verified public preferences could change.
-              </p>
-            </div>
-          </Container>
-        </SectionContainer>
-
-        <SectionContainer bgColor="background" borderPosition="bottom" padding="lg">
-          <Container size="xl">
-            <div className="mb-8 max-w-4xl">
-              <h2 className="mb-3 text-3xl font-black uppercase md:text-4xl">How to read the claims</h2>
-              <p className="text-lg font-bold">
-                The label on each claim matters. A published observation is not the same thing as an estimated global
-                denominator, a model output, or a forecast about collective action.
-              </p>
-            </div>
-            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-              <EvidenceTypeCard
-                label="Observed evidence"
-                color="bg-brutal-cyan"
-                description="Dates, trial results, designs, and study findings reported by the cited institutions or papers."
-              />
-              <EvidenceTypeCard
-                label="Estimate"
-                color="bg-brutal-yellow"
-                description="A best current approximation used where no complete global accounting exists."
-              />
-              <EvidenceTypeCard
-                label="Model projection"
-                color="bg-background"
-                description="A calculated scenario that depends on explicit inputs and assumptions."
-              />
-              <EvidenceTypeCard
-                label="Coordination hypothesis"
-                color="bg-brutal-pink text-white"
-                description="A plausible pathway to test, not an observed survey result or an automatic policy effect."
-              />
-            </div>
-          </Container>
-        </SectionContainer>
-
-        <SectionContainer bgColor="yellow" borderPosition="bottom" padding="lg">
-          <Container size="xl">
-            <div className="mb-8 max-w-4xl">
-              <p className="mb-3 text-sm font-black uppercase tracking-[0.2em]">Observed input + model estimate</p>
-              <h2 className="mb-4 text-3xl font-black uppercase md:text-5xl">Government spending context</h2>
-              <p className="text-lg font-bold">
-                The survey&apos;s allocation question compares two categories of government spending. It does not
-                compare military spending with all public and private medical research.
-              </p>
-            </div>
-
-            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-              <ResearchStatCard
-                label="Observed: military spending"
-                value={
-                  <a
-                    href="https://www.sipri.org/publications/2025/sipri-fact-sheets/trends-world-military-expenditure-2024"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline decoration-4 underline-offset-4"
-                  >
-                    $2.718T
-                  </a>
-                }
-                detail="SIPRI's estimate of world military expenditure in 2024."
-                color="bg-background"
-              />
-              <ResearchStatCard
-                label="Estimate: government trials"
-                value={
-                  <ParameterValue
-                    param={GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL}
-                    valueOverride="$4.5B"
-                    className="font-black"
-                  />
-                }
-                detail={`Current annual model estimate; uncertainty range ${governmentTrialSpendingRange}.`}
-                color="bg-brutal-cyan"
-              />
-              <ResearchStatCard
-                label="Calculated share"
-                value={`${GOVERNMENT_TRIAL_SHARE_OF_MILITARY_PCT.toFixed(3)}%`}
-                detail="$4.5 billion as a share of SIPRI's $2.718 trillion estimate."
-                color="bg-background"
-              />
-              <ResearchStatCard
-                label="Calculated ratio"
-                value={
-                  <ParameterValue
-                    param={MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO}
-                    format={{ precision: 0 }}
-                    className="font-black"
-                  />
-                }
-                detail="About $604 in military spending for every $1 in government clinical-trial spending."
-                color="bg-brutal-pink text-white"
-              />
-            </div>
-
-            <Card className="mt-8 gap-5 border-4 border-primary bg-background p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8">
-              <h3 className="text-2xl font-black uppercase">What the denominator does—and does not—mean</h3>
-              <div className="space-y-4 text-base font-bold leading-relaxed sm:text-lg">
-                <p>
-                  This is explicitly a{" "}
-                  <span className="font-black text-brutal-pink">government-to-government comparison</span>: global
-                  military expenditure versus estimated government spending on interventional clinical trials.
-                </p>
-                <p>
-                  No authoritative organization publishes a complete global accounting of government spending on
-                  interventional trials across every country. The{" "}
-                  <ParameterValue param={GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL} valueOverride="$4.5B" />{" "}
-                  denominator is therefore an estimate, not an observed world total. The current model uses a{" "}
-                  {governmentTrialSpendingRange} uncertainty range.
-                </p>
-                <p>
-                  Including private pharmaceutical trial spending and other non-government funding produces a
-                  substantially smaller comparison. The current all-trials estimate is{" "}
-                  <ParameterValue param={GLOBAL_CLINICAL_TRIALS_SPENDING_ANNUAL} />, which yields about{" "}
-                  <ParameterValue param={MILITARY_TO_CLINICAL_TRIALS_SPENDING_RATIO} format={{ precision: 0 }} />. That
-                  broader ratio answers a different question from the survey&apos;s public-budget comparison.
-                </p>
-              </div>
-            </Card>
-          </Container>
-        </SectionContainer>
-
-        <SectionContainer bgColor="background" borderPosition="bottom" padding="lg">
-          <Container size="xl">
-            <div className="mb-8 max-w-4xl">
-              <p className="mb-3 text-sm font-black uppercase tracking-[0.2em] text-brutal-pink">Observed evidence</p>
-              <h2 className="mb-4 text-3xl font-black uppercase md:text-5xl">What RECOVERY demonstrated</h2>
-              <p className="text-lg font-bold">
-                RECOVERY used a simple adaptive design embedded in routine NHS care. Existing clinical workflows and
-                routinely collected data reduced additional burden while preserving randomized comparisons.
-              </p>
-            </div>
-
-            <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
-              <ResearchStatCard
-                label="First patient"
-                value="19 MAR 2020"
-                detail="Oxford reports that RECOVERY recruited its first patient nine days after the protocol was drafted."
-                color="bg-brutal-cyan"
-              />
-              <ResearchStatCard
-                label="Dexamethasone result"
-                value="16 JUN 2020"
-                detail="The trial announced the first treatment shown to reduce COVID-19 mortality."
-                color="bg-brutal-yellow"
-              />
-              <ResearchStatCard
-                label="Elapsed time"
-                value={`${RECOVERY_DAYS_TO_DEXAMETHASONE} DAYS`}
-                detail="Calendar days from the first recruited patient to the dexamethasone announcement."
-                color="bg-background"
-              />
-              <ResearchStatCard
-                label="First 100 days"
-                value="3 TREATMENTS"
-                detail="Actionable results for hydroxychloroquine, dexamethasone, and lopinavir-ritonavir."
-                color="bg-brutal-pink text-white"
-              />
-            </div>
-
-            <Card className="mt-8 gap-6 border-4 border-primary bg-brutal-cyan p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8">
-              <div>
-                <p className="mb-2 text-sm font-black uppercase tracking-[0.2em]">Cost evidence</p>
-                <h3 className="text-2xl font-black uppercase sm:text-3xl">
-                  Large potential, not one universal multiplier
-                </h3>
-              </div>
-              <div className="grid gap-4">
-                <ComparisonRow
-                  label="RECOVERY estimate"
-                  value={<ParameterValue param={RECOVERY_TRIAL_COST_PER_PATIENT} className="font-black" />}
-                  detail="Approximate per-participant estimate for one unusually streamlined emergency platform trial."
-                />
-                <ComparisonRow
-                  label="Pivotal approval trials"
-                  value={
-                    <ParameterValue
-                      param={pivotalTrialMedianCostPerParticipant}
-                      valueOverride="$41,413"
-                      className="font-black"
-                    />
-                  }
-                  detail="Peer-reviewed median estimate per participant across 225 pivotal trials supporting drug approvals."
-                />
-                <ComparisonRow
-                  label="Embedded pragmatic trials"
-                  value={
-                    <ParameterValue
-                      param={embeddedPragmaticTrialMedianCostPerParticipant}
-                      valueOverride="$97"
-                      className="font-black"
-                    />
-                  }
-                  detail="Median research cost per randomized participant among 64 trials with available cost data."
-                />
-              </div>
-              <p className="text-base font-bold leading-relaxed sm:text-lg">
-                Dividing the pivotal-trial median by the RECOVERY estimate produces the familiar approximately{" "}
-                <ParameterValue param={RECOVERY_TRIAL_COST_REDUCTION_FACTOR} className="font-black" /> comparison. It is
-                a RECOVERY-versus-pivotal-trial comparison, not a guaranteed saving for every pragmatic trial. The
-                studies cover heterogeneous interventions, health systems, accounting methods, and trial designs.
-                Together they show major cost potential, not a universal multiplier.
-              </p>
-              <p className="text-sm font-bold">
-                Sources: Oxford&apos;s{" "}
-                <a
-                  href="https://www.ndm.ox.ac.uk/covid-19/covid-research/drug-trials-recovery"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline decoration-2 underline-offset-2"
-                >
-                  RECOVERY account
-                </a>
-                , the{" "}
-                <a
-                  href="https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline decoration-2 underline-offset-2"
-                >
-                  pivotal-trial cost study
-                </a>
-                , and the{" "}
-                <a
-                  href="https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline decoration-2 underline-offset-2"
-                >
-                  embedded pragmatic-trial review
-                </a>
-                .
-              </p>
-            </Card>
-          </Container>
-        </SectionContainer>
-
-        <SurveyRegulatorySection />
-
-        <SectionContainer bgColor="cyan" borderPosition="bottom" padding="lg">
-          <Container size="xl">
-            <div className="mb-8 max-w-4xl">
-              <p className="mb-3 text-sm font-black uppercase tracking-[0.2em]">
-                Model projection—not an observed outcome
-              </p>
-              <h2 className="mb-4 text-3xl font-black uppercase md:text-5xl">How the capacity scenario is built</h2>
-              <p className="text-lg font-bold">
-                The model uses a deliberately conservative pragmatic-trial cost input rather than treating
-                RECOVERY&apos;s emergency result as universally reproducible. Its outputs change when the inputs change.
-              </p>
-            </div>
-            <div className="grid gap-6 md:grid-cols-3">
-              <ResearchStatCard
-                label="Central cost input"
-                value={<ParameterValue param={DFDA_PRAGMATIC_TRIAL_COST_PER_PATIENT} className="font-black" />}
-                detail="Per participant, with an uncertainty interval informed by embedded-trial evidence and more complex trials."
-                color="bg-background"
-              />
-              <ResearchStatCard
-                label="Projected capacity"
-                value={
-                  <ParameterValue
-                    param={DFDA_TRIAL_CAPACITY_MULTIPLIER}
-                    format={{ precision: 1 }}
-                    className="font-black"
-                  />
-                }
-                detail="Scenario output at the model's trial-funding level, not an observed global expansion."
-                color="bg-brutal-yellow"
-              />
-              <ResearchStatCard
-                label="Projected queue"
-                value={
-                  <>
-                    <ParameterValue param={STATUS_QUO_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} />
-                    {" → "}
-                    <ParameterValue param={DFDA_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} />
-                    {" years"}
-                  </>
-                }
-                detail="Modeled treatment-research queue under current versus expanded capacity assumptions."
-                color="bg-brutal-pink text-white"
-              />
-            </div>
-          </Container>
-        </SectionContainer>
-
-        <SectionContainer bgColor="background" borderPosition="bottom" padding="lg">
-          <Container size="xl">
-            <div className="mb-8 max-w-5xl">
-              <p className="mb-3 text-sm font-black uppercase tracking-[0.2em] text-brutal-pink">
-                Coordination hypothesis—not an observed survey result
-              </p>
-              <h2 className="mb-4 text-3xl font-black uppercase md:text-5xl">What could a global majority change?</h2>
-              <p className="text-lg font-bold">
-                A verified majority would not enact a law by itself. It could create an election-scale public mandate
-                and coordination event that institutions can respond to independently.
-              </p>
-            </div>
-
-            <Card className="mb-8 gap-5 border-4 border-primary bg-brutal-yellow p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8">
-              <div className="grid gap-6 lg:grid-cols-[0.65fr_1.35fr] lg:items-center">
-                <div>
-                  <p className="text-6xl font-black sm:text-7xl">51%</p>
-                  <p className="mt-2 text-3xl font-black">
-                    <ParameterValue param={surveyMajorityTarget} format={{ precision: 2 }} />
-                  </p>
-                  <p className="mt-2 text-sm font-black uppercase">people at the current checked-in population input</p>
-                </div>
-                <div className="space-y-4 text-base font-bold leading-relaxed sm:text-lg">
-                  <p>
-                    The current global-population parameter is <ParameterValue param={GLOBAL_POPULATION_2024} />.
-                    Multiplying it by 51% gives 4.08 billion people—about 4.1 billion. As the population input rises
-                    above 8.2 billion, the same rule is about 4.2 billion; the target is calculated instead of frozen to
-                    a stale headcount.
-                  </p>
-                  <p>
-                    Public verification could reduce pluralistic ignorance: people may privately support a reform while
-                    incorrectly believing that most others do not. Country-level, auditable results could make dispersed
-                    preferences common knowledge and give decision-makers a visible mandate to answer.
-                  </p>
-                </div>
-              </div>
-            </Card>
-
-            <h3 className="mb-5 text-2xl font-black uppercase sm:text-3xl">Plausible independent responses</h3>
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {coordinationActors.map(([actor, response]) => (
-                <Card
-                  key={actor}
-                  className="gap-3 border-4 border-primary bg-background p-5 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]"
-                >
-                  <h4 className="text-lg font-black uppercase text-brutal-pink">{actor}</h4>
-                  <p className="text-sm font-bold leading-relaxed">{response}</p>
-                </Card>
-              ))}
-            </div>
-
-            <Card className="mt-8 gap-5 border-4 border-primary bg-foreground p-6 text-background shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8">
-              <h3 className="text-2xl font-black uppercase sm:text-3xl">The hypothesized causal chain</h3>
-              <ol className="grid gap-3">
-                {coordinationChain.map((step, index) => (
-                  <li key={step} className="grid gap-3 sm:grid-cols-[2.5rem_1fr] sm:items-center">
-                    <span className="flex h-10 w-10 items-center justify-center border-2 border-background bg-brutal-cyan text-lg font-black text-foreground">
-                      {index + 1}
-                    </span>
-                    <span className="text-base font-black uppercase sm:text-lg">
-                      {step}
-                      {index < coordinationChain.length - 1 ? (
-                        <span className="ml-3 text-brutal-cyan" aria-hidden="true">
-                          →
-                        </span>
-                      ) : null}
-                    </span>
-                  </li>
-                ))}
-              </ol>
-              <p className="border-t-2 border-background/40 pt-5 text-base font-bold">
-                Survey responses do not automatically enact laws, fund trials, establish causation, or eradicate
-                disease. Each arrow requires institutions and people to act, and the effects must be measured.
-              </p>
-            </Card>
-
-            <div className="mt-8 grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
-              <div>
-                <p className="mb-3 text-sm font-black uppercase tracking-[0.2em] text-brutal-pink">
-                  Conditions for credibility
-                </p>
-                <h3 className="text-2xl font-black uppercase sm:text-3xl">A majority claim must earn trust</h3>
-              </div>
-              <Card className="border-4 border-primary bg-brutal-cyan p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8">
-                <ul className="grid gap-4 sm:grid-cols-2">
-                  {coordinationConditions.map((condition) => (
-                    <li key={condition} className="flex gap-3 text-sm font-bold leading-relaxed sm:text-base">
-                      <span className="font-black" aria-hidden="true">
-                        ■
-                      </span>
-                      <span>{condition}</span>
-                    </li>
-                  ))}
-                </ul>
-              </Card>
-            </div>
-          </Container>
-        </SectionContainer>
-
-        <SectionContainer bgColor="pink" borderPosition="bottom" padding="lg">
-          <Container size="xl">
-            <div className="mb-8 max-w-4xl text-white">
-              <p className="mb-3 text-sm font-black uppercase tracking-[0.2em]">Source trail</p>
-              <h2 className="mb-4 text-3xl font-black uppercase md:text-5xl">Read the underlying evidence</h2>
-              <p className="text-lg font-bold">
-                Parameter values on this page open their own source and calculation details. These are the primary
-                institutional and peer-reviewed sources for the central observed claims.
-              </p>
-            </div>
-            <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-              <SourceLink
-                href="https://www.sipri.org/publications/2025/sipri-fact-sheets/trends-world-military-expenditure-2024"
-                title="SIPRI: World military expenditure, 2024"
-                detail="Observed military-spending input."
-              />
-              <SourceLink
-                href="https://www.ndm.ox.ac.uk/covid-19/covid-research/drug-trials-recovery"
-                title="Oxford: RECOVERY trial"
-                detail="First patient, dexamethasone date, and NHS embedding."
-              />
-              <SourceLink
-                href="https://www.ndph.ox.ac.uk/news/recovery-trial-celebrates-two-year-anniversary-of-life-saving-dexamethasone-result"
-                title="Oxford: Three results within 100 days"
-                detail="Institutional account of the trial's rapid results."
-              />
-              <SourceLink
-                href="https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/"
-                title="Pivotal trial cost study"
-                detail="Peer-reviewed $41,413 median cost per participant."
-              />
-              <SourceLink
-                href="https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/"
-                title="Embedded pragmatic trial review"
-                detail="Peer-reviewed review reporting a $97 median among 64 trials."
-              />
-              <SourceLink
-                href={
-                  RECOVERY_TRIAL_COST_PER_PATIENT.sourceUrl ??
-                  "https://manual.warondisease.org/knowledge/appendix/recovery-trial"
-                }
-                title="RECOVERY cost estimate"
-                detail="Source behind the approximate $500 model parameter."
-              />
-              <SourceLink
-                href="https://www.fda.gov/understanding-unapproved-use-approved-drugs-label"
-                title="FDA: Off-label use of approved drugs"
-                detail="What clinicians may prescribe in ordinary medical practice."
-              />
-              <SourceLink
-                href="https://www.fda.gov/drugs/investigational-new-drug-ind-application/ind-application-procedures-exemptions-ind-requirements"
-                title="FDA: IND exemption criteria"
-                detail="Conditions for studies of lawfully marketed drugs."
-              />
-              <SourceLink
-                href="https://www.hhs.gov/ohrp/regulations-and-policy/regulations/45-cfr-46/index.html"
-                title="HHS: Common Rule"
-                detail="IRB and informed-consent protections for covered research."
-              />
-              <SourceLink
-                href="https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/research/index.html"
-                title="HHS: HIPAA and research"
-                detail="Authorization and documented waiver routes for protected health information."
-              />
-              <SourceLink
-                href="https://www.cms.gov/medicare-coverage-database/view/ncd.aspx?NCDId=1&NCDver=3"
-                title="CMS: Routine costs in clinical trials"
-                detail="What Medicare covers in qualifying trials and what it excludes."
-              />
-              <SourceLink
-                href="https://www.fda.gov/patients/learn-about-expanded-access-and-other-treatment-options/right-try"
-                title="FDA: Federal Right to Try"
-                detail="Eligibility, manufacturer discretion, and the treatment-access pathway."
-              />
-              <SourceLink
-                href="https://archive.legmt.gov/content/Sessions/69th/Contractor_index/CH0621.pdf"
-                title="Montana SB 535, Chapter 621"
-                detail="The 2025 law establishing experimental-treatment centers."
-              />
-              <SourceLink
-                href="https://dphhs.mt.gov/oig/licensure/healthcarefacilitylicensure/lbfacilityapplications/lbexperimentaltreatmentcenters"
-                title="Montana: Experimental-treatment centers"
-                detail="Current licensing applications, statutes, and rules."
-              />
-            </div>
-          </Container>
-        </SectionContainer>
-
-        <CTASection
-          bgColor="yellow"
-          heading={
-            <>
-              TAKE THE
-              <br />
-              <span className="text-foreground">SURVEY</span>
-            </>
-          }
-        >
-          <Button
-            asChild
-            className="h-14 border-4 border-foreground bg-foreground px-8 text-lg font-black uppercase text-background hover:bg-background hover:text-foreground sm:px-12"
-          >
-            <Link href="/#vote">Take the survey</Link>
-          </Button>
-        </CTASection>
-      </div>
-    </Layout>
-  )
-}
-
-function SurveyRegulatorySection() {
-  return (
-    <SectionContainer bgColor="foreground" borderPosition="bottom" padding="lg">
-      <Container size="xl" className="text-background">
-        <div className="mb-8 max-w-5xl">
-          <p className="mb-3 text-sm font-black uppercase tracking-[0.2em] text-brutal-cyan">
-            Current legal and operational constraints
-          </p>
-          <h2 className="mb-4 text-3xl font-black uppercase md:text-5xl">
-            Why doesn&apos;t every doctor offer a pragmatic trial?
-          </h2>
-          <p className="text-lg font-bold">
-            Pragmatic trials are not categorically illegal. The difficulty is that a physician&apos;s treatment decision
-            becomes research—and often regulated research—when a protocol systematically assigns care and collects
-            data to produce generalizable evidence. That change adds duties that an ordinary clinic usually cannot
-            absorb alone.
-          </p>
-        </div>
-
-        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-          <EvidenceTypeCard
-            label="Treatment is not a trial"
-            color="bg-brutal-cyan text-foreground"
-            description="FDA says clinicians generally may prescribe an approved drug off-label when medically appropriate. Randomization and systematic evidence generation still require a research protocol and accountable sponsor."
-          />
-          <EvidenceTypeCard
-            label="IND-exempt is not oversight-free"
-            color="bg-brutal-yellow text-foreground"
-            description="A study of a marketed drug can avoid an IND only when every 21 CFR 312.2(b)(1) condition is met. IRB review and informed consent still apply; riskier or unapproved uses need another FDA pathway."
-          />
-          <EvidenceTypeCard
-            label="Consent and data are risk-dependent"
-            color="bg-background text-foreground"
-            description="The Common Rule and HIPAA allow documented waivers in qualifying minimal-risk research. An IRB or Privacy Board must still assess and document the study, privacy safeguards, and practicability."
-          />
-          <EvidenceTypeCard
-            label="Coverage is incomplete"
-            color="bg-brutal-pink text-white"
-            description="Medicare covers routine costs in qualifying trials, but not every investigational intervention or research-only service. Other coverage, site contracts, and unrecovered clinic work remain variable."
-          />
-        </div>
-
-        <p className="mt-6 text-sm font-bold leading-relaxed text-background/90">
-          A review of embedded pragmatic trials identified research governance, processes incompatible with clinical
-          operations, and unrecoverable costs as recurring barriers. Protections for consent, safety, and privacy
-          remain necessary; the policy question is how to make oversight proportionate and reusable.
-        </p>
-
-        <Card className="mt-8 gap-5 border-4 border-background bg-background p-6 text-foreground shadow-[8px_8px_0px_0px_rgba(0,217,255,1)] sm:p-8">
-          <div>
-            <p className="mb-2 text-sm font-black uppercase tracking-[0.2em] text-brutal-pink">
-              Policy design targets—not current rights
-            </p>
-            <h3 className="text-2xl font-black uppercase sm:text-3xl">What universal access would require</h3>
-          </div>
-          <div className="grid gap-4">
-            <PolicyTargetRow
-              label="Patient access"
-              today="No universal right to be screened, enrolled, or supplied an intervention."
-              target="A portable right to be informed and considered for eligible trials—not a right to demand an unsafe or unavailable treatment."
-            />
-            <PolicyTargetRow
-              label="Proportionate review"
-              today="IND, IRB, consent, privacy, and local-site determinations can be repeated or inconsistent."
-              target="Clear pathways for minimal-risk marketed-treatment comparisons, shared protocols, central review, and tiered consent."
-            />
-            <PolicyTargetRow
-              label="Payment"
-              today="Routine care may be covered while research-only work, infrastructure, or the intervention is not."
-              target="Reliable routine-care coverage plus public or shared research funding. Any patient-funded option needs equity and consent safeguards."
-            />
-            <PolicyTargetRow
-              label="Clinic workflow"
-              today="Site contracts, staff training, fragmented records, manual reporting, and unrecovered physician time block participation."
-              target="Reusable agreements, interoperable records, funded clinician time, and automated eligibility, safety, and outcome reporting."
-            />
-            <PolicyTargetRow
-              label="Accountability"
-              today="A clinician cannot safely become sponsor, data center, monitor, and regulator for every study."
-              target="A shared trial network that preserves independent review, privacy, adverse-event monitoring, public registration, results reporting, and clear liability."
-            />
-          </div>
-        </Card>
-
-        <Card className="mt-8 gap-6 border-4 border-background bg-brutal-yellow p-6 text-foreground shadow-[8px_8px_0px_0px_rgba(255,107,157,1)] sm:p-8">
-          <div>
-            <p className="mb-2 text-sm font-black uppercase tracking-[0.2em]">Adjacent legal experiment</p>
-            <h3 className="text-2xl font-black uppercase sm:text-3xl">Right to try is not right to trial</h3>
-          </div>
-          <p className="text-base font-bold leading-relaxed sm:text-lg">
-            Right-to-try and expanded-access laws primarily govern treatment with an investigational product outside a
-            clinical trial. Their purpose is access for an individual patient, not randomization or the production of
-            reliable comparative evidence.
-          </p>
-          <div className="grid gap-5 lg:grid-cols-2">
-            <div className="border-4 border-primary bg-background p-5 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
-              <h4 className="mb-3 text-lg font-black uppercase text-brutal-pink">Federal Right to Try, 2018</h4>
-              <p className="text-sm font-bold leading-relaxed">
-                The federal pathway is limited to a patient with a life-threatening condition who exhausted approved
-                options and cannot participate in a relevant trial. It does not require FDA or IRB review of an
-                individual request, and it does not require a manufacturer to provide the drug.
-              </p>
-            </div>
-            <div className="border-4 border-primary bg-brutal-cyan p-5 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
-              <h4 className="mb-3 text-lg font-black uppercase">Montana SB 535, 2025</h4>
-              <p className="text-sm font-bold leading-relaxed">
-                Montana created licensed experimental-treatment centers for interventions that completed phase 1 and
-                either remain under FDA-approved investigation or meet a state-defined documented-safety route.
-                Patients must evaluate approved options, receive a provider recommendation, and consent. Final
-                center-licensing rules took effect July 25, 2026.
-              </p>
-            </div>
-          </div>
-          <p className="text-sm font-bold leading-relaxed">
-            Montana permits payment arrangements but does not require a manufacturer, facility, insurer, or government
-            program to provide or pay for treatment. The law is therefore a live experiment in treatment access and
-            financing—not a universal right to join a pragmatic trial, a replacement for federal research rules, or a
-            guarantee that useful comparative evidence will result.
-          </p>
-        </Card>
-      </Container>
-    </SectionContainer>
-  )
-}
-
-function EvidenceTypeCard({ label, description, color }: { label: string; description: string; color: string }) {
-  return (
-    <Card className={`${color} gap-3 border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}>
-      <h3 className="text-xl font-black uppercase">{label}</h3>
-      <p className="text-sm font-bold leading-relaxed">{description}</p>
-    </Card>
-  )
-}
-
-function ResearchStatCard({
-  label,
-  value,
-  detail,
-  color,
-}: {
-  label: string
-  value: ReactNode
-  detail: string
-  color: string
-}) {
-  return (
-    <Card className={`${color} gap-3 border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}>
-      <h3 className="text-xs font-black uppercase tracking-[0.18em]">{label}</h3>
-      <p className="break-words text-3xl font-black sm:text-4xl">{value}</p>
-      <p className="text-sm font-bold leading-relaxed">{detail}</p>
-    </Card>
-  )
-}
-
-function ComparisonRow({ label, value, detail }: { label: string; value: ReactNode; detail: string }) {
-  return (
-    <div className="grid gap-2 border-4 border-primary bg-background p-4 sm:grid-cols-[1fr_0.55fr_1.45fr] sm:items-center">
-      <h4 className="text-sm font-black uppercase">{label}</h4>
-      <p className="text-2xl font-black">{value}</p>
-      <p className="text-sm font-bold leading-relaxed">{detail}</p>
-    </div>
-  )
-}
-
-function PolicyTargetRow({
-  label,
-  today,
-  target,
-}: {
-  label: string
-  today: string
-  target: string
-}) {
-  return (
-    <div className="grid gap-3 border-4 border-primary p-4 md:grid-cols-[0.45fr_1fr_1.35fr] md:items-start">
-      <h4 className="text-sm font-black uppercase text-brutal-pink">{label}</h4>
-      <p className="text-sm font-bold leading-relaxed">
-        <span className="font-black uppercase">Today: </span>
-        {today}
-      </p>
-      <p className="text-sm font-bold leading-relaxed">
-        <span className="font-black uppercase">Possible target: </span>
-        {target}
-      </p>
-    </div>
-  )
-}
-
-function SourceLink({ href, title, detail }: { href: string; title: string; detail: string }) {
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="block border-4 border-primary bg-background p-5 text-foreground shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[10px_10px_0px_0px_rgba(0,0,0,1)]"
-    >
-      <h3 className="mb-2 text-lg font-black uppercase">{title}</h3>
-      <p className="text-sm font-bold leading-relaxed">{detail}</p>
-    </a>
   )
 }
 

--- a/packages/site-kit/src/components/research-page.tsx
+++ b/packages/site-kit/src/components/research-page.tsx
@@ -50,6 +50,7 @@ const queueStatusQuo = formatParameter(STATUS_QUO_QUEUE_CLEARANCE_YEARS)
 const queueCompressed = formatParameter(DFDA_QUEUE_CLEARANCE_YEARS)
 const livesSaved = formatParameter(DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_LIVES_SAVED)
 const trialCapacityMultiplier = formatParameter(DFDA_TRIAL_CAPACITY_MULTIPLIER, { precision: 1 })
+const SURVEY_MAJORITY_SHARE = 0.51
 const governmentTrialSpendingRange = GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.confidenceInterval
   ?.map((value) => formatParameter({ ...GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL, value }))
   .join("–")
@@ -57,13 +58,20 @@ const governmentTrialShareOfMilitarySpending =
   (GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.value / 2_718_000_000_000) * 100
 const surveyMajorityTarget: Parameter = {
   ...GLOBAL_POPULATION_2024,
-  value: GLOBAL_POPULATION_2024.value * 0.51,
+  value: GLOBAL_POPULATION_2024.value * SURVEY_MAJORITY_SHARE,
   parameterName: "SURVEY_MAJORITY_RESPONSE_TARGET",
   displayName: "51% of the current global population",
   sourceType: "calculated",
   formula: "GLOBAL_POPULATION_2024 × 51%",
   inputs: ["GLOBAL_POPULATION_2024"],
   computeExpr: "GLOBAL_POPULATION_2024 * 0.51",
+  confidenceInterval: GLOBAL_POPULATION_2024.confidenceInterval
+    ? [
+        GLOBAL_POPULATION_2024.confidenceInterval[0] * SURVEY_MAJORITY_SHARE,
+        GLOBAL_POPULATION_2024.confidenceInterval[1] * SURVEY_MAJORITY_SHARE,
+      ]
+    : undefined,
+  stdError: undefined,
 }
 
 const headlineStats: StatCardProps[] = [
@@ -467,7 +475,11 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                   <div className="text-center">
                     <div className="text-6xl font-black">51%</div>
                     <div className="text-lg font-black">
-                      <ParameterValue param={surveyMajorityTarget} valueOverride="4.08B" /> people
+                      <ParameterValue
+                        param={surveyMajorityTarget}
+                        valueOverride={`${(surveyMajorityTarget.value / 1_000_000_000).toFixed(2)}B`}
+                      />{" "}
+                      people
                     </div>
                   </div>
                   <div className="space-y-4 text-base font-bold leading-relaxed">

--- a/packages/site-kit/src/components/research-page.tsx
+++ b/packages/site-kit/src/components/research-page.tsx
@@ -791,6 +791,8 @@ function SurveyResearchPage() {
           </Container>
         </SectionContainer>
 
+        <SurveyRegulatorySection />
+
         <SectionContainer bgColor="cyan" borderPosition="bottom" padding="lg">
           <Container size="xl">
             <div className="mb-8 max-w-4xl">
@@ -982,6 +984,46 @@ function SurveyResearchPage() {
                 title="RECOVERY cost estimate"
                 detail="Source behind the approximate $500 model parameter."
               />
+              <SourceLink
+                href="https://www.fda.gov/understanding-unapproved-use-approved-drugs-label"
+                title="FDA: Off-label use of approved drugs"
+                detail="What clinicians may prescribe in ordinary medical practice."
+              />
+              <SourceLink
+                href="https://www.fda.gov/drugs/investigational-new-drug-ind-application/ind-application-procedures-exemptions-ind-requirements"
+                title="FDA: IND exemption criteria"
+                detail="Conditions for studies of lawfully marketed drugs."
+              />
+              <SourceLink
+                href="https://www.hhs.gov/ohrp/regulations-and-policy/regulations/45-cfr-46/index.html"
+                title="HHS: Common Rule"
+                detail="IRB and informed-consent protections for covered research."
+              />
+              <SourceLink
+                href="https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/research/index.html"
+                title="HHS: HIPAA and research"
+                detail="Authorization and documented waiver routes for protected health information."
+              />
+              <SourceLink
+                href="https://www.cms.gov/medicare-coverage-database/view/ncd.aspx?NCDId=1&NCDver=3"
+                title="CMS: Routine costs in clinical trials"
+                detail="What Medicare covers in qualifying trials and what it excludes."
+              />
+              <SourceLink
+                href="https://www.fda.gov/patients/learn-about-expanded-access-and-other-treatment-options/right-try"
+                title="FDA: Federal Right to Try"
+                detail="Eligibility, manufacturer discretion, and the treatment-access pathway."
+              />
+              <SourceLink
+                href="https://archive.legmt.gov/content/Sessions/69th/Contractor_index/CH0621.pdf"
+                title="Montana SB 535, Chapter 621"
+                detail="The 2025 law establishing experimental-treatment centers."
+              />
+              <SourceLink
+                href="https://dphhs.mt.gov/oig/licensure/healthcarefacilitylicensure/lbfacilityapplications/lbexperimentaltreatmentcenters"
+                title="Montana: Experimental-treatment centers"
+                detail="Current licensing applications, statutes, and rules."
+              />
             </div>
           </Container>
         </SectionContainer>
@@ -1005,6 +1047,131 @@ function SurveyResearchPage() {
         </CTASection>
       </div>
     </Layout>
+  )
+}
+
+function SurveyRegulatorySection() {
+  return (
+    <SectionContainer bgColor="foreground" borderPosition="bottom" padding="lg">
+      <Container size="xl" className="text-background">
+        <div className="mb-8 max-w-5xl">
+          <p className="mb-3 text-sm font-black uppercase tracking-[0.2em] text-brutal-cyan">
+            Current legal and operational constraints
+          </p>
+          <h2 className="mb-4 text-3xl font-black uppercase md:text-5xl">
+            Why doesn&apos;t every doctor offer a pragmatic trial?
+          </h2>
+          <p className="text-lg font-bold">
+            Pragmatic trials are not categorically illegal. The difficulty is that a physician&apos;s treatment decision
+            becomes research—and often regulated research—when a protocol systematically assigns care and collects
+            data to produce generalizable evidence. That change adds duties that an ordinary clinic usually cannot
+            absorb alone.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+          <EvidenceTypeCard
+            label="Treatment is not a trial"
+            color="bg-brutal-cyan text-foreground"
+            description="FDA says clinicians generally may prescribe an approved drug off-label when medically appropriate. Randomization and systematic evidence generation still require a research protocol and accountable sponsor."
+          />
+          <EvidenceTypeCard
+            label="IND-exempt is not oversight-free"
+            color="bg-brutal-yellow text-foreground"
+            description="A study of a marketed drug can avoid an IND only when every 21 CFR 312.2(b)(1) condition is met. IRB review and informed consent still apply; riskier or unapproved uses need another FDA pathway."
+          />
+          <EvidenceTypeCard
+            label="Consent and data are risk-dependent"
+            color="bg-background text-foreground"
+            description="The Common Rule and HIPAA allow documented waivers in qualifying minimal-risk research. An IRB or Privacy Board must still assess and document the study, privacy safeguards, and practicability."
+          />
+          <EvidenceTypeCard
+            label="Coverage is incomplete"
+            color="bg-brutal-pink text-white"
+            description="Medicare covers routine costs in qualifying trials, but not every investigational intervention or research-only service. Other coverage, site contracts, and unrecovered clinic work remain variable."
+          />
+        </div>
+
+        <p className="mt-6 text-sm font-bold leading-relaxed text-background/90">
+          A review of embedded pragmatic trials identified research governance, processes incompatible with clinical
+          operations, and unrecoverable costs as recurring barriers. Protections for consent, safety, and privacy
+          remain necessary; the policy question is how to make oversight proportionate and reusable.
+        </p>
+
+        <Card className="mt-8 gap-5 border-4 border-background bg-background p-6 text-foreground shadow-[8px_8px_0px_0px_rgba(0,217,255,1)] sm:p-8">
+          <div>
+            <p className="mb-2 text-sm font-black uppercase tracking-[0.2em] text-brutal-pink">
+              Policy design targets—not current rights
+            </p>
+            <h3 className="text-2xl font-black uppercase sm:text-3xl">What universal access would require</h3>
+          </div>
+          <div className="grid gap-4">
+            <PolicyTargetRow
+              label="Patient access"
+              today="No universal right to be screened, enrolled, or supplied an intervention."
+              target="A portable right to be informed and considered for eligible trials—not a right to demand an unsafe or unavailable treatment."
+            />
+            <PolicyTargetRow
+              label="Proportionate review"
+              today="IND, IRB, consent, privacy, and local-site determinations can be repeated or inconsistent."
+              target="Clear pathways for minimal-risk marketed-treatment comparisons, shared protocols, central review, and tiered consent."
+            />
+            <PolicyTargetRow
+              label="Payment"
+              today="Routine care may be covered while research-only work, infrastructure, or the intervention is not."
+              target="Reliable routine-care coverage plus public or shared research funding. Any patient-funded option needs equity and consent safeguards."
+            />
+            <PolicyTargetRow
+              label="Clinic workflow"
+              today="Site contracts, staff training, fragmented records, manual reporting, and unrecovered physician time block participation."
+              target="Reusable agreements, interoperable records, funded clinician time, and automated eligibility, safety, and outcome reporting."
+            />
+            <PolicyTargetRow
+              label="Accountability"
+              today="A clinician cannot safely become sponsor, data center, monitor, and regulator for every study."
+              target="A shared trial network that preserves independent review, privacy, adverse-event monitoring, public registration, results reporting, and clear liability."
+            />
+          </div>
+        </Card>
+
+        <Card className="mt-8 gap-6 border-4 border-background bg-brutal-yellow p-6 text-foreground shadow-[8px_8px_0px_0px_rgba(255,107,157,1)] sm:p-8">
+          <div>
+            <p className="mb-2 text-sm font-black uppercase tracking-[0.2em]">Adjacent legal experiment</p>
+            <h3 className="text-2xl font-black uppercase sm:text-3xl">Right to try is not right to trial</h3>
+          </div>
+          <p className="text-base font-bold leading-relaxed sm:text-lg">
+            Right-to-try and expanded-access laws primarily govern treatment with an investigational product outside a
+            clinical trial. Their purpose is access for an individual patient, not randomization or the production of
+            reliable comparative evidence.
+          </p>
+          <div className="grid gap-5 lg:grid-cols-2">
+            <div className="border-4 border-primary bg-background p-5 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
+              <h4 className="mb-3 text-lg font-black uppercase text-brutal-pink">Federal Right to Try, 2018</h4>
+              <p className="text-sm font-bold leading-relaxed">
+                The federal pathway is limited to a patient with a life-threatening condition who exhausted approved
+                options and cannot participate in a relevant trial. It does not require FDA or IRB review of an
+                individual request, and it does not require a manufacturer to provide the drug.
+              </p>
+            </div>
+            <div className="border-4 border-primary bg-brutal-cyan p-5 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
+              <h4 className="mb-3 text-lg font-black uppercase">Montana SB 535, 2025</h4>
+              <p className="text-sm font-bold leading-relaxed">
+                Montana created licensed experimental-treatment centers for interventions that completed phase 1 and
+                either remain under FDA-approved investigation or meet a state-defined documented-safety route.
+                Patients must evaluate approved options, receive a provider recommendation, and consent. Final
+                center-licensing rules took effect July 25, 2026.
+              </p>
+            </div>
+          </div>
+          <p className="text-sm font-bold leading-relaxed">
+            Montana permits payment arrangements but does not require a manufacturer, facility, insurer, or government
+            program to provide or pay for treatment. The law is therefore a live experiment in treatment access and
+            financing—not a universal right to join a pragmatic trial, a replacement for federal research rules, or a
+            guarantee that useful comparative evidence will result.
+          </p>
+        </Card>
+      </Container>
+    </SectionContainer>
   )
 }
 
@@ -1043,6 +1210,30 @@ function ComparisonRow({ label, value, detail }: { label: string; value: ReactNo
       <h4 className="text-sm font-black uppercase">{label}</h4>
       <p className="text-2xl font-black">{value}</p>
       <p className="text-sm font-bold leading-relaxed">{detail}</p>
+    </div>
+  )
+}
+
+function PolicyTargetRow({
+  label,
+  today,
+  target,
+}: {
+  label: string
+  today: string
+  target: string
+}) {
+  return (
+    <div className="grid gap-3 border-4 border-primary p-4 md:grid-cols-[0.45fr_1fr_1.35fr] md:items-start">
+      <h4 className="text-sm font-black uppercase text-brutal-pink">{label}</h4>
+      <p className="text-sm font-bold leading-relaxed">
+        <span className="font-black uppercase">Today: </span>
+        {today}
+      </p>
+      <p className="text-sm font-bold leading-relaxed">
+        <span className="font-black uppercase">Possible target: </span>
+        {target}
+      </p>
     </div>
   )
 }

--- a/packages/site-kit/src/components/research-page.tsx
+++ b/packages/site-kit/src/components/research-page.tsx
@@ -24,11 +24,9 @@ import {
   DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_SUFFERING_HOURS,
   DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_YEARS,
   DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL,
-  GLOBAL_CLINICAL_TRIALS_SPENDING_ANNUAL,
   GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL,
   GLOBAL_MILITARY_SPENDING_ANNUAL_2024,
   GLOBAL_POPULATION_2024,
-  MILITARY_TO_CLINICAL_TRIALS_SPENDING_RATIO,
   MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO,
   NEW_DISEASE_FIRST_TREATMENTS_PER_YEAR,
   RECOVERY_TRIAL_COST_PER_PATIENT,
@@ -51,11 +49,12 @@ const queueCompressed = formatParameter(DFDA_QUEUE_CLEARANCE_YEARS)
 const livesSaved = formatParameter(DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_LIVES_SAVED)
 const trialCapacityMultiplier = formatParameter(DFDA_TRIAL_CAPACITY_MULTIPLIER, { precision: 1 })
 const SURVEY_MAJORITY_SHARE = 0.51
-const governmentTrialSpendingRange = GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.confidenceInterval
-  ?.map((value) => formatParameter({ ...GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL, value }))
-  .join("–")
 const governmentTrialShareOfMilitarySpending =
-  (GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.value / 2_718_000_000_000) * 100
+  (GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.value /
+    GLOBAL_MILITARY_SPENDING_ANNUAL_2024.value) *
+  100
+const compressedTimelineShare =
+  (DFDA_QUEUE_CLEARANCE_YEARS.value / STATUS_QUO_QUEUE_CLEARANCE_YEARS.value) * 100
 const surveyMajorityTarget: Parameter = {
   ...GLOBAL_POPULATION_2024,
   value: GLOBAL_POPULATION_2024.value * SURVEY_MAJORITY_SHARE,
@@ -73,6 +72,13 @@ const surveyMajorityTarget: Parameter = {
     : undefined,
   stdError: undefined,
 }
+const coordinationFlow = [
+  { emoji: "🗳️", label: "Verified preferences", color: "bg-background" },
+  { emoji: "📣", label: "Public mandate", color: "bg-brutal-cyan" },
+  { emoji: "🏛️", label: "Access + funding reform", color: "bg-brutal-yellow" },
+  { emoji: "🩺", label: "More trials + faster evidence", color: "bg-background" },
+  { emoji: "❤️", label: "Earlier treatment + less disease", color: "bg-brutal-cyan" },
+] as const
 
 const headlineStats: StatCardProps[] = [
   {
@@ -303,8 +309,7 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                     RECOVERY cost about <ParameterValue param={RECOVERY_TRIAL_COST_PER_PATIENT} /> per
                     patient, compared with a $41,413 median for pivotal drug trials—about{" "}
                     <ParameterValue param={RECOVERY_TRIAL_COST_REDUCTION_FACTOR} className="font-black" />.
-                    A separate review of 64 embedded trials found a $97 median. These studies show the
-                    cost potential; they do not set one price for every pragmatic trial.
+                    A separate review of 64 embedded trials found a $97 median.
                   </p>
                 </div>
               </Card>
@@ -313,33 +318,39 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                 TIMELINE <span className="text-brutal-pink">COMPRESSION</span>
               </h2>
               <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-brutal-yellow">
-                <div className="space-y-4 text-lg leading-relaxed">
-                  <p>
-                    At the current rate of ~15 diseases per year receiving a first effective treatment,
-                    finding treatments for all ~6,650 currently untreatable diseases would take an
-                    estimated{" "}
-                    <ParameterValue
-                      param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
-                      format={{ precision: 0 }}
-                      className="font-black"
-                    />{" "}
-                    <span className="font-black">years</span>.
-                  </p>
-                  <p>
-                    At the modeled funding level of about{" "}
-                    <ParameterValue param={DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL} className="font-black" />{" "}
-                    per year, scaling pragmatic trials would increase clinical trial capacity by{" "}
-                    <ParameterValue
-                      param={DFDA_TRIAL_CAPACITY_MULTIPLIER}
-                      format={{ precision: 1 }}
-                      className="font-black text-brutal-pink"
-                    />, compressing that timeline to approximately{" "}
-                    <ParameterValue
-                      param={DFDA_QUEUE_CLEARANCE_YEARS}
-                      format={{ precision: 0 }}
-                      className="font-black text-brutal-pink"
-                    />{" "}
-                    <span className="font-black text-brutal-pink">years</span>.
+                <div
+                  aria-label={`Modeled timeline falls from ${Math.round(STATUS_QUO_QUEUE_CLEARANCE_YEARS.value)} years to ${Math.round(DFDA_QUEUE_CLEARANCE_YEARS.value)} years`}
+                  className="space-y-6"
+                  role="group"
+                >
+                  <div>
+                    <div className="mb-2 flex items-end justify-between gap-4 font-black uppercase">
+                      <span>Current pace</span>
+                      <span className="text-3xl">
+                        <ParameterValue param={STATUS_QUO_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} /> years
+                      </span>
+                    </div>
+                    <div className="h-12 border-4 border-primary bg-background">
+                      <div className="h-full w-full bg-primary" />
+                    </div>
+                  </div>
+                  <div>
+                    <div className="mb-2 flex items-end justify-between gap-4 font-black uppercase">
+                      <span>Expanded trial capacity</span>
+                      <span className="text-3xl text-brutal-pink">
+                        <ParameterValue param={DFDA_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} /> years
+                      </span>
+                    </div>
+                    <div className="h-12 border-4 border-primary bg-background">
+                      <div
+                        className="h-full bg-brutal-pink"
+                        style={{ width: `${compressedTimelineShare}%` }}
+                      />
+                    </div>
+                  </div>
+                  <p className="text-base font-bold text-center">
+                    <ParameterValue param={DFDA_TRIAL_CAPACITY_MULTIPLIER} format={{ precision: 1 }} /> more trial
+                    capacity at <ParameterValue param={DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL} /> per year
                   </p>
                 </div>
               </Card>
@@ -403,38 +414,49 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                 PUBLIC SPENDING <span className="text-brutal-pink">GAP</span>
               </h2>
               <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-brutal-yellow">
-                <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4 text-center mb-6">
+                <div
+                  aria-label="Annual military spending is $2.718 trillion versus $4.5 billion in government clinical trial spending"
+                  className="space-y-6"
+                  role="group"
+                >
                   <div>
-                    <div className="text-3xl font-black">$2.718T</div>
-                    <div className="text-sm font-black uppercase">2024 military spending</div>
-                  </div>
-                  <div>
-                    <div className="text-3xl font-black">
-                      <ParameterValue param={GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL} valueOverride="$4.5B" />
+                    <div className="mb-2 flex items-end justify-between gap-4 font-black uppercase">
+                      <span>Military spending</span>
+                      <span className="text-3xl">$2.718T</span>
                     </div>
-                    <div className="text-sm font-black uppercase">Government trial estimate</div>
+                    <div className="h-12 border-4 border-primary bg-background">
+                      <div className="h-full w-full bg-primary" />
+                    </div>
                   </div>
                   <div>
+                    <div className="mb-2 flex items-end justify-between gap-4 font-black uppercase">
+                      <span>Clinical trial spending</span>
+                      <span className="text-3xl text-brutal-pink">
+                        <ParameterValue
+                          param={GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL}
+                          valueOverride="$4.5B"
+                        />
+                      </span>
+                    </div>
+                    <div className="h-12 border-4 border-primary bg-background">
+                      <div
+                        className="h-full min-w-1 bg-brutal-pink"
+                        style={{ width: `${governmentTrialShareOfMilitarySpending}%` }}
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-8 grid gap-4 text-center sm:grid-cols-2">
+                  <div className="border-4 border-primary bg-background p-4">
                     <div className="text-3xl font-black">{governmentTrialShareOfMilitarySpending.toFixed(3)}%</div>
-                    <div className="text-sm font-black uppercase">Trial share</div>
+                    <div className="text-sm font-black uppercase">Trial share of military spending</div>
                   </div>
-                  <div>
+                  <div className="border-4 border-primary bg-background p-4">
                     <div className="text-3xl font-black">
                       <ParameterValue param={MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO} format={{ precision: 0 }} />
                     </div>
-                    <div className="text-sm font-black uppercase">Military dollars per $1</div>
+                    <div className="text-sm font-black uppercase">Military dollars per trial dollar</div>
                   </div>
-                </div>
-                <div className="space-y-3 text-base font-bold leading-relaxed">
-                  <p>
-                    This is a government-to-government comparison. No complete global accounting exists,
-                    so the $4.5 billion trial figure is our estimate; its range is {governmentTrialSpendingRange}.
-                  </p>
-                  <p>
-                    Including private trial spending raises the denominator to about{" "}
-                    <ParameterValue param={GLOBAL_CLINICAL_TRIALS_SPENDING_ANNUAL} /> and lowers the ratio to about{" "}
-                    <ParameterValue param={MILITARY_TO_CLINICAL_TRIALS_SPENDING_RATIO} format={{ precision: 0 }} />.
-                  </p>
                 </div>
               </Card>
 
@@ -482,27 +504,41 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
                       people
                     </div>
                   </div>
-                  <div className="space-y-4 text-base font-bold leading-relaxed">
+                  <div className="text-base font-bold leading-relaxed">
                     <p>
                       A verified majority could make private preferences common knowledge and create an
                       election-scale mandate for trial access and funding reform.
                     </p>
-                    <p className="font-black">
-                      Verified preferences → public mandate → access and funding reform → more physician-embedded
-                      trials → faster evidence → earlier treatment → less disease
-                    </p>
-                    <p>
-                      The survey would not change law by itself. Patients and physicians must participate;
-                      health systems must embed trials; researchers must publish; foundations and insurers
-                      must fund; developers must supply treatments; and politicians and governments must act.
-                    </p>
                   </div>
                 </div>
-              </Card>
-              <Card className="p-6 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-brutal-yellow text-sm font-bold leading-relaxed">
-                A credible majority requires one verified response per person, transparent methods,
-                country results, separate representative and self-selected samples, clear translations,
-                published recruitment sources, respondent privacy, and concrete follow-up paths.
+                <ol
+                  aria-label="How verified preferences could lead to less disease"
+                  className="mt-8 flex flex-col items-stretch gap-2 lg:flex-row lg:items-center"
+                >
+                  {coordinationFlow.map((step, index) => (
+                    <li
+                      key={step.label}
+                      className="flex flex-col items-center gap-2 lg:min-w-0 lg:flex-1 lg:flex-row"
+                    >
+                      <div
+                        className={`${step.color} flex min-h-28 w-full flex-col items-center justify-center border-4 border-primary p-3 text-center shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]`}
+                      >
+                        <span aria-hidden="true" className="mb-2 text-3xl">
+                          {step.emoji}
+                        </span>
+                        <span className="text-sm font-black uppercase leading-tight">{step.label}</span>
+                      </div>
+                      {index < coordinationFlow.length - 1 ? (
+                        <span
+                          aria-hidden="true"
+                          className="rotate-90 text-3xl font-black leading-none lg:rotate-0"
+                        >
+                          →
+                        </span>
+                      ) : null}
+                    </li>
+                  ))}
+                </ol>
               </Card>
 
               <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8 pt-8">

--- a/packages/site-kit/src/components/research-page.tsx
+++ b/packages/site-kit/src/components/research-page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import Link from "next/link"
+import type { ReactNode } from "react"
 
 import Layout from "./layout"
 import { ParameterValue } from "./shared/ParameterValue"
@@ -24,8 +25,14 @@ import {
   DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_SUFFERING_HOURS,
   DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_YEARS,
   DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL,
+  GLOBAL_CLINICAL_TRIALS_SPENDING_ANNUAL,
+  GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL,
   GLOBAL_MILITARY_SPENDING_ANNUAL_2024,
+  GLOBAL_POPULATION_2024,
+  MILITARY_TO_CLINICAL_TRIALS_SPENDING_RATIO,
+  MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO,
   NEW_DISEASE_FIRST_TREATMENTS_PER_YEAR,
+  RECOVERY_TRIAL_COST_PER_PATIENT,
   RECOVERY_TRIAL_COST_REDUCTION_FACTOR,
   STATUS_QUO_QUEUE_CLEARANCE_YEARS,
   TREATY_ANNUAL_FUNDING,
@@ -44,6 +51,61 @@ const queueStatusQuo = formatParameter(STATUS_QUO_QUEUE_CLEARANCE_YEARS)
 const queueCompressed = formatParameter(DFDA_QUEUE_CLEARANCE_YEARS)
 const livesSaved = formatParameter(DFDA_TRIAL_CAPACITY_PLUS_EFFICACY_LAG_LIVES_SAVED)
 const trialCapacityMultiplier = formatParameter(DFDA_TRIAL_CAPACITY_MULTIPLIER, { precision: 1 })
+
+const SIPRI_2024_MILITARY_SPENDING_USD = 2_718_000_000_000
+const SURVEY_MAJORITY_SHARE = 0.51
+const GOVERNMENT_TRIAL_SHARE_OF_MILITARY_PCT =
+  (GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.value / SIPRI_2024_MILITARY_SPENDING_USD) * 100
+const RECOVERY_DAYS_TO_DEXAMETHASONE = Math.round(
+  (Date.UTC(2020, 5, 16) - Date.UTC(2020, 2, 19)) / (24 * 60 * 60 * 1000)
+)
+const surveyMajorityTarget: Parameter = {
+  ...GLOBAL_POPULATION_2024,
+  value: GLOBAL_POPULATION_2024.value * SURVEY_MAJORITY_SHARE,
+  parameterName: "SURVEY_MAJORITY_RESPONSE_TARGET",
+  displayName: "51% global response threshold",
+  description: "Current global-population parameter multiplied by 51%.",
+  sourceType: "calculated",
+  formula: "GLOBAL_POPULATION_2024 × 51%",
+  inputs: ["GLOBAL_POPULATION_2024"],
+  computeExpr: "GLOBAL_POPULATION_2024 * 0.51",
+}
+const pivotalTrialMedianCostPerParticipant: Parameter = {
+  ...TRADITIONAL_PHASE3_COST_PER_PATIENT,
+  value: 41_413,
+  parameterName: "PIVOTAL_TRIAL_MEDIAN_COST_PER_PARTICIPANT",
+  displayName: "Pivotal trial median cost per participant",
+  description:
+    "Median estimated cost per enrolled participant across 225 pivotal trials supporting US drug approvals from 2015 through 2017.",
+  sourceRef: undefined,
+  sourceUrl: "https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/",
+  calculationsUrl: undefined,
+  manualPageUrl: undefined,
+  manualPageTitle: undefined,
+  confidenceInterval: undefined,
+}
+const embeddedPragmaticTrialMedianCostPerParticipant: Parameter = {
+  ...DFDA_PRAGMATIC_TRIAL_COST_PER_PATIENT,
+  value: 97,
+  parameterName: "EMBEDDED_PRAGMATIC_TRIAL_MEDIAN_COST_PER_PARTICIPANT",
+  displayName: "Embedded pragmatic trial median cost per participant",
+  description:
+    "Median research cost per randomized participant among 64 embedded pragmatic trials with available cost data.",
+  sourceRef: undefined,
+  sourceUrl: "https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/",
+  calculationsUrl: undefined,
+  manualPageUrl: undefined,
+  manualPageTitle: undefined,
+  confidenceInterval: undefined,
+}
+const governmentTrialSpendingRange = GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.confidenceInterval
+  ?.map((value) =>
+    formatParameter({
+      ...GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL,
+      value,
+    })
+  )
+  .join("–")
 
 const headlineStats: StatCardProps[] = [
   {
@@ -224,194 +286,8 @@ export function generateSurveyResearchMetadata(): Metadata {
 }
 
 export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
-
-  // Survey variant: stripped-down methodology page — no advocacy, no military ROI, no quadrillions
   if (variant === "survey") {
-    return (
-      <Layout>
-        <div className="min-h-screen bg-background">
-          {/* Neutral Hero */}
-          <SectionContainer bgColor="foreground" borderPosition="bottom" padding="lg">
-            <Container size="md">
-              <h1 className="text-4xl sm:text-5xl md:text-6xl font-black uppercase text-center mb-6">
-                CLINICAL TRIAL EVIDENCE &<br />
-                <span className="text-brutal-cyan">DATA SOURCES</span>
-              </h1>
-              <p className="text-lg sm:text-xl font-bold text-center max-w-2xl mx-auto">
-                Peer-reviewed evidence on pragmatic clinical trials and the assumptions behind the survey&apos;s
-                capacity model.
-              </p>
-            </Container>
-          </SectionContainer>
-
-          {/* Pragmatic Trials Evidence */}
-          <SectionContainer bgColor="background" borderPosition="none" padding="lg">
-            <Container size="md" className="space-y-8">
-              <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8">
-                WHAT ARE <span className="text-brutal-pink">PRAGMATIC TRIALS?</span>
-              </h2>
-              <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-                <div className="space-y-6 text-lg leading-relaxed">
-                  <p>
-                    Pragmatic clinical trials test treatments in{" "}
-                    <span className="font-black">real-world healthcare settings</span> using existing
-                    medical records and routine care, rather than creating expensive artificial research
-                    environments.
-                  </p>
-                  <p>
-                    The landmark{" "}
-                    <span className="font-black text-brutal-pink">RECOVERY trial</span> at Oxford
-                    University demonstrated this approach at scale: it enrolled 40,000+ patients across
-                    176 NHS hospitals, identified effective COVID-19 treatments months ahead of
-                    traditional trials, and did so at{" "}
-                    <ParameterValue param={RECOVERY_TRIAL_COST_REDUCTION_FACTOR} className="font-black" />{" "}
-                    <span className="font-black">lower cost</span> per patient.
-                  </p>
-                  <p>
-                    RECOVERY is estimated to have saved over{" "}
-                    <span className="font-black">1 million lives</span> worldwide by rapidly
-                    identifying that dexamethasone reduces COVID mortality by one-third.
-                  </p>
-                </div>
-              </Card>
-
-              <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8 pt-8">
-                TIMELINE <span className="text-brutal-pink">COMPRESSION</span>
-              </h2>
-              <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-brutal-yellow">
-                <div className="space-y-4 text-lg leading-relaxed">
-                  <p>
-                    At the current rate of ~15 diseases per year receiving a first effective treatment,
-                    finding treatments for all ~6,650 currently untreatable diseases would take an
-                    estimated{" "}
-                    <ParameterValue
-                      param={STATUS_QUO_QUEUE_CLEARANCE_YEARS}
-                      format={{ precision: 0 }}
-                      className="font-black"
-                    />{" "}
-                    <span className="font-black">years</span>.
-                  </p>
-                  <p>
-                    At the modeled funding level of about{" "}
-                    <ParameterValue param={DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL} className="font-black" />{" "}
-                    per year, scaling pragmatic trials would increase clinical trial capacity by{" "}
-                    <ParameterValue
-                      param={DFDA_TRIAL_CAPACITY_MULTIPLIER}
-                      format={{ precision: 1 }}
-                      className="font-black text-brutal-pink"
-                    />, compressing that timeline to approximately{" "}
-                    <ParameterValue
-                      param={DFDA_QUEUE_CLEARANCE_YEARS}
-                      format={{ precision: 0 }}
-                      className="font-black text-brutal-pink"
-                    />{" "}
-                    <span className="font-black text-brutal-pink">years</span>.
-                  </p>
-                </div>
-              </Card>
-
-              <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8 pt-8">
-                KEY <span className="text-brutal-pink">FINDINGS</span>
-              </h2>
-              <div className="grid md:grid-cols-2 gap-6">
-                {[
-                  {
-                    stat: <ParameterValue param={RECOVERY_TRIAL_COST_REDUCTION_FACTOR} />,
-                    label: "COST REDUCTION",
-                    detail:
-                      "Pragmatic trials cost a fraction of traditional trials by using existing healthcare infrastructure.",
-                    color: "bg-brutal-cyan",
-                  },
-                  {
-                    stat: (
-                      <ParameterValue param={DFDA_TRIAL_CAPACITY_MULTIPLIER} format={{ precision: 1 }} />
-                    ),
-                    label: "CAPACITY INCREASE",
-                    detail: (
-                      <>
-                        At the model&apos;s{" "}
-                        <ParameterValue param={DIH_TREASURY_TO_MEDICAL_RESEARCH_ANNUAL} /> annual funding level,
-                        scaling pragmatic trials compresses the disease eradication timeline from{" "}
-                        <ParameterValue param={STATUS_QUO_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} />{" "}
-                        years to{" "}
-                        <ParameterValue param={DFDA_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} /> years.
-                      </>
-                    ),
-                    color: "bg-brutal-yellow",
-                  },
-                  {
-                    stat: "1M+",
-                    label: "LIVES SAVED (RECOVERY)",
-                    detail:
-                      "RECOVERY's identification of dexamethasone as an effective treatment saved over 1 million lives globally.",
-                    color: "bg-brutal-pink",
-                  },
-                  {
-                    stat: "MONTHS",
-                    label: "VS. YEARS",
-                    detail:
-                      "Pragmatic designs deliver actionable results in months, while traditional trials can take 5-10 years.",
-                    color: "bg-brutal-cyan",
-                  },
-                ].map((item, i) => (
-                  <Card
-                    key={i}
-                    className={`${item.color} border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}
-                  >
-                    <div className="text-3xl sm:text-4xl font-black mb-1">{item.stat}</div>
-                    <div className="text-sm font-black uppercase mb-3">{item.label}</div>
-                    <p className="text-sm font-bold">{item.detail}</p>
-                  </Card>
-                ))}
-              </div>
-
-              <h2 className="text-3xl md:text-4xl font-black uppercase text-center mb-8 pt-8">
-                <span className="text-brutal-pink">SOURCES</span>
-              </h2>
-              <Card className="p-8 border-4 border-primary shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-                <ul className="space-y-4 text-base leading-relaxed">
-                  <li>
-                    <span className="font-black">RECOVERY Trial</span> — Horby, P. et al. (2021).
-                    Dexamethasone in Hospitalized Patients with Covid-19. <em>New England Journal of Medicine</em>, 384(8), 693-704.
-                  </li>
-                  <li>
-                    <span className="font-black">Trial Cost Analysis</span> — Martin, L. et al. (2017).
-                    How much do clinical trials cost? <em>Nature Reviews Drug Discovery</em>, 16(6), 381-382.
-                  </li>
-                  <li>
-                    <span className="font-black">Pragmatic Trial Design</span> — Ford, I. & Norrie, J. (2016).
-                    Pragmatic Trials. <em>New England Journal of Medicine</em>, 375(5), 454-463.
-                  </li>
-                  <li>
-                    <span className="font-black">RECOVERY Impact</span> — Wellcome Trust (2022).
-                    The RECOVERY trial: one of the most important clinical trials ever run.
-                  </li>
-                </ul>
-              </Card>
-            </Container>
-          </SectionContainer>
-
-          {/* CTA */}
-          <CTASection
-            bgColor="yellow"
-            heading={
-              <>
-                TAKE THE
-                <br />
-                <span className="text-foreground">SURVEY</span>
-              </>
-            }
-          >
-            <Button
-              asChild
-              className="h-14 bg-foreground text-background border-4 border-foreground hover:bg-background hover:text-foreground px-8 sm:px-12 text-lg font-black uppercase"
-            >
-              <Link href="/#vote">Take the survey</Link>
-            </Button>
-          </CTASection>
-        </div>
-      </Layout>
-    )
+    return <SurveyResearchPage />
   }
 
   return (
@@ -623,6 +499,565 @@ export function ResearchPage({ variant }: { variant: ResearchPageVariant }) {
         </SectionContainer>
       </div>
     </Layout>
+  )
+}
+
+function SurveyResearchPage() {
+  const coordinationActors = [
+    ["Patients", "Ask about eligible trials, contribute outcomes, and identify unanswered treatment questions."],
+    ["Physicians", "Offer eligible patients trial participation through routine care."],
+    ["Health systems", "Embed randomization and outcome collection in clinical workflows and records."],
+    ["Researchers", "Publish reusable protocols, interoperable measures, and transparent analyses."],
+    ["Foundations", "Fund shared trial infrastructure and questions that lack commercial incentives."],
+    ["Insurers", "Support routine-care trial participation and evidence generation for covered treatments."],
+    ["Treatment developers", "Supply interventions and support comparative studies, including low-margin uses."],
+    ["Politicians", "Propose access, funding, privacy, and interoperability reforms."],
+    ["Governments", "Fund public trial networks and coordinate standards across borders."],
+  ]
+  const coordinationConditions = [
+    "One verified response per person",
+    "Transparent methodology",
+    "Country-level results",
+    "Representative-sample reporting kept separate from self-selected participation",
+    "Clear translations",
+    "Published recruitment sources",
+    "Protection of respondent privacy",
+    "Concrete follow-up paths for patients, physicians, organizations, funders, and governments",
+  ]
+  const coordinationChain = [
+    "Verified preferences",
+    "Common knowledge and political mandate",
+    "Trial-access and funding reforms",
+    "More physician-embedded pragmatic trials",
+    "Faster evidence",
+    "Earlier adoption of effective treatments",
+    "Reduced disease burden",
+  ]
+
+  return (
+    <Layout>
+      <div className="min-h-screen bg-background">
+        <SectionContainer bgColor="foreground" borderPosition="bottom" padding="lg">
+          <Container size="xl">
+            <div className="mx-auto max-w-5xl text-center text-background">
+              <p className="mb-4 text-sm font-black uppercase tracking-[0.2em] text-brutal-cyan">
+                Independent research initiative
+              </p>
+              <h1 className="mb-6 text-4xl font-black uppercase leading-none sm:text-5xl md:text-6xl">
+                Evidence behind the
+                <br />
+                <span className="text-brutal-pink">Trial Abundance Survey</span>
+              </h1>
+              <p className="mx-auto max-w-3xl text-lg font-bold sm:text-xl">
+                The three-question survey stays brief. This page separates observed evidence from estimates, model
+                projections, and a coordination hypothesis about what verified public preferences could change.
+              </p>
+            </div>
+          </Container>
+        </SectionContainer>
+
+        <SectionContainer bgColor="background" borderPosition="bottom" padding="lg">
+          <Container size="xl">
+            <div className="mb-8 max-w-4xl">
+              <h2 className="mb-3 text-3xl font-black uppercase md:text-4xl">How to read the claims</h2>
+              <p className="text-lg font-bold">
+                The label on each claim matters. A published observation is not the same thing as an estimated global
+                denominator, a model output, or a forecast about collective action.
+              </p>
+            </div>
+            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+              <EvidenceTypeCard
+                label="Observed evidence"
+                color="bg-brutal-cyan"
+                description="Dates, trial results, designs, and study findings reported by the cited institutions or papers."
+              />
+              <EvidenceTypeCard
+                label="Estimate"
+                color="bg-brutal-yellow"
+                description="A best current approximation used where no complete global accounting exists."
+              />
+              <EvidenceTypeCard
+                label="Model projection"
+                color="bg-background"
+                description="A calculated scenario that depends on explicit inputs and assumptions."
+              />
+              <EvidenceTypeCard
+                label="Coordination hypothesis"
+                color="bg-brutal-pink text-white"
+                description="A plausible pathway to test, not an observed survey result or an automatic policy effect."
+              />
+            </div>
+          </Container>
+        </SectionContainer>
+
+        <SectionContainer bgColor="yellow" borderPosition="bottom" padding="lg">
+          <Container size="xl">
+            <div className="mb-8 max-w-4xl">
+              <p className="mb-3 text-sm font-black uppercase tracking-[0.2em]">Observed input + model estimate</p>
+              <h2 className="mb-4 text-3xl font-black uppercase md:text-5xl">Government spending context</h2>
+              <p className="text-lg font-bold">
+                The survey&apos;s allocation question compares two categories of government spending. It does not
+                compare military spending with all public and private medical research.
+              </p>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+              <ResearchStatCard
+                label="Observed: military spending"
+                value={
+                  <a
+                    href="https://www.sipri.org/publications/2025/sipri-fact-sheets/trends-world-military-expenditure-2024"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline decoration-4 underline-offset-4"
+                  >
+                    $2.718T
+                  </a>
+                }
+                detail="SIPRI's estimate of world military expenditure in 2024."
+                color="bg-background"
+              />
+              <ResearchStatCard
+                label="Estimate: government trials"
+                value={
+                  <ParameterValue
+                    param={GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL}
+                    valueOverride="$4.5B"
+                    className="font-black"
+                  />
+                }
+                detail={`Current annual model estimate; uncertainty range ${governmentTrialSpendingRange}.`}
+                color="bg-brutal-cyan"
+              />
+              <ResearchStatCard
+                label="Calculated share"
+                value={`${GOVERNMENT_TRIAL_SHARE_OF_MILITARY_PCT.toFixed(3)}%`}
+                detail="$4.5 billion as a share of SIPRI's $2.718 trillion estimate."
+                color="bg-background"
+              />
+              <ResearchStatCard
+                label="Calculated ratio"
+                value={
+                  <ParameterValue
+                    param={MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO}
+                    format={{ precision: 0 }}
+                    className="font-black"
+                  />
+                }
+                detail="About $604 in military spending for every $1 in government clinical-trial spending."
+                color="bg-brutal-pink text-white"
+              />
+            </div>
+
+            <Card className="mt-8 gap-5 border-4 border-primary bg-background p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8">
+              <h3 className="text-2xl font-black uppercase">What the denominator does—and does not—mean</h3>
+              <div className="space-y-4 text-base font-bold leading-relaxed sm:text-lg">
+                <p>
+                  This is explicitly a{" "}
+                  <span className="font-black text-brutal-pink">government-to-government comparison</span>: global
+                  military expenditure versus estimated government spending on interventional clinical trials.
+                </p>
+                <p>
+                  No authoritative organization publishes a complete global accounting of government spending on
+                  interventional trials across every country. The{" "}
+                  <ParameterValue param={GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL} valueOverride="$4.5B" />{" "}
+                  denominator is therefore an estimate, not an observed world total. The current model uses a{" "}
+                  {governmentTrialSpendingRange} uncertainty range.
+                </p>
+                <p>
+                  Including private pharmaceutical trial spending and other non-government funding produces a
+                  substantially smaller comparison. The current all-trials estimate is{" "}
+                  <ParameterValue param={GLOBAL_CLINICAL_TRIALS_SPENDING_ANNUAL} />, which yields about{" "}
+                  <ParameterValue param={MILITARY_TO_CLINICAL_TRIALS_SPENDING_RATIO} format={{ precision: 0 }} />. That
+                  broader ratio answers a different question from the survey&apos;s public-budget comparison.
+                </p>
+              </div>
+            </Card>
+          </Container>
+        </SectionContainer>
+
+        <SectionContainer bgColor="background" borderPosition="bottom" padding="lg">
+          <Container size="xl">
+            <div className="mb-8 max-w-4xl">
+              <p className="mb-3 text-sm font-black uppercase tracking-[0.2em] text-brutal-pink">Observed evidence</p>
+              <h2 className="mb-4 text-3xl font-black uppercase md:text-5xl">What RECOVERY demonstrated</h2>
+              <p className="text-lg font-bold">
+                RECOVERY used a simple adaptive design embedded in routine NHS care. Existing clinical workflows and
+                routinely collected data reduced additional burden while preserving randomized comparisons.
+              </p>
+            </div>
+
+            <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+              <ResearchStatCard
+                label="First patient"
+                value="19 MAR 2020"
+                detail="Oxford reports that RECOVERY recruited its first patient nine days after the protocol was drafted."
+                color="bg-brutal-cyan"
+              />
+              <ResearchStatCard
+                label="Dexamethasone result"
+                value="16 JUN 2020"
+                detail="The trial announced the first treatment shown to reduce COVID-19 mortality."
+                color="bg-brutal-yellow"
+              />
+              <ResearchStatCard
+                label="Elapsed time"
+                value={`${RECOVERY_DAYS_TO_DEXAMETHASONE} DAYS`}
+                detail="Calendar days from the first recruited patient to the dexamethasone announcement."
+                color="bg-background"
+              />
+              <ResearchStatCard
+                label="First 100 days"
+                value="3 TREATMENTS"
+                detail="Actionable results for hydroxychloroquine, dexamethasone, and lopinavir-ritonavir."
+                color="bg-brutal-pink text-white"
+              />
+            </div>
+
+            <Card className="mt-8 gap-6 border-4 border-primary bg-brutal-cyan p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8">
+              <div>
+                <p className="mb-2 text-sm font-black uppercase tracking-[0.2em]">Cost evidence</p>
+                <h3 className="text-2xl font-black uppercase sm:text-3xl">
+                  Large potential, not one universal multiplier
+                </h3>
+              </div>
+              <div className="grid gap-4">
+                <ComparisonRow
+                  label="RECOVERY estimate"
+                  value={<ParameterValue param={RECOVERY_TRIAL_COST_PER_PATIENT} className="font-black" />}
+                  detail="Approximate per-participant estimate for one unusually streamlined emergency platform trial."
+                />
+                <ComparisonRow
+                  label="Pivotal approval trials"
+                  value={
+                    <ParameterValue
+                      param={pivotalTrialMedianCostPerParticipant}
+                      valueOverride="$41,413"
+                      className="font-black"
+                    />
+                  }
+                  detail="Peer-reviewed median estimate per participant across 225 pivotal trials supporting drug approvals."
+                />
+                <ComparisonRow
+                  label="Embedded pragmatic trials"
+                  value={
+                    <ParameterValue
+                      param={embeddedPragmaticTrialMedianCostPerParticipant}
+                      valueOverride="$97"
+                      className="font-black"
+                    />
+                  }
+                  detail="Median research cost per randomized participant among 64 trials with available cost data."
+                />
+              </div>
+              <p className="text-base font-bold leading-relaxed sm:text-lg">
+                Dividing the pivotal-trial median by the RECOVERY estimate produces the familiar approximately{" "}
+                <ParameterValue param={RECOVERY_TRIAL_COST_REDUCTION_FACTOR} className="font-black" /> comparison. It is
+                a RECOVERY-versus-pivotal-trial comparison, not a guaranteed saving for every pragmatic trial. The
+                studies cover heterogeneous interventions, health systems, accounting methods, and trial designs.
+                Together they show major cost potential, not a universal multiplier.
+              </p>
+              <p className="text-sm font-bold">
+                Sources: Oxford&apos;s{" "}
+                <a
+                  href="https://www.ndm.ox.ac.uk/covid-19/covid-research/drug-trials-recovery"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline decoration-2 underline-offset-2"
+                >
+                  RECOVERY account
+                </a>
+                , the{" "}
+                <a
+                  href="https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline decoration-2 underline-offset-2"
+                >
+                  pivotal-trial cost study
+                </a>
+                , and the{" "}
+                <a
+                  href="https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline decoration-2 underline-offset-2"
+                >
+                  embedded pragmatic-trial review
+                </a>
+                .
+              </p>
+            </Card>
+          </Container>
+        </SectionContainer>
+
+        <SectionContainer bgColor="cyan" borderPosition="bottom" padding="lg">
+          <Container size="xl">
+            <div className="mb-8 max-w-4xl">
+              <p className="mb-3 text-sm font-black uppercase tracking-[0.2em]">
+                Model projection—not an observed outcome
+              </p>
+              <h2 className="mb-4 text-3xl font-black uppercase md:text-5xl">How the capacity scenario is built</h2>
+              <p className="text-lg font-bold">
+                The model uses a deliberately conservative pragmatic-trial cost input rather than treating
+                RECOVERY&apos;s emergency result as universally reproducible. Its outputs change when the inputs change.
+              </p>
+            </div>
+            <div className="grid gap-6 md:grid-cols-3">
+              <ResearchStatCard
+                label="Central cost input"
+                value={<ParameterValue param={DFDA_PRAGMATIC_TRIAL_COST_PER_PATIENT} className="font-black" />}
+                detail="Per participant, with an uncertainty interval informed by embedded-trial evidence and more complex trials."
+                color="bg-background"
+              />
+              <ResearchStatCard
+                label="Projected capacity"
+                value={
+                  <ParameterValue
+                    param={DFDA_TRIAL_CAPACITY_MULTIPLIER}
+                    format={{ precision: 1 }}
+                    className="font-black"
+                  />
+                }
+                detail="Scenario output at the model's trial-funding level, not an observed global expansion."
+                color="bg-brutal-yellow"
+              />
+              <ResearchStatCard
+                label="Projected queue"
+                value={
+                  <>
+                    <ParameterValue param={STATUS_QUO_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} />
+                    {" → "}
+                    <ParameterValue param={DFDA_QUEUE_CLEARANCE_YEARS} format={{ precision: 0 }} />
+                    {" years"}
+                  </>
+                }
+                detail="Modeled treatment-research queue under current versus expanded capacity assumptions."
+                color="bg-brutal-pink text-white"
+              />
+            </div>
+          </Container>
+        </SectionContainer>
+
+        <SectionContainer bgColor="background" borderPosition="bottom" padding="lg">
+          <Container size="xl">
+            <div className="mb-8 max-w-5xl">
+              <p className="mb-3 text-sm font-black uppercase tracking-[0.2em] text-brutal-pink">
+                Coordination hypothesis—not an observed survey result
+              </p>
+              <h2 className="mb-4 text-3xl font-black uppercase md:text-5xl">What could a global majority change?</h2>
+              <p className="text-lg font-bold">
+                A verified majority would not enact a law by itself. It could create an election-scale public mandate
+                and coordination event that institutions can respond to independently.
+              </p>
+            </div>
+
+            <Card className="mb-8 gap-5 border-4 border-primary bg-brutal-yellow p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8">
+              <div className="grid gap-6 lg:grid-cols-[0.65fr_1.35fr] lg:items-center">
+                <div>
+                  <p className="text-6xl font-black sm:text-7xl">51%</p>
+                  <p className="mt-2 text-3xl font-black">
+                    <ParameterValue param={surveyMajorityTarget} format={{ precision: 2 }} />
+                  </p>
+                  <p className="mt-2 text-sm font-black uppercase">people at the current checked-in population input</p>
+                </div>
+                <div className="space-y-4 text-base font-bold leading-relaxed sm:text-lg">
+                  <p>
+                    The current global-population parameter is <ParameterValue param={GLOBAL_POPULATION_2024} />.
+                    Multiplying it by 51% gives 4.08 billion people—about 4.1 billion. As the population input rises
+                    above 8.2 billion, the same rule is about 4.2 billion; the target is calculated instead of frozen to
+                    a stale headcount.
+                  </p>
+                  <p>
+                    Public verification could reduce pluralistic ignorance: people may privately support a reform while
+                    incorrectly believing that most others do not. Country-level, auditable results could make dispersed
+                    preferences common knowledge and give decision-makers a visible mandate to answer.
+                  </p>
+                </div>
+              </div>
+            </Card>
+
+            <h3 className="mb-5 text-2xl font-black uppercase sm:text-3xl">Plausible independent responses</h3>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {coordinationActors.map(([actor, response]) => (
+                <Card
+                  key={actor}
+                  className="gap-3 border-4 border-primary bg-background p-5 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]"
+                >
+                  <h4 className="text-lg font-black uppercase text-brutal-pink">{actor}</h4>
+                  <p className="text-sm font-bold leading-relaxed">{response}</p>
+                </Card>
+              ))}
+            </div>
+
+            <Card className="mt-8 gap-5 border-4 border-primary bg-foreground p-6 text-background shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8">
+              <h3 className="text-2xl font-black uppercase sm:text-3xl">The hypothesized causal chain</h3>
+              <ol className="grid gap-3">
+                {coordinationChain.map((step, index) => (
+                  <li key={step} className="grid gap-3 sm:grid-cols-[2.5rem_1fr] sm:items-center">
+                    <span className="flex h-10 w-10 items-center justify-center border-2 border-background bg-brutal-cyan text-lg font-black text-foreground">
+                      {index + 1}
+                    </span>
+                    <span className="text-base font-black uppercase sm:text-lg">
+                      {step}
+                      {index < coordinationChain.length - 1 ? (
+                        <span className="ml-3 text-brutal-cyan" aria-hidden="true">
+                          →
+                        </span>
+                      ) : null}
+                    </span>
+                  </li>
+                ))}
+              </ol>
+              <p className="border-t-2 border-background/40 pt-5 text-base font-bold">
+                Survey responses do not automatically enact laws, fund trials, establish causation, or eradicate
+                disease. Each arrow requires institutions and people to act, and the effects must be measured.
+              </p>
+            </Card>
+
+            <div className="mt-8 grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
+              <div>
+                <p className="mb-3 text-sm font-black uppercase tracking-[0.2em] text-brutal-pink">
+                  Conditions for credibility
+                </p>
+                <h3 className="text-2xl font-black uppercase sm:text-3xl">A majority claim must earn trust</h3>
+              </div>
+              <Card className="border-4 border-primary bg-brutal-cyan p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8">
+                <ul className="grid gap-4 sm:grid-cols-2">
+                  {coordinationConditions.map((condition) => (
+                    <li key={condition} className="flex gap-3 text-sm font-bold leading-relaxed sm:text-base">
+                      <span className="font-black" aria-hidden="true">
+                        ■
+                      </span>
+                      <span>{condition}</span>
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            </div>
+          </Container>
+        </SectionContainer>
+
+        <SectionContainer bgColor="pink" borderPosition="bottom" padding="lg">
+          <Container size="xl">
+            <div className="mb-8 max-w-4xl text-white">
+              <p className="mb-3 text-sm font-black uppercase tracking-[0.2em]">Source trail</p>
+              <h2 className="mb-4 text-3xl font-black uppercase md:text-5xl">Read the underlying evidence</h2>
+              <p className="text-lg font-bold">
+                Parameter values on this page open their own source and calculation details. These are the primary
+                institutional and peer-reviewed sources for the central observed claims.
+              </p>
+            </div>
+            <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+              <SourceLink
+                href="https://www.sipri.org/publications/2025/sipri-fact-sheets/trends-world-military-expenditure-2024"
+                title="SIPRI: World military expenditure, 2024"
+                detail="Observed military-spending input."
+              />
+              <SourceLink
+                href="https://www.ndm.ox.ac.uk/covid-19/covid-research/drug-trials-recovery"
+                title="Oxford: RECOVERY trial"
+                detail="First patient, dexamethasone date, and NHS embedding."
+              />
+              <SourceLink
+                href="https://www.ndph.ox.ac.uk/news/recovery-trial-celebrates-two-year-anniversary-of-life-saving-dexamethasone-result"
+                title="Oxford: Three results within 100 days"
+                detail="Institutional account of the trial's rapid results."
+              />
+              <SourceLink
+                href="https://pmc.ncbi.nlm.nih.gov/articles/PMC7295430/"
+                title="Pivotal trial cost study"
+                detail="Peer-reviewed $41,413 median cost per participant."
+              />
+              <SourceLink
+                href="https://pmc.ncbi.nlm.nih.gov/articles/PMC6508852/"
+                title="Embedded pragmatic trial review"
+                detail="Peer-reviewed review reporting a $97 median among 64 trials."
+              />
+              <SourceLink
+                href={
+                  RECOVERY_TRIAL_COST_PER_PATIENT.sourceUrl ??
+                  "https://manual.warondisease.org/knowledge/appendix/recovery-trial"
+                }
+                title="RECOVERY cost estimate"
+                detail="Source behind the approximate $500 model parameter."
+              />
+            </div>
+          </Container>
+        </SectionContainer>
+
+        <CTASection
+          bgColor="yellow"
+          heading={
+            <>
+              TAKE THE
+              <br />
+              <span className="text-foreground">SURVEY</span>
+            </>
+          }
+        >
+          <Button
+            asChild
+            className="h-14 border-4 border-foreground bg-foreground px-8 text-lg font-black uppercase text-background hover:bg-background hover:text-foreground sm:px-12"
+          >
+            <Link href="/#vote">Take the survey</Link>
+          </Button>
+        </CTASection>
+      </div>
+    </Layout>
+  )
+}
+
+function EvidenceTypeCard({ label, description, color }: { label: string; description: string; color: string }) {
+  return (
+    <Card className={`${color} gap-3 border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}>
+      <h3 className="text-xl font-black uppercase">{label}</h3>
+      <p className="text-sm font-bold leading-relaxed">{description}</p>
+    </Card>
+  )
+}
+
+function ResearchStatCard({
+  label,
+  value,
+  detail,
+  color,
+}: {
+  label: string
+  value: ReactNode
+  detail: string
+  color: string
+}) {
+  return (
+    <Card className={`${color} gap-3 border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]`}>
+      <h3 className="text-xs font-black uppercase tracking-[0.18em]">{label}</h3>
+      <p className="break-words text-3xl font-black sm:text-4xl">{value}</p>
+      <p className="text-sm font-bold leading-relaxed">{detail}</p>
+    </Card>
+  )
+}
+
+function ComparisonRow({ label, value, detail }: { label: string; value: ReactNode; detail: string }) {
+  return (
+    <div className="grid gap-2 border-4 border-primary bg-background p-4 sm:grid-cols-[1fr_0.55fr_1.45fr] sm:items-center">
+      <h4 className="text-sm font-black uppercase">{label}</h4>
+      <p className="text-2xl font-black">{value}</p>
+      <p className="text-sm font-bold leading-relaxed">{detail}</p>
+    </div>
+  )
+}
+
+function SourceLink({ href, title, detail }: { href: string; title: string; detail: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block border-4 border-primary bg-background p-5 text-foreground shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[10px_10px_0px_0px_rgba(0,0,0,1)]"
+    >
+      <h3 className="mb-2 text-lg font-black uppercase">{title}</h3>
+      <p className="text-sm font-bold leading-relaxed">{detail}</p>
+    </a>
   )
 }
 


### PR DESCRIPTION
## Summary

- replace the allocation slider's blue circular thumb with the square black DIH NeoBrutalist thumb
- show the login or referral card immediately after the final answer and remove the two intermediate completion cards
- hide the survey title and three-question introduction after the first answer, while restoring them when users return to question 1
- preserve the three survey questions, local persistence, authenticated sync, confetti, and referral sharing
- restore the original concise `/research` page and its neobrutalist section rhythm
- add compact sections for public spending, trial-access barriers, federal and Montana Right to Try, and the 51% coordination case
- turn the disease-eradication timeline and weapons-and-military-versus-public-trial spending into responsive horizontal bar charts
- explain the 6,650 untreated diseases, 15 first treatments per year, 443-year backlog, 36-year modeled result, and 12.3x patient-slot increase in plain language
- illustrate the 51% coordination path with neobrutalist boxes, arrows, emojis, and accessible labels
- remove the government-accounting disclaimer, private-funding aside, price caveat, and post-flow qualification boxes
- replace vague labels and regulatory jargon with explicit patient, funding, treatment, and trial-system language
- prevent full-page screenshot scrolling from overwriting the timeline's deterministic visual-capture state
- regenerate the logged-out research snapshot from the rendered page

## Review routes

- `/?visual=self-funded`
- `/?visual=allocation`
- `/?visual=complete`
- `/research`

## Verification

- `pnpm copy trialabundancesurvey --routes=/research`
- `pnpm --filter @apps/trialabundancesurvey typecheck`
- `pnpm --filter @apps/trialabundancesurvey lint`
- `pnpm --filter @apps/trialabundancesurvey test:unit` (3 files, 10 tests)
- `pnpm --filter @apps/trialabundancesurvey build`
- `pnpm --filter @apps/curedao typecheck`
- `pnpm --filter @apps/curedao lint`
- `pnpm --filter @apps/curedao test:unit`
- `pnpm --filter @apps/curedao build`
- two independent CureDAO capture runs compare as 0 changed routes
- 64 desktop and mobile before/after screenshots in the stable local review; 3 intended survey states changed, 13 are unchanged, and UI coverage is 2/2 changed source files

Visual inspection found no overflow, overlap, missing content, or broken responsive layout in the research charts and mandate flow, questions 2 and 3, or the post-submit login state. Browser interaction confirms the introduction disappears after question 1 and returns when the user goes back. The CureDAO timeline finishes in the same capture state on repeated runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added improved slider thumb styling across supported browsers.
  - Streamlined survey completion with referral and authentication options.

- **Updates**
  - Refined the research page with a clearer overview of pragmatic trials, disease timelines, key findings, public spending gaps, trial access barriers, and potential solutions.
  - Updated research wording, labels, and source presentation for improved clarity.
  - Improved visual-capture behavior so the timeline remains stable after capture is complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->