### PR TITLE
Stop the site-app visual capture wedging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,8 @@ jobs:
               - 'packages/survey-embed/**'
               - 'packages/tracking/**'
               - 'packages/wishonia-widget/**'
+              - 'scripts/capture-lane.mjs'
+              - 'scripts/capture-lane.test.mjs'
               - 'scripts/site-app-navigation.test.ts'
               - 'scripts/site-app-visual-routes.mjs'
               - 'scripts/smoke-site-apps.mjs'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,8 @@ jobs:
               - '.github/scripts/**'
               - 'scripts/app-preview-urls.mjs'
               - 'scripts/app-preview-urls.test.mjs'
+              - 'scripts/capture-lane.mjs'
+              - 'scripts/capture-lane.test.mjs'
               - 'package.json'
               - 'pnpm-workspace.yaml'
               - 'apps/*/package.json'
@@ -227,7 +229,7 @@ jobs:
         with:
           node-version: 24
       - name: Test GitHub and Vercel automation
-        run: node --test .github/scripts/ci-change-detection.test.mjs .github/scripts/generate-pr-preview-links.test.mjs .github/scripts/preview-managed-data-filter.test.mjs .github/scripts/preview-smoke-scope.test.mjs .github/scripts/preview-neon-branch.test.mjs .github/scripts/preview-masking-workflow-order.test.mjs .github/scripts/preview-masking-demo-user.test.mjs .github/scripts/preview-masking-managed-triggers.test.mjs .github/scripts/preview-masking-private-execution.test.mjs .github/scripts/preview-deploy-smoke.test.mjs .github/scripts/smoke-deploy-demo-login.test.mjs .github/scripts/vercel-app-build-scope.test.mjs .github/scripts/vercel-app-projects.test.mjs scripts/app-preview-urls.test.mjs
+        run: node --test .github/scripts/ci-change-detection.test.mjs .github/scripts/generate-pr-preview-links.test.mjs .github/scripts/preview-managed-data-filter.test.mjs .github/scripts/preview-smoke-scope.test.mjs .github/scripts/preview-neon-branch.test.mjs .github/scripts/preview-masking-workflow-order.test.mjs .github/scripts/preview-masking-demo-user.test.mjs .github/scripts/preview-masking-managed-triggers.test.mjs .github/scripts/preview-masking-private-execution.test.mjs .github/scripts/preview-deploy-smoke.test.mjs .github/scripts/smoke-deploy-demo-login.test.mjs .github/scripts/vercel-app-build-scope.test.mjs .github/scripts/vercel-app-projects.test.mjs scripts/app-preview-urls.test.mjs scripts/capture-lane.test.mjs
 
   core-validate:
     name: core-validate

--- a/apps/optimitron/e2e/helpers/freeze-clock.mjs
+++ b/apps/optimitron/e2e/helpers/freeze-clock.mjs
@@ -20,17 +20,25 @@ export const FROZEN_NOW_MS = 1768435200000; // 2026-01-15T00:00:00.000Z
 export function freezeClock(page, time = FROZEN_NOW_MS) {
   return page.addInitScript((frozen) => {
     const RealDate = Date;
-    class FrozenDate extends RealDate {
-      constructor(...args) {
-        super(...(args.length === 0 ? [frozen] : args));
-      }
-      static now() {
-        return frozen;
-      }
-    }
-    FrozenDate.parse = RealDate.parse;
-    FrozenDate.UTC = RealDate.UTC;
-    Object.defineProperty(FrozenDate, "name", { value: "Date" });
-    globalThis.Date = FrozenDate;
+    // A proxy rather than a subclass: `Date` is callable as well as
+    // constructable, and `Date()` without `new` is a plain function call that
+    // returns a string. A `class` cannot be called that way, so replacing
+    // `Date` with one makes any page that calls `Date()` throw mid-capture.
+    // Proxying also keeps `Date.parse`, `Date.UTC`, `Date.prototype`,
+    // `instanceof` and the constructor's name intact for free.
+    globalThis.Date = new Proxy(RealDate, {
+      apply() {
+        // `Date()` ignores its arguments and reports the current time.
+        return new RealDate(frozen).toString();
+      },
+      construct(target, args) {
+        return args.length === 0 ? new RealDate(frozen) : new RealDate(...args);
+      },
+      get(target, property, receiver) {
+        return property === "now"
+          ? () => frozen
+          : Reflect.get(target, property, receiver);
+      },
+    });
   }, time);
 }

