### PR TITLE
Bound visual capture waits so a stalled page fails fast

### DIFF
--- a/apps/optimitron/e2e/utils/visual-settle.mjs
+++ b/apps/optimitron/e2e/utils/visual-settle.mjs
@@ -151,13 +151,9 @@ export async function prepareFullPageVisualCapture(page) {
   );
 
   await retryAfterNavigation(page, async () => {
-    await page.evaluate(async () => {
-      window.scrollTo(0, 0);
-      await new Promise((resolve) => {
-        requestAnimationFrame(() => requestAnimationFrame(resolve));
-      });
-    });
+    await page.evaluate(() => window.scrollTo(0, 0));
   });
+  await waitForPaint(page);
 
   await waitForCaptureReady(page);
   await waitForImagesSettled(page);
@@ -259,17 +255,59 @@ export async function waitForImagesSettled(page, timeout = 15_000) {
     await page.waitForTimeout(100);
   }
 
-  await Promise.all(
-    evaluationTargets(page).map((target) =>
-      retryingEvaluate(target, async () => {
-        await Promise.allSettled(
-          Array.from(document.images)
-            .filter((image) => image.complete && image.naturalWidth > 0)
-            .map((image) => image.decode()),
+  await withDeadline(
+    Promise.all(
+      evaluationTargets(page).map((target) =>
+        retryingEvaluate(target, async () => {
+          await Promise.allSettled(
+            Array.from(document.images)
+              .filter((image) => image.complete && image.naturalWidth > 0)
+              .map((image) => image.decode()),
+          );
+        }),
+      ),
+    ),
+    Math.max(1_000, deadline - Date.now()),
+    `Timed out after ${timeout}ms waiting for images to decode.`,
+  );
+}
+
+/** Raised by `withDeadline`, so callers can tell a stall from a real failure. */
+class DeadlineExceededError extends Error {}
+
+/**
+ * Reject if `work` has not settled within `timeout`.
+ *
+ * `page.evaluate` has no timeout of its own, so an evaluation whose promise
+ * never resolves — a wedged renderer, an image `decode()` that never settles —
+ * hangs the caller forever rather than failing. A capture that stops
+ * responding then consumes the entire CI job budget and reports nothing but
+ * "The operation was canceled", with no indication of which route stalled.
+ *
+ * Losing the race does not cancel the underlying evaluation; it stays pending
+ * until its context closes.
+ *
+ * @template T
+ * @param {Promise<T>} work
+ * @param {number} timeout
+ * @param {string} message
+ * @returns {Promise<T>}
+ */
+async function withDeadline(work, timeout, message) {
+  let timer;
+  try {
+    return await Promise.race([
+      work,
+      new Promise((_, reject) => {
+        timer = setTimeout(
+          () => reject(new DeadlineExceededError(message)),
+          timeout,
         );
       }),
-    ),
-  );
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**
@@ -323,17 +361,35 @@ export async function waitForFonts(target, timeout = 10_000) {
   }
 }
 
-/** @param {import("@playwright/test").Page} page */
-export async function waitForPaint(page) {
-  await retryAfterNavigation(page, async () => {
-    await page.evaluate(
-      () =>
-        new Promise((resolve) => {
-          requestAnimationFrame(() => {
-            requestAnimationFrame(() => resolve());
-          });
-        }),
-    );
+/**
+ * Settle on a painted frame, but do not require one.
+ *
+ * `requestAnimationFrame` only runs while the renderer is producing frames, so
+ * a page the browser has stopped rendering never invokes the callback. Unlike
+ * the readiness waits above, this is polish: `page.screenshot` forces its own
+ * frame, so proceeding without the extra paint costs nothing.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {number} [timeout]
+ */
+export async function waitForPaint(page, timeout = 5_000) {
+  await withDeadline(
+    retryAfterNavigation(page, async () => {
+      await page.evaluate(
+        () =>
+          new Promise((resolve) => {
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => resolve());
+            });
+          }),
+      );
+    }),
+    timeout,
+    `Timed out after ${timeout}ms waiting for a painted frame.`,
+  ).catch((error) => {
+    if (!(error instanceof DeadlineExceededError)) {
+      throw error;
+    }
   });
 }
 

--- a/apps/optimitron/e2e/utils/visual-settle.mjs
+++ b/apps/optimitron/e2e/utils/visual-settle.mjs
@@ -211,6 +211,8 @@ export async function waitForCaptureReady(page, timeout = 10_000) {
   }
 }
 
+const DECODE_MINIMUM_BUDGET_MS = 1_000;
+
 /**
  * Wait for every image to finish loading and decoding.
  *
@@ -255,6 +257,15 @@ export async function waitForImagesSettled(page, timeout = 15_000) {
     await page.waitForTimeout(100);
   }
 
+  // Whatever is left of the budget, floored so that a poll which consumed
+  // nearly all of it cannot fail a decode for want of time — these images are
+  // already downloaded, so decoding them is normally instant. The floor means
+  // a slow poll can push the total slightly past `timeout`, which is why the
+  // message below reports the budget actually given rather than `timeout`.
+  const decodeBudgetMs = Math.max(
+    DECODE_MINIMUM_BUDGET_MS,
+    deadline - Date.now(),
+  );
   await withDeadline(
     Promise.all(
       evaluationTargets(page).map((target) =>
@@ -267,8 +278,8 @@ export async function waitForImagesSettled(page, timeout = 15_000) {
         }),
       ),
     ),
-    Math.max(1_000, deadline - Date.now()),
-    `Timed out after ${timeout}ms waiting for images to decode.`,
+    decodeBudgetMs,
+    `Timed out after ${decodeBudgetMs}ms waiting for images to decode.`,
   );
 }
 
@@ -390,6 +401,9 @@ export async function waitForPaint(page, timeout = 5_000) {
     if (!(error instanceof DeadlineExceededError)) {
       throw error;
     }
+    // Bounding this is only useful if the fact reaches the log; a renderer
+    // that has stopped producing frames is worth knowing about.
+    console.warn(error.message);
   });
 }
 

--- a/apps/optimitron/e2e/utils/visual-settle.test.mjs
+++ b/apps/optimitron/e2e/utils/visual-settle.test.mjs
@@ -160,6 +160,35 @@ test("waits for images inside child frames", async () => {
   assert.equal(page.waits, 1);
 });
 
+test("fails loudly when a decode never settles", async () => {
+  // `page.evaluate` has no timeout, so a decode that never settles used to
+  // hang the whole capture until CI cancelled the job half an hour later with
+  // no error and no indication of which route stalled.
+  let decodeCalls = 0;
+  const page = {
+    calls: 0,
+    waits: 0,
+    async evaluate() {
+      page.calls++;
+      // The readiness poll reports no in-flight images, so the run reaches the
+      // decode pass; that pass then never resolves.
+      if (page.calls === 1) return [];
+      decodeCalls++;
+      return new Promise(() => {});
+    },
+    async waitForTimeout() {
+      page.waits++;
+    },
+    async waitForLoadState() {},
+  };
+
+  await assert.rejects(
+    () => waitForImagesSettled(page, 10),
+    /images to decode/,
+  );
+  assert.equal(decodeCalls, 1);
+});
+
 test("fails loudly when an image never arrives", async () => {
   // Proceeding here would capture exactly the missing artwork this helper
   // exists to prevent, and would do it without any signal.

--- a/scripts/smoke-site-apps.mjs
+++ b/scripts/smoke-site-apps.mjs
@@ -32,6 +32,8 @@ const apps = [
   ["courtofhumanity", 4017, VARIANTS.COURT_OF_HUMANITY],
 ];
 
+const ROUTE_CAPTURE_TIMEOUT_MS = 120_000;
+
 const screenshotProjects = [
   ["default", { viewport: { width: 1440, height: 900 } }],
   [
@@ -43,6 +45,45 @@ const screenshotProjects = [
     },
   ],
 ];
+
+/**
+ * A single route capture is a handful of bounded waits, but `page.evaluate`
+ * has no timeout, so one wedged renderer stalls the lane forever. Without a
+ * budget the job runs until the runner cancels it half an hour later, and the
+ * log ends on "capturing <route>" with no error and no indication that the
+ * route is the thing that stalled. Bound the whole capture so the failure
+ * names the route it happened on.
+ *
+ * The budget is deliberately far above a healthy capture — the slowest routes
+ * settle in a few seconds — so it only ever fires on a genuine stall.
+ *
+ * @template T
+ * @param {string} captureLabel
+ * @param {() => Promise<T>} capture
+ * @returns {Promise<T>}
+ */
+async function withCaptureBudget(captureLabel, capture) {
+  let timer;
+  try {
+    return await Promise.race([
+      capture(),
+      new Promise((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `Timed out after ${ROUTE_CAPTURE_TIMEOUT_MS}ms capturing ${captureLabel}. ` +
+                  `The page stopped responding partway through capture.`,
+              ),
+            ),
+          ROUTE_CAPTURE_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 const screenshotRootInput = process.env.SITE_APP_SCREENSHOT_ROOT?.trim();
 const screenshotRoot = screenshotRootInput
@@ -216,65 +257,67 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
             if (appName === "acceleratedmedicine" && routeName === "home") {
               pageUrl.searchParams.set("visual", "1");
             }
-            const url = pageUrl.toString();
             const captureLabel = `${projectName}/${routeName}`;
-            console.log(`@apps/${appName}: capturing ${captureLabel}`);
-            const response = await page.goto(url, {
-              timeout: 30_000,
-              waitUntil: "load",
-            });
-            const status = response?.status() ?? 0;
-            const statusIsExpected = expectNotFound
-              ? status === 404
-              : status >= 200 && status < 400;
-            if (!response || !statusIsExpected) {
-              throw new Error(
-                `${url} returned HTTP ${response?.status() ?? "unknown"}${expectNotFound ? " (expected 404)" : ""}`,
-              );
-            }
-            if (authenticated) {
-              const expectedPath = pageUrl.pathname;
-              const actualPath = new URL(page.url()).pathname;
-              if (actualPath !== expectedPath) {
+            await withCaptureBudget(captureLabel, async () => {
+              const url = pageUrl.toString();
+              console.log(`@apps/${appName}: capturing ${captureLabel}`);
+              const response = await page.goto(url, {
+                timeout: 30_000,
+                waitUntil: "load",
+              });
+              const status = response?.status() ?? 0;
+              const statusIsExpected = expectNotFound
+                ? status === 404
+                : status >= 200 && status < 400;
+              if (!response || !statusIsExpected) {
                 throw new Error(
-                  `${url} redirected to ${page.url()} instead of rendering its authenticated state`,
+                  `${url} returned HTTP ${response?.status() ?? "unknown"}${expectNotFound ? " (expected 404)" : ""}`,
                 );
               }
-            }
-            await page
-              .waitForLoadState("networkidle", { timeout: 15_000 })
-              .catch(() => {});
-            await page.waitForSelector(".animate-pulse.bg-muted", {
-              state: "detached",
-              timeout: 15_000,
-            });
-            if (!(await waitForFonts(page))) {
-              console.warn(
-                `@apps/${appName}: font readiness timed out for ${captureLabel}`,
+              if (authenticated) {
+                const expectedPath = pageUrl.pathname;
+                const actualPath = new URL(page.url()).pathname;
+                if (actualPath !== expectedPath) {
+                  throw new Error(
+                    `${url} redirected to ${page.url()} instead of rendering its authenticated state`,
+                  );
+                }
+              }
+              await page
+                .waitForLoadState("networkidle", { timeout: 15_000 })
+                .catch(() => {});
+              await page.waitForSelector(".animate-pulse.bg-muted", {
+                state: "detached",
+                timeout: 15_000,
+              });
+              if (!(await waitForFonts(page))) {
+                console.warn(
+                  `@apps/${appName}: font readiness timed out for ${captureLabel}`,
+                );
+              }
+              await forceAnimationsComplete(page);
+              await prepareFullPageVisualCapture(page);
+              await forceAnimationsComplete(page);
+              const screenshotPath = path.join(
+                outputDirectory,
+                `site-app-${appName}-${routeName}.png`,
               );
-            }
-            await forceAnimationsComplete(page);
-            await prepareFullPageVisualCapture(page);
-            await forceAnimationsComplete(page);
-            const screenshotPath = path.join(
-              outputDirectory,
-              `site-app-${appName}-${routeName}.png`,
-            );
-            if (captureSelector) {
-              const target = page.locator(captureSelector).first();
-              await target.scrollIntoViewIfNeeded();
-              await target.screenshot({
-                animations: "disabled",
-                path: screenshotPath,
-              });
-            } else {
-              await page.screenshot({
-                animations: "disabled",
-                fullPage: true,
-                path: screenshotPath,
-              });
-            }
-            console.log(`@apps/${appName}: captured ${captureLabel}`);
+              if (captureSelector) {
+                const target = page.locator(captureSelector).first();
+                await target.scrollIntoViewIfNeeded();
+                await target.screenshot({
+                  animations: "disabled",
+                  path: screenshotPath,
+                });
+              } else {
+                await page.screenshot({
+                  animations: "disabled",
+                  fullPage: true,
+                  path: screenshotPath,
+                });
+              }
+              console.log(`@apps/${appName}: captured ${captureLabel}`);
+            });
           }
         } finally {
           await Promise.all([


### PR DESCRIPTION
## Summary

The `site-apps-build (warondisease)` job on `main` (commit `058849e0`, run [33555891075](https://github.com/mikepsinn/optimitron/actions/runs/33555891075)) was cancelled after burning the full 30-minute job timeout, which took `site-apps-validate` down with it.

The log ends on `capturing visual-mobile/research` with no error. The mobile lane wedged on that one route at 20:36:15 and never moved again; the desktop lane carried on and captured all 43 of its routes normally. `fail-fast` is off on that matrix, so this was the job timeout, not a sibling failure.

Every wait in the capture pipeline carries a timeout except `page.evaluate`, which has none — so an evaluation whose promise never resolves hangs the lane forever instead of failing.

## What changed

- **`waitForImagesSettled` now bounds its decode pass.** Its `timeout` argument covered only the readiness poll; the `image.decode()` pass that follows was completely unbounded, even though a `decode()` that never settles is exactly the kind of promise that does not come back. The decode pass now takes whatever is left of the budget, floored at 1s so a poll that ran long cannot fail a decode of already-downloaded images for want of time. That floor means the total can run slightly past the caller's `timeout`, so the error reports the budget actually given rather than `timeout`.
- **Both double-`requestAnimationFrame` settles are bounded.** A renderer that has stopped producing frames never runs the callback. This one is polish rather than correctness — `page.screenshot` forces its own frame — so it warns off rather than failing, and a `DeadlineExceededError` keeps that from also swallowing real navigation errors, which the previous shape would have done.
- **Each route capture gets an overall budget in the smoke script.** Several `page.evaluate` calls in the settle pipeline are unbounded by nature, so this covers the whole class rather than only the instances found here. A stall now fails in two minutes naming the route it happened on, instead of consuming the job and reporting nothing.

## What this is not

**The `/research` page is not at fault.** It captures in about two seconds in isolation at the 390×844 viewport, and the three prior `main` runs all had `site-apps-build (warondisease)` green — their red was only the pre-existing `deploy-production` token failure (#299).

I reproduced the stall once in five full local smoke runs and could not reproduce it again in a further nine, so this is a rare wedge rather than a regression in the route. This PR does not claim to have eliminated it — it makes it fail fast and say which route and step it happened on, so the next occurrence is diagnosable instead of silent.

## Verification

- `node --test e2e/utils/visual-settle.test.mjs` — 10/10 pass, including a new test that a decode which never settles rejects rather than hangs. Verified it has teeth: with the fix reverted that test hangs and takes the rest of the file down with it.
- `node --test scripts/visual-review-coverage.test.mjs scripts/visual-capture-contract.test.mjs` — 16/16 pass.
- Full `smoke-site-apps.mjs warondisease` against a locally built app and seeded Postgres, six consecutive runs: 87/87 screenshots captured every run, exit 0 every run, the new budget never fired, 99-101s per run.

I also re-ran the cancelled `site-apps-build (warondisease)` job on `main`. It passed on attempt 2 of the same commit, and `site-apps-validate` went green with it, which confirms the stall was transient rather than anything about `058849e0`. That job's only dependent is `site-apps-validate`; `deploy-production` needs `[changes, web-validate]`, so nothing about the production deploy was retried, and its conclusion on that run is untouched.

## Note

`deploy-production` on `main` stays red until the Production `VERCEL_TOKEN` secret is rotated (#299). That is unrelated to this change and needs the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgYULvPW89bMAV3C6mXmtG
