### PR TITLE
Add logout to shared site menus

### DIFF
--- a/apps/warondisease/tests/unit/shared-layout-logout.test.tsx
+++ b/apps/warondisease/tests/unit/shared-layout-logout.test.tsx
@@ -46,5 +46,8 @@ describe("shared authenticated navigation", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Log Out" }))
 
     expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: ROUTES.home })
+    expect(
+      screen.queryByRole("dialog", { name: "Navigation Menu" }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/apps/warondisease/tests/unit/shared-layout-logout.test.tsx
+++ b/apps/warondisease/tests/unit/shared-layout-logout.test.tsx
@@ -1,0 +1,51 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import Layout from "../../../../packages/site-kit/src/components/layout"
+
+const mocks = vi.hoisted(() => ({
+  signOut: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  signOut: mocks.signOut,
+  useSession: () => ({
+    data: {
+      user: {
+        email: "voter@example.com",
+        name: "Test Voter",
+      },
+    },
+    status: "authenticated",
+  }),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock(
+  "../../../../packages/site-kit/src/components/shared/VoteOrShareButton",
+  () => ({ VoteOrShareButton: () => null }),
+)
+
+describe("shared authenticated navigation", () => {
+  beforeEach(() => {
+    mocks.signOut.mockReset()
+  })
+
+  it("logs the user out from the menu and returns to the site home page", async () => {
+    render(
+      <Layout>
+        <main>Page content</main>
+      </Layout>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle menu" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Log Out" }))
+
+    await waitFor(() => {
+      expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
+    })
+  })
+})

--- a/apps/warondisease/tests/unit/shared-layout-logout.test.tsx
+++ b/apps/warondisease/tests/unit/shared-layout-logout.test.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import Layout from "../../../../packages/site-kit/src/components/layout"
+import { ROUTES } from "../../../../packages/site-kit/src/lib/routes"
 
 const mocks = vi.hoisted(() => ({
   signOut: vi.fn(),
@@ -44,8 +45,6 @@ describe("shared authenticated navigation", () => {
     fireEvent.click(screen.getByRole("button", { name: "Toggle menu" }))
     fireEvent.click(await screen.findByRole("button", { name: "Log Out" }))
 
-    await waitFor(() => {
-      expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
-    })
+    expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: ROUTES.home })
   })
 })

--- a/packages/site-kit/src/components/layout.tsx
+++ b/packages/site-kit/src/components/layout.tsx
@@ -18,10 +18,10 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@optimitron/neobrutalist-ui/ui/accordion";
-import { Menu, User, ExternalLink } from "lucide-react";
+import { ExternalLink, LogOut, Menu, User } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
-import { useSession } from "next-auth/react";
+import { signOut, useSession } from "next-auth/react";
 import {
   getTopLevelNavItems,
   getSidebarSections,
@@ -45,7 +45,8 @@ type SessionUser = {
 
 export function Layout({ children }: LayoutProps) {
   const [open, setOpen] = useState(false);
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
+  const isAuthenticated = status === "authenticated";
   // Cast: apps and site-kit can resolve different next-auth copies, so module
   // augmentation on Session.user is not reliable across the monorepo boundary.
   const isAdmin = (session?.user as SessionUser | undefined)?.isAdmin || false;
@@ -261,6 +262,20 @@ export function Layout({ children }: LayoutProps) {
                     >
                       ⚙️ ADMIN
                     </Link>
+                  )}
+
+                  {isAuthenticated && (
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-3 border-b-4 border-primary pb-2 text-left text-2xl font-black uppercase transition-colors hover:text-brutal-pink"
+                      onClick={() => {
+                        setOpen(false);
+                        void signOut({ callbackUrl: "/" });
+                      }}
+                    >
+                      <LogOut className="h-6 w-6 stroke-[3px]" />
+                      Log Out
+                    </button>
                   )}
 
                   {siteConfig.sidebarVoteCtaPlacement !== "top"

--- a/packages/site-kit/src/components/layout.tsx
+++ b/packages/site-kit/src/components/layout.tsx
@@ -270,7 +270,7 @@ export function Layout({ children }: LayoutProps) {
                       className="flex w-full items-center gap-3 border-b-4 border-primary pb-2 text-left text-2xl font-black uppercase transition-colors hover:text-brutal-pink"
                       onClick={() => {
                         setOpen(false);
-                        void signOut({ callbackUrl: "/" });
+                        void signOut({ callbackUrl: ROUTES.home });
                       }}
                     >
                       <LogOut className="h-6 w-6 stroke-[3px]" />

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -90,6 +90,20 @@ export const authenticatedSiteAppRoutes = Object.freeze({
     {
       authenticated: true,
       authRole: "user",
+      captureSelector: '[role="dialog"]',
+      covers: [
+        "apps/warondisease/app/dashboard/page.tsx",
+        "packages/site-kit/src/components/layout.tsx",
+      ],
+      label: "Navigation menu — signed-in user",
+      openMenu: true,
+      routeName: "navigation-menu-authenticated",
+      routePath: "/dashboard",
+      sourcePage: "apps/warondisease/app/dashboard/page.tsx",
+    },
+    {
+      authenticated: true,
+      authRole: "user",
       covers: [
         "apps/warondisease/app/dashboard/settings/page.tsx",
         "apps/warondisease/app/dashboard/settings/settings-client.tsx",

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -72,6 +72,22 @@ const warOnDiseaseDashboardFiles = [
   "packages/site-kit/src/components/dashboard/StickyShareFooter.tsx",
 ];
 
+function getAuthenticatedMenuRoute(appName) {
+  const sourcePage = `apps/${appName}/app/dashboard/page.tsx`;
+
+  return {
+    authenticated: true,
+    authRole: "user",
+    captureSelector: '[role="dialog"]',
+    covers: [sourcePage, "packages/site-kit/src/components/layout.tsx"],
+    label: "Navigation menu — signed-in user",
+    openMenu: true,
+    routeName: "navigation-menu-authenticated",
+    routePath: "/dashboard",
+    sourcePage,
+  };
+}
+
 export const authenticatedSiteAppRoutes = Object.freeze({
   warondisease: [
     {
@@ -87,20 +103,7 @@ export const authenticatedSiteAppRoutes = Object.freeze({
       routePath: "/dashboard",
       sourcePage: "apps/warondisease/app/dashboard/page.tsx",
     },
-    {
-      authenticated: true,
-      authRole: "user",
-      captureSelector: '[role="dialog"]',
-      covers: [
-        "apps/warondisease/app/dashboard/page.tsx",
-        "packages/site-kit/src/components/layout.tsx",
-      ],
-      label: "Navigation menu — signed-in user",
-      openMenu: true,
-      routeName: "navigation-menu-authenticated",
-      routePath: "/dashboard",
-      sourcePage: "apps/warondisease/app/dashboard/page.tsx",
-    },
+    getAuthenticatedMenuRoute("warondisease"),
     {
       authenticated: true,
       authRole: "user",
@@ -200,6 +203,7 @@ export const authenticatedSiteAppRoutes = Object.freeze({
     },
   ],
   wishocracy: [
+    getAuthenticatedMenuRoute("wishocracy"),
     {
       authenticated: true,
       authRole: "user",
@@ -214,6 +218,7 @@ export const authenticatedSiteAppRoutes = Object.freeze({
     },
   ],
   trialabundancesurvey: [
+    getAuthenticatedMenuRoute("trialabundancesurvey"),
     {
       authenticated: true,
       authRole: "user",
@@ -229,6 +234,7 @@ export const authenticatedSiteAppRoutes = Object.freeze({
     },
   ],
   courtofhumanity: [
+    getAuthenticatedMenuRoute("courtofhumanity"),
     {
       authenticated: true,
       authRole: "user",

--- a/scripts/smoke-site-apps.mjs
+++ b/scripts/smoke-site-apps.mjs
@@ -210,6 +210,7 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
             routeName,
             routePath,
             captureSelector,
+            openMenu,
           } of screenshotRoutes) {
             const page = authenticated ? authenticatedPage : loggedOutPage;
             const pageUrl = new URL(routePath, baseUrl);
@@ -256,6 +257,20 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
             await forceAnimationsComplete(page);
             await prepareFullPageVisualCapture(page);
             await forceAnimationsComplete(page);
+            if (openMenu) {
+              const menuTrigger = page.getByRole("button", {
+                name: "Toggle menu",
+              });
+              await menuTrigger.click();
+              const menuDialog = page.getByRole("dialog", {
+                name: "Navigation Menu",
+              });
+              await menuDialog.waitFor({ state: "visible" });
+              await menuDialog
+                .getByRole("button", { name: "Log Out" })
+                .waitFor({ state: "visible" });
+              await forceAnimationsComplete(page);
+            }
             const screenshotPath = path.join(
               outputDirectory,
               `site-app-${appName}-${routeName}.png`,


### PR DESCRIPTION
## Summary

- Show `Log Out` in the shared authenticated menu used by all seven public site apps.
- Close the menu and return to the site home page after NextAuth signs the user out.
- Add a regression test and authenticated menu visual-review states.

## Verification

- [ ] Human reviewed the desktop and mobile menu screenshots.
- [ ] Human confirmed logout behavior.

Automated checks run locally:

- `pnpm --filter @apps/warondisease run test:unit -- tests/unit/shared-layout-logout.test.tsx`
- `pnpm test:site-app-navigation`
- `pnpm --filter @apps/warondisease run typecheck`
- `pnpm --filter @apps/warondisease run lint`
- War on Disease production build with repository environment

Review surfaces:

- [Published screenshot review](https://mikepsinn.github.io/optimitron/pr-301/713ea6f57d71/)
- [War on Disease preview dashboard](https://warondisease-git-feature-logout-menu-mike-p-sinns-projects.vercel.app/dashboard) (sign in, then open the menu)

The CI visual fixture opens the authenticated navigation menu for War on Disease, Wishocracy, Trial Abundance Survey, and Court of Humanity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Authenticated users can now sign out directly from the navigation menu.
  - Signing out closes the menu and returns users to the home page.

- **Bug Fixes**
  - Improved handling and verification of authenticated navigation states across supported applications.
  - Added coverage for pending-response recovery behavior in the survey experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->