--- a/apps/optimitron/e2e/helpers/freeze-clock.mjs
+++ b/apps/optimitron/e2e/helpers/freeze-clock.mjs
@@ -1,9 +1,36 @@
 export const FROZEN_NOW_MS = 1768435200000; // 2026-01-15T00:00:00.000Z
 
 /**
+ * Freeze `Date` for deterministic captures without Playwright's clock.
+ *
+ * `page.clock` wedges long capture runs. A single page looping the capture
+ * pipeline died at exactly the 33rd capture under `clock.install`, again at
+ * the 33rd under `clock.setFixedTime`, and completed 320 with no clock at
+ * all — so it is the injected clock itself, not its fake timers. The stall
+ * lands inside a `page.evaluate`, which has no timeout of its own, so it
+ * hangs the caller forever rather than failing.
+ *
+ * Captures only need `Date.now()` and `new Date()` to be stable; nothing here
+ * drives the clock manually (no caller uses `runFor`, `fastForward`, `pauseAt`
+ * or `resume`). So pin `Date` directly and leave every timer alone.
+ *
  * @param {import("@playwright/test").Page} page
  * @param {number} [time]
  */
 export function freezeClock(page, time = FROZEN_NOW_MS) {
-  return page.clock.install({ time });
+  return page.addInitScript((frozen) => {
+    const RealDate = Date;
+    class FrozenDate extends RealDate {
+      constructor(...args) {
+        super(...(args.length === 0 ? [frozen] : args));
+      }
+      static now() {
+        return frozen;
+      }
+    }
+    FrozenDate.parse = RealDate.parse;
+    FrozenDate.UTC = RealDate.UTC;
+    Object.defineProperty(FrozenDate, "name", { value: "Date" });
+    globalThis.Date = FrozenDate;
+  }, time);
 }

--- a/scripts/capture-lane.mjs
+++ b/scripts/capture-lane.mjs
@@ -1,0 +1,57 @@
+/**
+ * Walk a lane's routes, rebuilding the lane when its browser wears out.
+ *
+ * A browser accumulates something as pages are captured until a
+ * `page.evaluate` stops returning. `evaluate` has no timeout, so the capture
+ * hangs rather than failing, and the browser is unusable from then on. Nothing
+ * here can prevent that, so recover from it: discard the lane, open a fresh
+ * one, and retry the route that wedged.
+ *
+ * Only failures `isRecoverable` accepts are retried — an ordinary capture
+ * failure, such as a route returning the wrong status, must reach the caller
+ * on its first attempt rather than being retried three more times. Recycles
+ * are capped so a route that wedges every lane ends the run instead of
+ * rebuilding forever.
+ *
+ * @template TLane
+ * @template TRoute
+ * @param {object} options
+ * @param {TRoute[]} options.routes Routes to capture, in order.
+ * @param {() => Promise<TLane & { close: () => Promise<void> }>} options.openLane
+ * @param {(route: TRoute, lane: TLane) => Promise<void>} options.captureRoute
+ * @param {(error: unknown) => boolean} options.isRecoverable
+ * @param {number} options.maxRecycles
+ * @param {(route: TRoute, recycles: number) => void} [options.onRecycle]
+ */
+export async function runCaptureLane({
+  routes,
+  openLane,
+  captureRoute,
+  isRecoverable,
+  maxRecycles,
+  onRecycle,
+}) {
+  let lane = await openLane();
+  let recycles = 0;
+
+  try {
+    for (let index = 0; index < routes.length; index += 1) {
+      const route = routes[index];
+      try {
+        await captureRoute(route, lane);
+      } catch (error) {
+        if (!isRecoverable(error) || recycles >= maxRecycles) {
+          throw error;
+        }
+        recycles += 1;
+        onRecycle?.(route, recycles);
+        await lane.close();
+        lane = await openLane();
+        // Retry the route that wedged rather than skipping it.
+        index -= 1;
+      }
+    }
+  } finally {
+    await lane.close();
+  }
+}

