### PR TITLE
Restore the War on Disease Resend webhook URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,9 +31,11 @@ EMAIL_FROM=Earth Optimization Services <hello@updates.warondisease.org>
 # FAILED TaskCommunication rows in the listCommunications MCP tool.
 # OUTBOUND_EMAIL_MODE=allowlist
 # OUTBOUND_EMAIL_ALLOWLIST=m@thinkbynumbers.org,@example.org
-# Optional: inbound replies to task notification emails. Set both values only
-# after the inbound provider routes this domain to /api/webhooks/resend-inbound.
-RESEND_INBOUND_WEBHOOK_SECRET=
+# Resend webhook signing secret on the Optimitron deployment.
+# Register one endpoint: https://optimitron.com/api/webhooks/resend
+RESEND_WEBHOOK_SECRET=
+# Optional task replies: configure Resend receiving for this domain and enable
+# email.received on the same webhook before setting REPLY_EMAIL_DOMAIN.
 REPLY_EMAIL_DOMAIN=reply.warondisease.org
 # Google OAuth client credentials:
 # Console: https://console.cloud.google.com/apis/credentials

--- a/.github/scripts/smoke-site-deployment.mjs
+++ b/.github/scripts/smoke-site-deployment.mjs
@@ -37,6 +37,15 @@ async function main() {
   for (const routePath of app.smokePaths) {
     routes.push(await smokeRoute(targetUrl, routePath));
   }
+  if (appName === "warondisease") {
+    // An unsigned POST must reach the shared handler, not a 404 or login page.
+    routes.push(await smokeRoute(targetUrl, "/api/webhooks/resend", {
+      method: "POST",
+      body: "{}",
+      expectedStatus: 401,
+      expectedJson: { ok: false, reason: "invalid_signature" },
+    }));
+  }
   const failures = routes.filter(({ ok }) => !ok);
   const result = {
     success: failures.length === 0,
@@ -58,11 +67,11 @@ async function main() {
   if (failures.length > 0) process.exitCode = 1;
 }
 
-async function smokeRoute(baseUrl, routePath) {
+async function smokeRoute(baseUrl, routePath, options) {
   const url = new URL(routePath, baseUrl).toString();
   const attempts = [];
   for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
-    const current = await fetchRoute(url);
+    const current = await fetchRoute(url, options);
     attempts.push(current);
     if (current.ok) {
       return { ...current, path: routePath, url, attempts };
@@ -72,12 +81,14 @@ async function smokeRoute(baseUrl, routePath) {
   return { ...attempts.at(-1), path: routePath, url, attempts };
 }
 
-async function fetchRoute(url) {
+async function fetchRoute(url, options = {}) {
   const startedAt = Date.now();
   const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET?.trim();
   try {
     const response = await fetch(url, {
-      redirect: "follow",
+      redirect: options.method === "POST" ? "manual" : "follow",
+      method: options.method,
+      body: options.body,
       headers: bypassSecret
         ? {
             "x-vercel-protection-bypass": bypassSecret,
@@ -90,7 +101,22 @@ async function fetchRoute(url) {
     const matchedErrorMarker = ERROR_MARKERS.find((marker) =>
       body.includes(marker),
     );
-    const ok = response.ok && !matchedErrorMarker;
+    let matchesExpectedJson = true;
+    if (options.expectedJson) {
+      try {
+        const parsed = JSON.parse(body);
+        matchesExpectedJson = Object.entries(options.expectedJson).every(
+          ([key, value]) => parsed?.[key] === value,
+        );
+      } catch {
+        matchesExpectedJson = false;
+      }
+    }
+    const expectedStatus = options.expectedStatus ?? 200;
+    const statusOk = options.expectedStatus
+      ? response.status === expectedStatus
+      : response.ok;
+    const ok = statusOk && matchesExpectedJson && !matchedErrorMarker;
     return {
       ok,
       status: response.status,
@@ -99,7 +125,9 @@ async function fetchRoute(url) {
         ? undefined
         : matchedErrorMarker
           ? `Response contained ${matchedErrorMarker}`
-          : `Received HTTP ${response.status}`,
+          : !matchesExpectedJson
+            ? "Response did not contain the expected webhook rejection"
+            : `Received HTTP ${response.status}; expected ${expectedStatus}`,
       matchedErrorMarker,
     };
   } catch (error) {

--- a/.github/scripts/smoke-site-deployment.mjs
+++ b/.github/scripts/smoke-site-deployment.mjs
@@ -92,7 +92,11 @@ async function fetchRoute(url, options = {}) {
       headers: bypassSecret
         ? {
             "x-vercel-protection-bypass": bypassSecret,
-            "x-vercel-set-bypass-cookie": "true",
+            // Vercel answers cookie setup with a redirect. POST checks must
+            // exercise the handler directly with the bypass header alone.
+            ...(options.method === "POST"
+              ? {}
+              : { "x-vercel-set-bypass-cookie": "true" }),
           }
         : undefined,
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),

--- a/.github/scripts/smoke-site-deployment.mjs
+++ b/.github/scripts/smoke-site-deployment.mjs
@@ -92,11 +92,6 @@ async function fetchRoute(url, options = {}) {
       headers: bypassSecret
         ? {
             "x-vercel-protection-bypass": bypassSecret,
-            // Vercel answers cookie setup with a redirect. POST checks must
-            // exercise the handler directly with the bypass header alone.
-            ...(options.method === "POST"
-              ? {}
-              : { "x-vercel-set-bypass-cookie": "true" }),
           }
         : undefined,
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),

--- a/apps/warondisease/middleware.ts
+++ b/apps/warondisease/middleware.ts
@@ -6,5 +6,13 @@ import { createAuthMiddleware } from "@/lib/create-middleware"
 export default createAuthMiddleware({ handleVoteShare: false })
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|api/auth|api/stripe).*)"],
+  // `api/webhooks` is excluded because next.config.mjs rewrites
+  // /api/webhooks/resend to Optimitron, which owns the signature check.
+  // Middleware runs before `afterFiles` rewrites, so without this the auth
+  // redirect answers the webhook first and the rewrite never happens —
+  // Resend's POSTs would get a 302 to sign-in and its events would be
+  // dropped silently.
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|api/auth|api/stripe|api/webhooks).*)",
+  ],
 }

--- a/apps/warondisease/next.config.mjs
+++ b/apps/warondisease/next.config.mjs
@@ -41,6 +41,15 @@ const nextConfig = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      {
+        // Preserve the old webhook URL; Optimitron owns signature checks and dispatch.
+        source: "/api/webhooks/resend",
+        destination: "https://optimitron.com/api/webhooks/resend",
+      },
+    ];
+  },
   async redirects() {
     return [
       { source: "/campaigns", destination: "/", permanent: false },

--- a/docs/TASK_COMMUNICATION_MODEL.md
+++ b/docs/TASK_COMMUNICATION_MODEL.md
@@ -60,12 +60,14 @@ When a task has multiple `TaskCommunicationEndpoint` rows, the engine selects th
 
 ## Inbound email guardrails
 
-Optimitron has a guarded inbound reply path at `/api/webhooks/resend-inbound`. It decodes `reply+{taskId}@{REPLY_EMAIL_DOMAIN}`, authenticates the sender against the task creator, assignee, organization contact, or task contact endpoint, strips quoted text, and writes a `TaskComment(kind=INBOUND_MESSAGE)` plus `TaskCommunication(status=RECEIVED)`.
+Optimitron receives Resend events at `https://optimitron.com/api/webhooks/resend`. The War on Disease path `/api/webhooks/resend` forwards to this handler for compatibility. Keep one Resend webhook registration, pointed at the canonical Optimitron URL, to avoid duplicate deliveries.
+
+The handler records delivery events and handles bounces and complaints. For `email.received`, it decodes `reply+{taskId}@{REPLY_EMAIL_DOMAIN}`, authenticates the sender against the task creator, assignee, organization contact, or task contact endpoint, strips quoted text, and writes a `TaskComment(kind=INBOUND_MESSAGE)` plus `TaskCommunication(status=RECEIVED)`.
 
 Do not surface "reply by email" unless both of these are true:
 
-- `RESEND_INBOUND_WEBHOOK_SECRET` and `REPLY_EMAIL_DOMAIN` are configured for the deployment.
-- The inbound provider routes that domain to `/api/webhooks/resend-inbound` with the matching signature secret.
+- `RESEND_WEBHOOK_SECRET` and `REPLY_EMAIL_DOMAIN` are configured for the Optimitron deployment.
+- Resend receives mail for that domain and sends `email.received` to the enabled webhook with the matching signature secret.
 
 Still-required production guardrails before broad rollout:
 


### PR DESCRIPTION
The Resend webhook registered on War on Disease returned 404 after the site split. Restore that exact path with a proxy rewrite to the canonical Optimitron handler. Signature checks and event dispatch stay in one implementation.

Add a deployed regression check that requires an unsigned POST to return HTTP 401 with `invalid_signature`. It rejects missing routes, redirects, login pages, and unconfigured handlers. Use the Vercel bypass header without cookie setup so stateless smoke requests do not enter redirects. Correct the webhook URL and secret name in the environment example and communication documentation.

Validation:
- 75 War on Disease unit tests and 16 related deployment automation tests pass.
- The regression check reproduced the production 404 and passes through the local route and protected Vercel preview.
- Real HTTP checks through the local route and Vercel preview pass: unsigned 401, valid signature 200, tampered body 401, signed malformed event 400. The valid event is an ignored diagnostic and sends no email.
- No rendered UI changes.

Preview endpoint: https://warondisease-37zht4w9g-mike-p-sinns-projects.vercel.app/api/webhooks/resend (POST; no app login required). Branch preview: https://warondisease-git-feature-restore-r-8af813-mike-p-sinns-projects.vercel.app/api/webhooks/resend.

Production recovery is complete independently of this merge: the existing Resend registration now targets https://optimitron.com/api/webhooks/resend and is enabled. All 13 failed notifications from the outage were replayed successfully. Exactly one webhook registration remains. These were notification replays, not resends of the original emails.

The initial preview smoke failure came from cookie setup redirects and is fixed in the current script. Latest CI is in progress.

- [ ] Review the compatibility route and deployment regression check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Resend webhooks now use a unified endpoint while preserving the existing War on Disease URL.
  - Webhook processing now supports delivery events, bounces, complaints, and received emails.
  - Requests are verified for valid signatures before processing.

- **Documentation**
  - Updated setup guidance with the new webhook secret configuration.
  - Clarified endpoint routing, deployment ownership, optional task-reply settings, and the need for a single Resend webhook registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->