### PR TITLE
Match survey authentication errors to the app style

### DIFF
--- a/apps/trialabundancesurvey/app/auth/error/error-content.tsx
+++ b/apps/trialabundancesurvey/app/auth/error/error-content.tsx
@@ -3,7 +3,7 @@
 import { useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
-import { AlertCircle, Lightbulb } from "lucide-react"
+import { Lightbulb } from "lucide-react"
 import { ROUTES } from '@/lib/routes'
 import { AlertCard } from "@/components/ui/alert-card"
 import { getSurveyPostAuthPath } from "@/lib/auth-redirect"
@@ -34,57 +34,48 @@ export default function AuthErrorContent() {
   )
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-[#FF6B6B] to-[#4ECDC4] p-4">
-      <div className="w-full max-w-md space-y-8 rounded-3xl bg-white p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] border-4 border-black">
-        <div className="text-center">
-          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 border-4 border-black">
-            <AlertCircle className="h-8 w-8 text-red-600" />
-          </div>
-          <h1 className="text-4xl font-black mb-2">
-            {isVerificationError ? "Sign in again" : "Authentication Error"}
-          </h1>
-          <div className="mx-auto my-6 h-1 w-20 bg-black"></div>
+    <>
+      <h1 className="text-4xl font-black">
+        {isVerificationError ? "Sign in again" : "Authentication Error"}
+      </h1>
+
+      <div className="space-y-4">
+        <AlertCard
+          type="error"
+          message={errorMessages[error] || errorMessages.Default}
+        />
+
+        {error === "OAuthAccountNotLinked" && (
+          <AlertCard
+            type="warning"
+            icon={Lightbulb}
+            message="Tip: Try signing in with the same method you used when you first created your account."
+          />
+        )}
+
+        <div className="flex flex-col gap-3">
+          <Button asChild className="w-full h-12 text-lg font-black bg-brutal-pink border-4 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all">
+            <Link href={`${ROUTES.signIn}?callbackUrl=${encodeURIComponent(callbackUrl)}`}>
+              {isVerificationError ? "Get a new sign-in link" : "Try Again"}
+            </Link>
+          </Button>
+
+          <Button
+            asChild
+            variant="outline"
+            className="w-full h-12 text-lg font-black border-4 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,0.3)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all"
+          >
+            <Link href="/">Go Home</Link>
+          </Button>
         </div>
 
-        <div className="space-y-4">
-          <AlertCard
-            type="error"
-            message={errorMessages[error] || errorMessages.Default}
-          />
-
-          {error === "OAuthAccountNotLinked" && (
-            <AlertCard
-              type="warning"
-              icon={Lightbulb}
-              message="Tip: Try signing in with the same method you used when you first created your account."
-            />
-          )}
-
-          <div className="flex flex-col gap-3">
-            <Link href={`${ROUTES.signIn}?callbackUrl=${encodeURIComponent(callbackUrl)}`}>
-              <Button className="w-full h-12 text-lg font-black bg-brutal-pink border-4 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all">
-                {isVerificationError ? "Get a new sign-in link" : "Try Again"}
-              </Button>
-            </Link>
-
-            <Link href="/">
-              <Button
-                variant="outline"
-                className="w-full h-12 text-lg font-black border-4 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,0.3)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all"
-              >
-                Go Home
-              </Button>
-            </Link>
-          </div>
-
-          <div className="text-center text-sm text-gray-600 pt-4 border-t-4 border-gray-200">
-            <p>Still having issues?</p>
-            <Link href={ROUTES.contact} className="font-bold underline hover:text-brutal-pink">
-              Contact Support
-            </Link>
-          </div>
+        <div className="text-sm text-gray-600 pt-4">
+          <p>Still having issues?</p>
+          <Link href={ROUTES.contact} className="font-bold underline hover:text-brutal-pink">
+            Contact Support
+          </Link>
         </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/apps/trialabundancesurvey/app/auth/error/page.tsx
+++ b/apps/trialabundancesurvey/app/auth/error/page.tsx
@@ -1,27 +1,17 @@
 import { Suspense } from "react"
 import AuthErrorContent from "./error-content"
-import { AlertCircle } from "lucide-react"
-
-// Loading fallback component
-function ErrorLoading() {
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-[#FF6B6B] to-[#4ECDC4] p-4">
-      <div className="w-full max-w-md space-y-8 rounded-3xl bg-white p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] border-4 border-black">
-        <div className="text-center">
-          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 border-4 border-black">
-            <AlertCircle className="h-8 w-8 text-red-600" />
-          </div>
-          <h1 className="text-4xl font-black mb-2">Loading...</h1>
-        </div>
-      </div>
-    </div>
-  )
-}
+import { Layout } from "@/components/layout"
 
 export default function AuthErrorPage() {
   return (
-    <Suspense fallback={<ErrorLoading />}>
-      <AuthErrorContent />
-    </Suspense>
+    <Layout>
+      <div className="flex min-h-screen items-center justify-center bg-brutal-beige px-4 py-12">
+        <div className="w-full max-w-md space-y-6 border-4 border-black bg-white p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+          <Suspense fallback={<p className="text-lg font-bold" role="status">Loading...</p>}>
+            <AuthErrorContent />
+          </Suspense>
+        </div>
+      </div>
+    </Layout>
   )
 }


### PR DESCRIPTION
The survey authentication error page used a red-to-teal gradient and a rounded panel that did not match the other authentication pages. It now uses the shared header and footer, plain background, square panel, and existing pink action button. The loading fallback shares that layout. Error messages and retry destinations are unchanged.

Validation:
- Production build, type check, and lint of both changed files passed.
- All 8 existing email-authentication browser tests passed on desktop and mobile, including expired links and wrong-account recovery.
- Desktop and mobile before/after screenshots were captured and inspected locally. The existing-account warning was also inspected. No clipping or horizontal overflow was found; no masking or threshold changes were needed.
- An initial development-mode test attempt hit the email-capture preload reset issue and a cold compilation timeout. The normal production test configuration passed all tests.

Review states (survey app):
- `/auth/error?error=Verification&logout=1`
- `/auth/error?error=OAuthAccountNotLinked&logout=1`

The survey app does not have a hosted branch preview available in this checkout. Screenshots remain local.

- [ ] Human review of the style change
