### PR TITLE
Fix failed Accelerated Medicine survey submissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,6 +396,10 @@ jobs:
         if: ${{ fromJSON(needs.changes.outputs.site_apps || 'false') == true }}
         run: pnpm test:apps:unit
 
+      - name: Accelerated Medicine survey database regression tests
+        if: ${{ fromJSON(needs.changes.outputs.site_apps || 'false') == true }}
+        run: pnpm --filter @apps/acceleratedmedicine test:integration
+
   site-apps-build:
     name: site-apps-build (${{ matrix.app }})
     if: ${{ fromJSON(needs.changes.outputs.site_apps || 'false') == true }}

--- a/apps/acceleratedmedicine/lib/right-to-try-support-store.ts
+++ b/apps/acceleratedmedicine/lib/right-to-try-support-store.ts
@@ -194,8 +194,9 @@ export async function storeRightToTrySupport(
   const requestHash = hashJson(values);
 
   return prisma.$transaction(async (tx) => {
-    await tx.$queryRaw<Array<{ locked: boolean }>>`
-      SELECT pg_advisory_xact_lock(hashtextextended(${clientKey}, 0)) AS locked
+    // The lock returns PostgreSQL void, which Prisma cannot deserialize as a row.
+    await tx.$executeRaw`
+      SELECT pg_advisory_xact_lock(hashtextextended(${clientKey}, 0))
     `;
     const existing = await tx.formSubmission.findUnique({
       where: {

--- a/apps/acceleratedmedicine/package.json
+++ b/apps/acceleratedmedicine/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --exclude 'tests/integration/**'",
     "test:unit": "cross-env SKIP_DB_TEST_SETUP=1 vitest run --exclude 'tests/integration/**'",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "smoke:db": "tsx scripts/smoke-treaty-db.ts"
   },
   "dependencies": {

--- a/apps/acceleratedmedicine/tests/README.md
+++ b/apps/acceleratedmedicine/tests/README.md
@@ -6,6 +6,17 @@ This project uses **Vitest** for unit/integration tests and **Playwright** for E
 
 ## Running Tests
 
+### Survey Database Regression
+
+Set `DATABASE_URL` to a local PostgreSQL test database, such as `acceleratedmedicine_test`.
+Apply the repository migrations with `pnpm db:deploy` from the repository root.
+Run `pnpm --filter @apps/acceleratedmedicine test:integration` from the repository root.
+
+This suite calls the real submission endpoint and checks the saved answers.
+It also checks duplicate retries and concurrent rate limits.
+It disables email delivery and removes only its own response fixtures.
+The site-app CI job runs this suite after database migrations.
+
 ### Unit Tests (Vitest)
 ```bash
 # Run all unit tests

--- a/apps/acceleratedmedicine/tests/integration/right-to-try-support.test.ts
+++ b/apps/acceleratedmedicine/tests/integration/right-to-try-support.test.ts
@@ -1,0 +1,108 @@
+import { createHmac } from "node:crypto";
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "../../app/api/right-to-try-support/route";
+import { prisma } from "../../lib/prisma";
+
+const secret = "right-to-try-integration-test-secret";
+const address = "192.0.2.42";
+const keys = Array.from(
+  { length: 6 },
+  (_, index) => `6915f297-a64b-4000-8000-${String(index).padStart(12, "0")}`,
+);
+const validResponse = {
+  submissionKey: keys[0],
+  intent: "state-support",
+  state: "Missouri",
+  position: "yes",
+  role: "patient-or-caregiver",
+  email: "",
+  story: "Integration test response",
+  updates: false,
+  companyWebsite: "",
+};
+
+function submit(body: unknown) {
+  return POST(new Request("http://localhost/api/right-to-try-support", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-vercel-forwarded-for": address,
+    },
+    body: JSON.stringify(body),
+  }));
+}
+
+async function removeTestResponses() {
+  await prisma.formResponse.deleteMany({
+    where: { submission: { idempotencyKey: { in: keys } } },
+  });
+  await prisma.formSubmission.deleteMany({
+    where: { idempotencyKey: { in: keys } },
+  });
+}
+
+beforeAll(() => {
+  vi.stubEnv("RIGHT_TO_TRY_RATE_LIMIT_SECRET", secret);
+  // Exercise the real store without sending notifications to real recipients.
+  vi.stubEnv("RESEND_API_KEY", "");
+});
+beforeEach(removeTestResponses);
+afterAll(async () => {
+  try {
+    await removeTestResponses();
+  } finally {
+    await prisma.$disconnect();
+    vi.unstubAllEnvs();
+  }
+});
+
+describe("Right to Try POST with PostgreSQL", () => {
+  it.each([
+    { intent: "state-support", name: "", email: "", position: "yes" },
+    { intent: "volunteer", name: "Test Volunteer", email: "volunteer@example.invalid", position: undefined },
+  ])("persists a $intent response and deduplicates a retry", async (participant) => {
+    const input = { ...validResponse, ...participant };
+    const response = await submit(input);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, sentConfirmation: false });
+
+    const saved = await prisma.formSubmission.findFirstOrThrow({
+      where: { idempotencyKey: input.submissionKey },
+      include: { responses: { include: { field: { select: { key: true } } } } },
+    });
+    expect(saved.status).toBe("SUBMITTED");
+    expect(Object.fromEntries(saved.responses.map((item) => [item.field.key, item.valueJson])))
+      .toEqual({
+        intent: input.intent,
+        name: input.name,
+        state: input.state,
+        position: input.position || "",
+        role: input.role,
+        story: input.story,
+        email: input.email,
+        updates: false,
+        "client-key": createHmac("sha256", secret).update(address).digest("hex"),
+      });
+
+    expect((await submit(input)).status).toBe(200);
+    expect(await prisma.formSubmission.count({
+      where: { idempotencyKey: input.submissionKey },
+    })).toBe(1);
+  });
+
+  it("enforces the quota across concurrent submissions and still accepts retries", async () => {
+    const responses = await Promise.all(keys.map((submissionKey) =>
+      submit({ ...validResponse, submissionKey }),
+    ));
+    expect(responses.map((response) => response.status).sort())
+      .toEqual([200, 200, 200, 200, 200, 429]);
+    expect(await prisma.formSubmission.count({
+      where: { idempotencyKey: { in: keys } },
+    })).toBe(5);
+
+    const acceptedKey = keys[responses.findIndex((response) => response.status === 200)];
+    expect((await submit({ ...validResponse, submissionKey: acceptedKey })).status).toBe(200);
+  });
+});

