### PR TITLE
Fix survey email redirects and test authentication recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,6 +523,12 @@ jobs:
           PLAYWRIGHT_BROWSER_CHANNEL: chrome
           SITE_APP_SCREENSHOT_ROOT: apps/optimitron/output/playwright/site-app-screenshots
 
+      - name: Verify survey email authentication against the production build
+        if: ${{ matrix.app == 'trialabundancesurvey' }}
+        run: pnpm --filter @apps/trialabundancesurvey test:e2e:auth
+        env:
+          PLAYWRIGHT_BROWSER_CHANNEL: chrome
+
       - name: Upload @apps/${{ matrix.app }} visual screenshots
         uses: actions/upload-artifact@v6
         with:

--- a/apps/optimitron/scripts/build-visual-review.mjs
+++ b/apps/optimitron/scripts/build-visual-review.mjs
@@ -1130,8 +1130,9 @@ function getMarkdownSnapshot(routeName) {
 }
 
 function isAuthenticatedMarkdownRoute(routeName) {
+  const authenticated = routeSpecs.get(routeName)?.authenticated;
+  if (typeof authenticated === "boolean") return authenticated;
   return (
-    routeSpecs.get(routeName)?.authenticated === true ||
     /-auth(\b|$)/.test(routeName) ||
     routeName.endsWith("-auth")
   );

--- a/apps/trialabundancesurvey/app/auth/complete-signup/page.tsx
+++ b/apps/trialabundancesurvey/app/auth/complete-signup/page.tsx
@@ -7,6 +7,7 @@ import { Layout } from "@/components/layout"
 import { storage } from "@/lib/storage"
 import { syncPendingTrialAbundanceResponse } from "@/lib/trial-abundance-survey"
 import { createLogger } from "@/lib/logger"
+import { getSurveyPostAuthPath } from "@/lib/auth-redirect"
 
 const log = createLogger("complete-signup-page")
 
@@ -24,8 +25,12 @@ export default function CompleteSignupPage() {
 
       // Wait for session to be available
       if (status === "loading") return
+      const callbackUrl = getSurveyPostAuthPath(
+        searchParams?.get("callbackUrl"),
+        window.location.origin,
+      )
       if (status === "unauthenticated") {
-        router.push("/auth/signin")
+        router.replace(`/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`)
         return
       }
 
@@ -63,8 +68,7 @@ export default function CompleteSignupPage() {
         await syncPendingTrialAbundanceResponse(session)
 
         // Redirect to callback URL or dashboard
-        const callbackUrl = searchParams?.get("callbackUrl") || "/dashboard"
-        router.push(callbackUrl)
+        router.replace(callbackUrl)
       } catch (error) {
         log.error("Complete vote verification error", { error })
         setError("An error occurred. Redirecting to dashboard...")

--- a/apps/trialabundancesurvey/app/auth/error/error-content.tsx
+++ b/apps/trialabundancesurvey/app/auth/error/error-content.tsx
@@ -1,8 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
-import { useRouter, useSearchParams } from "next/navigation"
-import { useSession } from "next-auth/react"
+import { useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { AlertCircle, Lightbulb } from "lucide-react"
@@ -28,25 +26,12 @@ const errorMessages: Record<string, string> = {
 
 export default function AuthErrorContent() {
   const searchParams = useSearchParams()
-  const router = useRouter()
-  const { status } = useSession()
   const error = searchParams?.get("error") || "Default"
   const isVerificationError = error === "Verification"
   const callbackUrl = getSurveyPostAuthPath(
     searchParams?.get("callbackUrl"),
     typeof window === "undefined" ? "https://trialabundancesurvey.org" : window.location.origin,
   )
-
-  useEffect(() => {
-    if (isVerificationError && status === "authenticated") {
-      // Complete any pending survey save before the dashboard loads.
-      router.replace(`/auth/complete-signup?callbackUrl=${encodeURIComponent(callbackUrl)}`)
-    }
-  }, [callbackUrl, isVerificationError, router, status])
-
-  if (isVerificationError && status !== "unauthenticated") {
-    return <p className="p-8 text-center font-bold">Checking your sign-in...</p>
-  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-[#FF6B6B] to-[#4ECDC4] p-4">

--- a/apps/trialabundancesurvey/app/auth/error/error-content.tsx
+++ b/apps/trialabundancesurvey/app/auth/error/error-content.tsx
@@ -1,11 +1,14 @@
 "use client"
 
-import { useSearchParams } from "next/navigation"
+import { useEffect } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { useSession } from "next-auth/react"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { AlertCircle, Lightbulb } from "lucide-react"
 import { ROUTES } from '@/lib/routes'
 import { AlertCard } from "@/components/ui/alert-card"
+import { getSurveyPostAuthPath } from "@/lib/auth-redirect"
 
 const errorMessages: Record<string, string> = {
   Configuration: "There is a problem with the server configuration.",
@@ -25,7 +28,25 @@ const errorMessages: Record<string, string> = {
 
 export default function AuthErrorContent() {
   const searchParams = useSearchParams()
+  const router = useRouter()
+  const { status } = useSession()
   const error = searchParams?.get("error") || "Default"
+  const isVerificationError = error === "Verification"
+  const callbackUrl = getSurveyPostAuthPath(
+    searchParams?.get("callbackUrl"),
+    typeof window === "undefined" ? "https://trialabundancesurvey.org" : window.location.origin,
+  )
+
+  useEffect(() => {
+    if (isVerificationError && status === "authenticated") {
+      // Complete any pending survey save before the dashboard loads.
+      router.replace(`/auth/complete-signup?callbackUrl=${encodeURIComponent(callbackUrl)}`)
+    }
+  }, [callbackUrl, isVerificationError, router, status])
+
+  if (isVerificationError && status !== "unauthenticated") {
+    return <p className="p-8 text-center font-bold">Checking your sign-in...</p>
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-[#FF6B6B] to-[#4ECDC4] p-4">
@@ -34,7 +55,9 @@ export default function AuthErrorContent() {
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 border-4 border-black">
             <AlertCircle className="h-8 w-8 text-red-600" />
           </div>
-          <h1 className="text-4xl font-black mb-2">Authentication Error</h1>
+          <h1 className="text-4xl font-black mb-2">
+            {isVerificationError ? "Sign in again" : "Authentication Error"}
+          </h1>
           <div className="mx-auto my-6 h-1 w-20 bg-black"></div>
         </div>
 
@@ -53,9 +76,9 @@ export default function AuthErrorContent() {
           )}
 
           <div className="flex flex-col gap-3">
-            <Link href={ROUTES.signIn}>
+            <Link href={`${ROUTES.signIn}?callbackUrl=${encodeURIComponent(callbackUrl)}`}>
               <Button className="w-full h-12 text-lg font-black bg-brutal-pink border-4 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all">
-                Try Again
+                {isVerificationError ? "Get a new sign-in link" : "Try Again"}
               </Button>
             </Link>
 

--- a/apps/trialabundancesurvey/app/auth/signin/page.tsx
+++ b/apps/trialabundancesurvey/app/auth/signin/page.tsx
@@ -3,10 +3,14 @@
 import { useSearchParams } from "next/navigation"
 import { Layout } from "@/components/layout"
 import { AuthForm } from "@/components/auth/AuthForm"
+import { getSurveyPostAuthPath } from "@/lib/auth-redirect"
 
 export default function SignInPage() {
   const searchParams = useSearchParams()
-  const callbackUrl = searchParams?.get("callbackUrl") || "/dashboard"
+  const callbackUrl = getSurveyPostAuthPath(
+    searchParams?.get("callbackUrl"),
+    typeof window === "undefined" ? "https://trialabundancesurvey.org" : window.location.origin,
+  )
 
   return (
     <Layout>

--- a/apps/trialabundancesurvey/lib/auth-redirect.ts
+++ b/apps/trialabundancesurvey/lib/auth-redirect.ts
@@ -1,0 +1,19 @@
+/** Keep survey sign-in on this site, including links issued before the dashboard redirect. */
+export function getSurveyPostAuthPath(
+  callbackUrl: string | null | undefined,
+  origin: string,
+): string {
+  try {
+    const url = new URL(callbackUrl || "/dashboard", origin)
+    if (
+      url.origin !== new URL(origin).origin ||
+      url.pathname === "/" ||
+      /^\/(auth|api)(\/|$)/u.test(url.pathname)
+    ) {
+      return "/dashboard"
+    }
+    return `${url.pathname}${url.search}${url.hash}`
+  } catch {
+    return "/dashboard"
+  }
+}

--- a/apps/trialabundancesurvey/lib/auth-redirect.ts
+++ b/apps/trialabundancesurvey/lib/auth-redirect.ts
@@ -5,10 +5,11 @@ export function getSurveyPostAuthPath(
 ): string {
   try {
     const url = new URL(callbackUrl || "/dashboard", origin)
+    const pathname = decodeURIComponent(url.pathname)
     if (
       url.origin !== new URL(origin).origin ||
-      url.pathname === "/" ||
-      /^\/(auth|api)(\/|$)/u.test(url.pathname)
+      pathname === "/" ||
+      /^\/(auth|api)(\/|$)/u.test(pathname)
     ) {
       return "/dashboard"
     }

--- a/apps/trialabundancesurvey/package.json
+++ b/apps/trialabundancesurvey/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --exclude 'tests/integration/**'",
     "test:unit": "cross-env SKIP_DB_TEST_SETUP=1 vitest run --exclude 'tests/integration/**'",
+    "test:e2e:auth": "playwright test --config playwright.auth.config.ts",
     "smoke:db": "tsx scripts/smoke-treaty-db.ts"
   },
   "dependencies": {

--- a/apps/trialabundancesurvey/playwright.auth.config.ts
+++ b/apps/trialabundancesurvey/playwright.auth.config.ts
@@ -1,0 +1,60 @@
+import { defineConfig } from "@playwright/test"
+import { createRequire } from "node:module"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const appRoot = path.dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
+const baseURL = process.env.NEXTAUTH_URL || "http://127.0.0.1:3001"
+const database = new URL(process.env.DATABASE_URL || "postgresql://localhost/missing")
+const localHosts = ["localhost", "127.0.0.1", "[::1]"]
+if (
+  !localHosts.includes(new URL(baseURL).hostname) ||
+  !localHosts.includes(database.hostname) ||
+  !/(^|[_-])test($|[_-])|auth_e2e/u.test(database.pathname.slice(1))
+) {
+  throw new Error("Auth E2E requires a loopback web server and a local test database.")
+}
+
+const outbox = path.join(appRoot, "output/playwright/auth/mail.jsonl")
+process.env.AUTH_E2E_OUTBOX = outbox
+const preload = pathToFileURL(path.join(appRoot, "tests/e2e/capture-email.mjs")).href
+const next = require.resolve("next/dist/bin/next")
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  testMatch: "auth-email.spec.ts",
+  workers: 1,
+  retries: 0,
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  reporter: "list",
+  outputDir: "output/playwright/auth/results",
+  projects: [
+    { name: "desktop" },
+    { name: "mobile", use: { viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true } },
+  ],
+  use: {
+    baseURL,
+    channel: process.env.PLAYWRIGHT_BROWSER_CHANNEL || "chrome",
+    viewport: { width: 1280, height: 720 },
+    // Traces can contain single-use tokens and session cookies.
+    trace: "off",
+    video: "off",
+    screenshot: "off",
+  },
+  webServer: {
+    command: `node --import "${preload}" "${next}" ${process.env.AUTH_E2E_DEV === "1" ? "dev" : "start"} --hostname 127.0.0.1 --port ${new URL(baseURL).port || "3001"}`,
+    url: `${baseURL}/api/auth/providers`,
+    reuseExistingServer: false,
+    timeout: 120_000,
+    env: {
+      DATABASE_URL: process.env.DATABASE_URL!,
+      NEXTAUTH_URL: baseURL,
+      NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET || "local-auth-e2e-secret-not-for-production",
+      NEXT_PUBLIC_SITE_VARIANT: "trialabundancesurvey.org",
+      RESEND_API_KEY: "re_auth_e2e_no_real_delivery",
+      AUTH_E2E_OUTBOX: outbox,
+    },
+  },
+})

--- a/apps/trialabundancesurvey/tests/README.md
+++ b/apps/trialabundancesurvey/tests/README.md
@@ -15,6 +15,7 @@ This project uses **Vitest** for unit/integration tests and **Playwright** for E
 - Submit the survey, verify the email, and reach the dashboard with saved answers.
 - Open an old homepage callback in a fresh browser session.
 - Reopen a used link before and after logout.
+- Keep another person's pending draft intact when a failed link leaves the old account signed in.
 - Expire a token, request a replacement, and sign in again.
 
 Set `DATABASE_URL` to a dedicated local database whose name contains `test` or `auth_e2e`.

--- a/apps/trialabundancesurvey/tests/README.md
+++ b/apps/trialabundancesurvey/tests/README.md
@@ -6,6 +6,32 @@ This project uses **Vitest** for unit/integration tests and **Playwright** for E
 
 ## Running Tests
 
+### Email authentication regression tests
+
+`pnpm test:unit` checks callback destinations, including old `/#vote` links and same-origin preview URLs.
+
+`pnpm test:e2e:auth` checks the real NextAuth email-token flow against a local production build:
+
+- Submit the survey, verify the email, and reach the dashboard with saved answers.
+- Open an old homepage callback in a fresh browser session.
+- Reopen a used link before and after logout.
+- Expire a token, request a replacement, and sign in again.
+
+Set `DATABASE_URL` to a dedicated local database whose name contains `test` or `auth_e2e`.
+Set `NEXTAUTH_URL` to `http://127.0.0.1:3001` and set a test-only `NEXTAUTH_SECRET`.
+Apply migrations with `pnpm db:deploy` from the repository root.
+Run `pnpm build:app-dependencies` and `pnpm db:sync:managed-data -- --apply` at the root.
+Run `pnpm build`, then `pnpm test:e2e:auth` in this app.
+The runner starts and stops its own server. It fails if that port is occupied.
+
+Email delivery is intercepted in a test-process preload. No email or login bypass exists in the deployed app.
+The runner uses a fake Resend key and refuses remote databases and web servers.
+Token emails stay in an ignored local outbox, which the tests remove. Traces and videos are disabled.
+CI runs these tests after the survey production build. Failures fail the site-app checks.
+
+This does not verify live email delivery or Vercel environment settings.
+A live smoke test needs a dedicated inbox and account. Do not submit test votes to the public survey.
+
 ### Unit Tests (Vitest)
 ```bash
 # Run all unit tests

--- a/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
+++ b/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
@@ -39,6 +39,7 @@ async function capture(page: Page, name: string) {
   await mkdir(directory, { recursive: true })
   await page.evaluate(() => document.fonts.ready)
   await page.evaluate(() => window.scrollTo({ top: 0, behavior: "instant" }))
+  await page.mouse.move(0, 0)
   await page.screenshot({
     path: path.join(directory, `${name}-${test.info().project.name}-after.png`),
     fullPage: true,
@@ -81,9 +82,6 @@ test("survey email link saves the answers and lands on the dashboard", async ({ 
   await expect(page.getByText("Patient access: YES", { exact: true })).toBeVisible()
   await capture(page, "survey-auth-dashboard")
 
-  // A consumed link must not strand someone whose first click already signed them in.
-  await page.goto(link.href)
-  await expectDashboard(page)
   await page.getByRole("button", { name: "Toggle menu" }).click()
   await page.getByRole("button", { name: "Log Out", exact: true }).click()
   await expect(page).toHaveURL(/\/$/u)
@@ -149,4 +147,58 @@ test("an expired link offers a fresh login without creating a session", async ({
   const replacement = await requestLink(page, email)
   await page.goto(replacement.href)
   await expectDashboard(page)
+})
+
+test("a failed link cannot save another person's draft to the active account", async ({ page }) => {
+  const activeEmail = emailFor("active-account")
+  const pendingEmail = emailFor("pending-account")
+  await page.goto("/auth/signin")
+  const activeLink = await requestLink(page, activeEmail)
+  await page.goto(activeLink.href)
+  await expectDashboard(page)
+  const activeSession = await (await page.request.get("/api/auth/session")).json()
+  const accountState = async () => Promise.all([
+    pool.query(`SELECT u."newsletterSubscribed", p."displayName" FROM "User" u
+      LEFT JOIN "Person" p ON p.id = u."personId" WHERE u.id = $1`, [activeSession.user.id]),
+    pool.query('SELECT id, answer FROM "ReferendumVote" WHERE "userId" = $1 ORDER BY id', [activeSession.user.id]),
+  ]).then((results) => results.map(({ rows }) => rows))
+  const before = await accountState()
+
+  await page.goto("/auth/signin")
+  const failedLink = await requestLink(page, pendingEmail)
+  await pool.query('UPDATE "VerificationToken" SET expires = $1 WHERE identifier = $2', [
+    new Date("2000-01-01T00:00:00Z"), pendingEmail,
+  ])
+  // Model a second person's unsaved draft in a shared browser.
+  const pending = {
+    patientAccessAnswer: "NO", selfFundedAccessAnswer: "YES",
+    militaryAllocationPercent: 37, referredBy: null, timestamp: "2026-01-15T00:00:00Z",
+  }
+  await page.evaluate((draft) => {
+    localStorage.setItem("pendingTrialAbundanceResponse", JSON.stringify(draft))
+    localStorage.setItem("signup_name", "Pending respondent")
+    localStorage.setItem("signup_subscribe", "true")
+  }, pending)
+
+  await page.goto(failedLink.href)
+  await expect(page.getByRole("heading", { name: "Sign in again" })).toBeVisible()
+  await capture(page, "survey-auth-wrong-account")
+  expect((await (await page.request.get("/api/auth/session")).json()).user.id).toBe(activeSession.user.id)
+  expect(await accountState()).toEqual(before)
+  expect(await page.evaluate(() => JSON.parse(localStorage.getItem("pendingTrialAbundanceResponse")!))).toEqual(pending)
+
+  await page.getByRole("link", { name: "Get a new sign-in link" }).click()
+  const replacement = await requestLink(page, pendingEmail)
+  await page.goto(replacement.href)
+  await expectDashboard(page)
+  const verifiedSession = await (await page.request.get("/api/auth/session")).json()
+  expect(verifiedSession.user.email).toBe(pendingEmail)
+  expect(verifiedSession.user.id).not.toBe(activeSession.user.id)
+  await expect(page.getByText("Patient access: NO", { exact: true })).toBeVisible()
+  await expect(page.getByText("Patient-funded access: YES", { exact: true })).toBeVisible()
+  expect(await page.evaluate(() => localStorage.getItem("pendingTrialAbundanceResponse"))).toBeNull()
+
+  // Even a same-account consumed link must offer recovery, not infer identity.
+  await page.goto(replacement.href)
+  await expect(page.getByRole("heading", { name: "Sign in again" })).toBeVisible()
 })

--- a/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
+++ b/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test } from "@playwright/test"
+import type { Page } from "@playwright/test"
+import { readFile, rm, mkdir } from "node:fs/promises"
+import path from "node:path"
+import { Pool } from "pg"
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+const emailFor = (name: string) => `auth-e2e-${test.info().project.name}-${name}@example.invalid`
+
+async function verificationLink(email: string) {
+  const messages = (await readFile(process.env.AUTH_E2E_OUTBOX!, "utf8"))
+    .trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
+  const message = messages.findLast((item) => item.to === email || item.to?.includes(email))
+  expect(message, "The real email sender must deliver to the capture transport").toBeTruthy()
+  const link = message.text.match(/https?:\/\/[^\s]+\/api\/auth\/callback\/email\?[^\s]+/u)?.[0]
+  expect(Boolean(link), "The email must contain a verification link").toBe(true)
+  return new URL(link)
+}
+
+async function requestLink(page: Page, email: string) {
+  await page.getByRole("button", { name: "Continue with Email", exact: true }).click()
+  await page.getByLabel("Email", { exact: true }).fill(email)
+  await page.getByLabel("Subscribe for updates on our progress").uncheck()
+  await page.getByRole("button", { name: "Send magic link", exact: true }).click()
+  await expect(page.getByText("Check your email!", { exact: true })).toBeVisible()
+  return verificationLink(email)
+}
+
+async function expectDashboard(page: Page) {
+  await expect(page).toHaveURL(/\/dashboard$/u)
+  await expect(page.getByRole("heading", { name: "Your survey response" })).toBeVisible()
+  const session = await (await page.request.get("/api/auth/session")).json()
+  expect(Boolean(session.user?.id), "Email verification must create a real session").toBe(true)
+}
+
+async function capture(page: Page, name: string) {
+  if (!process.env.AUTH_CAPTURE_REVIEW) return
+  const directory = path.resolve("../optimitron/output/playwright/review")
+  await mkdir(directory, { recursive: true })
+  await page.evaluate(() => document.fonts.ready)
+  await page.evaluate(() => window.scrollTo({ top: 0, behavior: "instant" }))
+  await page.screenshot({
+    path: path.join(directory, `${name}-${test.info().project.name}-after.png`),
+    fullPage: true,
+    animations: "disabled",
+  })
+}
+
+test.afterAll(async () => {
+  await pool.end()
+  await rm(process.env.AUTH_E2E_OUTBOX!, { force: true })
+})
+
+test("survey email link saves the answers and lands on the dashboard", async ({ page }) => {
+  await page.goto("/")
+  await page.getByRole("button", { name: "Yes", exact: true }).click()
+  await expect(page.getByText("Question 2 of 3", { exact: true })).toBeVisible()
+  await page.getByRole("button", { name: "Not sure", exact: true }).click()
+  await page.getByRole("slider").press("ArrowRight")
+  await page.getByRole("button", { name: "Submit response", exact: true }).click()
+  await expect(page.getByRole("heading", { name: "Save your response" })).toBeVisible()
+  if (process.env.AUTH_CAPTURE_REVIEW) {
+    await expect(page.getByText("Question 3 of 3", { exact: true })).toHaveCount(0)
+    await expect(page.locator("canvas")).toHaveCount(0)
+  }
+  await capture(page, "survey-auth-form")
+  const email = emailFor("survey")
+  await page.getByLabel("Email", { exact: true }).fill(email)
+  await page.getByRole("button", { name: "Email me a verification link" }).click()
+  await expect(page.getByText("Check your email!", { exact: true })).toBeVisible()
+  const link = await verificationLink(email)
+  const completion = new URL(link.searchParams.get("callbackUrl")!)
+  expect(completion.pathname).toBe("/auth/complete-signup")
+  expect(completion.searchParams.get("callbackUrl")).toBe("/dashboard")
+  await page.goto(link.href)
+  await expectDashboard(page)
+  await expect(page.getByText("Patient access: YES", { exact: true })).toBeVisible()
+  await expect(page.getByText("Patient-funded access: NOT SURE", { exact: true })).toBeVisible()
+  await expect(page.getByText("Allocation: 49% military and weapons, 51% pragmatic clinical trials", { exact: true })).toBeVisible()
+  await page.reload()
+  await expect(page.getByText("Patient access: YES", { exact: true })).toBeVisible()
+  await capture(page, "survey-auth-dashboard")
+
+  // A consumed link must not strand someone whose first click already signed them in.
+  await page.goto(link.href)
+  await expectDashboard(page)
+  await page.getByRole("button", { name: "Toggle menu" }).click()
+  await page.getByRole("button", { name: "Log Out", exact: true }).click()
+  await expect(page).toHaveURL(/\/$/u)
+  await page.goto(link.href)
+  await expect(page.getByRole("heading", { name: "Sign in again" })).toBeVisible()
+  expect(await (await page.request.get("/api/auth/session")).json()).toEqual({})
+  await capture(page, "survey-auth-used-link")
+  await page.getByRole("link", { name: "Get a new sign-in link" }).click()
+  await expect(page.getByRole("button", { name: "Continue with Email", exact: true })).toBeVisible()
+  await capture(page, "survey-auth-signin")
+  const replacement = await requestLink(page, email)
+  await page.goto(replacement.href)
+  await expectDashboard(page)
+})
+
+test("an already-issued homepage callback finishes on the dashboard in a new browser", async ({ page, browser }) => {
+  // Request the legacy callback exactly as the old survey form did.
+  const csrf = await (await page.request.get("/api/auth/csrf")).json()
+  const result = await page.request.post("/api/auth/signin/email", {
+    form: {
+      email: emailFor("legacy"),
+      csrfToken: csrf.csrfToken,
+      callbackUrl: "/auth/complete-signup?callbackUrl=%2F%23vote",
+      json: "true",
+    },
+  })
+  expect(result.ok()).toBe(true)
+  const link = await verificationLink(emailFor("legacy"))
+  const freshContext = await browser.newContext()
+  try {
+    const freshPage = await freshContext.newPage()
+    await freshPage.goto(link.href)
+    await expect(freshPage).toHaveURL(/\/dashboard$/u)
+    await expect(freshPage.getByRole("heading", { name: "Your survey response" })).toBeVisible()
+    const session = await (await freshPage.request.get(new URL("/api/auth/session", link.origin).href)).json()
+    expect(Boolean(session.user?.id)).toBe(true)
+  } finally {
+    await freshContext.close()
+  }
+  if (process.env.AUTH_CAPTURE_REVIEW) {
+    await page.goto("/auth/complete-signup?visual=1")
+    await expect(page.getByRole("heading", { name: "Verifying response..." })).toBeVisible()
+    await capture(page, "survey-auth-completion")
+  }
+})
+
+test("an expired link offers a fresh login without creating a session", async ({ page }) => {
+  const email = emailFor("expired")
+  await page.goto("/auth/signin")
+  const link = await requestLink(page, email)
+  // Expire only this test's token. No clock sleeps or global database resets.
+  const expired = await pool.query(
+    'UPDATE "VerificationToken" SET expires = $1 WHERE identifier = $2',
+    [new Date("2000-01-01T00:00:00Z"), email],
+  )
+  expect(expired.rowCount).toBeGreaterThan(0)
+  await page.goto(link.href)
+  await expect(page.getByRole("heading", { name: "Sign in again" })).toBeVisible()
+  await expect(page.getByText("The verification link has expired or has already been used.")).toBeVisible()
+  expect(await (await page.request.get("/api/auth/session")).json()).toEqual({})
+  await capture(page, "survey-auth-expired-link")
+  await page.getByRole("link", { name: "Get a new sign-in link" }).click()
+  const replacement = await requestLink(page, email)
+  await page.goto(replacement.href)
+  await expectDashboard(page)
+})

--- a/apps/trialabundancesurvey/tests/e2e/capture-email.mjs
+++ b/apps/trialabundancesurvey/tests/e2e/capture-email.mjs
@@ -1,0 +1,29 @@
+// Test-process preload only. The deployed app has no email capture route or auth bypass.
+import { appendFile, mkdir, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+const localHosts = ["localhost", "127.0.0.1", "[::1]"]
+const database = new URL(process.env.DATABASE_URL)
+if (
+  !localHosts.includes(database.hostname) ||
+  !/(^|[_-])test($|[_-])|auth_e2e/u.test(database.pathname.slice(1)) ||
+  !localHosts.includes(new URL(process.env.NEXTAUTH_URL).hostname) ||
+  process.env.RESEND_API_KEY !== "re_auth_e2e_no_real_delivery" ||
+  !process.env.AUTH_E2E_OUTBOX
+) {
+  throw new Error("Email capture is restricted to the local auth E2E environment.")
+}
+
+const outbox = process.env.AUTH_E2E_OUTBOX
+await mkdir(path.dirname(outbox), { recursive: true })
+await writeFile(outbox, "", { mode: 0o600 })
+const server = setupServer(
+  http.post("https://api.resend.com/emails", async ({ request }) => {
+    const message = await request.json()
+    await appendFile(outbox, `${JSON.stringify(message)}\n`)
+    return HttpResponse.json({ id: "auth-e2e-captured-email" })
+  }),
+)
+server.listen({ onUnhandledRequest: "bypass" })

--- a/apps/trialabundancesurvey/tests/unit/auth-callback.test.ts
+++ b/apps/trialabundancesurvey/tests/unit/auth-callback.test.ts
@@ -1,0 +1,33 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import type { NextAuthOptions } from "next-auth"
+
+let redirect: NonNullable<NonNullable<NextAuthOptions["callbacks"]>["redirect"]>
+
+beforeAll(async () => {
+  vi.stubEnv("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+  vi.stubEnv("NEXTAUTH_SECRET", "local-auth-unit-test-secret-not-for-production")
+  vi.stubEnv("NEXTAUTH_URL", "http://localhost:3001")
+  const { authOptions } = await import("../../../../packages/site-kit/src/lib/auth")
+  redirect = authOptions.callbacks!.redirect!
+})
+
+afterAll(() => vi.unstubAllEnvs())
+
+describe("NextAuth callback URL round trip", () => {
+  it.each([
+    "http://localhost:3001",
+    "http://127.0.0.1:3001",
+    "https://trial-survey-branch-team.vercel.app",
+    "https://trialabundancesurvey.org",
+  ])("keeps the completion path after NextAuth resolves it on %s", async (baseUrl) => {
+    const path = "/auth/complete-signup?callbackUrl=%2Fdashboard"
+    const resolved = await redirect({ url: path, baseUrl })
+    expect(resolved).toBe(`${baseUrl}${path}`)
+    expect(await redirect({ url: resolved, baseUrl })).toBe(resolved)
+  })
+
+  it("does not treat an unrelated Vercel deployment as the same site", async () => {
+    const baseUrl = "https://trial-survey-branch-team.vercel.app"
+    expect(await redirect({ url: "https://unrelated.vercel.app/dashboard", baseUrl })).toBe(baseUrl)
+  })
+})

--- a/apps/trialabundancesurvey/tests/unit/auth-redirect.test.ts
+++ b/apps/trialabundancesurvey/tests/unit/auth-redirect.test.ts
@@ -20,6 +20,9 @@ describe("survey post-auth destination", () => {
     "javascript:alert(1)",
     "/auth/complete-signup",
     "/api/auth/signout",
+    "/%61uth/complete-signup",
+    "/%61pi/auth/signout",
+    "/auth%2Fcomplete-signup",
   ])("rejects external destinations and auth loops (%s)", (callback) => {
     expect(getSurveyPostAuthPath(callback, origin)).toBe("/dashboard")
   })

--- a/apps/trialabundancesurvey/tests/unit/auth-redirect.test.ts
+++ b/apps/trialabundancesurvey/tests/unit/auth-redirect.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import { getSurveyPostAuthPath } from "../../lib/auth-redirect"
+
+describe("survey post-auth destination", () => {
+  const origin = "https://trialabundancesurvey.org"
+
+  it.each([undefined, "", "/", "/#vote", `${origin}/#vote`])(
+    "sends missing or old homepage callbacks (%s) to the dashboard",
+    (callback) => expect(getSurveyPostAuthPath(callback, origin)).toBe("/dashboard"),
+  )
+
+  it.each(["/dashboard?tab=referrals#share", `${origin}/dashboard?tab=referrals#share`])(
+    "preserves a safe destination (%s)",
+    (callback) => expect(getSurveyPostAuthPath(callback, origin)).toBe("/dashboard?tab=referrals#share"),
+  )
+
+  it.each([
+    "https://example.com/phishing",
+    "//example.com/phishing",
+    "javascript:alert(1)",
+    "/auth/complete-signup",
+    "/api/auth/signout",
+  ])("rejects external destinations and auth loops (%s)", (callback) => {
+    expect(getSurveyPostAuthPath(callback, origin)).toBe("/dashboard")
+  })
+})

--- a/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
+++ b/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
@@ -364,7 +364,7 @@ export default function TrialAbundanceSurveySection({
                   link for referrals.
                 </p>
                 <AuthForm
-                  callbackUrl="/#vote"
+                  callbackUrl="/dashboard"
                   referralCode={referralCode}
                   inviteToken={inviteToken}
                   defaultEmailOpen

--- a/packages/site-kit/src/lib/auth.ts
+++ b/packages/site-kit/src/lib/auth.ts
@@ -317,6 +317,11 @@ export const authOptions: NextAuthOptions = {
       // Check if the URL is one of our allowed domains
       try {
         const urlObj = new URL(url)
+        // NextAuth resolves relative callbacks before calling this again.
+        // Keep same-origin callbacks on local servers and preview deployments too.
+        if (urlObj.origin === new URL(baseUrl).origin) {
+          return url
+        }
         if (allowedDomains.some(domain => urlObj.hostname === domain || urlObj.hostname.endsWith(`.${domain}`))) {
           return url
         }

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -573,6 +573,16 @@ export const publicSiteAppRoutes = Object.freeze({
       sourcePage: "apps/trialabundancesurvey/app/auth/signin/page.tsx",
     },
     {
+      covers: [
+        "apps/trialabundancesurvey/app/auth/error/page.tsx",
+        "apps/trialabundancesurvey/app/auth/error/error-content.tsx",
+      ],
+      label: "Expired sign-in link recovery",
+      routeName: "auth-error",
+      routePath: "/auth/error?error=Verification",
+      sourcePage: "apps/trialabundancesurvey/app/auth/error/page.tsx",
+    },
+    {
       covers: ["apps/trialabundancesurvey/app/not-found.tsx"],
       expectNotFound: true,
       label: "Page not found",
@@ -665,11 +675,6 @@ export const publicSiteAppRouteExemptions = Object.freeze([
     reason:
       "Shared auth scaffolding; this app captures /auth/signin and warondisease captures the full auth set.",
     sourcePage: "apps/wishocracy/app/auth/complete-signup/page.tsx",
-  },
-  {
-    reason:
-      "Shared auth scaffolding; this app captures /auth/signin and warondisease captures the full auth set.",
-    sourcePage: "apps/trialabundancesurvey/app/auth/error/page.tsx",
   },
   {
     reason:


### PR DESCRIPTION
## Summary

Survey email verification now saves pending responses and opens the dashboard, including links issued with the old homepage callback. Expired or consumed links offer a replacement without applying another person's draft to an existing session.

Callback validation preserves safe same-origin destinations and rejects encoded auth/API paths. The visual review uses explicit route authentication settings, so public sign-in and recovery pages receive the correct review links.

## Verification

- 33 survey unit tests passed, including encoded callback regressions.
- 8 desktop/mobile email-authentication tests passed against a production build and dedicated local PostgreSQL database.
- Tests cover persisted answers, old callbacks, expiry, token reuse, replacement links, logout, and failed links with another account still signed in. The latter verifies unchanged account data and an intact pending draft before successful replacement verification.
- Survey production build, typecheck, and source lint passed.
- Regenerated the visual review from CI artifacts: all four changed UI sources have captures. Public auth routes are marked logged out; authenticated dashboards retain signed-in review links.
- Fresh local screenshots cover the survey form, sign-in, completion, dashboard, and expired/used/wrong-account recovery on desktop and mobile. No clipping or overlapping controls found. Pointer hover and scroll-position noise were removed.
- The newly registered recovery route has no CI baseline. A production-before capture and fresh local-after captures were inspected locally. Other survey CI screenshots match the exact main baseline.
- Email delivery was intercepted locally. No live emails or public survey responses were created.

## Review

- [ ] Check that email confirmation opens the dashboard with saved answers.
- [ ] Check expired/used links and replacement sign-in with another active account.
- [ ] Review callback validation, tests, and CI changes.

Trial Abundance hosted previews are opt-in; this branch has no hosted survey preview. Reviewed route states: `/?visual=complete&logout=1`, `/auth/signin?logout=1`, `/auth/error?error=Verification&logout=1`, `/auth/complete-signup?visual=1&logout=1`, and authenticated `/dashboard` with a local test account. Wrong-account recovery uses the same error route with an existing local test session.

GitHub CI completed successfully on commit `0011436d5`: 29 checks passed, six checks were intentionally skipped/neutral, zero unresolved review threads, and merge state CLEAN. The final visual report has full coverage, zero unexpected screenshot/copy changes, and only the documented missing baseline for the newly registered recovery route. Ready for human review; not merged.