--- a/scripts/capture-lane.test.mjs
+++ b/scripts/capture-lane.test.mjs
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runCaptureLane } from "./capture-lane.mjs";
+
+class Wedged extends Error {}
+
+/** A lane factory that records every lane it opened and closed. */
+function laneFactory() {
+  const opened = [];
+  return {
+    opened,
+    async openLane() {
+      const lane = {
+        closed: false,
+        id: opened.length,
+        async close() {
+          lane.closed = true;
+        },
+      };
+      opened.push(lane);
+      return lane;
+    },
+  };
+}
+
+const isRecoverable = (error) => error instanceof Wedged;
+
+test("captures every route on one lane when nothing wedges", async () => {
+  const { opened, openLane } = laneFactory();
+  const captured = [];
+
+  await runCaptureLane({
+    routes: ["a", "b", "c"],
+    openLane,
+    captureRoute: async (route) => captured.push(route),
+    isRecoverable,
+    maxRecycles: 3,
+  });
+
+  assert.deepEqual(captured, ["a", "b", "c"]);
+  assert.equal(opened.length, 1);
+  assert.equal(opened[0].closed, true);
+});
+
+test("retries the wedged route on a fresh lane", async () => {
+  // The route that wedged must be captured, not skipped: a lane that dropped
+  // it would leave a stale screenshot in the review with nothing to say so.
+  const { opened, openLane } = laneFactory();
+  const attempts = [];
+  let wedge = true;
+
+  await runCaptureLane({
+    routes: ["a", "b", "c"],
+    openLane,
+    captureRoute: async (route, lane) => {
+      attempts.push(`${route}@${lane.id}`);
+      if (route === "b" && wedge) {
+        wedge = false;
+        throw new Wedged("b wedged");
+      }
+    },
+    isRecoverable,
+    maxRecycles: 3,
+  });
+
+  assert.deepEqual(attempts, ["a@0", "b@0", "b@1", "c@1"]);
+  assert.equal(opened.length, 2);
+  assert.deepEqual(
+    opened.map((lane) => lane.closed),
+    [true, true],
+  );
+});
+
+test("reports each recycle once", async () => {
+  const { openLane } = laneFactory();
+  const recycles = [];
+  let remaining = 2;
+
+  await runCaptureLane({
+    routes: ["a"],
+    openLane,
+    captureRoute: async () => {
+      if (remaining > 0) {
+        remaining -= 1;
+        throw new Wedged("still wedged");
+      }
+    },
+    isRecoverable,
+    maxRecycles: 3,
+    onRecycle: (route, count) => recycles.push(`${route}:${count}`),
+  });
+
+  assert.deepEqual(recycles, ["a:1", "a:2"]);
+});
+
+test("gives up once the recycle cap is spent", async () => {
+  // A route that wedges every lane has to end the run; rebuilding forever
+  // would burn the whole job and report nothing.
+  const { opened, openLane } = laneFactory();
+  let attempts = 0;
+
+  await assert.rejects(
+    () =>
+      runCaptureLane({
+        routes: ["a"],
+        openLane,
+        captureRoute: async () => {
+          attempts += 1;
+          throw new Wedged("always wedged");
+        },
+        isRecoverable,
+        maxRecycles: 3,
+      }),
+    /always wedged/,
+  );
+
+  // The first attempt plus one per recycle.
+  assert.equal(attempts, 4);
+  assert.equal(opened.length, 4);
+  assert.equal(
+    opened.every((lane) => lane.closed),
+    true,
+  );
+});
+
+test("lets an ordinary capture failure through on the first attempt", async () => {
+  // Retrying a real failure three times would bury it and waste six minutes
+  // of budget before reporting the same thing.
+  const { opened, openLane } = laneFactory();
+  let attempts = 0;
+
+  await assert.rejects(
+    () =>
+      runCaptureLane({
+        routes: ["a"],
+        openLane,
+        captureRoute: async () => {
+          attempts += 1;
+          throw new Error("returned HTTP 500");
+        },
+        isRecoverable,
+        maxRecycles: 3,
+      }),
+    /returned HTTP 500/,
+  );
+
+  assert.equal(attempts, 1);
+  assert.equal(opened.length, 1);
+  assert.equal(opened[0].closed, true);
+});
+
+test("closes the lane when a route fails", async () => {
+  const { opened, openLane } = laneFactory();
+
+  await assert.rejects(
+    () =>
+      runCaptureLane({
+        routes: ["a"],
+        openLane,
+        captureRoute: async () => {
+          throw new Error("boom");
+        },
+        isRecoverable,
+        maxRecycles: 0,
+      }),
+    /boom/,
+  );
+
+  assert.equal(opened[0].closed, true);
+});

