### PR TITLE
Add stable links

### DIFF
--- a/apps/optimitron/src/lib/resource-links.ts
+++ b/apps/optimitron/src/lib/resource-links.ts
@@ -11,7 +11,7 @@
 
 export const MANUAL_URLS = {
   readOnline: 'https://manual.warondisease.org',
-  kindle: 'https://www.amazon.com/dp/B0GPBH77XN',
+  kindle: 'https://warondisease.org/amazon/ebook',
   allRetailers: 'https://books2read.com/u/baegEq',
   goodreads: 'https://www.goodreads.com/book/show/248248875-how-to-end-war-and-disease',
 } as const

--- a/apps/warondisease/next.config.mjs
+++ b/apps/warondisease/next.config.mjs
@@ -6,6 +6,25 @@ import { pinAppNextAuthInstance } from "../shared-next-config.mjs";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const monorepoRoot = path.join(__dirname, "../..");
 
+const AMAZON_PAPERBACK_URL = "https://www.amazon.com/dp/B0HHKY4SBM";
+const AMAZON_EBOOK_URL = "https://www.amazon.com/dp/B0HHLR55CN";
+
+const AMAZON_BOOK_REDIRECTS = [
+  { source: "/amazon", destination: AMAZON_PAPERBACK_URL, permanent: false },
+  {
+    source: "/amazon/book",
+    destination: AMAZON_PAPERBACK_URL,
+    permanent: false,
+  },
+  {
+    source: "/amazon/paperback",
+    destination: AMAZON_PAPERBACK_URL,
+    permanent: false,
+  },
+  { source: "/amazon/ebook", destination: AMAZON_EBOOK_URL, permanent: false },
+  { source: "/amazon/kindle", destination: AMAZON_EBOOK_URL, permanent: false },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   env: {
@@ -52,6 +71,7 @@ const nextConfig = {
   },
   async redirects() {
     return [
+      ...AMAZON_BOOK_REDIRECTS,
       { source: "/campaigns", destination: "/", permanent: false },
       { source: "/campaigns/:path*", destination: "/", permanent: false },
       { source: "/auth/signup", destination: "/auth/signin", permanent: false },

--- a/packages/site-kit/src/lib/manual-links.ts
+++ b/packages/site-kit/src/lib/manual-links.ts
@@ -14,7 +14,7 @@ export const MANUAL_URLS = {
   readOnline: 'https://manual.warondisease.org',
 
   /** Amazon Kindle */
-  kindle: 'https://www.amazon.com/dp/B0GPBH77XN',
+  kindle: 'https://warondisease.org/amazon/ebook',
 
   /** Universal book link (Apple Books, Kobo, B&N, etc.) */
   allRetailers: 'https://books2read.com/u/baegEq',


### PR DESCRIPTION
## Summary

- add stable War on Disease redirects for the second-edition paperback and Kindle pages
- support `/amazon`, `/amazon/book`, `/amazon/paperback`, `/amazon/ebook`, and `/amazon/kindle`
- point shared Kindle references at the stable `/amazon/ebook` URL
- use temporary redirects so later editions can change destinations safely

## Verified destinations

- Paperback: https://www.amazon.com/dp/B0HHKY4SBM
- Kindle: https://www.amazon.com/dp/B0HHLR55CN

## Validation

- verified both Amazon listings live in KDP and on Amazon
- War on Disease typecheck passed
- War on Disease unit tests passed: 19 files, 75 tests
- GitHub War on Disease build passed
- Vercel preview and production builds passed
- all five preview and production routes return HTTP 307 with the intended Amazon destination
- latest deployment smoke passed; earlier webhook-smoke failures occurred before the final ready deployment and were superseded
- post-deploy error log scan found no errors

## Production deployment

- URL: https://warondisease.org
- Vercel deployment: https://warondisease-azgx5p5st-mike-p-sinns-projects.vercel.app
- Target: production
- Commit: f720ad55b996c880691901b1972dd006a08a4246
- Framework: Next.js 15.5.15
- Build duration: 4 minutes