--- a/apps/acceleratedmedicine/vitest.integration.config.ts
+++ b/apps/acceleratedmedicine/vitest.integration.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vitest/config";
+
+import baseConfig from "./vitest.config";
+
+const database = new URL(process.env.DATABASE_URL || "postgresql://localhost/missing");
+if (
+  !["localhost", "127.0.0.1", "[::1]"].includes(database.hostname) ||
+  !/(^|[_-])test($|[_-])/u.test(database.pathname.slice(1))
+) {
+  throw new Error("Integration tests require an explicit local test DATABASE_URL.");
+}
+
+export default defineConfig({
+  ...baseConfig,
+  test: {
+    ...baseConfig.test,
+    environment: "node",
+    passWithNoTests: false,
+    setupFiles: [],
+    include: ["tests/integration/**/*.test.ts"],
+    exclude: [],
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
Survey and volunteer submissions on acceleratedmedicine.org returned HTTP 503 with “We could not record this response.” Production Vercel logs show Prisma P2010: `Failed to deserialize column of type 'void'` at the advisory-lock query, before answers are saved.

Execute `pg_advisory_xact_lock` with `$executeRaw` instead of `$queryRaw`. The transaction keeps its rate-limit lock without asking Prisma to deserialize PostgreSQL's void return value.

Add three PostgreSQL integration tests through the real POST handler. They verify saved survey and volunteer answers, duplicate retries, and concurrent quota enforcement. CI runs them in the existing site-app database job. Tests require a local test database, disable email delivery, and remove only their response fixtures.

Validation:
- The tests reproduced the exact production P2010/503 failure before the fix; all three pass after it.
- All 26 existing unit tests pass.
- App type check, implementation lint, and production build pass.
- Browser submissions on the home survey and /contact reach their success states. A database query confirmed persistence.
- Desktop/mobile success screenshots were captured and inspected locally. No UI code changed. The contact page has pre-existing horizontal overflow outside this fix; the success panel remains readable. No masking or screenshot thresholds changed.

Review after deployment:
- [Home survey](https://acceleratedmedicine.org/?logout=1#state-support)
- [Survey page](https://acceleratedmedicine.org/survey?logout=1)
- [Volunteer form](https://acceleratedmedicine.org/contact?logout=1)

These are production review destinations, not branch previews. This fix is not deployed yet.

- [ ] Human review and merge