--- a/scripts/smoke-site-apps.mjs
+++ b/scripts/smoke-site-apps.mjs
@@ -15,6 +15,7 @@ import {
 import { freezeClock } from "../apps/optimitron/e2e/helpers/freeze-clock.mjs";
 import { signInViaApi } from "../apps/optimitron/e2e/utils/auth-api.mjs";
 import { SITE_APP_VISUAL_CAPTURE_VERSION } from "../apps/optimitron/scripts/visual-capture-contract.mjs";
+import { runCaptureLane } from "./capture-lane.mjs";
 import { getSiteAppScreenshotRoutes } from "./site-app-visual-routes.mjs";
 
 const repoRoot = path.resolve(
@@ -260,26 +261,43 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
               `@apps/${appName}: managed demo user could not sign in for authenticated screenshots`,
             );
           }
-          return { authenticatedPage, browser, loggedOutPage };
+          return {
+            authenticatedPage,
+            close: () => browser.close().catch(() => {}),
+            loggedOutPage,
+          };
         } catch (error) {
-          await browser.close();
+          // Swallow the close failure so the error that caused the cleanup is
+          // the one that surfaces; a browser that failed to open may well fail
+          // to close too.
+          await browser.close().catch(() => {});
           throw error;
         }
       }
 
-      let lane = await openLane();
-      let recycles = 0;
-
-      try {
-        for (let index = 0; index < screenshotRoutes.length; index += 1) {
-          const {
+      await runCaptureLane({
+        routes: screenshotRoutes,
+        openLane,
+        isRecoverable: (error) => error instanceof CaptureBudgetExceededError,
+        maxRecycles: MAX_LANE_RECYCLES,
+        onRecycle: ({ routeName }, recycles) => {
+          console.warn(
+            `@apps/${appName}: ${projectName}/${routeName} stopped responding; ` +
+              `restarting the browser and retrying it ` +
+              `(recycle ${recycles} of ${MAX_LANE_RECYCLES})`,
+          );
+        },
+        captureRoute: async (
+          {
             authenticated,
             expectNotFound,
             routeName,
             routePath,
             captureSelector,
             openMenu,
-          } = screenshotRoutes[index];
+          },
+          lane,
+        ) => {
           const page = authenticated
             ? lane.authenticatedPage
             : lane.loggedOutPage;
@@ -288,102 +306,82 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
             pageUrl.searchParams.set("visual", "1");
           }
           const captureLabel = `${projectName}/${routeName}`;
-          try {
-            await withCaptureBudget(captureLabel, async () => {
-              const url = pageUrl.toString();
-              console.log(`@apps/${appName}: capturing ${captureLabel}`);
-              const response = await page.goto(url, {
-                timeout: 30_000,
-                waitUntil: "load",
-              });
-              const status = response?.status() ?? 0;
-              const statusIsExpected = expectNotFound
-                ? status === 404
-                : status >= 200 && status < 400;
-              if (!response || !statusIsExpected) {
-                throw new Error(
-                  `${url} returned HTTP ${response?.status() ?? "unknown"}${expectNotFound ? " (expected 404)" : ""}`,
-                );
-              }
-              if (authenticated) {
-                const expectedPath = pageUrl.pathname;
-                const actualPath = new URL(page.url()).pathname;
-                if (actualPath !== expectedPath) {
-                  throw new Error(
-                    `${url} redirected to ${page.url()} instead of rendering its authenticated state`,
-                  );
-                }
-              }
-              await page
-                .waitForLoadState("networkidle", { timeout: 15_000 })
-                .catch(() => {});
-              await page.waitForSelector(".animate-pulse.bg-muted", {
-                state: "detached",
-                timeout: 15_000,
-              });
-              if (!(await waitForFonts(page))) {
-                console.warn(
-                  `@apps/${appName}: font readiness timed out for ${captureLabel}`,
-                );
-              }
-              await forceAnimationsComplete(page);
-              await prepareFullPageVisualCapture(page);
-              await forceAnimationsComplete(page);
-              if (openMenu) {
-                const menuTrigger = page.getByRole("button", {
-                  name: "Toggle menu",
-                });
-                await menuTrigger.click();
-                const menuDialog = page.getByRole("dialog", {
-                  name: "Navigation Menu",
-                });
-                await menuDialog.waitFor({ state: "visible" });
-                await menuDialog
-                  .getByRole("button", { name: "Log Out" })
-                  .waitFor({ state: "visible" });
-                await forceAnimationsComplete(page);
-              }
-              const screenshotPath = path.join(
-                outputDirectory,
-                `site-app-${appName}-${routeName}.png`,
-              );
-              if (captureSelector) {
-                const target = page.locator(captureSelector).first();
-                await target.scrollIntoViewIfNeeded();
-                await target.screenshot({
-                  animations: "disabled",
-                  path: screenshotPath,
-                });
-              } else {
-                await page.screenshot({
-                  animations: "disabled",
-                  fullPage: true,
-                  path: screenshotPath,
-                });
-              }
-              console.log(`@apps/${appName}: captured ${captureLabel}`);
+          await withCaptureBudget(captureLabel, async () => {
+            const url = pageUrl.toString();
+            console.log(`@apps/${appName}: capturing ${captureLabel}`);
+            const response = await page.goto(url, {
+              timeout: 30_000,
+              waitUntil: "load",
             });
-          } catch (error) {
-            if (
-              !(error instanceof CaptureBudgetExceededError) ||
-              recycles >= MAX_LANE_RECYCLES
-            ) {
-              throw error;
+            const status = response?.status() ?? 0;
+            const statusIsExpected = expectNotFound
+              ? status === 404
+              : status >= 200 && status < 400;
+            if (!response || !statusIsExpected) {
+              throw new Error(
+                `${url} returned HTTP ${response?.status() ?? "unknown"}${expectNotFound ? " (expected 404)" : ""}`,
+              );
             }
-            recycles += 1;
-            console.warn(
-              `@apps/${appName}: ${captureLabel} stopped responding; ` +
-                `restarting the browser and retrying it ` +
-                `(recycle ${recycles} of ${MAX_LANE_RECYCLES})`,
+            if (authenticated) {
+              const expectedPath = pageUrl.pathname;
+              const actualPath = new URL(page.url()).pathname;
+              if (actualPath !== expectedPath) {
+                throw new Error(
+                  `${url} redirected to ${page.url()} instead of rendering its authenticated state`,
+                );
+              }
+            }
+            await page
+              .waitForLoadState("networkidle", { timeout: 15_000 })
+              .catch(() => {});
+            await page.waitForSelector(".animate-pulse.bg-muted", {
+              state: "detached",
+              timeout: 15_000,
+            });
+            if (!(await waitForFonts(page))) {
+              console.warn(
+                `@apps/${appName}: font readiness timed out for ${captureLabel}`,
+              );
+            }
+            await forceAnimationsComplete(page);
+            await prepareFullPageVisualCapture(page);
+            await forceAnimationsComplete(page);
+            if (openMenu) {
+              const menuTrigger = page.getByRole("button", {
+                name: "Toggle menu",
+              });
+              await menuTrigger.click();
+              const menuDialog = page.getByRole("dialog", {
+                name: "Navigation Menu",
+              });
+              await menuDialog.waitFor({ state: "visible" });
+              await menuDialog
+                .getByRole("button", { name: "Log Out" })
+                .waitFor({ state: "visible" });
+              await forceAnimationsComplete(page);
+            }
+            const screenshotPath = path.join(
+              outputDirectory,
+              `site-app-${appName}-${routeName}.png`,
             );
-            await lane.browser.close().catch(() => {});
-            lane = await openLane();
-            index -= 1;
-          }
-        }
-      } finally {
-        await lane.browser.close().catch(() => {});
-      }
+            if (captureSelector) {
+              const target = page.locator(captureSelector).first();
+              await target.scrollIntoViewIfNeeded();
+              await target.screenshot({
+                animations: "disabled",
+                path: screenshotPath,
+              });
+            } else {
+              await page.screenshot({
+                animations: "disabled",
+                fullPage: true,
+                path: screenshotPath,
+              });
+            }
+            console.log(`@apps/${appName}: captured ${captureLabel}`);
+          });
+        },
+      });
     }),
   );
 

--- a/scripts/smoke-site-apps.mjs
+++ b/scripts/smoke-site-apps.mjs
@@ -33,6 +33,10 @@ const apps = [
 ];
 
 const ROUTE_CAPTURE_TIMEOUT_MS = 120_000;
+const MAX_LANE_RECYCLES = 3;
+
+/** Raised when a capture exceeds its budget, so a lane knows it can retry. */
+class CaptureBudgetExceededError extends Error {}
 
 const screenshotProjects = [
   ["default", { viewport: { width: 1440, height: 900 } }],
@@ -71,7 +75,7 @@ async function withCaptureBudget(captureLabel, capture) {
         timer = setTimeout(
           () =>
             reject(
-              new Error(
+              new CaptureBudgetExceededError(
                 `Timed out after ${ROUTE_CAPTURE_TIMEOUT_MS}ms capturing ${captureLabel}. ` +
                   `The page stopped responding partway through capture.`,
               ),
@@ -207,43 +211,47 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
       2,
     )}\n`,
   );
-  // Each viewport project gets its own browser. Something in a browser
-  // accumulates across captures until a `page.evaluate` stops returning, and
-  // `evaluate` has no timeout, so the lane hangs rather than failing. Pages in
-  // one browser share whatever runs out: with both projects in a single
-  // browser one lane would wedge partway through while the other finished all
-  // of its routes, either lane able to be the victim. A browser apiece halves
-  // what each one has to survive and stops one lane's work from exhausting the
-  // other's.
+  // A browser wears out. Something in it accumulates as pages are captured
+  // until a `page.evaluate` stops returning, and `evaluate` has no timeout, so
+  // the lane hangs instead of failing. Captured pixels, not captures, seem to
+  // be what is spent: the narrow viewport renders pages several times taller
+  // and exhausts a browser after a dozen or so routes, while the wide one gets
+  // through all of them. Freezing `Date` without Playwright's clock bought
+  // roughly nine times more headroom but did not remove the ceiling.
+  //
+  // So give each project its own browser and let a lane rebuild itself. When a
+  // capture exceeds its budget the lane discards the browser, starts a fresh
+  // one, and retries that route; a wedged browser is unusable afterwards, and
+  // a new one starts with a full allowance. Recycles are capped so a genuinely
+  // broken page still fails the run rather than looping.
   await Promise.all(
     screenshotProjects.map(async ([projectName, contextOptions]) => {
-      const browser = await chromium.launch({
-        channel: process.env.PLAYWRIGHT_BROWSER_CHANNEL || "chrome",
-        headless: true,
-      });
+      const outputDirectory = path.resolve(screenshotRoot, projectName);
+      await mkdir(outputDirectory, { recursive: true });
+      const needsAuthentication = screenshotRoutes.some(
+        ({ authenticated }) => authenticated,
+      );
 
-      try {
-        const outputDirectory = path.resolve(screenshotRoot, projectName);
-        await mkdir(outputDirectory, { recursive: true });
-        const loggedOutContext = await browser.newContext({
-          ...contextOptions,
-          baseURL: baseUrl,
+      async function openLane() {
+        const browser = await chromium.launch({
+          channel: process.env.PLAYWRIGHT_BROWSER_CHANNEL || "chrome",
+          headless: true,
         });
-        const authenticatedContext = await browser.newContext({
-          ...contextOptions,
-          baseURL: baseUrl,
-        });
-        const loggedOutPage = await loggedOutContext.newPage();
-        const authenticatedPage = await authenticatedContext.newPage();
-        await Promise.all([
-          freezeClock(loggedOutPage),
-          freezeClock(authenticatedPage),
-        ]);
-
         try {
-          const needsAuthentication = screenshotRoutes.some(
-            ({ authenticated }) => authenticated,
-          );
+          const loggedOutContext = await browser.newContext({
+            ...contextOptions,
+            baseURL: baseUrl,
+          });
+          const authenticatedContext = await browser.newContext({
+            ...contextOptions,
+            baseURL: baseUrl,
+          });
+          const loggedOutPage = await loggedOutContext.newPage();
+          const authenticatedPage = await authenticatedContext.newPage();
+          await Promise.all([
+            freezeClock(loggedOutPage),
+            freezeClock(authenticatedPage),
+          ]);
           if (
             needsAuthentication &&
             !(await signInViaApi(authenticatedContext.request))
@@ -252,20 +260,34 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
               `@apps/${appName}: managed demo user could not sign in for authenticated screenshots`,
             );
           }
+          return { authenticatedPage, browser, loggedOutPage };
+        } catch (error) {
+          await browser.close();
+          throw error;
+        }
+      }
 
-          for (const {
+      let lane = await openLane();
+      let recycles = 0;
+
+      try {
+        for (let index = 0; index < screenshotRoutes.length; index += 1) {
+          const {
             authenticated,
             expectNotFound,
             routeName,
             routePath,
             captureSelector,
-          } of screenshotRoutes) {
-            const page = authenticated ? authenticatedPage : loggedOutPage;
-            const pageUrl = new URL(routePath, baseUrl);
-            if (appName === "acceleratedmedicine" && routeName === "home") {
-              pageUrl.searchParams.set("visual", "1");
-            }
-            const captureLabel = `${projectName}/${routeName}`;
+          } = screenshotRoutes[index];
+          const page = authenticated
+            ? lane.authenticatedPage
+            : lane.loggedOutPage;
+          const pageUrl = new URL(routePath, baseUrl);
+          if (appName === "acceleratedmedicine" && routeName === "home") {
+            pageUrl.searchParams.set("visual", "1");
+          }
+          const captureLabel = `${projectName}/${routeName}`;
+          try {
             await withCaptureBudget(captureLabel, async () => {
               const url = pageUrl.toString();
               console.log(`@apps/${appName}: capturing ${captureLabel}`);
@@ -326,15 +348,26 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
               }
               console.log(`@apps/${appName}: captured ${captureLabel}`);
             });
+          } catch (error) {
+            if (
+              !(error instanceof CaptureBudgetExceededError) ||
+              recycles >= MAX_LANE_RECYCLES
+            ) {
+              throw error;
+            }
+            recycles += 1;
+            console.warn(
+              `@apps/${appName}: ${captureLabel} stopped responding; ` +
+                `restarting the browser and retrying it ` +
+                `(recycle ${recycles} of ${MAX_LANE_RECYCLES})`,
+            );
+            await lane.browser.close().catch(() => {});
+            lane = await openLane();
+            index -= 1;
           }
-        } finally {
-          await Promise.all([
-            loggedOutContext.close(),
-            authenticatedContext.close(),
-          ]);
         }
       } finally {
-        await browser.close();
+        await lane.browser.close().catch(() => {});
       }
     }),
   );

--- a/scripts/smoke-site-apps.mjs
+++ b/scripts/smoke-site-apps.mjs
@@ -207,14 +207,22 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
       2,
     )}\n`,
   );
-  const browser = await chromium.launch({
-    channel: process.env.PLAYWRIGHT_BROWSER_CHANNEL || "chrome",
-    headless: true,
-  });
+  // Each viewport project gets its own browser. Something in a browser
+  // accumulates across captures until a `page.evaluate` stops returning, and
+  // `evaluate` has no timeout, so the lane hangs rather than failing. Pages in
+  // one browser share whatever runs out: with both projects in a single
+  // browser one lane would wedge partway through while the other finished all
+  // of its routes, either lane able to be the victim. A browser apiece halves
+  // what each one has to survive and stops one lane's work from exhausting the
+  // other's.
+  await Promise.all(
+    screenshotProjects.map(async ([projectName, contextOptions]) => {
+      const browser = await chromium.launch({
+        channel: process.env.PLAYWRIGHT_BROWSER_CHANNEL || "chrome",
+        headless: true,
+      });
 
-  try {
-    await Promise.all(
-      screenshotProjects.map(async ([projectName, contextOptions]) => {
+      try {
         const outputDirectory = path.resolve(screenshotRoot, projectName);
         await mkdir(outputDirectory, { recursive: true });
         const loggedOutContext = await browser.newContext({
@@ -325,11 +333,11 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
             authenticatedContext.close(),
           ]);
         }
-      }),
-    );
-  } finally {
-    await browser.close();
-  }
+      } finally {
+        await browser.close();
+      }
+    }),
+  );
 
   console.log(
     `@apps/${appName}: captured ${screenshotRoutes.length * screenshotProjects.length} screenshots`,


### PR DESCRIPTION
## Summary

`site-apps-build (warondisease)` wedges partway through capturing screenshots and never resumes. Before #302 it consumed the whole 30-minute job timeout and reported nothing but "The operation was canceled"; since #302 it fails in two minutes naming the route. It has been red on `main` since `bda107ca`.

A lane stops inside a `page.evaluate` that never returns. `evaluate` has no timeout of its own, so nothing below the route budget can rescue it.

## What it actually is

A browser wears out. Something in it accumulates as pages are captured until an evaluation stops coming back, and I could not find a way to prevent that from outside Chromium. What I could measure, on one page looping the capture pipeline:

| condition | page wedges at |
|---|---|
| `clock.install()`, mobile emulation | capture **33** |
| `clock.install()`, no mobile emulation | capture **33** |
| `clock.setFixedTime()` | capture **33** |
| plain `Date` init script | capture **290** |
| no clock at all | 320+ (ran to the cap) |

Playwright's injected clock costs roughly nine times the headroom, and it is the clock itself rather than its fake timers — `setFixedTime` leaves timers real and dies at the identical capture.

What is spent looks like captured pixels rather than captures. Even on separate browsers the narrow viewport wedges at its twelfth to sixteenth route while the wide viewport completes all thirty-four, and the narrow viewport renders these pages several times taller.

## What changed

- **Freeze `Date` without Playwright's clock.** Captures only need `Date.now()` and `new Date()` to be stable, and nothing in the repo drives the clock manually — no caller uses `runFor`, `fastForward`, `pauseAt` or `resume` — so the clock machinery was buying nothing and costing most of the headroom. A small `addInitScript` shim pins `Date` and leaves every timer alone.
- **A browser per viewport project**, so one lane cannot exhaust the other's allowance, and so a lane can be rebuilt on its own.
- **Rebuild a lane when its browser wears out.** On a budget overrun the lane discards the browser, opens a fresh one and retries that route. A wedged browser is unusable afterwards; a new one starts with a full allowance. Recycles are capped at three so a genuinely broken page still fails the run rather than looping, and the budget error is now typed so an ordinary failure is never mistaken for a stall.

## Verification

**47 consecutive full smoke runs of `warondisease`, all green** — 35 before merging `main`, 12 after — every run capturing its full set (87 before #301's two `openMenu` routes landed, 89 after). The baseline on `main` failed 8–16% of runs.

Six of those runs took ~229s against a normal ~113s, which is one budget overrun plus a rebuild. One of them is logged in full:

```
@apps/warondisease: visual-mobile/soldiers stopped responding; restarting the browser and retrying it (recycle 1 of 3)
```

That run went on to capture 89/89 and exit 0. So the wedge still fires on roughly a fifth of runs, and is recovered from every time.

The cap and retry loop were exercised separately by shrinking the budget to 1.5s until every route wedged: the lane rebuilt three times, retried the same route each time, then failed with the capped error rather than looping.

The `Date` shim checked against a real page: `Date.now()` and `new Date()` frozen, explicit dates and `Date.parse`/`Date.UTC` preserved, `instanceof Date` intact, `Date.name` still `"Date"`, timers still real.

## What this is not

The third change is recovery, not a cure — the leak is still in there, this stops it failing the build. I tried three root-cause fixes first (bounding the settle waits, driving the viewport sweep from the driver, running the lanes sequentially); each explained the evidence I had at the time and none held up, and the sweep rewrite made the failure rate worse. Only the first of those, #302's budgets, was worth keeping, and it is what made this diagnosable at all.

## Please watch

`web-visual-review` is the check that matters here. `freezeClock` feeds eight visual specs, and this changes how `Date` is pinned for all of them — I believe it is inert for rendered output, but a shifted baseline would show up there rather than in the site-app smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgYULvPW89bMAV3C6mXmtG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated site capture reliability by retrying recoverable capture failures on a fresh browser session.
  - Ensured browser sessions close cleanly after successful captures and errors.
  - Improved frozen-clock behavior in browser testing while preserving standard date and time functionality.

- **Tests**
  - Expanded automated coverage for capture retries, failure handling, session cleanup, and frozen-clock behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->