### PR TITLE
Port the MCP and developer pages to the campaign app

### DIFF
--- a/apps/warondisease/app/developers/page.logged-out.md
+++ b/apps/warondisease/app/developers/page.logged-out.md
@@ -1,0 +1,144 @@
+# /developers
+
+## Metadata
+
+- Page title: Earth Optimization API
+- Meta description: Connect your survey, dFDA site, field tool, or civic app to Optimitron's shared work graph: OAuth, people, organizations, tasks, referrals, votes, and expected-value coordination.
+- Canonical: https://warondisease.org
+- Open Graph title: The International Campaign to End War and Disease
+- Open Graph description: Click a glowing rectangle. 15 seconds. 2.6 lives saved + 53 years of suffering prevented.
+- Open Graph image: https://warondisease.org/assets/warondisease/war-on-disease-og-1200x630.png
+- Twitter title: The International Campaign to End War and Disease
+- Twitter description: Click a glowing rectangle. 15 seconds. 2.6 lives saved + 53 years of suffering prevented.
+
+## Visible Page Copy
+
+- EARTH OPTIMIZATION API
+## OPTIMIZE EARTH FROM YOUR OWN APP OR WEBSITE.
+- Connect your survey, dFDA site, field tool, or civic app to Optimitron's shared work graph: OAuth, people, organizations, tasks, referrals, votes, and expected-value coordination.
+- OPENAPI CONTRACT
+- COPY
+
+```text
+https://optimitron.com/openapi.json
+```
+
+- [OPEN OPENAPI](https://optimitron.com/openapi.json)
+- [MCP TOOL REFERENCE](/developers/tools)
+- [INSTALL MCP](/mcp)
+- WHO USES IT
+### ONE TO-DO LIST BEATS FIVE HUNDRED HEROIC DUPLICATES.
+- Optimitron is useful when an app needs shared identity, people, organizations, tasks, and outcome tracking. The task engine ranks work by dollar-equivalent expected value, effort, cash cost, probability, dependencies, and health or income impact.
+#### SURVEY SITES
+- Run a calmer survey or pledge page, then send the verified vote, referral, and follow-up task back to Optimitron.
+#### DISEASE COMMUNITIES
+- Let a dFDA site collect patient priorities, treatment reports, or organization support without creating another isolated people database.
+#### RESEARCH FUNDERS
+- Publish bounties, assignments, or requests for evidence, then rank the next action by expected value instead of whoever shouted last.
+#### CIVIC AND NONPROFIT TOOLS
+- Coordinate outreach, volunteers, expert review, and institutional commitments against the same shared task and organization record.
+- OAUTH
+### SIGN IN ONCE. WRITE TO THE SAME WORK GRAPH.
+- Optimitron exposes OAuth authorization code with PKCE, dynamic client registration, rotating refresh tokens, and token revocation. The same scopes work for REST endpoints and the MCP server.
+- 1 REGISTER A PUBLIC CLIENT Send redirect URIs to dynamic client registration. Optimitron returns a client_id; public clients do not get a secret.
+- 2 START AUTHORIZATION Redirect the user to the authorization endpoint with PKCE, state, redirect_uri, and the scopes your app needs.
+- 3 EXCHANGE AND REFRESH Trade the authorization code for a Bearer token. Refresh tokens rotate, and revoke is available when the app disconnects.
+#### METADATA
+- Let OAuth clients discover the authorization, token, registration, and revocation endpoints.
+
+```text
+GET https://optimitron.com/.well-known/oauth-authorization-server
+```
+
+#### REGISTER
+- Create a public client for browser, mobile, and field apps.
+
+```text
+POST https://optimitron.com/api/mcp/oauth/register
+
+{
+  "client_name": "Treaty Field App",
+  "redirect_uris": [
+    "https://field-app.example/oauth/callback"
+  ],
+  "grant_types": [
+    "authorization_code",
+    "refresh_token"
+  ],
+  "scope": "tasks:personal earthdata:write"
+}
+```
+
+#### AUTHORIZE AND TOKEN
+- Use PKCE for the browser redirect, then exchange the code on your own server or backend.
+
+```text
+GET https://optimitron.com/api/mcp/oauth/authorize
+POST https://optimitron.com/api/mcp/oauth/token
+POST https://optimitron.com/api/mcp/oauth/revoke
+```
+
+- REST API
+### THE USEFUL PARTS ARE OPEN FIRST.
+- These are the open endpoints for embedding a survey, creating tasks for people, collecting votes, and keeping organization data attached to the same shared record.
+- BASE URL
+
+```text
+https://optimitron.com
+```
+
+#### TASKS
+- Create task assignments, list open work, claim work, complete claims, and keep comments with the task instead of in a lost chat thread.
+#### REFERRALS
+- Create referral invitations, attach them to tasks, and track whether a human copied, sent, declined, or finished the ask.
+#### VOTES
+- Let another site collect a referendum, survey, or treaty vote while writing the result into the same verified record Optimitron uses.
+#### PEOPLE AND ORGANIZATIONS
+- Search assignable people, create organizations, and update profiles so one contact or institution does not get rediscovered from scratch every Tuesday.
+- EXAMPLE
+### CREATE A TASK FOR A HUMAN.
+- A survey or outreach app can ask for a person, create the task, and then show whether that person answered, voted, completed the work, or needs another nudge.
+
+```text
+POST https://optimitron.com/api/tasks
+
+{
+  "title": "Ask Dr. Example to vote on the 1% Treaty",
+  "description": "Send the treaty vote link and answer any obvious question.",
+  "isPublic": false,
+  "assigneePersonInvite": {
+    "email": "doctor@example.org",
+    "firstName": "Ada",
+    "lastName": "Example"
+  },
+  "contactTemplate": "Please vote on the 1% Treaty and send it to two people who can help."
+}
+```
+
+- PERMISSIONS
+### ASK FOR THE SMALLEST SCOPE THAT WORKS.
+- Manage your private tasks, dependencies, comments, queues, and next-action recommendations
+- Manage private tasks for organizations where you have permission
+- Approve exact outbound-action payloads as an authenticated human
+- Admin-only: create and manage public Optimitron tasks, people, organizations, estimates, and dependencies
+- Create sourced public Earth-data records: memorials, evidence, intervention reports, organization signatories, and correction reports
+- Admin-only: hide, restore, merge, and resolve Earth-data records and reports
+- Admin-only: run coordinated public-task agents with leases and run logs
+- Admin-only: access the configured GitHub repos via the server-side PAT (search code, read files, list directories, generic API passthrough)
+### AGENTS USE THE SAME AUTHORIZATION.
+- MCP clients can discover tools, add impact estimates, and call the task graph with the same OAuth scopes used by REST clients.
+
+```text
+GET https://optimitron.com/api/mcp/tools
+POST https://optimitron.com/api/mcp
+```
+
+- [MCP SETUP](/mcp)
+### MACHINES CAN READ THE CONTRACT.
+- Point API clients, SDK generators, or documentation tooling at the OpenAPI document and stop guessing from source files.
+
+```text
+GET https://optimitron.com/openapi.json
+```
+
+- [OPEN JSON](https://optimitron.com/openapi.json)

--- a/apps/warondisease/app/developers/page.tsx
+++ b/apps/warondisease/app/developers/page.tsx
@@ -1,0 +1,436 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Layout from "@/components/layout";
+import { CopyableCode } from "@/components/shared/CopyableCode";
+import { MCP_SCOPES } from "@/lib/mcp-catalog";
+import { OPTIMITRON_ORIGIN, optimitronUrl } from "@/lib/optimitron-links";
+import { ROUTES } from "@/lib/routes";
+
+export const metadata: Metadata = {
+  title: "Earth Optimization API",
+  description:
+    "Connect your survey, dFDA site, field tool, or civic app to Optimitron's shared work graph: OAuth, people, organizations, tasks, referrals, votes, and expected-value coordination.",
+};
+
+// Every documented endpoint is served by optimitron.com. Printing the bare
+// paths here would tell a reader to call warondisease.org, which does not host
+// the API, so the copyable panels carry the absolute URL.
+const openApiUrl = optimitronUrl("/openapi.json");
+const oauthMetadataUrl = optimitronUrl(
+  "/.well-known/oauth-authorization-server",
+);
+const registrationUrl = optimitronUrl("/api/mcp/oauth/register");
+const authorizeUrl = optimitronUrl("/api/mcp/oauth/authorize");
+const tokenUrl = optimitronUrl("/api/mcp/oauth/token");
+const revokeUrl = optimitronUrl("/api/mcp/oauth/revoke");
+const toolsUrl = optimitronUrl("/api/mcp/tools");
+const mcpUrl = optimitronUrl("/api/mcp");
+
+const apiGroups = [
+  {
+    title: "Tasks",
+    body: "Create task assignments, list open work, claim work, complete claims, and keep comments with the task instead of in a lost chat thread.",
+    endpoints: [
+      "GET /api/tasks",
+      "POST /api/tasks",
+      "PATCH /api/tasks/{id}",
+      "POST /api/tasks/{id}/complete",
+    ],
+  },
+  {
+    title: "Referrals",
+    body: "Create referral invitations, attach them to tasks, and track whether a human copied, sent, declined, or finished the ask.",
+    endpoints: [
+      "GET /api/referral-invitations",
+      "POST /api/referral-invitations",
+    ],
+  },
+  {
+    title: "Votes",
+    body: "Let another site collect a referendum, survey, or treaty vote while writing the result into the same verified record Optimitron uses.",
+    endpoints: ["POST /api/referendums/{slug}/vote"],
+  },
+  {
+    title: "People and organizations",
+    body: "Search assignable people, create organizations, and update profiles so one contact or institution does not get rediscovered from scratch every Tuesday.",
+    endpoints: [
+      "GET /api/people/search",
+      "GET /api/organizations",
+      "POST /api/organizations",
+      "PATCH /api/organizations/{id}",
+    ],
+  },
+] as const;
+
+const useCases = [
+  {
+    title: "Survey sites",
+    body: "Run a calmer survey or pledge page, then send the verified vote, referral, and follow-up task back to Optimitron.",
+  },
+  {
+    title: "Disease communities",
+    body: "Let a dFDA site collect patient priorities, treatment reports, or organization support without creating another isolated people database.",
+  },
+  {
+    title: "Research funders",
+    body: "Publish bounties, assignments, or requests for evidence, then rank the next action by expected value instead of whoever shouted last.",
+  },
+  {
+    title: "Civic and nonprofit tools",
+    body: "Coordinate outreach, volunteers, expert review, and institutional commitments against the same shared task and organization record.",
+  },
+] as const;
+
+const oauthSteps = [
+  {
+    title: "Register a public client",
+    body: "Send redirect URIs to dynamic client registration. Optimitron returns a client_id; public clients do not get a secret.",
+  },
+  {
+    title: "Start authorization",
+    body: "Redirect the user to the authorization endpoint with PKCE, state, redirect_uri, and the scopes your app needs.",
+  },
+  {
+    title: "Exchange and refresh",
+    body: "Trade the authorization code for a Bearer token. Refresh tokens rotate, and revoke is available when the app disconnects.",
+  },
+] as const;
+
+const primaryButtonClassName =
+  "border border-foreground bg-foreground px-4 py-3 text-center text-sm font-black uppercase text-background hover:bg-background hover:text-foreground";
+const secondaryButtonClassName =
+  "border border-foreground bg-background px-4 py-3 text-center text-sm font-black uppercase text-foreground hover:bg-foreground hover:text-background";
+
+function InlineCode({ children }: { children: string }) {
+  return (
+    <code className="border border-foreground bg-background px-1.5 py-0.5 font-mono text-[0.92em] font-black">
+      {children}
+    </code>
+  );
+}
+
+function CodePanel({ code }: { code: string }) {
+  return (
+    <div className="mt-3 min-w-0 border border-foreground bg-background">
+      <CopyableCode code={code} />
+    </div>
+  );
+}
+
+function EndpointList({ endpoints }: { endpoints: readonly string[] }) {
+  return (
+    <div className="mt-4 flex flex-wrap gap-2">
+      {endpoints.map((endpoint) => (
+        <InlineCode key={endpoint}>{endpoint}</InlineCode>
+      ))}
+    </div>
+  );
+}
+
+function ApiGroupCard({
+  body,
+  endpoints,
+  title,
+}: {
+  body: string;
+  endpoints: readonly string[];
+  title: string;
+}) {
+  return (
+    <div className="min-w-0 border border-foreground bg-background p-4">
+      <h3 className="text-sm font-black uppercase tracking-[0.1em]">{title}</h3>
+      <p className="mt-2 text-sm font-bold leading-6 text-muted-foreground">
+        {body}
+      </p>
+      <EndpointList endpoints={endpoints} />
+    </div>
+  );
+}
+
+function EndpointBlock({
+  code,
+  summary,
+  title,
+}: {
+  code: string;
+  summary: string;
+  title: string;
+}) {
+  return (
+    <div className="min-w-0 border border-foreground bg-background p-4">
+      <h3 className="text-sm font-black uppercase tracking-[0.1em]">{title}</h3>
+      <p className="mt-2 text-sm font-bold leading-6 text-muted-foreground">
+        {summary}
+      </p>
+      <CodePanel code={code} />
+    </div>
+  );
+}
+
+export default function DevelopersPage() {
+  const createTaskExample = JSON.stringify(
+    {
+      title: "Ask Dr. Example to vote on the 1% Treaty",
+      description: "Send the treaty vote link and answer any obvious question.",
+      isPublic: false,
+      assigneePersonInvite: {
+        email: "doctor@example.org",
+        firstName: "Ada",
+        lastName: "Example",
+      },
+      contactTemplate:
+        "Please vote on the 1% Treaty and send it to two people who can help.",
+    },
+    null,
+    2,
+  );
+  const registerClientExample = JSON.stringify(
+    {
+      client_name: "Treaty Field App",
+      redirect_uris: ["https://field-app.example/oauth/callback"],
+      grant_types: ["authorization_code", "refresh_token"],
+      scope: "tasks:personal earthdata:write",
+    },
+    null,
+    2,
+  );
+
+  return (
+    <Layout>
+      <main className="bg-background text-foreground">
+        <section className="border-b border-foreground">
+          <div className="mx-auto max-w-5xl px-4 py-12 sm:px-6 sm:py-16 lg:px-8">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+              Earth Optimization API
+            </p>
+            <div className="mt-4 grid gap-6 lg:grid-cols-[1.1fr_0.9fr] lg:items-end">
+              <div>
+                <h1 className="max-w-3xl text-4xl font-black uppercase leading-none sm:text-6xl">
+                  Optimize Earth from your own app or website.
+                </h1>
+                <p className="mt-5 max-w-2xl text-lg font-bold leading-8 text-muted-foreground">
+                  Connect your survey, dFDA site, field tool, or civic app to
+                  Optimitron&apos;s shared work graph: OAuth, people,
+                  organizations, tasks, referrals, votes, and expected-value
+                  coordination.
+                </p>
+              </div>
+              <div className="min-w-0 border border-foreground bg-background p-4">
+                <p className="text-xs font-black uppercase tracking-[0.16em] text-muted-foreground">
+                  OpenAPI Contract
+                </p>
+                <CodePanel code={openApiUrl} />
+              </div>
+            </div>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <a className={primaryButtonClassName} href={openApiUrl}>
+                Open OpenAPI
+              </a>
+              <Link
+                className={secondaryButtonClassName}
+                href={ROUTES.developersTools}
+              >
+                MCP Tool Reference
+              </Link>
+              <Link className={secondaryButtonClassName} href={ROUTES.mcp}>
+                Install MCP
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-foreground">
+          <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+              Who Uses It
+            </p>
+            <h2 className="mt-2 text-3xl font-black uppercase">
+              One to-do list beats five hundred heroic duplicates.
+            </h2>
+            <p className="mt-4 max-w-3xl text-base font-bold leading-7 text-muted-foreground">
+              Optimitron is useful when an app needs shared identity, people,
+              organizations, tasks, and outcome tracking. The task engine ranks
+              work by dollar-equivalent expected value, effort, cash cost,
+              probability, dependencies, and health or income impact.
+            </p>
+            <div className="mt-6 grid gap-4 md:grid-cols-2">
+              {useCases.map((useCase) => (
+                <div
+                  className="min-w-0 border border-foreground bg-background p-4"
+                  key={useCase.title}
+                >
+                  <h3 className="text-sm font-black uppercase tracking-[0.1em]">
+                    {useCase.title}
+                  </h3>
+                  <p className="mt-2 text-sm font-bold leading-6 text-muted-foreground">
+                    {useCase.body}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto grid max-w-5xl gap-5 px-4 py-10 sm:px-6 lg:grid-cols-[0.95fr_1.05fr] lg:px-8">
+          <div className="min-w-0">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+              OAuth
+            </p>
+            <h2 className="mt-2 text-3xl font-black uppercase">
+              Sign in once. Write to the same work graph.
+            </h2>
+            <p className="mt-4 text-base font-bold leading-7 text-muted-foreground">
+              Optimitron exposes OAuth authorization code with PKCE, dynamic
+              client registration, rotating refresh tokens, and token
+              revocation. The same scopes work for REST endpoints and the MCP
+              server.
+            </p>
+            <ol className="mt-6 grid gap-3">
+              {oauthSteps.map((step, index) => (
+                <li
+                  className="grid grid-cols-[2.25rem_1fr] gap-3 border-t border-foreground/25 pt-3"
+                  key={step.title}
+                >
+                  <span className="flex h-8 w-8 items-center justify-center border border-foreground text-sm font-black">
+                    {index + 1}
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block text-sm font-black uppercase tracking-[0.08em]">
+                      {step.title}
+                    </span>
+                    <span className="mt-1 block text-sm font-bold leading-6 text-muted-foreground">
+                      {step.body}
+                    </span>
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          <div className="grid min-w-0 gap-4">
+            <EndpointBlock
+              title="Metadata"
+              summary="Let OAuth clients discover the authorization, token, registration, and revocation endpoints."
+              code={`GET ${oauthMetadataUrl}`}
+            />
+            <EndpointBlock
+              title="Register"
+              summary="Create a public client for browser, mobile, and field apps."
+              code={`POST ${registrationUrl}\n\n${registerClientExample}`}
+            />
+            <EndpointBlock
+              title="Authorize and token"
+              summary="Use PKCE for the browser redirect, then exchange the code on your own server or backend."
+              code={`GET ${authorizeUrl}\nPOST ${tokenUrl}\nPOST ${revokeUrl}`}
+            />
+          </div>
+        </section>
+
+        <section className="border-y border-foreground" id="api">
+          <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+              REST API
+            </p>
+            <h2 className="mt-2 text-3xl font-black uppercase">
+              The useful parts are open first.
+            </h2>
+            <p className="mt-4 max-w-3xl text-base font-bold leading-7 text-muted-foreground">
+              These are the open endpoints for embedding a survey, creating
+              tasks for people, collecting votes, and keeping organization data
+              attached to the same shared record.
+            </p>
+            <div className="mt-5 min-w-0 border border-foreground bg-background p-4">
+              <p className="text-xs font-black uppercase tracking-[0.16em] text-muted-foreground">
+                Base URL
+              </p>
+              <CodePanel code={OPTIMITRON_ORIGIN} />
+            </div>
+            <div className="mt-6 grid gap-4 md:grid-cols-2">
+              {apiGroups.map((group) => (
+                <ApiGroupCard key={group.title} {...group} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto grid max-w-5xl gap-8 px-4 py-10 sm:px-6 lg:grid-cols-[1fr_1fr] lg:px-8">
+          <div className="min-w-0">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+              Example
+            </p>
+            <h2 className="mt-2 text-3xl font-black uppercase">
+              Create a task for a human.
+            </h2>
+            <p className="mt-4 text-base font-bold leading-7 text-muted-foreground">
+              A survey or outreach app can ask for a person, create the task,
+              and then show whether that person answered, voted, completed the
+              work, or needs another nudge.
+            </p>
+            <CodePanel
+              code={`POST ${optimitronUrl("/api/tasks")}\n\n${createTaskExample}`}
+            />
+          </div>
+
+          <div className="min-w-0">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+              Permissions
+            </p>
+            <h2 className="mt-2 text-3xl font-black uppercase">
+              Ask for the smallest scope that works.
+            </h2>
+            <div className="mt-5 grid gap-3">
+              {MCP_SCOPES.map((scope) => (
+                <div
+                  className="min-w-0 border border-foreground p-4"
+                  key={scope.wire}
+                >
+                  <InlineCode>{scope.wire}</InlineCode>
+                  <p className="mt-2 text-sm font-bold leading-6 text-muted-foreground">
+                    {scope.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="border-t border-foreground">
+          <div className="mx-auto grid max-w-5xl gap-5 px-4 py-10 sm:px-6 lg:grid-cols-2 lg:px-8">
+            <div className="min-w-0 border border-foreground p-5">
+              <h2 className="text-2xl font-black uppercase">
+                Agents use the same authorization.
+              </h2>
+              <p className="mt-2 text-sm font-bold leading-6 text-muted-foreground">
+                MCP clients can discover tools, add impact estimates, and call
+                the task graph with the same OAuth scopes used by REST clients.
+              </p>
+              <CodePanel code={`GET ${toolsUrl}\nPOST ${mcpUrl}`} />
+              <Link
+                className={`${secondaryButtonClassName} mt-4 inline-block`}
+                href={ROUTES.mcp}
+              >
+                MCP Setup
+              </Link>
+            </div>
+            <div className="min-w-0 border border-foreground p-5">
+              <h2 className="text-2xl font-black uppercase">
+                Machines can read the contract.
+              </h2>
+              <p className="mt-2 text-sm font-bold leading-6 text-muted-foreground">
+                Point API clients, SDK generators, or documentation tooling at
+                the OpenAPI document and stop guessing from source files.
+              </p>
+              <CodePanel code={`GET ${openApiUrl}`} />
+              <a
+                className={`${primaryButtonClassName} mt-4 inline-block`}
+                href={openApiUrl}
+              >
+                Open JSON
+              </a>
+            </div>
+          </div>
+        </section>
+      </main>
+    </Layout>
+  );
+}

--- a/apps/warondisease/app/developers/tools/page.logged-out.md
+++ b/apps/warondisease/app/developers/tools/page.logged-out.md
@@ -1,0 +1,1180 @@
+# /developers/tools
+
+## Metadata
+
+- Page title: MCP Tool Reference
+- Meta description: Every tool the Optimitron MCP server exposes, with its required OAuth scope, admin gate, and parameters.
+- Canonical: https://warondisease.org
+- Open Graph title: The International Campaign to End War and Disease
+- Open Graph description: Click a glowing rectangle. 15 seconds. 2.6 lives saved + 53 years of suffering prevented.
+- Open Graph image: https://warondisease.org/assets/warondisease/war-on-disease-og-1200x630.png
+- Twitter title: The International Campaign to End War and Disease
+- Twitter description: Click a glowing rectangle. 15 seconds. 2.6 lives saved + 53 years of suffering prevented.
+
+## Visible Page Copy
+
+- DEVELOPERS
+## MCP TOOL REFERENCE
+- Every tool the Optimitron MCP server exposes — 171 tools (32 admin-gated) — generated from the same registry the live server enforces. The live machine-readable version is [optimitron.com/api/mcp/tools](https://optimitron.com/api/mcp/tools); connection instructions live at [/mcp](/mcp).
+- Each tool is listed once, under its primary scope; many accept more than one scope, so the badges on a tool name every scope that can call it.
+### OAUTH SCOPES
+### PUBLIC (NO SCOPE) (15)
+#### getNextTask
+- Get the highest expected-value unblocked task that the caller can work on. Returns the single best task to execute right now.
+- PARAMETERS (8)
+- skillTags (array) — Agent's skill tags for personalized ranking
+- interestTags (array) — Agent's interest tags for personalized ranking
+- credentialTags (array)
+- languageTags (array)
+- toolTags (array)
+- accessTags (array)
+- availableHoursPerWeek (number) — Hours per week the agent can commit
+- agentId (string) — Agent's unique identifier (to skip tasks leased by this agent)
+#### evaluateTaskEconomics
+- Evaluate the execution economics for a single task. Returns whether the current agent should execute directly, delegate, prepare procurement, or raise money first.
+- taskId (string, required) — Task ID
+- skillTags (array) — Agent's skill tags for capability matching
+- interestTags (array) — Agent's interest tags for capability matching
+#### listTasks
+- List tasks with optional filters. Returns up to 50 tasks sorted by accountability score. Signed-in callers see public tasks plus their own private work by default (visibility 'all'); pass visibility 'public' or 'private' to narrow. Returns the legacy task array unless paginated=true or cursor is supplied. Paginated inventory uses immutable task-ID order, not priority order.
+- PARAMETERS (17)
+- visibility (enum) — Which tasks to include: 'all' = public + your private work (default when signed in), 'public' = public only (default for anonymous callers), 'private' = only your non-public tasks.
+- status (enum) — Filter by task status
+- category (enum) — Filter by task category
+- assigneePersonId (string) — Filter by assignee person ID
+- assigneeOrganizationId (string) — Filter by assignee organization ID
+- ownerOrganizationId (string) — Filter by owner/reviewer organization ID
+- engagementKind (enum) — Filter by engagement kind.
+- applicationPolicy (enum) — Filter by application policy.
+- compensationKind (enum) — Filter by compensation kind.
+- remotePolicy (enum) — Filter by remote/hybrid/onsite policy.
+- executionMode (enum) — Filter by human/agent execution mode.
+- requiredTags (array) — Return tasks whose required/preferred/skill tags include any supplied tag.
+- assignedToMe (boolean) — Filter to tasks assigned to the authenticated user's canonical Person row.
+- parentTaskId (string) — Filter by parent task ID (get subtasks)
+- cursor (string) — Opaque cursor returned as nextCursor by the preceding page. Copy it verbatim and keep all filters unchanged.
+- paginated (boolean) — Return {tasks,nextCursor}. Omit for the legacy task-array response.
+- limit (integer) — Max results (default 20, max 50)
+#### getTask
+- Get task details by taskId with one canonical impact frame. Call getTaskImpactTrace for formulas and provenance. If you do not have a taskId yet, call searchTasks, listTasks, getMyQueue, or getNextAction first.
+- PARAMETERS (1)
+#### listOrganizations
+- List organizations (for example to create task targets), optionally including active/target-filtered tasks.
+- PARAMETERS (9)
+- query (string) — Search query for name, slug, description, website, or contact email.
+- type (enum) — Optional organization type filter.
+- status (enum) — Optional organization status filter.
+- includeTasks (boolean) — Include a short active task summary for each organization (default false).
+- limit (number) — Max organizations to return (default 100, max 500).
+- taskLimit (number) — Max tasks per organization when includeTasks=true (default 3, max 50).
+- taskVisibility (enum) — Which tasks to include in the summary: 'all' = public + your private work (default when signed in), 'public' = public only (default for anonymous callers), 'private' = only your non-public tasks.
+- taskScope (enum) — Deprecated alias of taskVisibility ('accessible' = 'all'). Prefer taskVisibility.
+- taskStatus (enum) — Task status used when includeTasks=true (default ACTIVE).
+#### getOrganizationTasks
+- List tasks currently assigned to a specific organization.
+- PARAMETERS (5)
+- organizationId (string, required) — Organization ID.
+- limit (number) — Max tasks to return (default 50, max 200).
+- scope (enum) — Deprecated alias of visibility ('accessible' = 'all'). Prefer visibility.
+- status (enum) — Optional task status filter.
+#### listPeople
+- List people (optionally public-figure-only) and optionally include their assigned active tasks.
+- query (string) — Search by display name, handle, current affiliation, source ref, or email.
+- publicProfilesOnly (boolean) — When true, only includes people marked as public-figure profiles (default true).
+- includeTasks (boolean) — Include a short active task summary for each person (default false).
+- limit (number) — Max people to return (default 100, max 500).
+- taskLimit (number) — Max tasks per person when includeTasks=true (default 3, max 50).
+#### getPersonTasks
+- List tasks currently assigned to a specific person.
+- personId (string, required) — Person ID.
+#### inspectToolAccess
+- Explain which MCP tools this connection can use and why. Optionally filter by tool name. Returns effective scopes, server identity, and stable access reason codes without exposing token data.
+- toolNames (array) — Optional tool names to inspect. Omit to inspect the complete compact catalog.
+#### listReferendums
+- List Optimitron referendums. Public callers see active referendums by default; admins can filter by DRAFT, ACTIVE, or CLOSED.
+- PARAMETERS (3)
+- status (enum) — Referendum status filter. Defaults to ACTIVE.
+- query (string) — Optional search over title, slug, and description.
+- limit (number) — Max referendums to return (default 20, max 100).
+#### listSitePages
+- Return a structured inventory of pages for configured Optimitron-owned domains. Agents should call this before creating a new page.
+- site (string) — Optional domain filter, e.g. optimitron.com, warondisease.org, dfda.earth, dih.earth, or manual.warondisease.org.
+#### getPageContent
+- Return the fully rendered logged-out text for an Optimitron-owned page as clean markdown, with its title, section headings, and last-modified metadata. Checked-in rendered snapshots are preferred so client-side loading shells are never mistaken for page content; this public reader does not expose authenticated page text.
+- url (string, required) — Full URL of an allowed page.
+#### searchManual
+- Search the Optimitron manual, disease eradication plan, and related documentation. Returns relevant context with citations.
+- PARAMETERS (2)
+- query (string, required) — Search query (e.g. 'FDA approval timeline', 'RAPPA preference aggregation')
+- maxResults (number) — Max results to return (default 5)
+#### askWishonia
+- Ask Wishonia a question — she answers in character using retrieved documentation from the Optimitron manual and disease eradication plan.
+- question (string, required) — Your question for Wishonia
+#### searchTasks
+- Fuzzy-search your accessible tasks by title, description, impact statement, task key, assignee, or organization. Signed-in results may include public tasks and private tasks you created, manage, are assigned, claimed, or can access through an organization; other users' private work remains excluded. Use this before createTask/updateTask to find parents, duplicates, blockerTaskIds, or blockedTaskIds. Long snippets are capped at 200 characters and include a getTask instruction for reading the full description. For Optimitron code or documentation work, query the stable key 'optimitron:dev', select that exact result, and call createTask with parentTaskKey='optimitron:dev'. Returns the legacy result array unless paginated=true or cursor is supplied. Paginated inventory uses immutable task-ID order, not relevance order.
+- PARAMETERS (7)
+- query (string, required) — Search query text.
+- cursor (string) — Opaque cursor returned as nextCursor by the preceding page. Copy it verbatim and keep query and filters unchanged.
+- paginated (boolean) — Return {tasks,nextCursor}. Omit for the legacy result-array response.
+- limit (number) — Max results to return (default 20, max 100)
+- visibility (enum) — Which tasks to search: 'all' = public + your private work (default when signed in), 'public' = public only (default for anonymous callers), 'private' = only your non-public tasks.
+- status (enum) — Optional status filter to narrow dependency candidates.
+### TASKS:PERSONAL (91)
+#### recordMeasurement tasks:personal
+- Record a personal dFDA/N-of-1 measurement such as a medication dose, food, symptom, mood, sleep, activity, lab, or vital sign. Use variableName plus category/unit for new variables, or globalVariableId for an existing variable.
+- PARAMETERS (15)
+- globalVariableId (string)
+- variableName (string)
+- categoryName (string) — Required when variableName does not already exist. Examples: Treatment, Food, Drink, Nutrient, Symptom, Emotion, Sleep, Activity, Vital Sign, or Biomarker.
+- value (number, required)
+- unitId (string)
+- unitAbbreviation (string) — Short unit such as mg, IU, servings, count, or 1-5. serving and {serving} are accepted aliases for servings.
+- unitName (string) — Full unit name; matched case-insensitively.
+- startTime (string) — ISO date/time.
+- duration (number) — Duration in seconds.
+- note (string)
+- sourceName (string)
+- combinationOperation (enum)
+- fillingType (enum)
+- latitude (number)
+- longitude (number)
+#### listMeasurements tasks:personal
+- List the authenticated user's own recorded measurements, newest first. Covers everything logged through recordMeasurement or a tracking-reminder response. Filter by globalVariableId or variableName for one variable, or omit both to see every variable. Use this to review logged doses, foods, symptoms, moods, sleep, activity, labs, and vitals, or to check whether a reminder was actually answered. Each row carries startTime (UTC) and startTimeLocal (the user's zone): report times to the user from startTimeLocal.
+- PARAMETERS (6)
+- variableName (string) — Variable name, matched case-insensitively. An unknown variable is an error, not an empty result.
+- startTimeAfter (string) — ISO date/time. Only measurements at or after this time.
+- startTimeBefore (string) — ISO date/time. Only measurements at or before this time.
+- limit (number) — Page size. Default 100, maximum 500.
+- cursor (string) — nextCursor from the previous page. Repeat the same filters until nextCursor is null.
+#### updateMeasurement tasks:personal
+- Correct one of the authenticated user's measurements by ID. Use listMeasurements to get the ID. Pass value in the normalized unit. If the measurement was converted between units, also pass originalValue in its original unit. Units and variable identity stay unchanged. Optional metadata fields patch the existing row. The tool rejects measurements owned by another user and refreshes cached summaries.
+- measurementId (string, required)
+- originalValue (number) — Corrected value in the existing original unit. Required when originalUnitId differs from unitId; otherwise defaults to value.
+- duration (number | null) — Duration in seconds. Null clears it.
+- note (string | null)
+- sourceName (string | null)
+- latitude (number | null)
+- longitude (number | null)
+#### deleteMeasurement tasks:personal
+- Soft-delete one of the authenticated user's measurements by ID. Use listMeasurements to get the ID. The tool rejects measurements owned by another user and refreshes cached summaries.
+#### upsertTrackingReminder tasks:personal
+- Create or edit a personal tracking reminder for medications, food, symptoms, mood, sleep, activity, labs, or vitals. When creating a new variable, pass categoryName; Food defaults to servings. To edit a reminder in place, pass trackingReminderId plus only the fields to change. Omit trackingReminderId to create or idempotently update the reminder identified by variable, start time, and frequency. Unit fields set your personal recording unit for the variable; the canonical variable default is unchanged. The response's top-level unit is the unit answers record in. The reminder can later be answered as TRACKED (value 0 for a not-taken day) or SNOOZED.
+- trackingReminderId (string) — Existing reminder ID to edit in place. Patchable: active, defaultValue, instructions, reminderStartTime, reminderEndTime, reminderFrequency, startTrackingDate, stopTrackingDate, unit fields, and fillingType. Fixed at creation: the tracked variable (variableName, globalVariableId, categoryName, combinationOperation) — to change it, create a new reminder and set active: false on this one.
+- defaultValue (number | null) — Pre-filled value, such as a normal medication dose or symptom rating. Pass null to clear it when editing.
+- unitAbbreviation (string) — Short unit such as mg, IU, servings, count, or 1-5. serving and {serving} are accepted aliases for servings. Sets your personal recording unit for this variable, on create or on edit.
+- reminderStartTime (string) — Local wall-clock time in HH:mm, for example 08:00.
+- reminderEndTime (string | null) — Optional local end/quiet time in HH:mm. Pass null to clear it when editing.
+- reminderFrequency (number) — Seconds between reminders. Default 86400.
+- active (boolean)
+- instructions (string | null)
+- startTrackingDate (string | null) — ISO date/time, or null to clear it when editing.
+- stopTrackingDate (string | null) — ISO date/time, or null to clear it when editing.
+#### listTrackingReminders tasks:personal
+- List the authenticated user's personal tracking reminders, active by default. Returns a compact shape by default: id, name, schedule, defaultValue, recording unit, fillingType, and an instructions preview. Pass compact: false for full records. Use getTrackingReminder for one reminder with full instructions.
+- includeInactive (boolean)
+- compact (boolean) — Defaults to true. Pass false for full records with expanded variable and unit objects and untruncated instructions.
+#### getTrackingReminder tasks:personal
+- Get one of the authenticated user's tracking reminders in full, including untruncated instructions, the expanded variable, and the effective recording unit. Use listTrackingReminders to find the ID.
+- trackingReminderId (string, required)
+#### listTrackingReminderNotifications tasks:personal
+- List the authenticated user's tracking notification queue for one local day or an inclusive local-date range. A reminder defines a schedule; a notification is one occurrence. Filter by trackingReminderId or effective status, including OVERDUE. The default compact shape carries id (the trackingReminderId to answer with), name, due (local time), status, defaultValue, unit, and fillingType, so an agent can answer without a second lookup. An OVERDUE item with sameDayMeasurementCount already has same-day data for its variable recorded outside this notification: verify with listMeasurements before answering again, or you may duplicate data. Pass compact: false for full records with scheduledAt, effective notifyAt, and snoozedUntil. Set includeCompleted to include recent TRACKED notifications.
+- dateKey (string) — One local date in YYYY-MM-DD. Defaults to today. Do not combine with startDateKey or endDateKey.
+- startDateKey (string) — First local date in an inclusive range. Defaults to endDateKey when omitted.
+- endDateKey (string) — Last local date in an inclusive range. Defaults to startDateKey when omitted. Ranges may include at most 31 days.
+- trackingReminderId (string) — Return occurrences for only this reminder.
+- status (enum) — Return only this effective status. An elapsed snooze becomes PENDING or OVERDUE. OVERDUE means effective notifyAt is in the past and the occurrence remains unanswered.
+- compact (boolean) — Defaults to true. Pass false for full records including scheduledAt, snooze detail, and instructions.
+- includeCompleted (boolean) — Include answered TRACKED or legacy SKIPPED occurrences. SNOOZED occurrences are always returned with snoozedUntil.
+#### listDueTrackingReminders tasks:personal
+- Deprecated alias for listTrackingReminderNotifications. It keeps the reminders response key for existing callers.
+- dateKey (string) — Local date in YYYY-MM-DD. Defaults to today.
+- compact (boolean) — Return trackingReminderId as id, plus name, due, and status.
+- includeCompleted (boolean) — When true, include reminders already answered or snoozed for the date.
+#### respondToTrackingReminderNotifications tasks:personal
+- Answer several tracking reminder notifications in one call. To answer specific reminders, send only except entries and omit defaultStatus; every other reminder stays untouched. Send defaultStatus only when you intend to answer the whole day. An except entry can also correct a response you already recorded. All-or-nothing: if any exception ID is not scheduled for the date, the tool writes nothing and returns an error. The call targets one local date; when catching up a past day (for example after midnight), pass that day's dateKey. Each result reports notifyAtLocal, the occurrence the answer landed on: verify it is the day you meant.
+- defaultStatus (enum) — Optional. Apply this status to every due and unanswered notification without an exception. Omit it to answer only the except entries. Already-answered notifications are never touched by the default.
+- except (array) — Answer or correct individual notifications by trackingReminderId. Each entry needs a status when defaultStatus is omitted.
+- snoozeMinutes (number) — Set the snooze duration. The default is 30 minutes. The server caps the deferred time at the local day's end.
+#### respondToTrackingReminder tasks:personal
+- Answer a due tracking reminder. TRACKED records a measurement. Record value 0 when the treatment, food, or activity was not taken; those zero days are the baseline that causal analysis needs. SNOOZED defers the notification. Deactivate the reminder when it no longer applies. SKIPPED is retired: it now records a zero and returns a deprecation notice. When dateKey and trackedAt are omitted, the answer targets the reminder's most recent due occurrence within the last 7 days that is still unanswered — so an after-midnight catch-up resolves yesterday's occurrence, not tomorrow's. The response's notifyAtLocal shows where the answer landed.
+- PARAMETERS (11)
+- status (enum, required) — TRACKED records a measurement; pass value 0 for a not-taken day. SNOOZED defers the notification. SKIPPED is accepted but retired and records a zero.
+- value (number) — Override dose/rating/value. If omitted for TRACKED, the reminder defaultValue is used.
+- unitAbbreviation (string)
+- unitName (string)
+- trackedAt (string) — ISO date/time the measurement actually happened. Also anchors the target day when dateKey is omitted.
+- dateKey (string) — Local date in YYYY-MM-DD of the occurrence to answer. Defaults from trackedAt when given, else to the most recent unanswered due occurrence.
+#### getQueueAudit tasks:personal or tasks:organization
+- Start here before trusting a personal task queue. Audits active private tasks created by this user or assigned to their Person for missing estimates, blocked dependencies, impossible priority inputs, required/expiring deadline risks, and other data issues. A life-planning agent should repair or clarify high-severity issues before relying on getNextAction.
+- NO PARAMETERS
+#### getMyQueue tasks:personal or tasks:organization
+- Get the authenticated user's available private self-work in two lanes. deadlineLane contains unblocked REQUIRED or EXPIRES work that is past due or past latest-start, sorted most-overdue first and never truncated by maxResults. evLane contains all other executable work in the existing expected-value order and is limited by maxResults. Returns tasks the user created OR has been assigned to (via assigneePersonId).
+- maxResults (number) — Max number of evLane tasks to return (default 20, max 100). Does not truncate deadlineLane.
+- buybackRate (number) — USD per hour used to convert cash cost into time-equivalent penalty (default 1000)
+#### getAIQueue tasks:personal or tasks:organization
+- Get the authenticated user's available private AI-agent tasks that fit one bounded execution attempt, sorted by computed priority. Oversized leaves appear in itemsNeedingDecomposition. Use executor_type='AI Agent' for autonomous work; otherwise use executor_type='Self'.
+- agentId (string) — Current agent ID. Required to see this agent's own leased tasks: any leased task is omitted unless agentId is passed and matches the lease holder.
+- maxResults (number) — Max number of tasks to return (default 20, max 100)
+#### getExecutionPlan tasks:personal or tasks:organization
+- Build a capacity-bounded execution plan for the authenticated user, their Person record, or an organization they administer. Uses frontier-replanning-v1: repeatedly chooses the highest-priority feasible atomic task, simulates completion to unlock dependencies, and never starts AI work or writes Calendar events.
+- target (object)
+- planningWindowStart (string) — ISO 8601 start. Defaults to now.
+- planningWindowEnd (string) — ISO 8601 end. Defaults to 24 hours after start.
+- fixedCommitments (array) — Calendar meetings or invitations that consume capacity but are not imported as tasks.
+- availableMinutes (number) — Maximum work minutes. The planner also caps this at free time left after fixed commitments.
+- maxResults (number) — Maximum checklist and AI proposal items (default 20, max 100).
+- buybackRate (number) — USD per hour used to convert cash cost into time-equivalent penalty (default 1000).
+#### getNextAction tasks:personal or tasks:organization
+- Get the best next self-work action from the same two-lane result as getMyQueue. Returns the most-overdue deadlineLane task whenever that lane is non-empty; otherwise returns the highest-ranked evLane task.
+#### recordTaskActuals tasks:personal or tasks:organization or tasks:admin
+- Append an execution-history attempt and update aggregate actual cash cost and effort. Personal callers may record actuals only for their own private or assigned tasks; this does not create health measurements or run causal analysis.
+- actualCashCostUsd (number) — Observed external cash cost in USD
+- actualEffortSeconds (number) — Observed effort in seconds
+- note (string) — Short execution note or procurement/funding rationale
+- completedAt (string) — ISO 8601 completion time. Defaults to now.
+#### findTasksForUser tasks:personal or tasks:admin
+- Rank accessible active tasks for a user using their private matching preferences plus the task impact score. Non-admin callers can only rank their own user.
+- userId (string) — Optional target user ID. Admin-only unless it is the authenticated user.
+- limit (number) — Max results, default 20, max 50.
+- preferLeafExecution (boolean) — When true, return only executable tasks without active subtasks; never fall back to parent tasks.
+#### applyToTask tasks:personal
+- Create or update the authenticated user's application to an OPEN or INVITE_ONLY task/role opening.
+- taskId (string, required) — Task or role opening ID.
+- applicationMessage (string) — Applicant message, cover note, or proposal.
+- answersJson (object | array | null) — Structured answers to task.applicationQuestionsJson.
+- applicantNameSnapshot (string) — Optional applicant name snapshot.
+- applicantEmailSnapshot (string) — Optional applicant email snapshot.
+- originUrl (string) — Where the application started.
+- utmJson (object | null) — UTM/campaign metadata.
+#### listTaskApplications tasks:personal or tasks:admin
+- List applications for one task. Caller must be admin, task creator, task manager, or owner/admin of the owner/assignee organization.
+- taskId (string, required) — Task ID.
+#### reviewTaskApplication tasks:personal or tasks:admin
+- Review one task application. Optionally assign the task to the accepted applicant's Person row.
+- applicationId (string, required) — Application ID.
+- status (enum) — New application status.
+- reviewScore (integer | null) — Reviewer score, conventionally 0-100.
+- reviewNote (string | null) — Reviewer note.
+- answersJson (object | array | null) — Reviewer-normalized answer data.
+- assignTaskOnAccept (boolean) — If status is ACCEPTED, set task.assigneePersonId to the applicant person.
+#### listTaskCandidateMatches tasks:personal or tasks:admin
+- List saved candidate matches for a task. Non-admin callers must have application-review rights for the task.
+- taskId (string, required)
+- status (enum)
+- limit (number) — Max results, default 50.
+#### listCommunications tasks:personal or tasks:admin
+- List task communications (email, in-app, external URL, manual) across all channels. Admins see everything; other callers see only communications on tasks they created or are assigned to, with recipient emails masked (m***@domain). Suppressed sends surface as FAILED/CANCELLED rows with a suppressionReason.
+- taskId (string) — Filter to one task.
+- organizationId (string) — Filter by recipient organization ID.
+- personId (string) — Filter by recipient person ID.
+- sinceIso (string) — Only rows created at or after this ISO-8601 timestamp.
+- untilIso (string) — Only rows created at or before this ISO-8601 timestamp.
+- channel (enum) — Filter by communication channel.
+- status (enum) — Filter by lifecycle status.
+- limit (number) — Max rows to return (default 50, max 200).
+#### getCommunicationLog tasks:personal or tasks:admin
+- Fetch one task communication by ID: full message body (via the linked task comment), envelope metadata, email delivery details (provider IDs, delivery status), and trigger/idempotency metadata. Same visibility and masking rules as listCommunications.
+- id (string, required) — TaskCommunication ID.
+#### getMe tasks:personal or tasks:organization
+- Return the authenticated user's profile (User + canonical Person row). Use this to discover who you are acting as: userId, email, displayName, handle, avatar, bio, headline, website, social links, and visibility flags. No arguments — identity is taken from the OAuth bearer token.
+#### updateMyProfile tasks:personal
+- Update the authenticated user's profile. Person is canonical for the public-facing fields (displayName, handle, bio, headline, coverImage, website, isPublic); this tool writes Person directly. Only fields you supply are changed. Pass `handle: ""` (or null) to clear the handle. Returns the fresh profile.
+- PARAMETERS (28)
+- name (string) — Display name shown across the app.
+- image (string | null) — Profile avatar image URL.
+- handle (string | null) — Player-name handle, 3–24 chars, [A-Za-z0-9_-]. Empty/null clears it. Must be unique.
+- bio (string) — Short bio.
+- headline (string | null) — Optional one-line headline shown above the bio.
+- website (string | null) — Personal/profile URL.
+- coverImage (string | null) — Profile cover image URL.
+- isPublic (boolean) — Whether the profile is publicly visible.
+- newsletterSubscribed (boolean) — Whether to receive the newsletter.
+- unsubscribedScopes (array) — Email scopes to opt out of (transactional/master scopes are filtered out server-side).
+- skillTags (array)
+- interestTags (array)
+- preferredPaymentRails (array)
+- workPreferenceTags (array)
+- preferredTaskTags (array)
+- unavailableTaskTags (array)
+- availableHoursPerWeek (number | null)
+- availableFrom (string | null) — ISO 8601 date.
+- countryCode (string | null)
+- regionCode (string | null)
+- city (string | null)
+- postalCode (string | null)
+#### createTask tasks:personal or tasks:organization or tasks:admin
+- Create an ACTIVE task. Visibility defaults to PRIVATE; admin organization assignments default PUBLIC. Only admins may create PUBLIC tasks. Required: title, description, one parentTaskId or parentTaskKey, taskKey, category, hours, value, p_success, acceptanceCriteria, and impactStatement. Call getMe first: personalRoot is the caller's private Optimize-{name} root and organizationRoots lists accessible organization roots. Choose the closest parent; use personalRoot.taskKey only for personal work. Never guess or default. Optimize Earth is reserved. For Optimitron code or documentation improvements, search for duplicate work and set parentTaskKey='optimitron:dev'. Estimate instead of omitting numbers. Use testable acceptance criteria and one sentence explaining impact. Reference tasks as titled Markdown links to https://optimitron.com/tasks/<id>, never as bare IDs. Use depends_on for true prerequisites; executor_type='Self' for user work and 'AI Agent' only for autonomous assistant work; deadline_policy='REQUIRED' for must-do legal/health/safety tasks and 'EXPIRES' for opportunities that vanish after due_at. taskKey is the idempotency key: retrying the same create returns the existing task instead of creating a duplicate. The response includes a writeReceipt and a missingFields[] array for soft-recommended metadata.
+- PARAMETERS (79)
+- title (string) — Short imperative title
+- description (string) — Full explanation and acceptance criteria
+- parentTaskId (string) — Existing parent task ID. Provide this or parentTaskKey, not both. Call getMe for personalRoot and organizationRoots, then choose the closest objective or task; do not use Optimize Earth directly.
+- parentTaskKey (string) — Exact stable key of the existing parent task. Provide this or parentTaskId, not both. For personal work use getMe.personalRoot.taskKey; for Optimitron development work use 'optimitron:dev'.
+- taskKey (string) — Stable dedup key (e.g. accountability:us:golf-2025)
+- category (enum) — Task category
+- skillTags (array) — Skills needed
+- interestTags (array) — Related topics/causes
+- engagementKind (enum) — Commitment shape: ONE_OFF, ONGOING, PART_TIME, FULL_TIME, CONTRACT.
+- applicationPolicy (enum) — Whether users can apply: CLOSED, OPEN, or INVITE_ONLY.
+- preferredSkillTags (array) — Skills that improve fit beyond required skillTags.
+- requiredCredentialTags (array) — Credentials, licenses, or qualifications required.
+- preferredCredentialTags (array) — Credentials that improve fit.
+- requiredLanguageTags (array) — Languages required.
+- preferredLanguageTags (array) — Languages that improve fit.
+- requiredToolTags (array) — Tools, platforms, or software required.
+- preferredToolTags (array) — Tools that improve fit.
+- requiredAccessTags (array) — Accounts, clearance, location, network, or social access required.
+- preferredAccessTags (array) — Access that improves fit.
+- ownerOrganizationId (string | null) — Organization that owns/reviews this opening or task.
+- compensationKind (enum) — Compensation category.
+- compensationCadence (enum) — Compensation cadence. Null clears it.
+- compensationCurrency (string | null) — Lowercase currency code, usually usd.
+- compensationMinAmountMinorUnits (integer | null) — Minimum compensation in currency minor units.
+- compensationMaxAmountMinorUnits (integer | null) — Maximum compensation in currency minor units.
+- compensationMinAmountUsd (number | null) — Minimum compensation in whole US dollars; the server converts to minor units (cents). USD alternative to compensationMinAmountMinorUnits.
+- compensationMaxAmountUsd (number | null) — Maximum compensation in whole US dollars; the server converts to minor units (cents). USD alternative to compensationMaxAmountMinorUnits.
+- compensationPaymentRails (array) — Acceptable payment rails, such as stripe, ach, usdc, wire.
+- estimatedHoursPerWeekMin (integer | null) — Minimum weekly hours for ongoing work.
+- estimatedHoursPerWeekMax (integer | null) — Maximum weekly hours for ongoing work.
+- remotePolicy (enum) — UNSPECIFIED, REMOTE, HYBRID, or ONSITE.
+- locationText (string | null) — Human-readable location constraint.
+- workLocationCountryCode (string | null)
+- workLocationRegionCode (string | null)
+- workLocationCity (string | null)
+- workLocationPostalCode (string | null)
+- workLocationLatitude (number | null)
+- workLocationLongitude (number | null)
+- workLocationRadiusKm (number | null)
+- workTimeZone (string | null) — IANA time zone preferred for the work.
+- applicationQuestionsJson (object | array | null) — Structured questions for applicants. Null clears it.
+- executionMode (enum) — HUMAN_OR_AGENT, HUMAN_ONLY, or AGENT_ONLY.
+- maxClaims (integer | null) — Max simultaneous claims when claimPolicy is OPEN_MANY.
+- depends_on (array) — Alias for blockerTaskIds: existing task IDs that must be VERIFIED before this task appears in active queues. Use only for real prerequisites, not generic importance.
+- blockerTaskRefs (array) — Prerequisite task IDs or exact taskKeys.
+- blockerTaskIds (array) — Optional IDs of existing tasks that block this task (must be completed first). Use searchTasks first to discover valid blocker task IDs.
+- blockedTaskRefs (array) — Blocked task IDs or exact taskKeys.
+- blockedTaskIds (array) — Optional IDs of existing tasks that are blocked by this task (tasks that depend on it). Use searchTasks first to discover valid dependent task IDs.
+- estimatedEffortHours (number) — Estimated hours to complete
+- hours (number) — Alias for estimatedEffortHours. Required for reliable priority; use expected user hours, not calendar duration.
+- value (number) — Gross conditional value if the task succeeds. For required tasks, include avoided downside such as penalties, health loss, or system failure.
+- p_success (number) — Success probability, 0-1. MCP computes expected value as value * p_success when value is supplied.
+- cash_cost (number) — Cash cost in USD. Priority converts this to hour-equivalent cost using buybackRate, default $1000/hr.
+- executor_type (enum) — Who should execute this task. Use Self for normal user tasks even if AI assists; use AI Agent only for autonomous assistant tasks.
+- expectedEconomicValueUsdBase (number) — Expected economic value in USD-equivalent welfare (probability-adjusted by your model)
+- successProbabilityBase (number) — Estimated success probability for the task outcome, 0-1
+- estimatedCashCostUsdBase (number) — One-time cash cost expected to execute this task (USD)
+- timeToImpactStartDays (number) — Days until value can start being realized. Metadata/public impact-frame input; not part of personal priority.
+- available_at (string) — Earliest time this task should appear in active queues (ISO 8601). Use for tasks that cannot or should not be started yet.
+- dueAt (string) — Due date (ISO 8601)
+- due_at (string) — Alias for dueAt
+- deadline_policy (enum) — Whether due_at is ignored, a soft target, an expiring opportunity, or required work. REQUIRED is for must-do tasks like taxes or medicine refills; EXPIRES is for grants/applications/opportunities that vanish after due_at.
+- deadline_rationale (string) — Freeform rationale for the deadline policy, e.g. taxes must be filed by a legal deadline.
+- claimPolicy (enum) — How work is claimed. Assigned tasks always use ASSIGNED_ONLY. Unassigned tasks default to OPEN_SINGLE; use OPEN_MANY only for ongoing independent contributions.
+- assigneePersonId (string) — Person ID to assign this task to
+- assigneeOrganizationId (string) — Organization ID to assign this task to
+- roleTitle (string) — Role of the assignee (e.g. President, Commissioner)
+- sourceUrl (string) — URL to the source/evidence for this task
+- contactUrl (string) — URL for contacting the assignee
+- contactLabel (string) — Label for the contact channel
+- impactStatement (string) — Why this matters
+- ev_math (string) — Freeform rationale for value/probability/hour assumptions
+- can_delegate (boolean) — Whether an agent or contractor can do this task
+- best_route (string) — Best execution route, e.g. self, agent, contractor
+- acceptanceCriteria (array) — Structured acceptance criteria. If omitted, createTask also extracts checklist bullets under a markdown 'Acceptance criteria' heading in description.
+- visibility (enum) — Optional visibility override. Defaults to PUBLIC for organization-assigned tasks and PRIVATE otherwise.
+- isPublic (boolean) — Legacy boolean visibility alias. Prefer visibility='PUBLIC' or 'PRIVATE'. Ignored when visibility is supplied.
+- contextJson (object) — Optional advanced task metadata. Prefer the typed top-level task fields.
+- sortOrder (number) — Manual display order for public/task-tree views (lower = earlier). Not the computed personal priority score.
+#### deleteTask tasks:personal or tasks:organization or tasks:admin
+- Delete a task by soft delete. Admins may delete any task within the client boundary. Non-admin callers may delete only a private task they have MANAGE access to; a public task is always rejected for non-admin callers with 'Deleting public tasks requires an admin user.', even though they can look one up by ID without MANAGE access.
+- taskId (string, required) — Task ID to delete
+#### proposeTaskBundle tasks:personal or tasks:organization or tasks:admin
+- Propose a bundle of tasks for review. Creates each as DRAFT, runs validation, returns review decisions. Does NOT auto-promote.
+- candidates (array, required) — Tasks to propose
+#### promoteTask tasks:personal or tasks:organization or tasks:admin
+- Promote reviewed DRAFT tasks to ACTIVE. Promotion reruns governance review and rejects tasks that fail the current checks.
+- proposalRefs (array, required) — Proposal refs (task IDs or taskKeys) to promote
+#### updateTask tasks:personal or tasks:organization or tasks:admin
+- Update task metadata, estimates, ancestry, dependencies, deadline, or executor. Reparent with exactly one of parentTaskId or parentTaskKey. Reference tasks in descriptions as titled Markdown links to https://optimitron.com/tasks/<id>, never as bare IDs. Completion and verification use the execution tools. Passing depends_on replaces the blocker set idempotently, so keep it complete.
+- PARAMETERS (68)
+- claimPolicy (enum) — How work is claimed. Use ASSIGNED_ONLY for a named person or organization, OPEN_SINGLE for one claim that completes the task, and OPEN_MANY only for ongoing independent contributions.
+- title (string)
+- description (string)
+- parentTaskId (string) — Existing rooted parent task ID. Provide this or parentTaskKey, not both. Search first; cannot be Optimize Earth or create a hierarchy cycle.
+- parentTaskKey (string) — Exact stable key of the existing rooted parent task. Provide this or parentTaskId, not both. Call getMe for personalRoot and organizationRoots.
+- impactStatement (string)
+- category (enum) — Re-categorize the task. Affects category-filtered listTasks queries; not part of personal priority score.
+- taskKey (string) — Stable dedup key
+- assigneePersonId (string) — Person ID to assign (use empty string to clear)
+- assigneeOrganizationId (string) — Organization ID to assign (use empty string to clear)
+- roleTitle (string) — Role of the assignee
+- sourceUrl (string) — URL to the source/evidence
+- available_at (string) — Earliest time this task should appear in active queues (ISO 8601), use empty string to clear
+- dueAt (string) — Due date (ISO 8601), use empty string to clear
+- due_at (string) — Alias for dueAt, use empty string to clear
+- deadline_policy (enum) — Whether dueAt is ignored, a soft target, an expiring opportunity, or required work.
+- deadline_rationale (string) — Freeform rationale for the deadline policy.
+- contextJson (object) — Optional advanced task metadata merged with existing contextJson.
+- depends_on (array) — Replace blocker dependencies with this exact list of task IDs. Blockers must be completed/VERIFIED before this task appears in active queues.
+- blockerTaskRefs (array) — Replace blockers using task IDs or exact taskKeys.
+- blockerTaskIds (array) — Replace blocker dependencies with this exact list of task IDs.
+- hours (number) — Alias for estimatedEffortHours. Keep this current when task scope changes.
+- value (number) — Gross conditional value if the task succeeds. Update when the upside/downside estimate changes.
+- p_success (number) — Success probability, 0-1. Update after new information changes the odds.
+- cash_cost (number) — Cash cost in USD. Update if execution cost changes.
+- executor_type (enum) — Who should execute this task. Use Self for normal user tasks even with AI assistance; AI Agent means autonomous assistant work.
+- acceptanceCriteria (array) — Structured acceptance criteria. If omitted while description is updated, updateTask can extract checklist bullets under a markdown 'Acceptance criteria' heading.
+#### searchParameters tasks:personal or earthdata:write
+- Search published parameters used by Optimitron calculations.
+- query (string) — Key, display name, or description text.
+- limit (number) — Maximum results (default 20, max 100).
+#### getParameterTrace tasks:personal or earthdata:write
+- Get one exact parameter revision with formula, uncertainty, pinned input revisions, source metadata, inert calculation code, assumptions, and publication state.
+- revisionId (string) — Exact revision id. Preferred for reproducible traces.
+- key (string) — Parameter key when looking up the current revision.
+#### proposeParameterBundle tasks:personal or tasks:admin
+- Create one or more immutable parameter revision drafts. Returns numerical diffs, formulas or inert calculation code, exact input revisions, and provenance for human review. This never publishes revisions.
+- parameters (array, required)
+#### reviewParameterRevision tasks:personal or tasks:admin
+- Publish or reject one reviewed parameter revision.
+- revisionId (string, required)
+- action (enum, required)
+#### proposeTaskImpact tasks:personal or tasks:admin
+- Create an immutable task-impact draft with materialized values, formulas or inert calculation code, assumptions, and sources. Public drafts require admin review before use.
+- PARAMETERS (14)
+- frameKey (enum)
+- frame (object)
+- metrics (array)
+- assumptions (array)
+- formulaText (string)
+- formulaLatex (string)
+- calculationCode (string)
+- calculationLanguage (string)
+- sourceUrls (array)
+- calculationSource (object) — Exact Python, notebook, or other calculation source to retain as inert content-addressed data. Optimitron stores but never executes it.
+- estimateNotes (string)
+- calculationVersion (string)
+- methodologyKey (string)
+#### getTaskImpactTrace tasks:personal or earthdata:write
+- Trace the current or specified task-impact estimate through its formula, materialized values, recursive parameter tree, and source metadata.
+- taskId (string)
+- estimateSetId (string)
+#### claimTask tasks:personal or tasks:organization
+- Claim a task as the authenticated user.
+- taskId (string, required) — Task ID to claim
+#### claimSignerReminder tasks:personal
+- Commit to reminding a specific head of state (or other 1% Treaty signer) to sign. Creates a private reminder subtask for you, parented to the signer task. The subtask carries an actionLink to a Google search for the signer's official contact, plus an outreach message template with your referral code embedded so any signer click-through credits you. Idempotent: calling twice with the same signer returns the existing subtask. The subtask auto-VERIFIES when the signer signs the treaty via your referral.
+- signerTaskId (string, required) — Task ID of the parent signer task (e.g. 1-pct-treaty-signer-us). Use listTasks or searchTasks with status=ACTIVE to find candidates.
+#### completeTask tasks:personal
+- Mark one private Self task you own VERIFIED in a single call so it leaves your active queue. This owner-attestation shortcut is only for uncompensated, childless personal tasks that are unassigned or assigned only to you and have no formal work history. Use the submission-and-verification workflow for OPEN_MANY, delegated, shared, paid, public, organization, or agent work. If a one-person task was incorrectly stored as OPEN_MANY and has no formal history, update its claimPolicy to OPEN_SINGLE first.
+- taskId (string, required) — Private Self task ID
+- completionEvidence (string, required) — A short factual description of what was completed
+#### completeTaskClaim tasks:personal or tasks:organization
+- Claim an open task if needed, then mark only the authenticated user's claim completed. This does not itself complete the task. An authorized reviewer may later verify the claim; OPEN_SINGLE then resolves the task, while OPEN_MANY remains active for more contributions. Safe to retry after claim completion.
+- completionEvidence (string, required) — What was done and proof it worked
+#### addDependency tasks:personal or tasks:organization or tasks:admin
+- Add a dependency between tasks. The blocked task cannot proceed until the blocker is done. Optional edge metadata can estimate how much the blocker raises downstream success probability or accelerates downstream value.
+- PARAMETERS (12)
+- blockedTaskRef (string) — Canonical task ID or exact taskKey for the task that is blocked.
+- blockedTaskId (string) — Task that is blocked
+- blockerTaskRef (string) — Canonical task ID or exact taskKey for the task that must complete first.
+- blockerTaskId (string) — Task that must complete first
+- probabilityDeltaBase (number) — Base probability lift, 0-1, produced by completing blockerTaskId for blockedTaskId.
+- increases_p_success (number) — Alias for probabilityDeltaBase. Use for Notion-style 'this prerequisite raises downstream P(success)' estimates.
+- timeDeltaDaysBase (number) — Base days of acceleration produced by completing blockerTaskId for blockedTaskId.
+- time_delta_days (number) — Alias for timeDeltaDaysBase.
+- assumptions (array) — Short assumptions behind the edge lift estimate.
+- calculationVersion (string) — Optional version tag for the edge-lift calculation.
+- label (string) — Optional note describing the dependency
+- notes (string) — Optional note describing the dependency
+#### getBlockers tasks:personal or tasks:organization
+- Get all tasks blocking a given task, and all tasks this task blocks.
+#### postTaskComment tasks:personal or tasks:organization
+- Post a comment on a task. Message is GitHub-flavored markdown with these extensions: - Math: $inline$ or $$block$$ (rendered via KaTeX) - Diagrams: ```mermaid ... ``` fences (rendered via Mermaid) - Charts: ```chart { ...Chart.js config JSON... } ``` fences - Images: ![alt](url) inline - Tables, lists, strikethrough, code blocks, blockquotes — all standard Max length: 20,000 characters. Rate limit: 5 comments per task per hour. Posting a comment automatically sends comment notifications to task recipients and triggers a Wishonia auto-reply in the background.
+- PARAMETERS (4)
+- taskId (string, required) — Task ID to comment on
+- parentCommentId (string) — Optional parent comment ID if this is a reply
+- message (string, required) — Markdown body (1-20000 chars, supports math/mermaid/chart fences)
+- mediaUrl (string) — Optional evidence URL (tweet, screenshot, article)
+#### voteTaskComment tasks:personal or tasks:organization
+- Upvote (+1), downvote (-1), or remove vote (0) on a task comment.
+- commentId (string, required) — Comment ID to vote on
+- value (number, required) — +1 upvote, -1 downvote, 0 remove vote
+#### deleteTaskComment tasks:personal or tasks:organization
+- Soft-delete your own comment (or any comment if you are a curator).
+- commentId (string, required) — Comment ID to delete
+#### getTaskComments tasks:personal or tasks:organization
+- Fetch paginated comments for a task. Returns comments with vote scores, nested replies, and recent activity events.
+- taskId (string, required) — Task ID to read comments for
+- sort (enum) — 'new' (default) or 'top'
+- cursor (string) — ISO timestamp cursor from a previous response's nextCursor
+- limit (number) — Default 50, max 100
+#### listTaskTemplates tasks:personal or tasks:admin
+- List reusable task templates. This is a friendly view over TaskTrigger rows.
+- eventName (string)
+- enabled (boolean)
+- jurisdictionId (string)
+- limit (number) — Default 100, max 500
+#### getTaskTemplate tasks:personal or tasks:admin
+- Get one task template, including spawned task specs and recent fires.
+- templateKey (string, required)
+- recentFires (number) — How many recent fires to include. Default 10, max 100.
+#### previewTaskTemplate tasks:personal or tasks:admin
+- Render a task template for a target/context without writing anything. Use before enabling or assigning a template.
+- targetPersonId (string) — Person ID to assign/render for. Adds context.target={kind:'person',id} and context.recipientPersonId.
+- targetOrganizationId (string) — Organization ID to assign/render for. Adds context.target={kind:'organization',id} and context.organizationId.
+- targetUserId (string) — User ID to render for. Adds context.target={kind:'user',id} and context.user.id.
+- context (object) — Extra template context. Explicit fields here are preserved unless a target helper fills a missing field.
+#### listTaskTriggers tasks:personal or tasks:admin
+- List TaskTriggers, optionally filtered by eventName, enabled, or jurisdictionId. Returns triggerKey + summary fields, no specs.
+#### getTaskTrigger tasks:personal or tasks:admin
+- Get full details of a TaskTrigger by triggerKey, including all spec rows and the most recent fires.
+- triggerKey (string, required)
+#### fireTaskTrigger tasks:personal or tasks:admin
+- Fire a TaskTrigger manually with arbitrary context. Use dryRun:true to render templates and return the planned spawn without committing — critical for iterating on a template before it goes live. Without dryRun: writes are committed and idempotent (re-firing the same idempotencyKey returns the cached result).
+- context (object, required) — Arbitrary event context. Templates and resolvers read from this.
+- dryRun (boolean) — Default false. True = render-only, no writes.
+#### importNotionBundle tasks:personal or tasks:admin
+- Validate and import a lossless Notion export bundle. Dry-run is the default; set dryRun to false only after reviewing the returned create, update, unchanged, and error items. Imported tasks remain private drafts, and formula or rollup definitions are preserved without execution.
+- bundle (object, required)
+- dryRun (boolean)
+#### createCollection tasks:personal or tasks:admin
+- Create a private structured collection with stable fields. Formula and rollup fields preserve imported definitions and outputs but are not executed.
+- name (string, required)
+- organizationId (string)
+- visibility (enum)
+- idempotencyKey (string, required)
+- fields (array)
+#### updateCollection tasks:personal or tasks:admin
+- Update collection metadata with optimistic concurrency. Sharing and ownership still require full access.
+- collectionId (string, required)
+- expectedVersion (number, required)
+- name (string)
+#### getCollection tasks:personal or tasks:admin
+- Get a collection schema, saved views, and effective permission.
+#### listCollections tasks:personal or tasks:admin
+- List collections the current user can see.
+- limit (number)
+#### createCollectionRecord tasks:personal or tasks:admin
+- Create a collection record. Normal edits cannot write file, relation, formula, rollup, or canonical-entity fields through values; use relations for links.
+- values (object, required)
+- relations (array)
+- taskId (string | null)
+- personId (string | null)
+- organizationId (string | null)
+- documentId (string | null)
+#### updateCollectionRecord tasks:personal or tasks:admin
+- Update record values or relations and reject stale versions.
+- recordId (string, required)
+- values (object)
+#### upsertCollectionRecordsBatch tasks:personal or tasks:admin
+- Atomically create or update up to 100 collection records. Creates require stable idempotency keys; updates require the expected record version. Any invalid or stale operation rolls back the entire batch.
+- operations (array, required)
+#### queryCollectionRecords tasks:personal or tasks:admin
+- Query collection records with bounded filters, ordered sorts, cursor pagination, and linked-entity authorization.
+- cursor (string)
+- query (string)
+- filters (array)
+- sorts (array)
+#### searchContent tasks:personal or tasks:admin
+- Search authorized Markdown documents and collection records without exposing inaccessible matches.
+- query (string, required)
+#### saveCollectionView tasks:personal or tasks:admin
+- Create or update a saved table view with visible fields, filters, and sorts.
+- viewId (string)
+- expectedVersion (number)
+- visibleFieldIds (array)
+- isDefault (boolean)
+#### createDocument tasks:personal or tasks:organization or tasks:admin
+- Create a markdown document (version 1). Private by default. Optionally attach it to a task you can view.
+- title (string, required) — Document title
+- body (string, required) — Markdown body
+- taskId (string) — Optional task to attach the document to
+- jurisdictionId (string) — Optional jurisdiction. Defaults to the attached task's jurisdiction.
+- organizationId (string) — Optional organization that owns the document
+- parentDocumentId (string) — Optional parent document
+- idempotencyKey (string, required) — Stable retry key for this create request
+- visibility (enum) — PRIVATE (default) or PUBLIC.
+#### updateDocument tasks:personal or tasks:organization or tasks:admin
+- Update a document. Writes an immutable revision and rejects stale edits. Omitted fields carry forward.
+- documentId (string, required) — Stable document ID
+- expectedVersion (number, required) — Version returned by getDocument
+- body (string) — Full replacement markdown body
+- organizationId (any) — Organization owner, or null to remove it
+- parentDocumentId (any) — Parent document, or null to move it to the root
+- taskId (any) — Linked task, or null to remove the task link
+#### getDocument tasks:personal or tasks:organization or tasks:admin
+- Read a document or historical revision plus its revision list when you have access.
+- documentId (string, required) — Stable document ID or historical revision ID
+#### listDocuments tasks:personal or tasks:organization or tasks:admin
+- List documents you can see. Filter by taskId to see a task's documents.
+- taskId (string) — Only documents on this task
+#### getDocumentReview tasks:personal or tasks:organization or tasks:admin
+- Read the exact document revision and instructions assigned to the authenticated reviewer.
+- reviewTaskId (string, required)
+#### createDocumentProposal tasks:personal or tasks:organization or tasks:admin
+- Create a separate private proposal document from selected comments on one exact document revision.
+- authorityTaskId (string, required)
+- baseDocumentRevisionId (string, required)
+- body (string, required)
+- idempotencyKey (string, required) — Stable retry key for this operation.
+- sourceCommentIds (array, required)
+- summary (string, required)
+- title (string, required)
+#### applyDocumentProposal tasks:personal or tasks:organization or tasks:admin
+- Apply a pinned proposal artifact to its unchanged base document as a new immutable revision.
+- proposalArtifactId (string, required)
+#### requestDocumentReview tasks:personal or tasks:organization or tasks:admin
+- Create a private assigned review task pinned to one exact immutable document revision.
+- documentRevisionId (string, required)
+- instructions (string, required)
+- reviewerPersonId (string, required)
+#### submitDocumentReview tasks:personal or tasks:organization or tasks:admin
+- Submit an explained verdict for the exact revision assigned to the authenticated reviewer.
+- explanation (string, required)
+- verdict (enum, required)
+#### decideDocumentRevision tasks:personal or tasks:organization or tasks:admin
+- Record an authorized immutable internal ADOPT or REJECT decision on one exact current revision.
+- reason (string)
+- reviewArtifactId (string, required)
+#### manageContentAccess tasks:personal or tasks:admin
+- List, grant, or revoke access to a document or collection. Grant and revoke require full access. A user may be identified by Optimitron user ID or account email.
+- resourceId (string, required)
+- resourceType (enum, required)
+- granteeType (enum)
+- granteeId (string)
+- granteeEmail (string)
+- accessLevel (enum)
+#### manageContentFiles tasks:personal or tasks:admin
+- List files, prepare or complete an upload, obtain a short-lived authorized download URL, or delete a private document/collection-record file.
+- attachmentId (string)
+- documentId (string)
+- collectionRecordId (string)
+- checksumSha256 (string)
+- contentType (string)
+- fileName (string)
+- sizeBytes (number)
+#### exportContent tasks:personal or tasks:admin
+- Export an authorized document snapshot or one cursor-paginated collection page. Private file metadata is included, but storage keys and unsigned object URLs are never returned.
+#### reviewPrivateTaskBundle tasks:personal or tasks:organization
+- Validate, normalize, deduplicate, and hash a user-selected private conversation-to-work batch without writing tasks. Review every returned error and action before applyPrivateTaskBundle.
+- rootTaskId (string, required) — Private personal or organization root/container task ID.
+- source (object, required)
+- candidates (array, required)
+#### applyPrivateTaskBundle tasks:personal or tasks:organization
+- Atomically apply a previously reviewed private task bundle as ACTIVE tasks. The server recomputes reviewHash; changed or invalid bundles are rejected. Raw transcript text is not accepted.
+- reviewHash (string, required)
+#### startTaskExecution tasks:personal or tasks:organization
+- Start the canonical execution attempt for an accessible active, unblocked leaf task. Reserved roots, containers, and tasks with active or pending-verification attempts are rejected.
+- agentExecutorId (string | null)
+- confidence (number | null)
+- estimatedCost (object | null)
+- estimatedDurationSeconds (number | null)
+- runContext (object | null)
+#### submitTaskArtifact tasks:personal or tasks:organization
+- Submit exactly one immutable artifact for a running execution attempt: a task-linked document revision, content attachment, task-comment attachment, external URL, or structured result.
+- contentAttachmentId (string)
+- documentRevisionId (string)
+- externalUrl (string)
+- label (string | null)
+- metadata (object | null)
+- structuredResult (any)
+- taskCommentAttachmentId (string)
+- taskExecutionAttemptId (string, required)
+#### submitTaskForVerification tasks:personal or tasks:organization
+- Finish a running attempt, snapshot the task's acceptance criteria, record actual duration/cost, and create a pending typed verification. At least one artifact is required.
+- actualCost (object | null)
+- actualDurationSeconds (number, required)
+- method (enum)
+- outputSummary (string, required)
+#### verifyTaskExecution tasks:personal or tasks:organization
+- Accept or reject one pending execution verification against its immutable criteria snapshot. Acceptance verifies the task; rejection preserves evidence and requeues it as ACTIVE.
+- criterionResults (array, required)
+- evidence (object | null)
+- result (enum, required)
+- taskVerificationId (string, required)
+#### getTaskAuditTrail tasks:personal or tasks:organization
+- Read the accessible task's provenance, claims, comments, execution attempts, artifact hashes, and verification history without exposing raw private source content.
+#### proposeExternalAction tasks:personal or tasks:organization
+- Create an immutable outbound message or browser-action request for human approval. This does not approve or execute anything; editing requires a new idempotency key and request.
+- destination (string, required)
+- expiresAt (string)
+- operation (string, required)
+- payload (object, required)
+- taskExecutionAttemptId (string | null)
+#### recordExternalActionResult tasks:personal or tasks:organization
+- Record one terminal execution receipt for an already human-approved external action. The exact approved payload cannot be changed or replayed through this tool.
+- externalActionRequestId (string, required)
+- failureMessage (string | null)
+- receipt (object | null)
+#### exportPrivateWork tasks:personal or tasks:organization
+- Export one private root subtree you manage, including tasks, internal comments, safe attachment metadata, source provenance, execution evidence, linked current documents, and internal dependency edges.
+- rootTaskId (string, required)
+#### deletePrivateSourceSelection tasks:personal or tasks:organization
+- Scrub and unlink one reviewed private source selection you own or administer. Derived tasks remain; approved excerpts, anchors, aliases, URLs, and external identifiers are removed.
+- sourceArtifactId (string, required)
+#### findReviewedAnswers tasks:personal or tasks:organization
+- Find reusable reviewed text answers for one person or organization.
+- subject (object, required)
+- question (string, required)
+- knowledgeKey (string)
+- contextTags (array)
+- asOf (string)
+#### prepareFormResponses tasks:personal or tasks:organization
+- Capture a form's narrative fields, prepare reusable responses, and create one shared review task for each unresolved answer.
+- formKey (string)
+- formTitle (string)
+- formSourceUrl (string)
+- formPurpose (enum)
+- formTaskId (string, required)
+- questions (array, required)
+#### proposeFormSubmission tasks:personal or tasks:organization
+- Propose the exact prepared form submission for human approval without executing it.
+- formSubmissionId (string, required)
+### EARTHDATA:WRITE (33)
+#### castReferendumVote earthdata:write
+- Cast or update the authenticated user's own referendum vote.
+- answer (enum)
+- publicComment (string)
+- referendumSlug (string)
+#### recordRepresentedReferendumVote earthdata:write
+- Record a represented or memorial referendum vote for an existing Person.
+- isPublic (boolean)
+- personId (string, required)
+#### searchPeople earthdata:write
+- Search public Person records by name, handle, affiliation, or source key.
+- publicOnly (boolean)
+#### getPerson earthdata:write
+- Fetch one Person by id or handle, including public memorial/vote context.
+- idOrHandle (string)
+- personId (string)
+- publicOnly (boolean) — Admin-only escape hatch. Non-admin callers always receive public data.
+#### searchOrganizations earthdata:write
+- Search organization records by name, slug, website, or source key.
+#### signReferendumAsOrganization earthdata:write
+- Sign a referendum as an organization, auto-active under post-moderation.
+- newOrganizationName (string)
+- type (string)
+- website (string)
+- donationUrl (string)
+- squareLogoUrl (string) — Square logo mark URL. Use uploadImageFromUrl with kind=organization-square-logo first when starting from a remote public image URL.
+- wordmarkLogoUrl (string) — Horizontal wordmark logo URL. Use uploadImageFromUrl with kind=organization-wordmark-logo first when starting from a remote public image URL.
+- contactEmail (string)
+- position (enum)
+- statement (string)
+#### upsertMemorialPerson earthdata:write
+- Create or update a memorial/represented Person, optional condition, memorial, evidence, responsible party, relationship, and YES referendum vote. Agent imports require sourceKey/sourceRef plus sourceUrl or sourceArtifactId.
+- PARAMETERS (25)
+- displayName (string, required)
+- lifeStatus (enum)
+- birthDate (string)
+- dateOfDeath (string)
+- deathCountryCode (string)
+- conditionName (string)
+- conditionCodeSystem (string)
+- conditionCode (string)
+- causeCategory (string)
+- conflictId (string)
+- conflictName (string)
+- responsiblePartyName (string)
+- relationshipType (string)
+- imageUrl (string)
+- memorialMessage (string)
+- consentCourtEvidence (boolean)
+- recordTreatyVote (boolean)
+- sourceKind (enum)
+- sourceKey (string)
+- sourceRef (string)
+- sourceUrl (string)
+- sourceArtifactId (string)
+#### addMemorialEvidence earthdata:write
+- Attach public non-sensitive sourced evidence to a memorial. Requires sourceUrl or sourceArtifactId.
+- memorialId (string, required)
+- evidenceKind (string)
+- isPublic (boolean) — Must be true; private evidence is not accepted.
+- containsSensitiveData (boolean) — Must be false; do not submit sensitive evidence.
+#### addMemorialResponsibleParty earthdata:write
+- Attach a government, organization, or free-text responsible party to a memorial.
+- PARAMETERS (10)
+- roleSlug (string)
+- isPrimary (boolean)
+- confidenceScore (number)
+#### upsertConflict earthdata:write
+- Create or update a named conflict reference by slug/name/source key.
+- slug (string)
+- startDate (string)
+- endDate (string)
+- primaryJurisdictionId (string)
+#### resolveGlobalVariable earthdata:write
+- Find or create a canonical condition, intervention, side-effect, outcome, or policy GlobalVariable, with optional external code.
+- kind (enum)
+- codeSystem (string)
+- code (string)
+- variableCategoryName (string)
+#### upsertSourceArtifact earthdata:write
+- Store source/provenance data without executing it. For Python, notebooks, or other calculation code, use artifactType CALCULATION_SOURCE and payloadJson with language and source; Optimitron marks it inert, computes its content hash, and rejects mutation under the same sourceKey.
+- sourceKey (string, required)
+- sourceSystem (string)
+- artifactType (string)
+- externalKey (string)
+- versionKey (string)
+- contentHash (string)
+- payloadJson (object) — For calculation code: { language, source, runtime?, dependencies?, entrypoint?, inputs?, outputs?, notes? }. Code is retained as inert data and is never run by this tool or by the web application.
+#### upsertCourtCase earthdata:write
+- Create or update a Court of Humanity case root record.
+- id (string)
+- summary (string)
+- nominalPlaintiffSubjectId (string)
+- primaryRespondentSubjectId (string)
+- beneficiarySubjectId (string)
+- rootTaskId (string)
+- juryReferendumId (string)
+- metadataJson (object)
+#### addCourtCaseParty earthdata:write
+- Attach a plaintiff, respondent, class, beneficiary, or amicus Subject to a Court of Humanity case.
+- PARAMETERS (16)
+- caseId (string, required)
+- partyKey (string)
+- subjectId (string)
+- subjectExternalId (string)
+- subjectDisplayName (string)
+- subjectType (string)
+- role (enum, required)
+- capacity (enum)
+- displayNameSnapshot (string)
+- standingTheory (string)
+- powerToRemedyScore (number)
+- blameAttributionScore (number)
+- publicAccountabilityScore (number)
+- sortOrder (number)
+#### addCourtCaseClaim earthdata:write
+- Add a structured allegation or requested finding to a Court of Humanity case.
+- claimKey (string)
+- claimType (string)
+- argumentMarkdown (string, required)
+- requestedFinding (string)
+#### addCourtCaseHarm earthdata:write
+- Add a quantified or qualitative harm catalog row to a Court of Humanity case.
+- PARAMETERS (18)
+- claimId (string)
+- harmKey (string)
+- harmType (string)
+- bodyMarkdown (string)
+- affectedSubjectId (string)
+- parameterName (string)
+- lowValue (number)
+- baseValue (number)
+- highValue (number)
+- unit (string)
+#### addCourtCaseEvidence earthdata:write
+- Attach public non-sensitive evidence to a Court of Humanity case, claim, or harm.
+- PARAMETERS (19)
+- harmId (string)
+- evidenceKey (string)
+- evidenceType (string)
+- personMemorialId (string)
+- containsSensitiveData (boolean) — Must be false; sensitive evidence is not accepted.
+- reviewStatus (enum)
+#### addCourtCaseRemedy earthdata:write
+- Add a requested remedy that can point at an existing enforcement Task.
+- targetPartyId (string)
+- remedyKey (string)
+- remedyType (string)
+- bodyMarkdown (string, required)
+- amountUsdLow (number)
+- amountUsdBase (number)
+- amountUsdHigh (number)
+- deadlineAt (string)
+- enforcementTaskId (string)
+#### getCourtCase earthdata:write
+- Fetch a Court of Humanity case with parties, claims, harms, evidence, remedies, and jury referendum.
+- caseIdOrSlug (string)
+#### openCourtCaseJuryVote earthdata:write
+- Open or update the public referendum used as a Court of Humanity jury vote.
+- caseIdOrSlug (string, required)
+- questionKey (string)
+- questionTitle (string)
+#### upsertInterventionApprovalTimeline earthdata:write
+- Create or update a regulatory first-evidence/approval timeline for an intervention and condition.
+- interventionName (string, required)
+- conditionName (string, required)
+- interventionGlobalVariableId (string)
+- conditionGlobalVariableId (string)
+- brandName (string)
+- regulatorName (string)
+- firstEvidenceDate (string)
+- approvalDate (string)
+#### upsertVariableRelationshipEvidenceEstimate earthdata:write
+- Import or update evidence for predictor GlobalVariable -> outcome GlobalVariable effects.
+- PARAMETERS (13)
+- predictorGlobalVariableId (string, required)
+- outcomeGlobalVariableId (string, required)
+- contextGlobalVariableId (string)
+- metricKind (string)
+- sourceType (string)
+- value (number)
+- participants (number)
+- studies (number)
+- rationale (string)
+#### recordInterventionExperience earthdata:write
+- Record a user's intervention experience with optional outcomes and side effects.
+- interventionGlobalVariableId (string, required)
+- status (string)
+- startedAt (string)
+- endedAt (string)
+- doseValue (number)
+- doseUnitId (string)
+- frequencyText (string)
+- notes (string)
+- outcomes (array)
+- sideEffects (array)
+#### runEfficacyLagMatcher earthdata:write
+- Match memorial deaths to approval timelines and create efficacy-lag evidence candidates.
+#### reportContent earthdata:write
+- Report wrong, duplicate, spam, impersonation, abusive, or unsourced public data for post-moderation review.
+- targetType (string, required)
+- targetId (string, required)
+- reasonType (string, required)
+- message (string)
+- correctionJson (object)
+#### suggestCorrection earthdata:write
+- Suggest structured replacement fields for an existing public data record.
+- reasonType (string)
+- correctionJson (object, required)
+#### uploadImageFromUrl earthdata:write or tasks:admin
+- Fetch a public image URL, normalize it through the same image pipeline used by the web app, upload it to object storage, and return the canonical public URL. Use this before createOrganization/updateOrganization when you have a remote square logo, wordmark, or person photo URL.
+- url (string, required) — Public http(s) image URL. Local/private network hosts are rejected.
+- kind (enum, required) — Upload target. Organization logos usually use organization-square-logo and organization-wordmark-logo.
+- filename (string) — Optional filename to use before normalization. Defaults to the URL path filename.
+#### createOrganization earthdata:write or tasks:admin
+- Create an approved organization for task assignment. Uses post-moderation: create now, reject later if needed. Visibility defaults to PRIVATE (visible only to members) unless visibility='PUBLIC' is passed explicitly — only make an organization PUBLIC when it needs to be publicly discoverable or assigned public tasks.
+- name (string, required) — Organization name
+- type (enum, required) — Organization type
+- slug (string) — Optional URL slug. Defaults to a kebab-case slug generated from name.
+- website (string) — Website URL
+- contactEmail (string) — Primary contact email
+- description (string) — Mission or provenance note
+- status (enum) — Organization status. Defaults to APPROVED.
+- visibility (enum) — Discoverability. PRIVATE organizations are visible only to their members. MCP-created organizations default to PRIVATE — pass visibility='PUBLIC' explicitly to make it publicly discoverable and referenceable by public tasks.
+- donationUrl (string) — Direct support or donation page URL
+- jurisdictionId (string) — Optional jurisdiction ID
+#### updateOrganization earthdata:write or tasks:admin
+- Edit an existing Organization. Caller must be an owner/admin of the org. status and jurisdictionId changes additionally require platform-admin privileges.
+- organizationId (string, required) — Organization ID to update
+- name (string) — New name
+- slug (string) — New URL slug. Pass empty string to regenerate from the (possibly updated) name. Slug collisions auto-disambiguate with -2, -3, etc.
+- type (enum)
+- status (enum) — Approval status. Platform-admin only.
+- visibility (enum) — Organization discoverability. Owner/admin members may flip either direction; no extra platform-admin gate. Switching to PRIVATE is rejected if the organization owns or is assigned any PUBLIC task.
+- website (string) — Website URL (empty string clears)
+- description (string) — Mission or provenance note (empty string clears)
+- donationUrl (string) — Direct support or donation page URL (empty string clears)
+- squareLogoUrl (string) — Square logo mark URL (empty string clears). Use uploadImageFromUrl with kind=organization-square-logo first when starting from a remote public image URL.
+- wordmarkLogoUrl (string) — Horizontal wordmark logo URL (empty string clears). Use uploadImageFromUrl with kind=organization-wordmark-logo first when starting from a remote public image URL.
+- contactEmail (string) — Primary contact email (empty string clears)
+- jurisdictionId (string) — Jurisdiction ID (empty string clears). Platform-admin only.
+#### addOrganizationMember earthdata:write or tasks:admin
+- Add a user to an Organization with a given role, or update an existing member's role to that value. Caller must be an owner/admin of the org. Accepts only userId (no email lookup — that would expose User-account enumeration).
+- organizationId (string, required) — Organization ID
+- userId (string, required) — User ID to add as a member
+- role (enum) — Role within the organization. Default: member.
+#### removeOrganizationMember earthdata:write or tasks:admin
+- Remove a user from an Organization. Caller must be an owner/admin of the org, OR be removing themselves. Cannot remove the last remaining owner — transfer ownership first by adding another owner.
+- userId (string, required) — User ID to remove
+#### updateOrganizationMemberRole earthdata:write or tasks:admin
+- Change a member's role within an Organization. Caller must be an owner/admin. Cannot demote the last remaining owner.
+- userId (string, required) — User ID whose role to change
+- role (enum, required) — New role.
+#### listOrganizationMembers earthdata:write
+- List members of an Organization with their roles, emails, and display names. Caller must be an owner/admin of the org.
+### ADMIN-ONLY (32)
+#### hideContent ADMIN earthdata:admin
+- Admin-only: hide or soft-delete a supported public Earth-data record.
+#### restoreContent ADMIN earthdata:admin
+- Admin-only: restore a hidden supported Earth-data record.
+#### resolveContentReport ADMIN earthdata:admin
+- Admin-only: mark a content report as resolved or dismissed.
+- id (string, required)
+- resolutionNote (string)
+#### getTaskTreeAudit ADMIN tasks:admin
+- Admin-only complete audit of the task graph rooted at Optimize Earth. Pages stable findings—not tasks—so a steward can inspect every structural, duplicate, routing, provenance, estimate, and bounded-agent-work issue without the listTasks result cap. Treat requiresApproval=true findings as proposals only.
+- cursor (string) — Stable issue cursor returned by the preceding page. Omit for the first page.
+- limit (number) — Findings per page (default 100, maximum 500).
+- rootTaskId (string) — Root task ID. Defaults to optimize-earth.
+#### findTaskCandidates ADMIN tasks:admin
+- Admin-only: score users and active agent executors as possible executors for one task.
+- limit (number) — Max candidates, default 20, max 100.
+- includeAgents (boolean) — Include active AgentExecutor rows. Default true.
+#### saveTaskCandidateMatch ADMIN tasks:admin
+- Admin-only: upsert a scored candidate match for a task so later chats/agents can review or assign it.
+- candidateKind (enum, required)
+- candidateKey (string) — Stable key. If omitted, derived from candidateUserId/personId/organizationId/agentExecutorId.
+- candidateUserId (string)
+- candidatePersonId (string)
+- candidateOrganizationId (string)
+- agentExecutorId (string)
+- score (number, required)
+- scoreVersion (string)
+- reasonJson (object | array | null)
+- blockersJson (object | array | null)
+- estimatedCostMinorUnits (integer | null)
+- estimatedCostCurrency (string | null)
+- estimatedDurationSeconds (integer | null)
+#### updateTaskCandidateMatchStatus ADMIN tasks:admin
+- Admin-only: update a saved task candidate match status.
+- matchId (string, required)
+- status (enum, required)
+#### listAgentExecutors ADMIN agent:run or tasks:admin
+- Admin-only: list non-human executors addressable by task routing.
+- provider (string)
+- capabilityTags (array)
+#### upsertAgentExecutor ADMIN agent:run or tasks:admin
+- Admin-only: create or update a non-human task executor.
+- agentKey (string, required)
+- provider (string | null)
+- modelName (string | null)
+- averageCostUsd (number | null)
+- averageLatencySeconds (number | null)
+- successRate (number | null)
+- metadata (object | array | null)
+#### setAgentExecutorStatus ADMIN agent:run or tasks:admin
+- Admin-only: set an AgentExecutor status.
+#### listTaskEmails ADMIN tasks:admin
+- Admin-only: list task email communications and linked email logs for one task.
+- email (string) — Optional recipient email filter.
+- q (string) — Optional search across subject, recipient, task title, and provider email address.
+#### listRecipientEmails ADMIN tasks:admin
+- Admin-only: list task email communications and email logs sent to a user, person, organization, or raw email address.
+- email (string) — Recipient email address.
+- organizationId (string) — Recipient organization ID.
+- personId (string) — Recipient person ID.
+- userId (string) — Recipient user ID.
+#### listEmailLogs ADMIN tasks:admin
+- Admin-only: list provider-level email logs, optionally filtered by task, recipient email, user, person, organization, or search text.
+- organizationId (string) — Recipient organization ID through task communications.
+- personId (string) — Recipient person ID through task communications.
+- q (string) — Optional search across subject, recipient, task title, template, and provider message id.
+- taskId (string) — Linked task ID.
+#### createPerson ADMIN tasks:admin
+- Create or idempotently update a person profile by displayName, email, sourceRef, or public-figure signature.
+- displayName (string, required) — Person display name.
+- email (string) — Person email (used for de-dup and notification).
+- currentAffiliation (string) — Current organization/affiliation.
+- countryCode (string) — ISO-3166 country code.
+- image (string) — Avatar image URL. Use uploadImageFromUrl with kind=person-photo first when starting from a remote public image URL.
+- isPublicFigure (boolean) — Marks this person as a public-facing profile.
+- sourceRef (string) — Stable source key for idempotent updates.
+- sourceUrl (string) — Source URL for provenance.
+#### mergeTask ADMIN tasks:admin
+- Admin-only: fold a duplicate task into a canonical task. Re-points every live relation (children, claims, applications, comments, edges, communications, funding, documents, etc.) to the canonical task, records merge provenance in both tasks' contextJson, then soft-deletes the duplicate. Refuses a duplicate that carries a taskKey (managed or trigger-owned tasks) — pick the keyed task as the canonical instead. Unique-constraint collisions are skipped and left on the duplicate; the canonical task's status, completion, and actuals are never changed. Effectively irreversible — review both tasks first. Returns per-relation moved/skipped counts.
+- duplicateTaskId (string, required) — Task ID to fold into the canonical task and soft-delete
+- canonicalTaskId (string, required) — Task ID that survives and receives the duplicate's relations
+#### upsertOrganization ADMIN earthdata:admin or tasks:admin
+- Create or update a general Organization record for task assignment. This is not outreach-specific; use it for nonprofits, governments, companies, universities, and other assignees.
+- type (enum) — Organization type
+- contactEmail (string) — General contact email
+- sourceRef (string) — Stable source reference for idempotent imports
+- sourceUrl (string) — Source URL proving this organization/contact
+#### deleteOrganization ADMIN earthdata:admin or tasks:admin
+- Soft-delete an Organization (sets deletedAt). Caller must be an owner of the org AND a platform admin. Tasks previously assigned to this org keep their assigneeOrganizationId — orphan visibility is intentional for accountability.
+- organizationId (string, required) — Organization ID to soft-delete
+#### setTaskImpact ADMIN tasks:admin
+- Create or replace a task impact estimate. Values are USD-equivalent welfare; expectedEconomicValueUsd* fields must already be probability-weighted. Include low/base/high ranges, assumptions, and sourceUrls for subjective or high-value estimates. Negative values represent harm caused.
+- taskId (string, required) — Task ID to attach impact to
+- frameKey (enum) — Time horizon for evaluation (default: FIVE_YEAR)
+- frame (object) — Low/base/high impact frame. expectedEconomicValueUsd* is already probability-weighted; for Notion imports use P(success) * Value.
+- metrics (array) — Custom impact metrics (lives lost, taxpayer cost, suffering hours, etc.)
+- assumptions (array) — Human-readable assumptions, including probability gates and why subjective values are plausible
+- sourceUrls (array) — Sources/citations for the value, probability, deadline, or conversion assumptions
+- estimateNotes (string) — Short explanation of the calculation and what would change the estimate
+- formulaText (string) — The arithmetic behind the number, in plain text, so a reader can check it without running anything
+- formulaLatex (string) — Same formula as LaTeX, rendered on the task page
+- calculationVersion (string) — Version tag for the calculation method
+#### logAgentRun ADMIN agent:run
+- Log an agent's work — what it did, what it cost, what task it advanced.
+- runId (string, required) — Unique run identifier
+- provider (string, required) — AI provider (gemini, anthropic, openai)
+- costUsd (number, required) — Total cost in USD
+- apiCalls (number, required) — Number of API calls
+- taskId (string, required) — Task this run worked on
+- agentId (string) — Stable agent identifier, usually matching the lease agentId
+- outputSummary (string) — What the run produced
+#### acquireLease ADMIN agent:run
+- Acquire a short-lived lease on a task to prevent other agents from working it simultaneously.
+- taskId (string, required) — Task ID to lease
+- agentId (string, required) — Unique agent identifier
+- leaseSeconds (number) — Lease duration in seconds (default 600)
+#### heartbeatLease ADMIN agent:run
+- Extend an active lease. Call periodically to prevent expiry while working.
+- agentId (string, required) — Agent identifier
+- leaseSeconds (number) — New lease duration in seconds (default 600)
+#### releaseLease ADMIN agent:run
+- Voluntarily release a lease so another agent can pick up the task.
+#### createReferendum ADMIN tasks:admin
+- Create a new referendum row. Defaults to DRAFT so a new question does not start accepting votes until intentionally activated.
+- title (string, required) — Human-readable referendum title.
+- slug (string) — Optional URL slug. Defaults to a slugified title.
+- description (string) — Short public summary for cards, lists, and metadata.
+- question (string, required) — Canonical yes/no ballot question voters answer.
+- bodyMarkdown (string) — Full public referendum detail text in Markdown.
+- kind (enum) — Referendum kind. Defaults to GENERAL.
+- status (enum) — Initial status. Defaults to DRAFT.
+- jurisdictionId (string) — Optional jurisdiction ID if this referendum is scoped.
+#### searchRepo ADMIN github
+- Search allowed GitHub repositories through the server-side GitHub API token. Returns matching files and text-match snippets without exposing the token.
+- query (string, required) — Search string, e.g. a function name, symbol, or code fragment.
+- repo (string) — Repository name or owner/repo. Default: the configured Optimitron repo.
+- path (string) — Optional directory path qualifier, e.g. apps/optimitron/src/lib.
+- fileType (string) — Optional file extension without a dot, e.g. ts or tsx.
+- limit (number) — Max GitHub code-search results to return (default 10, max 25).
+#### getFileContent ADMIN github
+- Fetch one allowed GitHub repository file through the server-side GitHub Contents API.
+- repo (string, required) — Repository name or owner/repo.
+- path (string, required) — File path within the repo.
+- ref (string) — Optional branch, tag, or commit SHA. Default: main.
+#### listRepoFiles ADMIN github
+- List files/directories from an allowed GitHub repository directory through the server-side GitHub Contents API.
+- path (string) — Directory path within the repo. Default: repo root.
+#### githubApi ADMIN github
+- Admin-only generic pass-through to api.github.com using the server-side token. Use this for issues, PRs, discussions, commit statuses, workflow runs, agent tasks, etc. — anything the dedicated tools don't already cover. Repo-allowlist is enforced on /repos/<owner>/<repo>/* paths; non-repo paths (/user, /search/code, /octocat) rely on the token's fine-grained scopes for safety. Returns { status, ok, body }.
+- method (enum) — HTTP method. Default: GET.
+- path (string, required) — Path on api.github.com starting with '/', e.g. '/repos/mikepsinn/optimitron/issues' or '/search/code'.
+- query (object) — Optional query-string params, e.g. { per_page: 50, state: 'open' }.
+- body (any) — Optional request body for non-GET requests. Pass an object (auto-JSON.stringify'd) or a raw string.
+#### createTaskTemplate ADMIN tasks:admin
+- Create a reusable task template backed by TaskTrigger. Use this when a task should be stamped out for many people/orgs or fired by an event such as user.signup. Defaults to eventName='manual' and disabled until previewed/enabled.
+- templateKey (string, required) — Stable unique key for this template, e.g. mission:first-hour.
+- eventName (string) — Event that fires this template. Defaults to manual. Use user.signup for everyone-on-signup tasks.
+- idempotencyKeyTemplate (string) — Template producing one stable task-key base per target. Defaults to '<templateKey>:{{target.kind}}:{{target.id}}', or '<templateKey>:user:{{user.id}}' for user.* events.
+- eventFilter (object)
+- completionGate (object)
+- enabled (boolean) — Defaults to false. Preview first, then enable when the template is right.
+- spawnSpecs (array, required) — One spawned task per spec. Use assigneePersonResolver='context.target.id' for person targets, assigneeOrganizationResolver='context.target.id' for organization targets, or resolver='actor' for the calling user.
+- metadata (object)
+#### assignTaskTemplate ADMIN tasks:admin
+- Stamp out a task template for one target. Writes are idempotent through the template's idempotencyKeyTemplate and the spawned taskKey values.
+#### createTaskTrigger ADMIN tasks:admin
+- Create a new TaskTrigger blueprint. The trigger fires on a named event (e.g. 'user.signup', 'referral.sent', 'cron.<name>') and either spawns tasks, verifies a task on a completion gate, or spawns a communication. Templates use {{path.to.field}} substitution against the event context. This is the data-driven way to add new onboarding flows / reminder cadences / task spawners without a code commit. Returns the created trigger row.
+- triggerKey (string, required) — Stable unique key, e.g. 'user-onboarding:treaty'.
+- eventName (string, required) — Event that fires this trigger.
+- triggerKind (enum) — What the trigger does. Defaults to spawnTasks.
+- idempotencyKeyTemplate (string, required) — Template producing a unique key per logical fire, e.g. 'user-onboarding:treaty:{{user.id}}'.
+- eventFilter (object) — Optional JSON filter (equals/matches/and/or/not/exists).
+- completionGate (object) — Optional gate spec (allOf/anyOf/count/always). Add inputScope: 'siblings' to gate against the verify target's siblings instead of its children.
+- jurisdictionId (string) — Optional jurisdiction scope.
+- notes (string) — Free-form notes.
+- enabled (boolean) — Defaults to false for MCP-authored triggers.
+- schedule (string) — Optional cron expression (e.g. '30 * * * *'). When set, /api/cron/run-due-triggers fires this trigger when the schedule is due since its last successful fire. Omit for triggers that fire only on application events (user.signup, referral.sent, etc.).
+- iterationSource (enum) — Optional resolver key for the data the cron handler iterates over before firing. 'overdue-tasks' fires the trigger once per overdue Task; 'none' fires once with no record. Omit for non-cron triggers.
+- spawnSpecs (array) — For triggerKind=spawnTasks: one spec per task to create. At most one isParent=true. Children get taskKey '<idempotencyKey>:<kind>'; parent gets just '<idempotencyKey>'.
+- communicationSpawnSpecs (array) — For triggerKind=spawnCommunication: one spec per outbound message.
+#### updateTaskTrigger ADMIN tasks:admin
+- Update an existing TaskTrigger by triggerKey. Pass only the fields you want to change. spawnSpecs / communicationSpawnSpecs, when supplied, REPLACE the existing specs (delete + recreate).
+- triggerKind (enum)
+- idempotencyKeyTemplate (string)
+- schedule (string) — Cron expression. See createTaskTrigger.
+- iterationSource (enum) — Resolver key. See createTaskTrigger.
+- spawnSpecs (array)
+- communicationSpawnSpecs (array) — Replaces existing communication specs. Each item supports the same fields as in createTaskTrigger, including minSendCount / maxSendCount for escalating-tone variants.
+#### disableTaskTrigger ADMIN tasks:admin
+- Soft-disable a TaskTrigger. Sets enabled=false with an optional reason. Re-enable by calling updateTaskTrigger with enabled:true.
+- disabledReason (string)

--- a/apps/warondisease/app/developers/tools/page.tsx
+++ b/apps/warondisease/app/developers/tools/page.tsx
@@ -1,0 +1,162 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Layout from "@/components/layout";
+import {
+  MCP_ADMIN_TOOL_COUNT,
+  MCP_SCOPES,
+  MCP_TOOLS,
+  groupMcpToolsForDisplay,
+  mcpParameterTypeLabel,
+  type McpCatalogTool,
+} from "@/lib/mcp-catalog";
+import { optimitronUrl } from "@/lib/optimitron-links";
+import { ROUTES } from "@/lib/routes";
+
+export const metadata: Metadata = {
+  title: "MCP Tool Reference",
+  description:
+    "Every tool the Optimitron MCP server exposes, with its required OAuth scope, admin gate, and parameters.",
+};
+
+const toolsJsonUrl = optimitronUrl("/api/mcp/tools");
+
+function requiredParams(tool: McpCatalogTool): Set<string> {
+  return new Set(tool.inputSchema?.required ?? []);
+}
+
+function schemaProperties(tool: McpCatalogTool) {
+  return Object.entries(tool.inputSchema?.properties ?? {});
+}
+
+export default function McpToolReferencePage() {
+  const groups = groupMcpToolsForDisplay();
+
+  return (
+    <Layout>
+      <main className="min-h-screen bg-background px-4 py-10 text-foreground sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-4xl">
+          <p className="mb-3 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            Developers
+          </p>
+          <h1 className="text-3xl font-black uppercase leading-tight sm:text-4xl">
+            MCP Tool Reference
+          </h1>
+          <p className="mt-4 max-w-2xl text-base leading-relaxed text-foreground">
+            Every tool the Optimitron MCP server exposes — {MCP_TOOLS.length}{" "}
+            tools ({MCP_ADMIN_TOOL_COUNT} admin-gated) — generated from the same
+            registry the live server enforces. The live machine-readable version
+            is{" "}
+            <a
+              className="underline underline-offset-4"
+              href={toolsJsonUrl}
+            >
+              optimitron.com/api/mcp/tools
+            </a>
+            ; connection instructions live at{" "}
+            <Link className="underline underline-offset-4" href={ROUTES.mcp}>
+              /mcp
+            </Link>
+            .
+          </p>
+          <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+            Each tool is listed once, under its primary scope; many accept more
+            than one scope, so the badges on a tool name every scope that can
+            call it.
+          </p>
+
+          <section className="mt-8 border-2 border-foreground p-4">
+            <h2 className="text-sm font-black uppercase tracking-[0.16em]">
+              OAuth scopes
+            </h2>
+            <dl className="mt-3 space-y-2">
+              {MCP_SCOPES.map((scope) => (
+                <div className="text-sm leading-relaxed" key={scope.wire}>
+                  <dt className="inline font-mono font-bold">{scope.wire}</dt>
+                  <dd className="inline text-muted-foreground">
+                    {" "}
+                    — {scope.description}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          {groups.map((group) => (
+            <section className="mt-10" key={group.label}>
+              <h2 className="border-b-2 border-foreground pb-2 text-xl font-black uppercase leading-tight">
+                {group.label}{" "}
+                <span className="text-sm font-bold text-muted-foreground">
+                  ({group.tools.length})
+                </span>
+              </h2>
+              <div className="mt-4 space-y-6">
+                {group.tools.map((tool) => {
+                  const required = requiredParams(tool);
+                  const properties = schemaProperties(tool);
+                  return (
+                    <article
+                      className="border border-foreground p-4"
+                      id={tool.name}
+                      key={tool.name}
+                    >
+                      {/* Tool names are single unbreakable identifiers, some
+                          longer than a phone viewport, so they must be allowed
+                          to break rather than widen the page. */}
+                      <h3 className="break-words font-mono text-base font-black">
+                        {tool.name}
+                        {tool.adminOnly ? (
+                          <span className="ml-2 border border-foreground px-1.5 py-0.5 text-[10px] font-black uppercase">
+                            admin
+                          </span>
+                        ) : null}
+                        {tool.requiredScopes.length > 0 ? (
+                          <span className="ml-2 text-xs font-bold text-muted-foreground">
+                            {tool.requiredScopes.join(" or ")}
+                          </span>
+                        ) : null}
+                      </h3>
+                      <p className="mt-2 whitespace-pre-line text-sm leading-relaxed text-foreground">
+                        {tool.description}
+                      </p>
+                      {properties.length > 0 ? (
+                        <details className="mt-3">
+                          <summary className="cursor-pointer text-xs font-black uppercase tracking-[0.14em]">
+                            Parameters ({properties.length})
+                          </summary>
+                          <ul className="mt-2 space-y-1.5">
+                            {properties.map(([name, property]) => (
+                              <li
+                                className="break-words text-sm leading-snug"
+                                key={name}
+                              >
+                                <span className="font-mono font-bold">
+                                  {name}
+                                </span>
+                                <span className="text-muted-foreground">
+                                  {" "}
+                                  ({mcpParameterTypeLabel(property)}
+                                  {required.has(name) ? ", required" : ""})
+                                  {property.description
+                                    ? ` — ${property.description}`
+                                    : ""}
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                        </details>
+                      ) : (
+                        <p className="mt-2 text-xs font-bold uppercase text-muted-foreground">
+                          No parameters
+                        </p>
+                      )}
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/apps/warondisease/app/mcp/page.logged-out.md
+++ b/apps/warondisease/app/mcp/page.logged-out.md
@@ -1,0 +1,111 @@
+# /mcp
+
+## Metadata
+
+- Page title: Optimitron MCP
+- Meta description: Connect Claude, ChatGPT, or another MCP client to the live Optimitron task graph so an agent can pick work, read the evidence, and coordinate through task comments.
+- Canonical: https://warondisease.org
+- Open Graph title: The International Campaign to End War and Disease
+- Open Graph description: Click a glowing rectangle. 15 seconds. 2.6 lives saved + 53 years of suffering prevented.
+- Open Graph image: https://warondisease.org/assets/warondisease/war-on-disease-og-1200x630.png
+- Twitter title: The International Campaign to End War and Disease
+- Twitter description: Click a glowing rectangle. 15 seconds. 2.6 lives saved + 53 years of suffering prevented.
+
+## Visible Page Copy
+
+- OPTIMITRON MCP
+## GIVE YOUR AI THE LIVE TASK GRAPH.
+- Connect Claude, ChatGPT, or another MCP client to Optimitron so the agent can choose useful work, read the evidence, coordinate through task comments, and stop hallucinating from old chat history.
+- MCP SERVER URL
+- COPY
+
+```text
+https://optimitron.com/api/mcp
+```
+
+- [INSTALL MCP](#install)
+- [SEE TOOLS](#tools)
+- CLAUDE CODE
+### ONE COMMAND, THEN /MCP.
+- Use this when the agent is working in a repo and needs the live queue, manual, task comments, and coordination tools.
+
+```text
+claude mcp add --transport http optimitron https://optimitron.com/api/mcp
+```
+
+- 1 RUN THE COMMAND Paste it in the terminal where Claude Code is installed.
+- 2 OPEN /MCP Inside Claude Code, run /mcp and follow the browser sign-in flow.
+- 3 AUTHORIZE OPTIMITRON Approve the requested scopes. The connector uses OAuth and PKCE; no client secret goes in your config.
+- CLAUDE
+### ADD A CUSTOM CONNECTOR.
+- Use this for Claude on the web, desktop, mobile, Cowork, Team, or Enterprise.
+- 1 OPEN CONNECTORS Go to Customize > Connectors, then add a custom connector.
+- 2 PASTE THE URL Name it Optimitron and use the MCP Server URL above.
+- 3 CONNECT Sign in and authorize the connector. Claude should discover the OAuth endpoints automatically.
+- CHATGPT
+### CREATE A CUSTOM MCP APP.
+- Use this when your ChatGPT plan and workspace settings allow custom MCP apps.
+- 1 ENABLE DEVELOPER MODE Workspace admins enable Developer mode / Create custom MCP connectors under workspace permissions.
+- 2 ADD AN MCP APP Open Apps & Connectors, create a custom connector/app, choose OAuth, and paste the MCP Server URL.
+- 3 AUTHORIZE Sign in to Optimitron. Use regular chat or agent mode; some deep research surfaces only show search/fetch tools.
+- OTHER MCP CLIENTS
+### PASTE THE JSON IF YOUR CLIENT WANTS CONFIG.
+- Cursor, Windsurf, Cline, Zed, and similar clients usually want a small MCP server block.
+
+```text
+{
+  "mcpServers": {
+    "optimitron": {
+      "url": "https://optimitron.com/api/mcp"
+    }
+  }
+}
+```
+
+- 1 FIND YOUR MCP CONFIG Use your client's MCP settings or config file.
+- 2 PASTE THE BLOCK If your client asks for transport, choose Streamable HTTP or HTTP.
+- 3 COMPLETE OAUTH Open the authorization URL your client gives you and approve the scopes.
+- WHAT AGENTS GET
+### LESS GUESSING. MORE USEFUL WORK.
+#### PICK WORK
+- Audit the queue, compare expected value, and ask for the next useful action.
+#### READ THE EVIDENCE
+- Search the manual, inspect task details, and fetch page text before proposing changes.
+#### COORDINATE AGENTS
+- Claim work, leave task comments, heartbeat leases, and close the loop when work is done.
+#### IMPROVE THE QUEUE
+- Draft task bundles, add dependencies, and attach impact estimates for human review.
+- [FULL TOOL REFERENCE](/developers/tools)
+- REFERENCE
+### ENDPOINT AND DISCOVERY.
+#### MCP ENDPOINT
+
+```text
+POST https://optimitron.com/api/mcp
+```
+
+#### TOOL CATALOG
+
+```text
+GET https://optimitron.com/api/mcp/tools
+```
+
+#### OAUTH METADATA
+
+```text
+GET https://optimitron.com/.well-known/oauth-authorization-server
+```
+
+- PERMISSIONS
+### SCOPES ARE THE LEASH.
+- Manage your private tasks, dependencies, comments, queues, and next-action recommendations
+- Manage private tasks for organizations where you have permission
+- Approve exact outbound-action payloads as an authenticated human
+- Admin-only: create and manage public Optimitron tasks, people, organizations, estimates, and dependencies
+- Create sourced public Earth-data records: memorials, evidence, intervention reports, organization signatories, and correction reports
+- Admin-only: hide, restore, merge, and resolve Earth-data records and reports
+- Admin-only: run coordinated public-task agents with leases and run logs
+- Admin-only: access the configured GitHub repos via the server-side PAT (search code, read files, list directories, generic API passthrough)
+### WANT THE LONG VERSION?
+- The repo doc explains the personal task engine, expected-value fields, task triggers, and local stdio setup.
+- [READ DOCS](https://github.com/mikepsinn/optimitron/blob/main/docs/MCP_SERVER.md)

--- a/apps/warondisease/app/mcp/page.tsx
+++ b/apps/warondisease/app/mcp/page.tsx
@@ -1,0 +1,390 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Layout from "@/components/layout";
+import { CopyableCode } from "@/components/shared/CopyableCode";
+import { MCP_SCOPES } from "@/lib/mcp-catalog";
+import { optimitronUrl } from "@/lib/optimitron-links";
+import { ROUTES } from "@/lib/routes";
+
+export const metadata: Metadata = {
+  title: "Optimitron MCP",
+  description:
+    "Connect Claude, ChatGPT, or another MCP client to the live Optimitron task graph so an agent can pick work, read the evidence, and coordinate through task comments.",
+};
+
+interface InstallStep {
+  body: string;
+  title: string;
+}
+
+interface InstallBlockProps {
+  code?: string;
+  kicker: string;
+  steps: InstallStep[];
+  summary: string;
+  title: string;
+}
+
+// The MCP server, its OAuth endpoints, and the tool catalog are all served by
+// optimitron.com. This page documents them from warondisease.org, so every URL
+// a reader copies has to be absolute.
+const mcpUrl = optimitronUrl("/api/mcp");
+const toolsUrl = optimitronUrl("/api/mcp/tools");
+const oauthMetadataUrl = optimitronUrl(
+  "/.well-known/oauth-authorization-server",
+);
+
+const toolGroups = [
+  {
+    title: "Pick work",
+    body: "Audit the queue, compare expected value, and ask for the next useful action.",
+    tools: ["getQueueAudit", "getNextAction", "getMyQueue"],
+  },
+  {
+    title: "Read the evidence",
+    body: "Search the manual, inspect task details, and fetch page text before proposing changes.",
+    tools: ["searchManual", "askWishonia", "getTask"],
+  },
+  {
+    title: "Coordinate agents",
+    body: "Claim work, leave task comments, heartbeat leases, and close the loop when work is done.",
+    tools: ["acquireLease", "postTaskComment", "completeTaskClaim"],
+  },
+  {
+    title: "Improve the queue",
+    body: "Draft task bundles, add dependencies, and attach impact estimates for human review.",
+    tools: ["proposeTaskBundle", "addDependency", "setTaskImpact"],
+  },
+] as const;
+
+const primaryButtonClassName =
+  "border border-foreground bg-foreground px-4 py-3 text-center text-sm font-black uppercase text-background hover:bg-background hover:text-foreground";
+const secondaryButtonClassName =
+  "border border-foreground bg-background px-4 py-3 text-center text-sm font-black uppercase text-foreground hover:bg-foreground hover:text-background";
+
+function InlineCode({ children }: { children: string }) {
+  return (
+    <code className="border border-foreground bg-background px-1.5 py-0.5 font-mono text-[0.92em] font-black">
+      {children}
+    </code>
+  );
+}
+
+function CodePanel({ code }: { code: string }) {
+  return (
+    <div className="mt-4 min-w-0 border border-foreground bg-background">
+      <CopyableCode code={code} />
+    </div>
+  );
+}
+
+function InstallBlock({
+  code,
+  kicker,
+  steps,
+  summary,
+  title,
+}: InstallBlockProps) {
+  return (
+    <section className="min-w-0 border border-foreground bg-background p-5 sm:p-6">
+      <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {kicker}
+      </p>
+      <h2 className="mt-2 text-2xl font-black uppercase leading-tight">
+        {title}
+      </h2>
+      <p className="mt-3 text-base font-bold leading-7 text-foreground">
+        {summary}
+      </p>
+      {code ? <CodePanel code={code} /> : null}
+      <ol className="mt-5 grid gap-3">
+        {steps.map((step, index) => (
+          <li
+            className="grid grid-cols-[2.25rem_1fr] gap-3 border-t border-foreground/25 pt-3"
+            key={step.title}
+          >
+            <span className="flex h-8 w-8 items-center justify-center border border-foreground text-sm font-black">
+              {index + 1}
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-black uppercase tracking-[0.08em]">
+                {step.title}
+              </span>
+              <span className="mt-1 block whitespace-pre-line text-sm font-bold leading-6 text-muted-foreground">
+                {step.body}
+              </span>
+            </span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function ToolGroupCard({
+  body,
+  title,
+  tools,
+}: {
+  body: string;
+  title: string;
+  tools: readonly string[];
+}) {
+  return (
+    <div className="border border-foreground bg-background p-4">
+      <h3 className="text-sm font-black uppercase tracking-[0.1em]">{title}</h3>
+      <p className="mt-2 text-sm font-bold leading-6 text-muted-foreground">
+        {body}
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {tools.map((tool) => (
+          <InlineCode key={tool}>{tool}</InlineCode>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function McpPage() {
+  const claudeCodeCommand = `claude mcp add --transport http optimitron ${mcpUrl}`;
+  const genericClientJson = JSON.stringify(
+    {
+      mcpServers: {
+        optimitron: {
+          url: mcpUrl,
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+  return (
+    <Layout>
+      <main className="bg-background text-foreground">
+        <section className="border-b border-foreground">
+          <div className="mx-auto max-w-5xl px-4 py-12 sm:px-6 sm:py-16 lg:px-8">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+              Optimitron MCP
+            </p>
+            <div className="mt-4 grid gap-6 lg:grid-cols-[1.1fr_0.9fr] lg:items-end">
+              <div>
+                <h1 className="max-w-3xl text-4xl font-black uppercase leading-none sm:text-6xl">
+                  Give your AI the live task graph.
+                </h1>
+                <p className="mt-5 max-w-2xl text-lg font-bold leading-8 text-muted-foreground">
+                  Connect Claude, ChatGPT, or another MCP client to Optimitron
+                  so the agent can choose useful work, read the evidence,
+                  coordinate through task comments, and stop hallucinating from
+                  old chat history.
+                </p>
+              </div>
+              <div className="min-w-0 border border-foreground bg-background p-4">
+                <p className="text-xs font-black uppercase tracking-[0.16em] text-muted-foreground">
+                  MCP Server URL
+                </p>
+                <CodePanel code={mcpUrl} />
+              </div>
+            </div>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <a className={primaryButtonClassName} href="#install">
+                Install MCP
+              </a>
+              <a className={secondaryButtonClassName} href="#tools">
+                See Tools
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section
+          className="mx-auto grid max-w-5xl gap-5 px-4 py-10 sm:px-6 lg:px-8"
+          id="install"
+        >
+          <InstallBlock
+            kicker="Claude Code"
+            title="One command, then /mcp."
+            summary="Use this when the agent is working in a repo and needs the live queue, manual, task comments, and coordination tools."
+            code={claudeCodeCommand}
+            steps={[
+              {
+                title: "Run the command",
+                body: "Paste it in the terminal where Claude Code is installed.",
+              },
+              {
+                title: "Open /mcp",
+                body: "Inside Claude Code, run /mcp and follow the browser sign-in flow.",
+              },
+              {
+                title: "Authorize Optimitron",
+                body: "Approve the requested scopes. The connector uses OAuth and PKCE; no client secret goes in your config.",
+              },
+            ]}
+          />
+
+          <div className="grid gap-5 lg:grid-cols-2">
+            <InstallBlock
+              kicker="Claude"
+              title="Add a custom connector."
+              summary="Use this for Claude on the web, desktop, mobile, Cowork, Team, or Enterprise."
+              code={mcpUrl}
+              steps={[
+                {
+                  title: "Open connectors",
+                  body: "Go to Customize > Connectors, then add a custom connector.",
+                },
+                {
+                  title: "Paste the URL",
+                  body: "Name it Optimitron and use the MCP Server URL above.",
+                },
+                {
+                  title: "Connect",
+                  body: "Sign in and authorize the connector. Claude should discover the OAuth endpoints automatically.",
+                },
+              ]}
+            />
+
+            <InstallBlock
+              kicker="ChatGPT"
+              title="Create a custom MCP app."
+              summary="Use this when your ChatGPT plan and workspace settings allow custom MCP apps."
+              code={mcpUrl}
+              steps={[
+                {
+                  title: "Enable developer mode",
+                  body: "Workspace admins enable Developer mode / Create custom MCP connectors under workspace permissions.",
+                },
+                {
+                  title: "Add an MCP app",
+                  body: "Open Apps & Connectors, create a custom connector/app, choose OAuth, and paste the MCP Server URL.",
+                },
+                {
+                  title: "Authorize",
+                  body: "Sign in to Optimitron. Use regular chat or agent mode; some deep research surfaces only show search/fetch tools.",
+                },
+              ]}
+            />
+          </div>
+
+          <InstallBlock
+            kicker="Other MCP Clients"
+            title="Paste the JSON if your client wants config."
+            summary="Cursor, Windsurf, Cline, Zed, and similar clients usually want a small MCP server block."
+            code={genericClientJson}
+            steps={[
+              {
+                title: "Find your MCP config",
+                body: "Use your client's MCP settings or config file.",
+              },
+              {
+                title: "Paste the block",
+                body: "If your client asks for transport, choose Streamable HTTP or HTTP.",
+              },
+              {
+                title: "Complete OAuth",
+                body: "Open the authorization URL your client gives you and approve the scopes.",
+              },
+            ]}
+          />
+        </section>
+
+        <section className="border-y border-foreground" id="tools">
+          <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+              What agents get
+            </p>
+            <h2 className="mt-2 text-3xl font-black uppercase">
+              Less guessing. More useful work.
+            </h2>
+            <div className="mt-6 grid gap-4 md:grid-cols-2">
+              {toolGroups.map((group) => (
+                <ToolGroupCard key={group.title} {...group} />
+              ))}
+            </div>
+            <Link
+              className={`${secondaryButtonClassName} mt-6 inline-block`}
+              href={ROUTES.developersTools}
+            >
+              Full Tool Reference
+            </Link>
+          </div>
+        </section>
+
+        <section className="mx-auto grid min-w-0 max-w-5xl gap-8 px-4 py-10 sm:px-6 lg:grid-cols-[1fr_1fr] lg:px-8">
+          <div className="min-w-0">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+              Reference
+            </p>
+            <h2 className="mt-2 text-3xl font-black uppercase">
+              Endpoint and discovery.
+            </h2>
+            <div className="mt-5 space-y-4">
+              <div className="min-w-0 border border-foreground p-4">
+                <h3 className="text-sm font-black uppercase tracking-[0.1em]">
+                  MCP Endpoint
+                </h3>
+                <CodePanel code={`POST ${mcpUrl}`} />
+              </div>
+              <div className="min-w-0 border border-foreground p-4">
+                <h3 className="text-sm font-black uppercase tracking-[0.1em]">
+                  Tool Catalog
+                </h3>
+                <CodePanel code={`GET ${toolsUrl}`} />
+              </div>
+              <div className="min-w-0 border border-foreground p-4">
+                <h3 className="text-sm font-black uppercase tracking-[0.1em]">
+                  OAuth Metadata
+                </h3>
+                <CodePanel code={`GET ${oauthMetadataUrl}`} />
+              </div>
+            </div>
+          </div>
+
+          <div className="min-w-0">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+              Permissions
+            </p>
+            <h2 className="mt-2 text-3xl font-black uppercase">
+              Scopes are the leash.
+            </h2>
+            <div className="mt-5 grid gap-3">
+              {MCP_SCOPES.map((scope) => (
+                <div
+                  className="min-w-0 border border-foreground p-4"
+                  key={scope.wire}
+                >
+                  <InlineCode>{scope.wire}</InlineCode>
+                  <p className="mt-2 text-sm font-bold leading-6 text-muted-foreground">
+                    {scope.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="border-t border-foreground">
+          <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
+            <div className="border border-foreground p-5 sm:flex sm:items-center sm:justify-between sm:gap-6">
+              <div>
+                <h2 className="text-2xl font-black uppercase">
+                  Want the long version?
+                </h2>
+                <p className="mt-2 text-sm font-bold leading-6 text-muted-foreground">
+                  The repo doc explains the personal task engine,
+                  expected-value fields, task triggers, and local stdio setup.
+                </p>
+              </div>
+              <a
+                className={`${secondaryButtonClassName} mt-4 inline-block sm:mt-0 sm:shrink-0`}
+                href="https://github.com/mikepsinn/optimitron/blob/main/docs/MCP_SERVER.md"
+              >
+                Read Docs
+              </a>
+            </div>
+          </div>
+        </section>
+      </main>
+    </Layout>
+  );
+}

--- a/apps/warondisease/app/search/campaign-search.server.ts
+++ b/apps/warondisease/app/search/campaign-search.server.ts
@@ -252,6 +252,33 @@ const CAMPAIGN_PAGES: CampaignPageDocument[] = [
     title: "Contact",
   },
   {
+    description:
+      "Connect Claude, ChatGPT, or another MCP client to the live Optimitron task graph.",
+    emoji: "🔌",
+    href: ROUTES.mcp,
+    keywords: ["mcp", "claude", "chatgpt", "agent", "connector", "ai"],
+    section: "Build on it",
+    title: "Optimitron MCP",
+  },
+  {
+    description:
+      "OAuth, tasks, referrals, votes, people, and organizations for your own app.",
+    emoji: "🛠️",
+    href: ROUTES.developers,
+    keywords: ["developers", "api", "oauth", "openapi", "rest", "integration"],
+    section: "Build on it",
+    title: "Earth Optimization API",
+  },
+  {
+    description:
+      "Every MCP tool the server exposes, with its scope, admin gate, and parameters.",
+    emoji: "📖",
+    href: ROUTES.developersTools,
+    keywords: ["mcp tools", "tool reference", "scopes", "parameters", "api"],
+    section: "Build on it",
+    title: "MCP Tool Reference",
+  },
+  {
     description: "What we collect and what we do not.",
     emoji: "🔒",
     href: ROUTES.privacy,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "build:app-dependencies": "pnpm --filter @optimitron/optimizer run build && pnpm --filter @optimitron/db run build",
     "smoke:apps": "pnpm --dir apps/optimitron exec tsx ../../scripts/smoke-site-apps.mjs",
     "copy": "pnpm --dir apps/optimitron exec tsx ../../scripts/copy-snapshot-sites.ts",
+    "mcp:catalog": "pnpm --dir apps/optimitron exec tsx ../../scripts/generate-mcp-catalog.ts",
     "test:site-app-navigation": "pnpm --dir apps/optimitron exec tsx --test ../../scripts/site-app-navigation.test.ts ../../scripts/lib/copy-preview-dom.test.ts",
     "test:apps:unit": "pnpm --filter \"@apps/*\" run test:unit",
     "test:warondisease:unit": "pnpm --filter @apps/warondisease run test:unit",

--- a/packages/site-kit/src/components/shared/CopyableCode.tsx
+++ b/packages/site-kit/src/components/shared/CopyableCode.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { useState } from "react"
+import { Check, Copy } from "lucide-react"
+import { cn } from "@optimitron/neobrutalist-ui/cn"
+import { copyTextToClipboard } from "../../lib/clipboard"
+
+interface CopyableCodeProps {
+  className?: string
+  /** The exact value a developer is meant to paste somewhere else. */
+  code: string
+}
+
+/**
+ * A code block with a copy button.
+ *
+ * Every value on the developer pages — the MCP server URL, the `claude mcp add`
+ * command, the JSON config block, an endpoint — is something the reader has to
+ * reproduce byte-for-byte in a terminal, a config file, or another site's form.
+ * Selecting a wrapped multi-line value by hand is where the typos come from.
+ */
+export function CopyableCode({ className, code }: CopyableCodeProps) {
+  const [copied, setCopied] = useState(false)
+
+  async function handleCopy() {
+    try {
+      await copyTextToClipboard(code)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard unavailable; the text is still selectable.
+    }
+  }
+
+  return (
+    <div className={cn("min-w-0 max-w-full overflow-hidden", className)}>
+      <div className="flex justify-end border-b border-foreground/30 p-2">
+        <button
+          aria-label={copied ? "Copied to clipboard" : "Copy to clipboard"}
+          className="inline-flex items-center gap-1 border-2 border-foreground bg-background px-2 py-1 text-xs font-black uppercase text-foreground transition-colors hover:bg-foreground hover:text-background"
+          onClick={() => void handleCopy()}
+          type="button"
+        >
+          {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <pre className="max-w-full overflow-x-auto whitespace-pre-wrap break-words p-4 text-sm font-bold">
+        <code>{code}</code>
+      </pre>
+    </div>
+  )
+}

--- a/packages/site-kit/src/components/shared/CopyableCode.tsx
+++ b/packages/site-kit/src/components/shared/CopyableCode.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Check, Copy } from "lucide-react"
 import { cn } from "@optimitron/neobrutalist-ui/cn"
 import { copyTextToClipboard } from "../../lib/clipboard"
@@ -21,12 +21,21 @@ interface CopyableCodeProps {
  */
 export function CopyableCode({ className, code }: CopyableCodeProps) {
   const [copied, setCopied] = useState(false)
+  const resetTimer = useRef<number>()
+
+  // Clearing the pending timer before starting a new one keeps the
+  // confirmation visible for a full two seconds after the *latest* copy.
+  // Without it, copying twice in quick succession lets the first timer clear
+  // the badge while the second copy still looks unacknowledged. The unmount
+  // cleanup stops the same timer from setting state on a gone component.
+  useEffect(() => () => window.clearTimeout(resetTimer.current), [])
 
   async function handleCopy() {
     try {
       await copyTextToClipboard(code)
       setCopied(true)
-      window.setTimeout(() => setCopied(false), 2000)
+      window.clearTimeout(resetTimer.current)
+      resetTimer.current = window.setTimeout(() => setCopied(false), 2000)
     } catch {
       // Clipboard unavailable; the text is still selectable.
     }

--- a/packages/site-kit/src/lib/mcp-catalog.ts
+++ b/packages/site-kit/src/lib/mcp-catalog.ts
@@ -1,0 +1,93 @@
+/**
+ * The Optimitron MCP tool and scope catalog, for the campaign developer pages.
+ *
+ * `catalog.generated.json` is a committed snapshot of what the live MCP server
+ * exposes. Regenerate it with `pnpm mcp:catalog` (see
+ * `scripts/generate-mcp-catalog.ts`) after any change to a tool definition,
+ * description, required scope, or admin gate.
+ *
+ * It is a snapshot rather than a live import because the registry lives inside
+ * `apps/optimitron` next to handlers that use the Prisma client, and a package
+ * may not import an app. The same data is served live at
+ * `https://optimitron.com/api/mcp/tools`.
+ */
+
+import catalog from "./mcp/catalog.generated.json"
+
+export interface McpToolSchemaProperty {
+  description?: string
+  enum?: unknown[]
+  type?: string | string[]
+}
+
+export interface McpToolInputSchema {
+  properties?: Record<string, McpToolSchemaProperty>
+  required?: string[]
+  type?: string
+}
+
+export interface McpCatalogTool {
+  adminOnly: boolean
+  description: string
+  inputSchema: McpToolInputSchema
+  name: string
+  /** OAuth wire-format scopes, any one of which may call the tool. */
+  requiredScopes: string[]
+}
+
+export interface McpCatalogScope {
+  description: string
+  /** OAuth wire format, e.g. `tasks:personal`. */
+  wire: string
+}
+
+export const MCP_TOOLS = catalog.tools as unknown as McpCatalogTool[]
+export const MCP_SCOPES = catalog.scopes as unknown as McpCatalogScope[]
+export const MCP_TRANSPORT = catalog.transport
+export const MCP_ENDPOINT_PATH = catalog.endpoint
+
+export const MCP_ADMIN_TOOL_COUNT = MCP_TOOLS.filter(
+  (tool) => tool.adminOnly,
+).length
+
+const PUBLIC_GROUP_LABEL = "Public (no scope)"
+const ADMIN_GROUP_LABEL = "Admin-only"
+
+/** The label a tool is listed under: admin gate first, then its primary scope. */
+export function mcpToolGroupLabel(tool: McpCatalogTool): string {
+  if (tool.adminOnly) return ADMIN_GROUP_LABEL
+  if (tool.requiredScopes.length === 0) return PUBLIC_GROUP_LABEL
+  return tool.requiredScopes[0]
+}
+
+/**
+ * Tools grouped for display, in a stable order: unscoped tools, then one group
+ * per scope in catalog order, then the admin-gated ones. Groups with no tools
+ * are dropped so the page never prints an empty heading.
+ */
+export function groupMcpToolsForDisplay(): Array<{
+  label: string
+  tools: McpCatalogTool[]
+}> {
+  const groups = new Map<string, McpCatalogTool[]>()
+  for (const tool of MCP_TOOLS) {
+    const label = mcpToolGroupLabel(tool)
+    groups.set(label, [...(groups.get(label) ?? []), tool])
+  }
+  return [
+    PUBLIC_GROUP_LABEL,
+    ...MCP_SCOPES.map((scope) => scope.wire),
+    ADMIN_GROUP_LABEL,
+  ]
+    .filter((label) => groups.has(label))
+    .map((label) => ({ label, tools: groups.get(label)! }))
+}
+
+/** `string`, `number`, `enum`, or a union — whatever the schema declares. */
+export function mcpParameterTypeLabel(
+  property: McpToolSchemaProperty,
+): string {
+  if (property.enum) return "enum"
+  if (Array.isArray(property.type)) return property.type.join(" | ")
+  return property.type ?? "any"
+}

--- a/packages/site-kit/src/lib/mcp/catalog.generated.json
+++ b/packages/site-kit/src/lib/mcp/catalog.generated.json
@@ -1,0 +1,9866 @@
+{
+  "endpoint": "/api/mcp",
+  "scopes": [
+    {
+      "description": "Manage your private tasks, dependencies, comments, queues, and next-action recommendations",
+      "wire": "tasks:personal"
+    },
+    {
+      "description": "Manage private tasks for organizations where you have permission",
+      "wire": "tasks:organization"
+    },
+    {
+      "description": "Approve exact outbound-action payloads as an authenticated human",
+      "wire": "actions:approve"
+    },
+    {
+      "description": "Admin-only: create and manage public Optimitron tasks, people, organizations, estimates, and dependencies",
+      "wire": "tasks:admin"
+    },
+    {
+      "description": "Create sourced public Earth-data records: memorials, evidence, intervention reports, organization signatories, and correction reports",
+      "wire": "earthdata:write"
+    },
+    {
+      "description": "Admin-only: hide, restore, merge, and resolve Earth-data records and reports",
+      "wire": "earthdata:admin"
+    },
+    {
+      "description": "Admin-only: run coordinated public-task agents with leases and run logs",
+      "wire": "agent:run"
+    },
+    {
+      "description": "Admin-only: access the configured GitHub repos via the server-side PAT (search code, read files, list directories, generic API passthrough)",
+      "wire": "github"
+    }
+  ],
+  "tools": [
+    {
+      "adminOnly": false,
+      "description": "Cast or update the authenticated user's own referendum vote.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "answer": {
+            "type": "string",
+            "enum": [
+              "YES",
+              "NO",
+              "ABSTAIN"
+            ]
+          },
+          "publicComment": {
+            "type": "string"
+          },
+          "referendumSlug": {
+            "type": "string"
+          }
+        }
+      },
+      "name": "castReferendumVote",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Record a represented or memorial referendum vote for an existing Person.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "answer": {
+            "type": "string",
+            "enum": [
+              "YES",
+              "NO",
+              "ABSTAIN"
+            ]
+          },
+          "isPublic": {
+            "type": "boolean"
+          },
+          "personId": {
+            "type": "string"
+          },
+          "publicComment": {
+            "type": "string"
+          },
+          "referendumSlug": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "personId"
+        ]
+      },
+      "name": "recordRepresentedReferendumVote",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Search public Person records by name, handle, affiliation, or source key.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "publicOnly": {
+            "type": "boolean"
+          }
+        }
+      },
+      "name": "searchPeople",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Fetch one Person by id or handle, including public memorial/vote context.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "idOrHandle": {
+            "type": "string"
+          },
+          "personId": {
+            "type": "string"
+          },
+          "publicOnly": {
+            "type": "boolean",
+            "description": "Admin-only escape hatch. Non-admin callers always receive public data."
+          }
+        }
+      },
+      "name": "getPerson",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Search organization records by name, slug, website, or source key.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number"
+          }
+        }
+      },
+      "name": "searchOrganizations",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Sign a referendum as an organization, auto-active under post-moderation.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string"
+          },
+          "newOrganizationName": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "website": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "donationUrl": {
+            "type": "string"
+          },
+          "squareLogoUrl": {
+            "type": "string",
+            "description": "Square logo mark URL. Use uploadImageFromUrl with kind=organization-square-logo first when starting from a remote public image URL."
+          },
+          "wordmarkLogoUrl": {
+            "type": "string",
+            "description": "Horizontal wordmark logo URL. Use uploadImageFromUrl with kind=organization-wordmark-logo first when starting from a remote public image URL."
+          },
+          "contactEmail": {
+            "type": "string"
+          },
+          "referendumSlug": {
+            "type": "string"
+          },
+          "position": {
+            "type": "string",
+            "enum": [
+              "YES",
+              "NO",
+              "ABSTAIN"
+            ]
+          },
+          "statement": {
+            "type": "string"
+          }
+        }
+      },
+      "name": "signReferendumAsOrganization",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create or update a memorial/represented Person, optional condition, memorial, evidence, responsible party, relationship, and YES referendum vote. Agent imports require sourceKey/sourceRef plus sourceUrl or sourceArtifactId.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "lifeStatus": {
+            "type": "string",
+            "enum": [
+              "UNKNOWN",
+              "LIVING",
+              "DECEASED"
+            ]
+          },
+          "birthDate": {
+            "type": "string"
+          },
+          "dateOfDeath": {
+            "type": "string"
+          },
+          "deathCountryCode": {
+            "type": "string"
+          },
+          "conditionName": {
+            "type": "string"
+          },
+          "conditionCodeSystem": {
+            "type": "string"
+          },
+          "conditionCode": {
+            "type": "string"
+          },
+          "causeCategory": {
+            "type": "string"
+          },
+          "conflictId": {
+            "type": "string"
+          },
+          "conflictName": {
+            "type": "string"
+          },
+          "responsiblePartyName": {
+            "type": "string"
+          },
+          "relationshipType": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "memorialMessage": {
+            "type": "string"
+          },
+          "publicComment": {
+            "type": "string"
+          },
+          "isPublic": {
+            "type": "boolean"
+          },
+          "consentCourtEvidence": {
+            "type": "boolean"
+          },
+          "recordTreatyVote": {
+            "type": "boolean"
+          },
+          "referendumSlug": {
+            "type": "string"
+          },
+          "sourceKind": {
+            "type": "string",
+            "enum": [
+              "PERSONAL_TESTIMONY",
+              "PUBLIC_IMPORT"
+            ]
+          },
+          "sourceKey": {
+            "type": "string"
+          },
+          "sourceRef": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "sourceArtifactId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "displayName"
+        ]
+      },
+      "name": "upsertMemorialPerson",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Attach public non-sensitive sourced evidence to a memorial. Requires sourceUrl or sourceArtifactId.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "memorialId": {
+            "type": "string"
+          },
+          "evidenceKind": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "sourceArtifactId": {
+            "type": "string"
+          },
+          "sourceKey": {
+            "type": "string"
+          },
+          "isPublic": {
+            "type": "boolean",
+            "description": "Must be true; private evidence is not accepted."
+          },
+          "containsSensitiveData": {
+            "type": "boolean",
+            "description": "Must be false; do not submit sensitive evidence."
+          }
+        },
+        "required": [
+          "memorialId"
+        ]
+      },
+      "name": "addMemorialEvidence",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Attach a government, organization, or free-text responsible party to a memorial.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "memorialId": {
+            "type": "string"
+          },
+          "jurisdictionId": {
+            "type": "string"
+          },
+          "organizationId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "roleSlug": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "sourceArtifactId": {
+            "type": "string"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          },
+          "isPublic": {
+            "type": "boolean"
+          },
+          "confidenceScore": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "memorialId"
+        ]
+      },
+      "name": "addMemorialResponsibleParty",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create or update a named conflict reference by slug/name/source key.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "primaryJurisdictionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "name": "upsertConflict",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Find or create a canonical condition, intervention, side-effect, outcome, or policy GlobalVariable, with optional external code.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "condition",
+              "intervention",
+              "outcome",
+              "side_effect",
+              "policy",
+              "other"
+            ]
+          },
+          "codeSystem": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "sourceArtifactId": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "variableCategoryName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "name": "resolveGlobalVariable",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Store source/provenance data without executing it. For Python, notebooks, or other calculation code, use artifactType CALCULATION_SOURCE and payloadJson with language and source; Optimitron marks it inert, computes its content hash, and rejects mutation under the same sourceKey.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "sourceKey": {
+            "type": "string"
+          },
+          "sourceSystem": {
+            "type": "string"
+          },
+          "artifactType": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "sourceRef": {
+            "type": "string"
+          },
+          "externalKey": {
+            "type": "string"
+          },
+          "versionKey": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "contentHash": {
+            "type": "string"
+          },
+          "payloadJson": {
+            "type": "object",
+            "description": "For calculation code: { language, source, runtime?, dependencies?, entrypoint?, inputs?, outputs?, notes? }. Code is retained as inert data and is never run by this tool or by the web application."
+          }
+        },
+        "required": [
+          "sourceKey"
+        ]
+      },
+      "name": "upsertSourceArtifact",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create or update a Court of Humanity case root record.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "OPEN",
+              "VOTING",
+              "JUDGED",
+              "ARCHIVED"
+            ]
+          },
+          "isPublic": {
+            "type": "boolean"
+          },
+          "nominalPlaintiffSubjectId": {
+            "type": "string"
+          },
+          "primaryRespondentSubjectId": {
+            "type": "string"
+          },
+          "beneficiarySubjectId": {
+            "type": "string"
+          },
+          "rootTaskId": {
+            "type": "string"
+          },
+          "juryReferendumId": {
+            "type": "string"
+          },
+          "metadataJson": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      },
+      "name": "upsertCourtCase",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Attach a plaintiff, respondent, class, beneficiary, or amicus Subject to a Court of Humanity case.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "caseId": {
+            "type": "string"
+          },
+          "partyKey": {
+            "type": "string"
+          },
+          "subjectId": {
+            "type": "string"
+          },
+          "subjectExternalId": {
+            "type": "string"
+          },
+          "subjectDisplayName": {
+            "type": "string"
+          },
+          "subjectType": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "NOMINAL_PLAINTIFF",
+              "NAMED_PLAINTIFF",
+              "REPRESENTATIVE_CLASS",
+              "RESPONDENT",
+              "AMICUS",
+              "BENEFICIARY"
+            ]
+          },
+          "capacity": {
+            "type": "string",
+            "enum": [
+              "INSTITUTIONAL",
+              "OFFICIAL_CAPACITY",
+              "PERSONAL_CAPACITY",
+              "OVERSIGHT_CAPACITY",
+              "CLASS_REPRESENTATIVE"
+            ]
+          },
+          "displayNameSnapshot": {
+            "type": "string"
+          },
+          "standingTheory": {
+            "type": "string"
+          },
+          "powerToRemedyScore": {
+            "type": "number"
+          },
+          "blameAttributionScore": {
+            "type": "number"
+          },
+          "publicAccountabilityScore": {
+            "type": "number"
+          },
+          "sortOrder": {
+            "type": "number"
+          },
+          "isPublic": {
+            "type": "boolean"
+          },
+          "metadataJson": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "caseId",
+          "role"
+        ]
+      },
+      "name": "addCourtCaseParty",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Add a structured allegation or requested finding to a Court of Humanity case.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "caseId": {
+            "type": "string"
+          },
+          "claimKey": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "claimType": {
+            "type": "string"
+          },
+          "argumentMarkdown": {
+            "type": "string"
+          },
+          "requestedFinding": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PROPOSED",
+              "ACCEPTED",
+              "REJECTED",
+              "SUPERSEDED"
+            ]
+          },
+          "juryReferendumId": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "number"
+          },
+          "isPublic": {
+            "type": "boolean"
+          },
+          "metadataJson": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "caseId",
+          "title",
+          "argumentMarkdown"
+        ]
+      },
+      "name": "addCourtCaseClaim",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Add a quantified or qualitative harm catalog row to a Court of Humanity case.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "caseId": {
+            "type": "string"
+          },
+          "claimId": {
+            "type": "string"
+          },
+          "harmKey": {
+            "type": "string"
+          },
+          "harmType": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "bodyMarkdown": {
+            "type": "string"
+          },
+          "affectedSubjectId": {
+            "type": "string"
+          },
+          "globalVariableId": {
+            "type": "string"
+          },
+          "parameterName": {
+            "type": "string"
+          },
+          "lowValue": {
+            "type": "number"
+          },
+          "baseValue": {
+            "type": "number"
+          },
+          "highValue": {
+            "type": "number"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "confidenceScore": {
+            "type": "number"
+          },
+          "sortOrder": {
+            "type": "number"
+          },
+          "isPublic": {
+            "type": "boolean"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PROPOSED",
+              "ACCEPTED",
+              "REJECTED",
+              "SUPERSEDED"
+            ]
+          },
+          "metadataJson": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "caseId",
+          "title"
+        ]
+      },
+      "name": "addCourtCaseHarm",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Attach public non-sensitive evidence to a Court of Humanity case, claim, or harm.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "caseId": {
+            "type": "string"
+          },
+          "claimId": {
+            "type": "string"
+          },
+          "harmId": {
+            "type": "string"
+          },
+          "evidenceKey": {
+            "type": "string"
+          },
+          "evidenceType": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "bodyMarkdown": {
+            "type": "string"
+          },
+          "sourceArtifactId": {
+            "type": "string"
+          },
+          "personMemorialId": {
+            "type": "string"
+          },
+          "globalVariableId": {
+            "type": "string"
+          },
+          "parameterName": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "contentHash": {
+            "type": "string"
+          },
+          "isPublic": {
+            "type": "boolean",
+            "description": "Must be true; private evidence is not accepted."
+          },
+          "containsSensitiveData": {
+            "type": "boolean",
+            "description": "Must be false; sensitive evidence is not accepted."
+          },
+          "reviewStatus": {
+            "type": "string",
+            "enum": [
+              "PROPOSED",
+              "ACCEPTED",
+              "REJECTED",
+              "SUPERSEDED"
+            ]
+          },
+          "confidenceScore": {
+            "type": "number"
+          },
+          "sortOrder": {
+            "type": "number"
+          },
+          "metadataJson": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "caseId",
+          "title"
+        ]
+      },
+      "name": "addCourtCaseEvidence",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Add a requested remedy that can point at an existing enforcement Task.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "caseId": {
+            "type": "string"
+          },
+          "claimId": {
+            "type": "string"
+          },
+          "targetPartyId": {
+            "type": "string"
+          },
+          "remedyKey": {
+            "type": "string"
+          },
+          "remedyType": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "bodyMarkdown": {
+            "type": "string"
+          },
+          "amountUsdLow": {
+            "type": "number"
+          },
+          "amountUsdBase": {
+            "type": "number"
+          },
+          "amountUsdHigh": {
+            "type": "number"
+          },
+          "deadlineAt": {
+            "type": "string"
+          },
+          "enforcementTaskId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PROPOSED",
+              "ACCEPTED",
+              "REJECTED",
+              "SUPERSEDED"
+            ]
+          },
+          "sortOrder": {
+            "type": "number"
+          },
+          "isPublic": {
+            "type": "boolean"
+          },
+          "metadataJson": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "caseId",
+          "title",
+          "bodyMarkdown"
+        ]
+      },
+      "name": "addCourtCaseRemedy",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Fetch a Court of Humanity case with parties, claims, harms, evidence, remedies, and jury referendum.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "caseIdOrSlug": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          }
+        }
+      },
+      "name": "getCourtCase",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Open or update the public referendum used as a Court of Humanity jury vote.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "caseIdOrSlug": {
+            "type": "string"
+          },
+          "claimId": {
+            "type": "string"
+          },
+          "questionKey": {
+            "type": "string"
+          },
+          "questionTitle": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "caseIdOrSlug"
+        ]
+      },
+      "name": "openCourtCaseJuryVote",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create or update a regulatory first-evidence/approval timeline for an intervention and condition.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "interventionName": {
+            "type": "string"
+          },
+          "conditionName": {
+            "type": "string"
+          },
+          "interventionGlobalVariableId": {
+            "type": "string"
+          },
+          "conditionGlobalVariableId": {
+            "type": "string"
+          },
+          "brandName": {
+            "type": "string"
+          },
+          "regulatorName": {
+            "type": "string"
+          },
+          "jurisdictionId": {
+            "type": "string"
+          },
+          "firstEvidenceDate": {
+            "type": "string"
+          },
+          "approvalDate": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "sourceKey": {
+            "type": "string"
+          },
+          "sourceArtifactId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "interventionName",
+          "conditionName"
+        ]
+      },
+      "name": "upsertInterventionApprovalTimeline",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Import or update evidence for predictor GlobalVariable -> outcome GlobalVariable effects.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "predictorGlobalVariableId": {
+            "type": "string"
+          },
+          "outcomeGlobalVariableId": {
+            "type": "string"
+          },
+          "contextGlobalVariableId": {
+            "type": "string"
+          },
+          "metricKind": {
+            "type": "string"
+          },
+          "sourceType": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          },
+          "unitId": {
+            "type": "string"
+          },
+          "confidenceScore": {
+            "type": "number"
+          },
+          "participants": {
+            "type": "number"
+          },
+          "studies": {
+            "type": "number"
+          },
+          "rationale": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "sourceArtifactId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "predictorGlobalVariableId",
+          "outcomeGlobalVariableId"
+        ]
+      },
+      "name": "upsertVariableRelationshipEvidenceEstimate",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Record a user's intervention experience with optional outcomes and side effects.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "subjectId": {
+            "type": "string"
+          },
+          "conditionGlobalVariableId": {
+            "type": "string"
+          },
+          "interventionGlobalVariableId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "startedAt": {
+            "type": "string"
+          },
+          "endedAt": {
+            "type": "string"
+          },
+          "doseValue": {
+            "type": "number"
+          },
+          "doseUnitId": {
+            "type": "string"
+          },
+          "frequencyText": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "sourceArtifactId": {
+            "type": "string"
+          },
+          "isPublic": {
+            "type": "boolean"
+          },
+          "outcomes": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "sideEffects": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "required": [
+          "interventionGlobalVariableId"
+        ]
+      },
+      "name": "recordInterventionExperience",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Match memorial deaths to approval timelines and create efficacy-lag evidence candidates.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number"
+          }
+        }
+      },
+      "name": "runEfficacyLagMatcher",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Report wrong, duplicate, spam, impersonation, abusive, or unsourced public data for post-moderation review.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "targetType": {
+            "type": "string"
+          },
+          "targetId": {
+            "type": "string"
+          },
+          "reasonType": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "correctionJson": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "targetType",
+          "targetId",
+          "reasonType"
+        ]
+      },
+      "name": "reportContent",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Suggest structured replacement fields for an existing public data record.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "targetType": {
+            "type": "string"
+          },
+          "targetId": {
+            "type": "string"
+          },
+          "reasonType": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "correctionJson": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "targetType",
+          "targetId",
+          "correctionJson"
+        ]
+      },
+      "name": "suggestCorrection",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: hide or soft-delete a supported public Earth-data record.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "targetType": {
+            "type": "string"
+          },
+          "targetId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "targetType",
+          "targetId"
+        ]
+      },
+      "name": "hideContent",
+      "requiredScopes": [
+        "earthdata:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: restore a hidden supported Earth-data record.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "targetType": {
+            "type": "string"
+          },
+          "targetId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "targetType",
+          "targetId"
+        ]
+      },
+      "name": "restoreContent",
+      "requiredScopes": [
+        "earthdata:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: mark a content report as resolved or dismissed.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "OPEN",
+              "RESOLVED",
+              "DISMISSED"
+            ]
+          },
+          "resolutionNote": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "name": "resolveContentReport",
+      "requiredScopes": [
+        "earthdata:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Record a personal dFDA/N-of-1 measurement such as a medication dose, food, symptom, mood, sleep, activity, lab, or vital sign. Use variableName plus category/unit for new variables, or globalVariableId for an existing variable.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "globalVariableId": {
+            "type": "string"
+          },
+          "variableName": {
+            "type": "string"
+          },
+          "categoryName": {
+            "type": "string",
+            "description": "Required when variableName does not already exist. Examples: Treatment, Food, Drink, Nutrient, Symptom, Emotion, Sleep, Activity, Vital Sign, or Biomarker."
+          },
+          "value": {
+            "type": "number"
+          },
+          "unitId": {
+            "type": "string"
+          },
+          "unitAbbreviation": {
+            "type": "string",
+            "description": "Short unit such as mg, IU, servings, count, or 1-5. serving and {serving} are accepted aliases for servings."
+          },
+          "unitName": {
+            "type": "string",
+            "description": "Full unit name; matched case-insensitively."
+          },
+          "startTime": {
+            "type": "string",
+            "description": "ISO date/time."
+          },
+          "duration": {
+            "type": "number",
+            "description": "Duration in seconds."
+          },
+          "note": {
+            "type": "string"
+          },
+          "sourceName": {
+            "type": "string"
+          },
+          "combinationOperation": {
+            "type": "string",
+            "enum": [
+              "SUM",
+              "MEAN"
+            ]
+          },
+          "fillingType": {
+            "type": "string",
+            "enum": [
+              "ZERO",
+              "NONE",
+              "INTERPOLATION",
+              "VALUE"
+            ]
+          },
+          "latitude": {
+            "type": "number"
+          },
+          "longitude": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "value"
+        ]
+      },
+      "name": "recordMeasurement",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List the authenticated user's own recorded measurements, newest first. Covers everything logged through recordMeasurement or a tracking-reminder response. Filter by globalVariableId or variableName for one variable, or omit both to see every variable. Use this to review logged doses, foods, symptoms, moods, sleep, activity, labs, and vitals, or to check whether a reminder was actually answered. Each row carries startTime (UTC) and startTimeLocal (the user's zone): report times to the user from startTimeLocal.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "globalVariableId": {
+            "type": "string"
+          },
+          "variableName": {
+            "type": "string",
+            "description": "Variable name, matched case-insensitively. An unknown variable is an error, not an empty result."
+          },
+          "startTimeAfter": {
+            "type": "string",
+            "description": "ISO date/time. Only measurements at or after this time."
+          },
+          "startTimeBefore": {
+            "type": "string",
+            "description": "ISO date/time. Only measurements at or before this time."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Page size. Default 100, maximum 500."
+          },
+          "cursor": {
+            "type": "string",
+            "description": "nextCursor from the previous page. Repeat the same filters until nextCursor is null."
+          }
+        }
+      },
+      "name": "listMeasurements",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Correct one of the authenticated user's measurements by ID. Use listMeasurements to get the ID. Pass value in the normalized unit. If the measurement was converted between units, also pass originalValue in its original unit. Units and variable identity stay unchanged. Optional metadata fields patch the existing row. The tool rejects measurements owned by another user and refreshes cached summaries.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "measurementId": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          },
+          "originalValue": {
+            "type": "number",
+            "description": "Corrected value in the existing original unit. Required when originalUnitId differs from unitId; otherwise defaults to value."
+          },
+          "duration": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Duration in seconds. Null clears it."
+          },
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sourceName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "longitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "measurementId",
+          "value"
+        ]
+      },
+      "name": "updateMeasurement",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Soft-delete one of the authenticated user's measurements by ID. Use listMeasurements to get the ID. The tool rejects measurements owned by another user and refreshes cached summaries.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "measurementId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "measurementId"
+        ]
+      },
+      "name": "deleteMeasurement",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create or edit a personal tracking reminder for medications, food, symptoms, mood, sleep, activity, labs, or vitals. When creating a new variable, pass categoryName; Food defaults to servings. To edit a reminder in place, pass trackingReminderId plus only the fields to change. Omit trackingReminderId to create or idempotently update the reminder identified by variable, start time, and frequency. Unit fields set your personal recording unit for the variable; the canonical variable default is unchanged. The response's top-level unit is the unit answers record in. The reminder can later be answered as TRACKED (value 0 for a not-taken day) or SNOOZED.",
+      "inputSchema": {
+        "type": "object",
+        "anyOf": [
+          {
+            "required": [
+              "trackingReminderId"
+            ]
+          },
+          {
+            "required": [
+              "reminderStartTime"
+            ]
+          }
+        ],
+        "properties": {
+          "trackingReminderId": {
+            "type": "string",
+            "description": "Existing reminder ID to edit in place. Patchable: active, defaultValue, instructions, reminderStartTime, reminderEndTime, reminderFrequency, startTrackingDate, stopTrackingDate, unit fields, and fillingType. Fixed at creation: the tracked variable (variableName, globalVariableId, categoryName, combinationOperation) — to change it, create a new reminder and set active: false on this one."
+          },
+          "globalVariableId": {
+            "type": "string"
+          },
+          "variableName": {
+            "type": "string"
+          },
+          "categoryName": {
+            "type": "string",
+            "description": "Required when variableName does not already exist. Examples: Treatment, Food, Drink, Nutrient, Symptom, Emotion, Sleep, Activity, Vital Sign, or Biomarker."
+          },
+          "defaultValue": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Pre-filled value, such as a normal medication dose or symptom rating. Pass null to clear it when editing."
+          },
+          "unitId": {
+            "type": "string"
+          },
+          "unitAbbreviation": {
+            "type": "string",
+            "description": "Short unit such as mg, IU, servings, count, or 1-5. serving and {serving} are accepted aliases for servings. Sets your personal recording unit for this variable, on create or on edit."
+          },
+          "unitName": {
+            "type": "string",
+            "description": "Full unit name; matched case-insensitively."
+          },
+          "reminderStartTime": {
+            "type": "string",
+            "description": "Local wall-clock time in HH:mm, for example 08:00."
+          },
+          "reminderEndTime": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional local end/quiet time in HH:mm. Pass null to clear it when editing."
+          },
+          "reminderFrequency": {
+            "type": "number",
+            "description": "Seconds between reminders. Default 86400."
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "instructions": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "startTrackingDate": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO date/time, or null to clear it when editing."
+          },
+          "stopTrackingDate": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO date/time, or null to clear it when editing."
+          },
+          "combinationOperation": {
+            "type": "string",
+            "enum": [
+              "SUM",
+              "MEAN"
+            ]
+          },
+          "fillingType": {
+            "type": "string",
+            "enum": [
+              "ZERO",
+              "NONE",
+              "INTERPOLATION",
+              "VALUE"
+            ]
+          }
+        }
+      },
+      "name": "upsertTrackingReminder",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List the authenticated user's personal tracking reminders, active by default. Returns a compact shape by default: id, name, schedule, defaultValue, recording unit, fillingType, and an instructions preview. Pass compact: false for full records. Use getTrackingReminder for one reminder with full instructions.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "includeInactive": {
+            "type": "boolean"
+          },
+          "compact": {
+            "type": "boolean",
+            "description": "Defaults to true. Pass false for full records with expanded variable and unit objects and untruncated instructions."
+          }
+        }
+      },
+      "name": "listTrackingReminders",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Get one of the authenticated user's tracking reminders in full, including untruncated instructions, the expanded variable, and the effective recording unit. Use listTrackingReminders to find the ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "trackingReminderId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "trackingReminderId"
+        ]
+      },
+      "name": "getTrackingReminder",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List the authenticated user's tracking notification queue for one local day or an inclusive local-date range. A reminder defines a schedule; a notification is one occurrence. Filter by trackingReminderId or effective status, including OVERDUE. The default compact shape carries id (the trackingReminderId to answer with), name, due (local time), status, defaultValue, unit, and fillingType, so an agent can answer without a second lookup. An OVERDUE item with sameDayMeasurementCount already has same-day data for its variable recorded outside this notification: verify with listMeasurements before answering again, or you may duplicate data. Pass compact: false for full records with scheduledAt, effective notifyAt, and snoozedUntil. Set includeCompleted to include recent TRACKED notifications.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "dateKey": {
+            "type": "string",
+            "description": "One local date in YYYY-MM-DD. Defaults to today. Do not combine with startDateKey or endDateKey."
+          },
+          "startDateKey": {
+            "type": "string",
+            "description": "First local date in an inclusive range. Defaults to endDateKey when omitted."
+          },
+          "endDateKey": {
+            "type": "string",
+            "description": "Last local date in an inclusive range. Defaults to startDateKey when omitted. Ranges may include at most 31 days."
+          },
+          "trackingReminderId": {
+            "type": "string",
+            "description": "Return occurrences for only this reminder."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "SENT",
+              "TRACKED",
+              "SKIPPED",
+              "SNOOZED",
+              "OVERDUE"
+            ],
+            "description": "Return only this effective status. An elapsed snooze becomes PENDING or OVERDUE. OVERDUE means effective notifyAt is in the past and the occurrence remains unanswered."
+          },
+          "compact": {
+            "type": "boolean",
+            "description": "Defaults to true. Pass false for full records including scheduledAt, snooze detail, and instructions."
+          },
+          "includeCompleted": {
+            "type": "boolean",
+            "description": "Include answered TRACKED or legacy SKIPPED occurrences. SNOOZED occurrences are always returned with snoozedUntil."
+          }
+        }
+      },
+      "name": "listTrackingReminderNotifications",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Deprecated alias for listTrackingReminderNotifications. It keeps the reminders response key for existing callers.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "dateKey": {
+            "type": "string",
+            "description": "Local date in YYYY-MM-DD. Defaults to today."
+          },
+          "compact": {
+            "type": "boolean",
+            "description": "Return trackingReminderId as id, plus name, due, and status."
+          },
+          "includeCompleted": {
+            "type": "boolean",
+            "description": "When true, include reminders already answered or snoozed for the date."
+          }
+        }
+      },
+      "name": "listDueTrackingReminders",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Answer several tracking reminder notifications in one call. To answer specific reminders, send only except entries and omit defaultStatus; every other reminder stays untouched. Send defaultStatus only when you intend to answer the whole day. An except entry can also correct a response you already recorded. All-or-nothing: if any exception ID is not scheduled for the date, the tool writes nothing and returns an error. The call targets one local date; when catching up a past day (for example after midnight), pass that day's dateKey. Each result reports notifyAtLocal, the occurrence the answer landed on: verify it is the day you meant.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "dateKey": {
+            "type": "string",
+            "description": "Local date in YYYY-MM-DD. Defaults to today."
+          },
+          "defaultStatus": {
+            "type": "string",
+            "enum": [
+              "TRACKED",
+              "SNOOZED"
+            ],
+            "description": "Optional. Apply this status to every due and unanswered notification without an exception. Omit it to answer only the except entries. Already-answered notifications are never touched by the default."
+          },
+          "except": {
+            "type": "array",
+            "description": "Answer or correct individual notifications by trackingReminderId. Each entry needs a status when defaultStatus is omitted.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "trackingReminderId": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "TRACKED",
+                    "SNOOZED"
+                  ]
+                },
+                "value": {
+                  "type": "number"
+                },
+                "snoozeMinutes": {
+                  "type": "number"
+                },
+                "note": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "trackingReminderId"
+              ]
+            }
+          },
+          "note": {
+            "type": "string"
+          },
+          "snoozeMinutes": {
+            "type": "number",
+            "description": "Set the snooze duration. The default is 30 minutes. The server caps the deferred time at the local day's end."
+          }
+        }
+      },
+      "name": "respondToTrackingReminderNotifications",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Answer a due tracking reminder. TRACKED records a measurement. Record value 0 when the treatment, food, or activity was not taken; those zero days are the baseline that causal analysis needs. SNOOZED defers the notification. Deactivate the reminder when it no longer applies. SKIPPED is retired: it now records a zero and returns a deprecation notice. When dateKey and trackedAt are omitted, the answer targets the reminder's most recent due occurrence within the last 7 days that is still unanswered — so an after-midnight catch-up resolves yesterday's occurrence, not tomorrow's. The response's notifyAtLocal shows where the answer landed.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "trackingReminderId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "TRACKED",
+              "SNOOZED"
+            ],
+            "description": "TRACKED records a measurement; pass value 0 for a not-taken day. SNOOZED defers the notification. SKIPPED is accepted but retired and records a zero."
+          },
+          "snoozeMinutes": {
+            "type": "number",
+            "description": "Set the snooze duration. The default is 30 minutes. The server caps the deferred time at the local day's end."
+          },
+          "value": {
+            "type": "number",
+            "description": "Override dose/rating/value. If omitted for TRACKED, the reminder defaultValue is used."
+          },
+          "unitId": {
+            "type": "string"
+          },
+          "unitAbbreviation": {
+            "type": "string"
+          },
+          "unitName": {
+            "type": "string"
+          },
+          "trackedAt": {
+            "type": "string",
+            "description": "ISO date/time the measurement actually happened. Also anchors the target day when dateKey is omitted."
+          },
+          "dateKey": {
+            "type": "string",
+            "description": "Local date in YYYY-MM-DD of the occurrence to answer. Defaults from trackedAt when given, else to the most recent unanswered due occurrence."
+          },
+          "note": {
+            "type": "string"
+          },
+          "sourceName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "trackingReminderId",
+          "status"
+        ]
+      },
+      "name": "respondToTrackingReminder",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Get the highest expected-value unblocked task that the caller can work on. Returns the single best task to execute right now.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "skillTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Agent's skill tags for personalized ranking"
+          },
+          "interestTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Agent's interest tags for personalized ranking"
+          },
+          "credentialTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "languageTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "toolTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "accessTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "availableHoursPerWeek": {
+            "type": "number",
+            "description": "Hours per week the agent can commit"
+          },
+          "agentId": {
+            "type": "string",
+            "description": "Agent's unique identifier (to skip tasks leased by this agent)"
+          }
+        }
+      },
+      "name": "getNextTask",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "Start here before trusting a personal task queue. Audits active private tasks created by this user or assigned to their Person for missing estimates, blocked dependencies, impossible priority inputs, required/expiring deadline risks, and other data issues. A life-planning agent should repair or clarify high-severity issues before relying on getNextAction.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      },
+      "name": "getQueueAudit",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only complete audit of the task graph rooted at Optimize Earth. Pages stable findings—not tasks—so a steward can inspect every structural, duplicate, routing, provenance, estimate, and bounded-agent-work issue without the listTasks result cap. Treat requiresApproval=true findings as proposals only.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "cursor": {
+            "type": "string",
+            "description": "Stable issue cursor returned by the preceding page. Omit for the first page."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Findings per page (default 100, maximum 500)."
+          },
+          "rootTaskId": {
+            "type": "string",
+            "description": "Root task ID. Defaults to optimize-earth."
+          }
+        }
+      },
+      "name": "getTaskTreeAudit",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Get the authenticated user's available private self-work in two lanes. deadlineLane contains unblocked REQUIRED or EXPIRES work that is past due or past latest-start, sorted most-overdue first and never truncated by maxResults. evLane contains all other executable work in the existing expected-value order and is limited by maxResults. Returns tasks the user created OR has been assigned to (via assigneePersonId).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "maxResults": {
+            "type": "number",
+            "description": "Max number of evLane tasks to return (default 20, max 100). Does not truncate deadlineLane."
+          },
+          "buybackRate": {
+            "type": "number",
+            "description": "USD per hour used to convert cash cost into time-equivalent penalty (default 1000)"
+          }
+        }
+      },
+      "name": "getMyQueue",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Get the authenticated user's available private AI-agent tasks that fit one bounded execution attempt, sorted by computed priority. Oversized leaves appear in itemsNeedingDecomposition. Use executor_type='AI Agent' for autonomous work; otherwise use executor_type='Self'.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "agentId": {
+            "type": "string",
+            "description": "Current agent ID. Required to see this agent's own leased tasks: any leased task is omitted unless agentId is passed and matches the lease holder."
+          },
+          "maxResults": {
+            "type": "number",
+            "description": "Max number of tasks to return (default 20, max 100)"
+          },
+          "buybackRate": {
+            "type": "number",
+            "description": "USD per hour used to convert cash cost into time-equivalent penalty (default 1000)"
+          }
+        }
+      },
+      "name": "getAIQueue",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Build a capacity-bounded execution plan for the authenticated user, their Person record, or an organization they administer. Uses frontier-replanning-v1: repeatedly chooses the highest-priority feasible atomic task, simulates completion to unlock dependencies, and never starts AI work or writes Calendar events.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "target": {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "self",
+                  "person",
+                  "organization"
+                ],
+                "description": "Planning subject. Defaults to self."
+              },
+              "id": {
+                "type": "string",
+                "description": "Person or organization ID. Omit for the self target."
+              }
+            }
+          },
+          "planningWindowStart": {
+            "type": "string",
+            "description": "ISO 8601 start. Defaults to now."
+          },
+          "planningWindowEnd": {
+            "type": "string",
+            "description": "ISO 8601 end. Defaults to 24 hours after start."
+          },
+          "fixedCommitments": {
+            "type": "array",
+            "description": "Calendar meetings or invitations that consume capacity but are not imported as tasks.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "startAt": {
+                  "type": "string"
+                },
+                "endAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "startAt",
+                "endAt"
+              ]
+            }
+          },
+          "availableMinutes": {
+            "type": "number",
+            "description": "Maximum work minutes. The planner also caps this at free time left after fixed commitments."
+          },
+          "maxResults": {
+            "type": "number",
+            "description": "Maximum checklist and AI proposal items (default 20, max 100)."
+          },
+          "buybackRate": {
+            "type": "number",
+            "description": "USD per hour used to convert cash cost into time-equivalent penalty (default 1000)."
+          }
+        }
+      },
+      "name": "getExecutionPlan",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Get the best next self-work action from the same two-lane result as getMyQueue. Returns the most-overdue deadlineLane task whenever that lane is non-empty; otherwise returns the highest-ranked evLane task.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "buybackRate": {
+            "type": "number",
+            "description": "USD per hour used to convert cash cost into time-equivalent penalty (default 1000)"
+          }
+        }
+      },
+      "name": "getNextAction",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Evaluate the execution economics for a single task. Returns whether the current agent should execute directly, delegate, prepare procurement, or raise money first.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID"
+          },
+          "skillTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Agent's skill tags for capability matching"
+          },
+          "interestTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Agent's interest tags for capability matching"
+          },
+          "credentialTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "languageTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "toolTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "accessTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "availableHoursPerWeek": {
+            "type": "number",
+            "description": "Hours per week the agent can commit"
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "evaluateTaskEconomics",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "Append an execution-history attempt and update aggregate actual cash cost and effort. Personal callers may record actuals only for their own private or assigned tasks; this does not create health measurements or run causal analysis.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID"
+          },
+          "actualCashCostUsd": {
+            "type": "number",
+            "description": "Observed external cash cost in USD"
+          },
+          "actualEffortSeconds": {
+            "type": "number",
+            "description": "Observed effort in seconds"
+          },
+          "note": {
+            "type": "string",
+            "description": "Short execution note or procurement/funding rationale"
+          },
+          "completedAt": {
+            "type": "string",
+            "description": "ISO 8601 completion time. Defaults to now."
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "recordTaskActuals",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List tasks with optional filters. Returns up to 50 tasks sorted by accountability score. Signed-in callers see public tasks plus their own private work by default (visibility 'all'); pass visibility 'public' or 'private' to narrow. Returns the legacy task array unless paginated=true or cursor is supplied. Paginated inventory uses immutable task-ID order, not priority order.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "all",
+              "public",
+              "private"
+            ],
+            "description": "Which tasks to include: 'all' = public + your private work (default when signed in), 'public' = public only (default for anonymous callers), 'private' = only your non-public tasks."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "ACTIVE",
+              "VERIFIED",
+              "STALE"
+            ],
+            "description": "Filter by task status"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "ADVOCACY",
+              "RESEARCH",
+              "COMMUNICATION",
+              "ENGINEERING",
+              "ORGANIZING",
+              "OUTREACH",
+              "GOVERNANCE",
+              "SCIENCE",
+              "LEGAL",
+              "CREATIVE",
+              "OTHER"
+            ],
+            "description": "Filter by task category"
+          },
+          "assigneePersonId": {
+            "type": "string",
+            "description": "Filter by assignee person ID"
+          },
+          "assigneeOrganizationId": {
+            "type": "string",
+            "description": "Filter by assignee organization ID"
+          },
+          "ownerOrganizationId": {
+            "type": "string",
+            "description": "Filter by owner/reviewer organization ID"
+          },
+          "engagementKind": {
+            "type": "string",
+            "enum": [
+              "ONE_OFF",
+              "ONGOING",
+              "PART_TIME",
+              "FULL_TIME",
+              "CONTRACT"
+            ],
+            "description": "Filter by engagement kind."
+          },
+          "applicationPolicy": {
+            "type": "string",
+            "enum": [
+              "CLOSED",
+              "OPEN",
+              "INVITE_ONLY"
+            ],
+            "description": "Filter by application policy."
+          },
+          "compensationKind": {
+            "type": "string",
+            "enum": [
+              "UNSPECIFIED",
+              "VOLUNTEER",
+              "PAID",
+              "BOUNTY",
+              "EQUITY",
+              "OTHER"
+            ],
+            "description": "Filter by compensation kind."
+          },
+          "remotePolicy": {
+            "type": "string",
+            "enum": [
+              "UNSPECIFIED",
+              "REMOTE",
+              "HYBRID",
+              "ONSITE"
+            ],
+            "description": "Filter by remote/hybrid/onsite policy."
+          },
+          "executionMode": {
+            "type": "string",
+            "enum": [
+              "HUMAN_OR_AGENT",
+              "HUMAN_ONLY",
+              "AGENT_ONLY"
+            ],
+            "description": "Filter by human/agent execution mode."
+          },
+          "requiredTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Return tasks whose required/preferred/skill tags include any supplied tag."
+          },
+          "assignedToMe": {
+            "type": "boolean",
+            "description": "Filter to tasks assigned to the authenticated user's canonical Person row."
+          },
+          "parentTaskId": {
+            "type": "string",
+            "description": "Filter by parent task ID (get subtasks)"
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Opaque cursor returned as nextCursor by the preceding page. Copy it verbatim and keep all filters unchanged."
+          },
+          "paginated": {
+            "type": "boolean",
+            "description": "Return {tasks,nextCursor}. Omit for the legacy task-array response."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "description": "Max results (default 20, max 50)"
+          }
+        }
+      },
+      "name": "listTasks",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "Get task details by taskId with one canonical impact frame. Call getTaskImpactTrace for formulas and provenance. If you do not have a taskId yet, call searchTasks, listTasks, getMyQueue, or getNextAction first.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID"
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "getTask",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "Rank accessible active tasks for a user using their private matching preferences plus the task impact score. Non-admin callers can only rank their own user.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "description": "Optional target user ID. Admin-only unless it is the authenticated user."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results, default 20, max 50."
+          },
+          "preferLeafExecution": {
+            "type": "boolean",
+            "description": "When true, return only executable tasks without active subtasks; never fall back to parent tasks."
+          }
+        }
+      },
+      "name": "findTasksForUser",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create or update the authenticated user's application to an OPEN or INVITE_ONLY task/role opening.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task or role opening ID."
+          },
+          "applicationMessage": {
+            "type": "string",
+            "description": "Applicant message, cover note, or proposal."
+          },
+          "answersJson": {
+            "type": [
+              "object",
+              "array",
+              "null"
+            ],
+            "description": "Structured answers to task.applicationQuestionsJson."
+          },
+          "applicantNameSnapshot": {
+            "type": "string",
+            "description": "Optional applicant name snapshot."
+          },
+          "applicantEmailSnapshot": {
+            "type": "string",
+            "description": "Optional applicant email snapshot."
+          },
+          "originUrl": {
+            "type": "string",
+            "description": "Where the application started."
+          },
+          "utmJson": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "UTM/campaign metadata."
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "applyToTask",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List applications for one task. Caller must be admin, task creator, task manager, or owner/admin of the owner/assignee organization.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID."
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "listTaskApplications",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Review one task application. Optionally assign the task to the accepted applicant's Person row.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "applicationId": {
+            "type": "string",
+            "description": "Application ID."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "APPLIED",
+              "INVITED",
+              "UNDER_REVIEW",
+              "SHORTLISTED",
+              "INTERVIEWING",
+              "OFFERED",
+              "ACCEPTED",
+              "REJECTED",
+              "WITHDRAWN",
+              "ARCHIVED"
+            ],
+            "description": "New application status."
+          },
+          "reviewScore": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Reviewer score, conventionally 0-100."
+          },
+          "reviewNote": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Reviewer note."
+          },
+          "answersJson": {
+            "type": [
+              "object",
+              "array",
+              "null"
+            ],
+            "description": "Reviewer-normalized answer data."
+          },
+          "assignTaskOnAccept": {
+            "type": "boolean",
+            "description": "If status is ACCEPTED, set task.assigneePersonId to the applicant person."
+          }
+        },
+        "required": [
+          "applicationId"
+        ]
+      },
+      "name": "reviewTaskApplication",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: score users and active agent executors as possible executors for one task.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max candidates, default 20, max 100."
+          },
+          "includeAgents": {
+            "type": "boolean",
+            "description": "Include active AgentExecutor rows. Default true."
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "findTaskCandidates",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: upsert a scored candidate match for a task so later chats/agents can review or assign it.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string"
+          },
+          "candidateKind": {
+            "type": "string",
+            "enum": [
+              "USER",
+              "PERSON",
+              "ORGANIZATION",
+              "AGENT",
+              "EXTERNAL"
+            ]
+          },
+          "candidateKey": {
+            "type": "string",
+            "description": "Stable key. If omitted, derived from candidateUserId/personId/organizationId/agentExecutorId."
+          },
+          "candidateUserId": {
+            "type": "string"
+          },
+          "candidatePersonId": {
+            "type": "string"
+          },
+          "candidateOrganizationId": {
+            "type": "string"
+          },
+          "agentExecutorId": {
+            "type": "string"
+          },
+          "score": {
+            "type": "number"
+          },
+          "scoreVersion": {
+            "type": "string"
+          },
+          "reasonJson": {
+            "type": [
+              "object",
+              "array",
+              "null"
+            ]
+          },
+          "blockersJson": {
+            "type": [
+              "object",
+              "array",
+              "null"
+            ]
+          },
+          "estimatedCostMinorUnits": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "estimatedCostCurrency": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "estimatedDurationSeconds": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "SUGGESTED",
+              "CONTACTED",
+              "DECLINED",
+              "REJECTED"
+            ]
+          }
+        },
+        "required": [
+          "taskId",
+          "candidateKind",
+          "score"
+        ]
+      },
+      "name": "saveTaskCandidateMatch",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List saved candidate matches for a task. Non-admin callers must have application-review rights for the task.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "SUGGESTED",
+              "CONTACTED",
+              "DECLINED",
+              "REJECTED"
+            ]
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results, default 50."
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "listTaskCandidateMatches",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: update a saved task candidate match status.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "matchId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "SUGGESTED",
+              "CONTACTED",
+              "DECLINED",
+              "REJECTED"
+            ]
+          },
+          "reasonJson": {
+            "type": [
+              "object",
+              "array",
+              "null"
+            ]
+          },
+          "blockersJson": {
+            "type": [
+              "object",
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "matchId",
+          "status"
+        ]
+      },
+      "name": "updateTaskCandidateMatchStatus",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: list non-human executors addressable by task routing.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "PAUSED",
+              "RETIRED"
+            ]
+          },
+          "provider": {
+            "type": "string"
+          },
+          "capabilityTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results, default 50."
+          }
+        }
+      },
+      "name": "listAgentExecutors",
+      "requiredScopes": [
+        "agent:run",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: create or update a non-human task executor.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "agentKey": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "provider": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "modelName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "capabilityTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "toolTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "accessTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "averageCostUsd": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "averageLatencySeconds": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "successRate": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "PAUSED",
+              "RETIRED"
+            ]
+          },
+          "metadata": {
+            "type": [
+              "object",
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "agentKey",
+          "displayName"
+        ]
+      },
+      "name": "upsertAgentExecutor",
+      "requiredScopes": [
+        "agent:run",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: set an AgentExecutor status.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "agentKey": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "PAUSED",
+              "RETIRED"
+            ]
+          }
+        },
+        "required": [
+          "agentKey",
+          "status"
+        ]
+      },
+      "name": "setAgentExecutorStatus",
+      "requiredScopes": [
+        "agent:run",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: list task email communications and linked email logs for one task.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID."
+          },
+          "email": {
+            "type": "string",
+            "description": "Optional recipient email filter."
+          },
+          "q": {
+            "type": "string",
+            "description": "Optional search across subject, recipient, task title, and provider email address."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max rows to return (default 50, max 200)."
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "listTaskEmails",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: list task email communications and email logs sent to a user, person, organization, or raw email address.",
+      "inputSchema": {
+        "type": "object",
+        "anyOf": [
+          {
+            "required": [
+              "email"
+            ]
+          },
+          {
+            "required": [
+              "organizationId"
+            ]
+          },
+          {
+            "required": [
+              "personId"
+            ]
+          },
+          {
+            "required": [
+              "userId"
+            ]
+          }
+        ],
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Recipient email address."
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "Recipient organization ID."
+          },
+          "personId": {
+            "type": "string",
+            "description": "Recipient person ID."
+          },
+          "userId": {
+            "type": "string",
+            "description": "Recipient user ID."
+          },
+          "q": {
+            "type": "string",
+            "description": "Optional search across subject, recipient, task title, and provider email address."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max rows to return (default 50, max 200)."
+          }
+        }
+      },
+      "name": "listRecipientEmails",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: list provider-level email logs, optionally filtered by task, recipient email, user, person, organization, or search text.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Recipient email address."
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "Recipient organization ID through task communications."
+          },
+          "personId": {
+            "type": "string",
+            "description": "Recipient person ID through task communications."
+          },
+          "q": {
+            "type": "string",
+            "description": "Optional search across subject, recipient, task title, template, and provider message id."
+          },
+          "taskId": {
+            "type": "string",
+            "description": "Linked task ID."
+          },
+          "userId": {
+            "type": "string",
+            "description": "Recipient user ID."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max rows to return (default 50, max 200)."
+          }
+        }
+      },
+      "name": "listEmailLogs",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List task communications (email, in-app, external URL, manual) across all channels. Admins see everything; other callers see only communications on tasks they created or are assigned to, with recipient emails masked (m***@domain). Suppressed sends surface as FAILED/CANCELLED rows with a suppressionReason.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Filter to one task."
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "Filter by recipient organization ID."
+          },
+          "personId": {
+            "type": "string",
+            "description": "Filter by recipient person ID."
+          },
+          "sinceIso": {
+            "type": "string",
+            "description": "Only rows created at or after this ISO-8601 timestamp."
+          },
+          "untilIso": {
+            "type": "string",
+            "description": "Only rows created at or before this ISO-8601 timestamp."
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "EMAIL",
+              "IN_APP",
+              "SMS",
+              "PUSH",
+              "EXTERNAL_URL",
+              "MAILTO",
+              "MANUAL"
+            ],
+            "description": "Filter by communication channel."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "SENT",
+              "RECEIVED",
+              "FAILED",
+              "CANCELLED"
+            ],
+            "description": "Filter by lifecycle status."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max rows to return (default 50, max 200)."
+          }
+        }
+      },
+      "name": "listCommunications",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Fetch one task communication by ID: full message body (via the linked task comment), envelope metadata, email delivery details (provider IDs, delivery status), and trigger/idempotency metadata. Same visibility and masking rules as listCommunications.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "TaskCommunication ID."
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "name": "getCommunicationLog",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List organizations (for example to create task targets), optionally including active/target-filtered tasks.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search query for name, slug, description, website, or contact email."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "UNIVERSITY",
+              "RESEARCH_CENTER",
+              "NONPROFIT",
+              "DAO",
+              "GOVERNMENT",
+              "GOVERNMENT_AGENCY",
+              "HOSPITAL",
+              "BIOTECH",
+              "COMPANY",
+              "FOUNDATION",
+              "INTERGOVERNMENTAL",
+              "MEDIA",
+              "POLITICAL_PARTY",
+              "ADVOCACY",
+              "OTHER"
+            ],
+            "description": "Optional organization type filter."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "APPROVED",
+              "REJECTED"
+            ],
+            "description": "Optional organization status filter."
+          },
+          "includeTasks": {
+            "type": "boolean",
+            "description": "Include a short active task summary for each organization (default false)."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max organizations to return (default 100, max 500)."
+          },
+          "taskLimit": {
+            "type": "number",
+            "description": "Max tasks per organization when includeTasks=true (default 3, max 50)."
+          },
+          "taskVisibility": {
+            "type": "string",
+            "enum": [
+              "all",
+              "public",
+              "private"
+            ],
+            "description": "Which tasks to include in the summary: 'all' = public + your private work (default when signed in), 'public' = public only (default for anonymous callers), 'private' = only your non-public tasks."
+          },
+          "taskScope": {
+            "type": "string",
+            "enum": [
+              "public",
+              "accessible"
+            ],
+            "description": "Deprecated alias of taskVisibility ('accessible' = 'all'). Prefer taskVisibility."
+          },
+          "taskStatus": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "ACTIVE",
+              "VERIFIED",
+              "STALE"
+            ],
+            "description": "Task status used when includeTasks=true (default ACTIVE)."
+          }
+        }
+      },
+      "name": "listOrganizations",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "List tasks currently assigned to a specific organization.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Organization ID."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max tasks to return (default 50, max 200)."
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "all",
+              "public",
+              "private"
+            ],
+            "description": "Which tasks to include: 'all' = public + your private work (default when signed in), 'public' = public only (default for anonymous callers), 'private' = only your non-public tasks."
+          },
+          "scope": {
+            "type": "string",
+            "enum": [
+              "public",
+              "accessible"
+            ],
+            "description": "Deprecated alias of visibility ('accessible' = 'all'). Prefer visibility."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "ACTIVE",
+              "VERIFIED",
+              "STALE"
+            ],
+            "description": "Optional task status filter."
+          }
+        },
+        "required": [
+          "organizationId"
+        ]
+      },
+      "name": "getOrganizationTasks",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "List people (optionally public-figure-only) and optionally include their assigned active tasks.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search by display name, handle, current affiliation, source ref, or email."
+          },
+          "publicProfilesOnly": {
+            "type": "boolean",
+            "description": "When true, only includes people marked as public-figure profiles (default true)."
+          },
+          "includeTasks": {
+            "type": "boolean",
+            "description": "Include a short active task summary for each person (default false)."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max people to return (default 100, max 500)."
+          },
+          "taskLimit": {
+            "type": "number",
+            "description": "Max tasks per person when includeTasks=true (default 3, max 50)."
+          },
+          "taskVisibility": {
+            "type": "string",
+            "enum": [
+              "all",
+              "public",
+              "private"
+            ],
+            "description": "Which tasks to include in the summary: 'all' = public + your private work (default when signed in), 'public' = public only (default for anonymous callers), 'private' = only your non-public tasks."
+          },
+          "taskScope": {
+            "type": "string",
+            "enum": [
+              "public",
+              "accessible"
+            ],
+            "description": "Deprecated alias of taskVisibility ('accessible' = 'all'). Prefer taskVisibility."
+          },
+          "taskStatus": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "ACTIVE",
+              "VERIFIED",
+              "STALE"
+            ],
+            "description": "Task status used when includeTasks=true (default ACTIVE)."
+          }
+        }
+      },
+      "name": "listPeople",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "List tasks currently assigned to a specific person.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "personId": {
+            "type": "string",
+            "description": "Person ID."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max tasks to return (default 50, max 200)."
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "all",
+              "public",
+              "private"
+            ],
+            "description": "Which tasks to include: 'all' = public + your private work (default when signed in), 'public' = public only (default for anonymous callers), 'private' = only your non-public tasks."
+          },
+          "scope": {
+            "type": "string",
+            "enum": [
+              "public",
+              "accessible"
+            ],
+            "description": "Deprecated alias of visibility ('accessible' = 'all'). Prefer visibility."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "ACTIVE",
+              "VERIFIED",
+              "STALE"
+            ],
+            "description": "Optional task status filter."
+          }
+        },
+        "required": [
+          "personId"
+        ]
+      },
+      "name": "getPersonTasks",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": true,
+      "description": "Create or idempotently update a person profile by displayName, email, sourceRef, or public-figure signature.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string",
+            "description": "Person display name."
+          },
+          "email": {
+            "type": "string",
+            "description": "Person email (used for de-dup and notification)."
+          },
+          "currentAffiliation": {
+            "type": "string",
+            "description": "Current organization/affiliation."
+          },
+          "countryCode": {
+            "type": "string",
+            "description": "ISO-3166 country code."
+          },
+          "image": {
+            "type": "string",
+            "description": "Avatar image URL. Use uploadImageFromUrl with kind=person-photo first when starting from a remote public image URL."
+          },
+          "isPublicFigure": {
+            "type": "boolean",
+            "description": "Marks this person as a public-facing profile."
+          },
+          "sourceRef": {
+            "type": "string",
+            "description": "Stable source key for idempotent updates."
+          },
+          "sourceUrl": {
+            "type": "string",
+            "description": "Source URL for provenance."
+          }
+        },
+        "required": [
+          "displayName"
+        ]
+      },
+      "name": "createPerson",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Return the authenticated user's profile (User + canonical Person row). Use this to discover who you are acting as: userId, email, displayName, handle, avatar, bio, headline, website, social links, and visibility flags. No arguments — identity is taken from the OAuth bearer token.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      },
+      "name": "getMe",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Explain which MCP tools this connection can use and why. Optionally filter by tool name. Returns effective scopes, server identity, and stable access reason codes without exposing token data.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "toolNames": {
+            "type": "array",
+            "description": "Optional tool names to inspect. Omit to inspect the complete compact catalog.",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200,
+            "uniqueItems": true
+          }
+        }
+      },
+      "name": "inspectToolAccess",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "Update the authenticated user's profile. Person is canonical for the public-facing fields (displayName, handle, bio, headline, coverImage, website, isPublic); this tool writes Person directly. Only fields you supply are changed. Pass `handle: \"\"` (or null) to clear the handle. Returns the fresh profile.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name shown across the app."
+          },
+          "image": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Profile avatar image URL."
+          },
+          "handle": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Player-name handle, 3–24 chars, [A-Za-z0-9_-]. Empty/null clears it. Must be unique."
+          },
+          "bio": {
+            "type": "string",
+            "description": "Short bio."
+          },
+          "headline": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional one-line headline shown above the bio."
+          },
+          "website": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Personal/profile URL."
+          },
+          "coverImage": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Profile cover image URL."
+          },
+          "isPublic": {
+            "type": "boolean",
+            "description": "Whether the profile is publicly visible."
+          },
+          "newsletterSubscribed": {
+            "type": "boolean",
+            "description": "Whether to receive the newsletter."
+          },
+          "unsubscribedScopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Email scopes to opt out of (transactional/master scopes are filtered out server-side)."
+          },
+          "skillTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "credentialTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "interestTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "languageTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "toolTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "accessTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "preferredPaymentRails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "workPreferenceTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "preferredTaskTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "unavailableTaskTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "availableHoursPerWeek": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "availableFrom": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 8601 date."
+          },
+          "countryCode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "regionCode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "city": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "postalCode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "longitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        }
+      },
+      "name": "updateMyProfile",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Fetch a public image URL, normalize it through the same image pipeline used by the web app, upload it to object storage, and return the canonical public URL. Use this before createOrganization/updateOrganization when you have a remote square logo, wordmark, or person photo URL.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Public http(s) image URL. Local/private network hosts are rejected."
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "memorial-evidence-image",
+              "organization-square-logo",
+              "organization-wordmark-logo",
+              "person-photo"
+            ],
+            "description": "Upload target. Organization logos usually use organization-square-logo and organization-wordmark-logo."
+          },
+          "filename": {
+            "type": "string",
+            "description": "Optional filename to use before normalization. Defaults to the URL path filename."
+          }
+        },
+        "required": [
+          "url",
+          "kind"
+        ]
+      },
+      "name": "uploadImageFromUrl",
+      "requiredScopes": [
+        "earthdata:write",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create an approved organization for task assignment. Uses post-moderation: create now, reject later if needed. Visibility defaults to PRIVATE (visible only to members) unless visibility='PUBLIC' is passed explicitly — only make an organization PUBLIC when it needs to be publicly discoverable or assigned public tasks.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Organization name"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "UNIVERSITY",
+              "RESEARCH_CENTER",
+              "NONPROFIT",
+              "DAO",
+              "GOVERNMENT",
+              "GOVERNMENT_AGENCY",
+              "HOSPITAL",
+              "BIOTECH",
+              "COMPANY",
+              "FOUNDATION",
+              "INTERGOVERNMENTAL",
+              "MEDIA",
+              "POLITICAL_PARTY",
+              "ADVOCACY",
+              "OTHER"
+            ],
+            "description": "Organization type"
+          },
+          "slug": {
+            "type": "string",
+            "description": "Optional URL slug. Defaults to a kebab-case slug generated from name."
+          },
+          "website": {
+            "type": "string",
+            "description": "Website URL"
+          },
+          "contactEmail": {
+            "type": "string",
+            "description": "Primary contact email"
+          },
+          "description": {
+            "type": "string",
+            "description": "Mission or provenance note"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "APPROVED",
+              "REJECTED"
+            ],
+            "description": "Organization status. Defaults to APPROVED."
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "PUBLIC",
+              "PRIVATE"
+            ],
+            "description": "Discoverability. PRIVATE organizations are visible only to their members. MCP-created organizations default to PRIVATE — pass visibility='PUBLIC' explicitly to make it publicly discoverable and referenceable by public tasks."
+          },
+          "donationUrl": {
+            "type": "string",
+            "description": "Direct support or donation page URL"
+          },
+          "squareLogoUrl": {
+            "type": "string",
+            "description": "Square logo mark URL. Use uploadImageFromUrl with kind=organization-square-logo first when starting from a remote public image URL."
+          },
+          "wordmarkLogoUrl": {
+            "type": "string",
+            "description": "Horizontal wordmark logo URL. Use uploadImageFromUrl with kind=organization-wordmark-logo first when starting from a remote public image URL."
+          },
+          "jurisdictionId": {
+            "type": "string",
+            "description": "Optional jurisdiction ID"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ]
+      },
+      "name": "createOrganization",
+      "requiredScopes": [
+        "earthdata:write",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create an ACTIVE task. Visibility defaults to PRIVATE; admin organization assignments default PUBLIC. Only admins may create PUBLIC tasks. Required: title, description, one parentTaskId or parentTaskKey, taskKey, category, hours, value, p_success, acceptanceCriteria, and impactStatement. Call getMe first: personalRoot is the caller's private Optimize-{name} root and organizationRoots lists accessible organization roots. Choose the closest parent; use personalRoot.taskKey only for personal work. Never guess or default. Optimize Earth is reserved. For Optimitron code or documentation improvements, search for duplicate work and set parentTaskKey='optimitron:dev'. Estimate instead of omitting numbers. Use testable acceptance criteria and one sentence explaining impact. Reference tasks as titled Markdown links to https://optimitron.com/tasks/<id>, never as bare IDs. Use depends_on for true prerequisites; executor_type='Self' for user work and 'AI Agent' only for autonomous assistant work; deadline_policy='REQUIRED' for must-do legal/health/safety tasks and 'EXPIRES' for opportunities that vanish after due_at. taskKey is the idempotency key: retrying the same create returns the existing task instead of creating a duplicate. The response includes a writeReceipt and a missingFields[] array for soft-recommended metadata.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Short imperative title"
+          },
+          "description": {
+            "type": "string",
+            "description": "Full explanation and acceptance criteria"
+          },
+          "parentTaskId": {
+            "type": "string",
+            "description": "Existing parent task ID. Provide this or parentTaskKey, not both. Call getMe for personalRoot and organizationRoots, then choose the closest objective or task; do not use Optimize Earth directly."
+          },
+          "parentTaskKey": {
+            "type": "string",
+            "description": "Exact stable key of the existing parent task. Provide this or parentTaskId, not both. For personal work use getMe.personalRoot.taskKey; for Optimitron development work use 'optimitron:dev'."
+          },
+          "taskKey": {
+            "type": "string",
+            "description": "Stable dedup key (e.g. accountability:us:golf-2025)"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "ADVOCACY",
+              "RESEARCH",
+              "COMMUNICATION",
+              "ENGINEERING",
+              "ORGANIZING",
+              "OUTREACH",
+              "GOVERNANCE",
+              "SCIENCE",
+              "LEGAL",
+              "CREATIVE",
+              "OTHER"
+            ],
+            "description": "Task category"
+          },
+          "skillTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Skills needed"
+          },
+          "interestTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Related topics/causes"
+          },
+          "engagementKind": {
+            "type": "string",
+            "enum": [
+              "ONE_OFF",
+              "ONGOING",
+              "PART_TIME",
+              "FULL_TIME",
+              "CONTRACT"
+            ],
+            "description": "Commitment shape: ONE_OFF, ONGOING, PART_TIME, FULL_TIME, CONTRACT."
+          },
+          "applicationPolicy": {
+            "type": "string",
+            "enum": [
+              "CLOSED",
+              "OPEN",
+              "INVITE_ONLY"
+            ],
+            "description": "Whether users can apply: CLOSED, OPEN, or INVITE_ONLY."
+          },
+          "preferredSkillTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Skills that improve fit beyond required skillTags."
+          },
+          "requiredCredentialTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Credentials, licenses, or qualifications required."
+          },
+          "preferredCredentialTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Credentials that improve fit."
+          },
+          "requiredLanguageTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Languages required."
+          },
+          "preferredLanguageTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Languages that improve fit."
+          },
+          "requiredToolTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Tools, platforms, or software required."
+          },
+          "preferredToolTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Tools that improve fit."
+          },
+          "requiredAccessTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Accounts, clearance, location, network, or social access required."
+          },
+          "preferredAccessTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Access that improves fit."
+          },
+          "ownerOrganizationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Organization that owns/reviews this opening or task."
+          },
+          "compensationKind": {
+            "type": "string",
+            "enum": [
+              "UNSPECIFIED",
+              "VOLUNTEER",
+              "PAID",
+              "BOUNTY",
+              "EQUITY",
+              "OTHER"
+            ],
+            "description": "Compensation category."
+          },
+          "compensationCadence": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "FIXED",
+              "HOURLY",
+              "WEEKLY",
+              "MONTHLY",
+              "ANNUAL",
+              null
+            ],
+            "description": "Compensation cadence. Null clears it."
+          },
+          "compensationCurrency": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Lowercase currency code, usually usd."
+          },
+          "compensationMinAmountMinorUnits": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Minimum compensation in currency minor units."
+          },
+          "compensationMaxAmountMinorUnits": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Maximum compensation in currency minor units."
+          },
+          "compensationMinAmountUsd": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Minimum compensation in whole US dollars; the server converts to minor units (cents). USD alternative to compensationMinAmountMinorUnits."
+          },
+          "compensationMaxAmountUsd": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Maximum compensation in whole US dollars; the server converts to minor units (cents). USD alternative to compensationMaxAmountMinorUnits."
+          },
+          "compensationPaymentRails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Acceptable payment rails, such as stripe, ach, usdc, wire."
+          },
+          "estimatedHoursPerWeekMin": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Minimum weekly hours for ongoing work."
+          },
+          "estimatedHoursPerWeekMax": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Maximum weekly hours for ongoing work."
+          },
+          "remotePolicy": {
+            "type": "string",
+            "enum": [
+              "UNSPECIFIED",
+              "REMOTE",
+              "HYBRID",
+              "ONSITE"
+            ],
+            "description": "UNSPECIFIED, REMOTE, HYBRID, or ONSITE."
+          },
+          "locationText": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable location constraint."
+          },
+          "workLocationCountryCode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "workLocationRegionCode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "workLocationCity": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "workLocationPostalCode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "workLocationLatitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "workLocationLongitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "workLocationRadiusKm": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "workTimeZone": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "IANA time zone preferred for the work."
+          },
+          "applicationQuestionsJson": {
+            "type": [
+              "object",
+              "array",
+              "null"
+            ],
+            "description": "Structured questions for applicants. Null clears it."
+          },
+          "executionMode": {
+            "type": "string",
+            "enum": [
+              "HUMAN_OR_AGENT",
+              "HUMAN_ONLY",
+              "AGENT_ONLY"
+            ],
+            "description": "HUMAN_OR_AGENT, HUMAN_ONLY, or AGENT_ONLY."
+          },
+          "maxClaims": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Max simultaneous claims when claimPolicy is OPEN_MANY."
+          },
+          "depends_on": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Alias for blockerTaskIds: existing task IDs that must be VERIFIED before this task appears in active queues. Use only for real prerequisites, not generic importance.",
+            "minItems": 0
+          },
+          "blockerTaskRefs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Prerequisite task IDs or exact taskKeys.",
+            "minItems": 0
+          },
+          "blockerTaskIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional IDs of existing tasks that block this task (must be completed first). Use searchTasks first to discover valid blocker task IDs.",
+            "minItems": 0
+          },
+          "blockedTaskRefs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Blocked task IDs or exact taskKeys.",
+            "minItems": 0
+          },
+          "blockedTaskIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional IDs of existing tasks that are blocked by this task (tasks that depend on it). Use searchTasks first to discover valid dependent task IDs.",
+            "minItems": 0
+          },
+          "estimatedEffortHours": {
+            "type": "number",
+            "description": "Estimated hours to complete"
+          },
+          "hours": {
+            "type": "number",
+            "description": "Alias for estimatedEffortHours. Required for reliable priority; use expected user hours, not calendar duration."
+          },
+          "value": {
+            "type": "number",
+            "description": "Gross conditional value if the task succeeds. For required tasks, include avoided downside such as penalties, health loss, or system failure."
+          },
+          "p_success": {
+            "type": "number",
+            "description": "Success probability, 0-1. MCP computes expected value as value * p_success when value is supplied."
+          },
+          "cash_cost": {
+            "type": "number",
+            "description": "Cash cost in USD. Priority converts this to hour-equivalent cost using buybackRate, default $1000/hr."
+          },
+          "executor_type": {
+            "type": "string",
+            "enum": [
+              "Self",
+              "AI Agent"
+            ],
+            "description": "Who should execute this task. Use Self for normal user tasks even if AI assists; use AI Agent only for autonomous assistant tasks."
+          },
+          "expectedEconomicValueUsdBase": {
+            "type": "number",
+            "description": "Expected economic value in USD-equivalent welfare (probability-adjusted by your model)"
+          },
+          "successProbabilityBase": {
+            "type": "number",
+            "description": "Estimated success probability for the task outcome, 0-1"
+          },
+          "estimatedCashCostUsdBase": {
+            "type": "number",
+            "description": "One-time cash cost expected to execute this task (USD)"
+          },
+          "timeToImpactStartDays": {
+            "type": "number",
+            "description": "Days until value can start being realized. Metadata/public impact-frame input; not part of personal priority."
+          },
+          "available_at": {
+            "type": "string",
+            "description": "Earliest time this task should appear in active queues (ISO 8601). Use for tasks that cannot or should not be started yet."
+          },
+          "dueAt": {
+            "type": "string",
+            "description": "Due date (ISO 8601)"
+          },
+          "due_at": {
+            "type": "string",
+            "description": "Alias for dueAt"
+          },
+          "deadline_policy": {
+            "type": "string",
+            "enum": [
+              "NONE",
+              "SOFT",
+              "EXPIRES",
+              "REQUIRED"
+            ],
+            "description": "Whether due_at is ignored, a soft target, an expiring opportunity, or required work. REQUIRED is for must-do tasks like taxes or medicine refills; EXPIRES is for grants/applications/opportunities that vanish after due_at."
+          },
+          "deadline_rationale": {
+            "type": "string",
+            "description": "Freeform rationale for the deadline policy, e.g. taxes must be filed by a legal deadline."
+          },
+          "claimPolicy": {
+            "type": "string",
+            "enum": [
+              "ASSIGNED_ONLY",
+              "OPEN_SINGLE",
+              "OPEN_MANY"
+            ],
+            "description": "How work is claimed. Assigned tasks always use ASSIGNED_ONLY. Unassigned tasks default to OPEN_SINGLE; use OPEN_MANY only for ongoing independent contributions."
+          },
+          "assigneePersonId": {
+            "type": "string",
+            "description": "Person ID to assign this task to"
+          },
+          "assigneeOrganizationId": {
+            "type": "string",
+            "description": "Organization ID to assign this task to"
+          },
+          "roleTitle": {
+            "type": "string",
+            "description": "Role of the assignee (e.g. President, Commissioner)"
+          },
+          "sourceUrl": {
+            "type": "string",
+            "description": "URL to the source/evidence for this task"
+          },
+          "contactUrl": {
+            "type": "string",
+            "description": "URL for contacting the assignee"
+          },
+          "contactLabel": {
+            "type": "string",
+            "description": "Label for the contact channel"
+          },
+          "impactStatement": {
+            "type": "string",
+            "description": "Why this matters"
+          },
+          "ev_math": {
+            "type": "string",
+            "description": "Freeform rationale for value/probability/hour assumptions"
+          },
+          "can_delegate": {
+            "type": "boolean",
+            "description": "Whether an agent or contractor can do this task"
+          },
+          "best_route": {
+            "type": "string",
+            "description": "Best execution route, e.g. self, agent, contractor"
+          },
+          "acceptanceCriteria": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Structured acceptance criteria. If omitted, createTask also extracts checklist bullets under a markdown 'Acceptance criteria' heading in description."
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "PUBLIC",
+              "PRIVATE"
+            ],
+            "description": "Optional visibility override. Defaults to PUBLIC for organization-assigned tasks and PRIVATE otherwise."
+          },
+          "isPublic": {
+            "type": "boolean",
+            "description": "Legacy boolean visibility alias. Prefer visibility='PUBLIC' or 'PRIVATE'. Ignored when visibility is supplied."
+          },
+          "contextJson": {
+            "type": "object",
+            "description": "Optional advanced task metadata. Prefer the typed top-level task fields.",
+            "additionalProperties": true
+          },
+          "sortOrder": {
+            "type": "number",
+            "description": "Manual display order for public/task-tree views (lower = earlier). Not the computed personal priority score."
+          }
+        }
+      },
+      "name": "createTask",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Delete a task by soft delete. Admins may delete any task within the client boundary. Non-admin callers may delete only a private task they have MANAGE access to; a public task is always rejected for non-admin callers with 'Deleting public tasks requires an admin user.', even though they can look one up by ID without MANAGE access.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID to delete"
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "deleteTask",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only: fold a duplicate task into a canonical task. Re-points every live relation (children, claims, applications, comments, edges, communications, funding, documents, etc.) to the canonical task, records merge provenance in both tasks' contextJson, then soft-deletes the duplicate. Refuses a duplicate that carries a taskKey (managed or trigger-owned tasks) — pick the keyed task as the canonical instead. Unique-constraint collisions are skipped and left on the duplicate; the canonical task's status, completion, and actuals are never changed. Effectively irreversible — review both tasks first. Returns per-relation moved/skipped counts.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "duplicateTaskId": {
+            "type": "string",
+            "description": "Task ID to fold into the canonical task and soft-delete"
+          },
+          "canonicalTaskId": {
+            "type": "string",
+            "description": "Task ID that survives and receives the duplicate's relations"
+          }
+        },
+        "required": [
+          "duplicateTaskId",
+          "canonicalTaskId"
+        ]
+      },
+      "name": "mergeTask",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Create or update a general Organization record for task assignment. This is not outreach-specific; use it for nonprofits, governments, companies, universities, and other assignees.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Organization name"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "UNIVERSITY",
+              "RESEARCH_CENTER",
+              "NONPROFIT",
+              "DAO",
+              "GOVERNMENT",
+              "GOVERNMENT_AGENCY",
+              "HOSPITAL",
+              "BIOTECH",
+              "COMPANY",
+              "FOUNDATION",
+              "INTERGOVERNMENTAL",
+              "MEDIA",
+              "POLITICAL_PARTY",
+              "ADVOCACY",
+              "OTHER"
+            ],
+            "description": "Organization type"
+          },
+          "website": {
+            "type": "string",
+            "description": "Website URL"
+          },
+          "contactEmail": {
+            "type": "string",
+            "description": "General contact email"
+          },
+          "description": {
+            "type": "string",
+            "description": "Mission or provenance note"
+          },
+          "donationUrl": {
+            "type": "string",
+            "description": "Direct support or donation page URL"
+          },
+          "squareLogoUrl": {
+            "type": "string",
+            "description": "Square logo mark URL. Use uploadImageFromUrl with kind=organization-square-logo first when starting from a remote public image URL."
+          },
+          "wordmarkLogoUrl": {
+            "type": "string",
+            "description": "Horizontal wordmark logo URL. Use uploadImageFromUrl with kind=organization-wordmark-logo first when starting from a remote public image URL."
+          },
+          "sourceRef": {
+            "type": "string",
+            "description": "Stable source reference for idempotent imports"
+          },
+          "sourceUrl": {
+            "type": "string",
+            "description": "Source URL proving this organization/contact"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "name": "upsertOrganization",
+      "requiredScopes": [
+        "earthdata:admin",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Edit an existing Organization. Caller must be an owner/admin of the org. status and jurisdictionId changes additionally require platform-admin privileges.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Organization ID to update"
+          },
+          "name": {
+            "type": "string",
+            "description": "New name"
+          },
+          "slug": {
+            "type": "string",
+            "description": "New URL slug. Pass empty string to regenerate from the (possibly updated) name. Slug collisions auto-disambiguate with -2, -3, etc."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "UNIVERSITY",
+              "RESEARCH_CENTER",
+              "NONPROFIT",
+              "DAO",
+              "GOVERNMENT",
+              "GOVERNMENT_AGENCY",
+              "HOSPITAL",
+              "BIOTECH",
+              "COMPANY",
+              "FOUNDATION",
+              "INTERGOVERNMENTAL",
+              "MEDIA",
+              "POLITICAL_PARTY",
+              "ADVOCACY",
+              "OTHER"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "APPROVED",
+              "REJECTED"
+            ],
+            "description": "Approval status. Platform-admin only."
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "PUBLIC",
+              "PRIVATE"
+            ],
+            "description": "Organization discoverability. Owner/admin members may flip either direction; no extra platform-admin gate. Switching to PRIVATE is rejected if the organization owns or is assigned any PUBLIC task."
+          },
+          "website": {
+            "type": "string",
+            "description": "Website URL (empty string clears)"
+          },
+          "description": {
+            "type": "string",
+            "description": "Mission or provenance note (empty string clears)"
+          },
+          "donationUrl": {
+            "type": "string",
+            "description": "Direct support or donation page URL (empty string clears)"
+          },
+          "squareLogoUrl": {
+            "type": "string",
+            "description": "Square logo mark URL (empty string clears). Use uploadImageFromUrl with kind=organization-square-logo first when starting from a remote public image URL."
+          },
+          "wordmarkLogoUrl": {
+            "type": "string",
+            "description": "Horizontal wordmark logo URL (empty string clears). Use uploadImageFromUrl with kind=organization-wordmark-logo first when starting from a remote public image URL."
+          },
+          "contactEmail": {
+            "type": "string",
+            "description": "Primary contact email (empty string clears)"
+          },
+          "jurisdictionId": {
+            "type": "string",
+            "description": "Jurisdiction ID (empty string clears). Platform-admin only."
+          }
+        },
+        "required": [
+          "organizationId"
+        ]
+      },
+      "name": "updateOrganization",
+      "requiredScopes": [
+        "earthdata:write",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Soft-delete an Organization (sets deletedAt). Caller must be an owner of the org AND a platform admin. Tasks previously assigned to this org keep their assigneeOrganizationId — orphan visibility is intentional for accountability.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Organization ID to soft-delete"
+          }
+        },
+        "required": [
+          "organizationId"
+        ]
+      },
+      "name": "deleteOrganization",
+      "requiredScopes": [
+        "earthdata:admin",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Add a user to an Organization with a given role, or update an existing member's role to that value. Caller must be an owner/admin of the org. Accepts only userId (no email lookup — that would expose User-account enumeration).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Organization ID"
+          },
+          "userId": {
+            "type": "string",
+            "description": "User ID to add as a member"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "owner",
+              "admin",
+              "member",
+              "viewer"
+            ],
+            "description": "Role within the organization. Default: member."
+          }
+        },
+        "required": [
+          "organizationId",
+          "userId"
+        ]
+      },
+      "name": "addOrganizationMember",
+      "requiredScopes": [
+        "earthdata:write",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Remove a user from an Organization. Caller must be an owner/admin of the org, OR be removing themselves. Cannot remove the last remaining owner — transfer ownership first by adding another owner.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Organization ID"
+          },
+          "userId": {
+            "type": "string",
+            "description": "User ID to remove"
+          }
+        },
+        "required": [
+          "organizationId",
+          "userId"
+        ]
+      },
+      "name": "removeOrganizationMember",
+      "requiredScopes": [
+        "earthdata:write",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Change a member's role within an Organization. Caller must be an owner/admin. Cannot demote the last remaining owner.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Organization ID"
+          },
+          "userId": {
+            "type": "string",
+            "description": "User ID whose role to change"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "owner",
+              "admin",
+              "member",
+              "viewer"
+            ],
+            "description": "New role."
+          }
+        },
+        "required": [
+          "organizationId",
+          "userId",
+          "role"
+        ]
+      },
+      "name": "updateOrganizationMemberRole",
+      "requiredScopes": [
+        "earthdata:write",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List members of an Organization with their roles, emails, and display names. Caller must be an owner/admin of the org.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Organization ID"
+          }
+        },
+        "required": [
+          "organizationId"
+        ]
+      },
+      "name": "listOrganizationMembers",
+      "requiredScopes": [
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Propose a bundle of tasks for review. Creates each as DRAFT, runs validation, returns review decisions. Does NOT auto-promote.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "candidates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string",
+                  "description": "Short imperative title"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Action and acceptance criteria"
+                },
+                "taskKey": {
+                  "type": "string",
+                  "description": "Stable key for dedup"
+                },
+                "ref": {
+                  "type": "string",
+                  "description": "Canonical same-request alias used by parentTaskRef, blockerRefs, proposalRef, and referenceMap."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Draft reference ID"
+                },
+                "assigneePersonId": {
+                  "type": "string"
+                },
+                "assigneeOrganizationId": {
+                  "type": "string"
+                },
+                "roleTitle": {
+                  "type": "string"
+                },
+                "contactUrl": {
+                  "type": "string"
+                },
+                "sourceUrls": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "blockerRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "IDs or taskKeys of tasks that must complete first"
+                },
+                "dependencies": {
+                  "type": "array",
+                  "description": "Prerequisites with optional explicit marginal probability or time contribution.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "taskRef": {
+                        "type": "string"
+                      },
+                      "probabilityDeltaBase": {
+                        "type": "number",
+                        "description": "Probability lift from 0 to 1."
+                      },
+                      "timeDeltaDaysBase": {
+                        "type": "number",
+                        "description": "Days accelerated by the prerequisite."
+                      },
+                      "assumptions": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "calculationVersion": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "taskRef"
+                    ]
+                  }
+                },
+                "parentTaskRef": {
+                  "type": "string",
+                  "description": "Required ID/taskKey of the best existing or same-bundle parent. Search first. Use $target-root only when no more specific parent exists."
+                },
+                "estimatedEffortHours": {
+                  "type": "number"
+                },
+                "isPublic": {
+                  "type": "boolean"
+                },
+                "executorType": {
+                  "type": "string",
+                  "enum": [
+                    "Self",
+                    "AI Agent"
+                  ]
+                },
+                "bestRoute": {
+                  "type": "string"
+                },
+                "dueAt": {
+                  "type": "string"
+                },
+                "deadlinePolicy": {
+                  "type": "string",
+                  "enum": [
+                    "NONE",
+                    "SOFT",
+                    "EXPIRES",
+                    "REQUIRED"
+                  ]
+                },
+                "acceptanceCriteria": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "source": {
+                  "type": "object",
+                  "description": "Stable Notion/manual/external provenance. Long source content stays linked rather than copied into the task body.",
+                  "properties": {
+                    "sourceKey": {
+                      "type": "string"
+                    },
+                    "sourceHash": {
+                      "type": "string"
+                    },
+                    "sourceUrl": {
+                      "type": "string"
+                    },
+                    "sourceSystem": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "sourceKey",
+                    "sourceSystem"
+                  ]
+                },
+                "impact": {
+                  "type": "object",
+                  "properties": {
+                    "delayDalysLostPerDay": {
+                      "type": "number",
+                      "description": "Expected DALYs lost per day of delay; use only with a sourced delay model"
+                    },
+                    "delayEconomicValueUsdLostPerDay": {
+                      "type": "number",
+                      "description": "Expected USD-equivalent welfare lost per day of delay; use only with a sourced delay model"
+                    },
+                    "expectedValuePerHourDalys": {
+                      "type": "number",
+                      "description": "Probability-weighted expected DALYs per hour, not gross conditional value"
+                    },
+                    "expectedValuePerHourUsd": {
+                      "type": "number",
+                      "description": "Probability-weighted expected USD-equivalent welfare per hour, not gross conditional value"
+                    },
+                    "expectedEconomicValueUsdLow": {
+                      "type": "number"
+                    },
+                    "expectedEconomicValueUsdBase": {
+                      "type": "number"
+                    },
+                    "expectedEconomicValueUsdHigh": {
+                      "type": "number"
+                    },
+                    "expectedDalysAvertedLow": {
+                      "type": "number"
+                    },
+                    "expectedDalysAvertedBase": {
+                      "type": "number"
+                    },
+                    "expectedDalysAvertedHigh": {
+                      "type": "number"
+                    },
+                    "medianHealthyLifeYearsEffectLow": {
+                      "type": "number"
+                    },
+                    "medianHealthyLifeYearsEffectBase": {
+                      "type": "number"
+                    },
+                    "medianHealthyLifeYearsEffectHigh": {
+                      "type": "number"
+                    },
+                    "medianIncomeGrowthEffectPpPerYearLow": {
+                      "type": "number"
+                    },
+                    "medianIncomeGrowthEffectPpPerYearBase": {
+                      "type": "number"
+                    },
+                    "medianIncomeGrowthEffectPpPerYearHigh": {
+                      "type": "number"
+                    },
+                    "successProbabilityLow": {
+                      "type": "number"
+                    },
+                    "successProbabilityBase": {
+                      "type": "number"
+                    },
+                    "successProbabilityHigh": {
+                      "type": "number"
+                    },
+                    "estimatedCashCostUsdLow": {
+                      "type": "number"
+                    },
+                    "estimatedCashCostUsdBase": {
+                      "type": "number"
+                    },
+                    "estimatedCashCostUsdHigh": {
+                      "type": "number"
+                    },
+                    "assumptions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "required": [
+                "title",
+                "parentTaskRef"
+              ]
+            },
+            "description": "Tasks to propose"
+          }
+        },
+        "required": [
+          "candidates"
+        ]
+      },
+      "name": "proposeTaskBundle",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Promote reviewed DRAFT tasks to ACTIVE. Promotion reruns governance review and rejects tasks that fail the current checks.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "proposalRefs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Proposal refs (task IDs or taskKeys) to promote"
+          }
+        },
+        "required": [
+          "proposalRefs"
+        ]
+      },
+      "name": "promoteTask",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Update task metadata, estimates, ancestry, dependencies, deadline, or executor. Reparent with exactly one of parentTaskId or parentTaskKey. Reference tasks in descriptions as titled Markdown links to https://optimitron.com/tasks/<id>, never as bare IDs. Completion and verification use the execution tools. Passing depends_on replaces the blocker set idempotently, so keep it complete.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "ACTIVE",
+              "STALE"
+            ]
+          },
+          "claimPolicy": {
+            "type": "string",
+            "enum": [
+              "ASSIGNED_ONLY",
+              "OPEN_SINGLE",
+              "OPEN_MANY"
+            ],
+            "description": "How work is claimed. Use ASSIGNED_ONLY for a named person or organization, OPEN_SINGLE for one claim that completes the task, and OPEN_MANY only for ongoing independent contributions."
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "parentTaskId": {
+            "type": "string",
+            "description": "Existing rooted parent task ID. Provide this or parentTaskKey, not both. Search first; cannot be Optimize Earth or create a hierarchy cycle."
+          },
+          "parentTaskKey": {
+            "type": "string",
+            "description": "Exact stable key of the existing rooted parent task. Provide this or parentTaskId, not both. Call getMe for personalRoot and organizationRoots."
+          },
+          "impactStatement": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "ADVOCACY",
+              "RESEARCH",
+              "COMMUNICATION",
+              "ENGINEERING",
+              "ORGANIZING",
+              "OUTREACH",
+              "GOVERNANCE",
+              "SCIENCE",
+              "LEGAL",
+              "CREATIVE",
+              "OTHER"
+            ],
+            "description": "Re-categorize the task. Affects category-filtered listTasks queries; not part of personal priority score."
+          },
+          "engagementKind": {
+            "type": "string",
+            "enum": [
+              "ONE_OFF",
+              "ONGOING",
+              "PART_TIME",
+              "FULL_TIME",
+              "CONTRACT"
+            ],
+            "description": "Commitment shape: ONE_OFF, ONGOING, PART_TIME, FULL_TIME, CONTRACT."
+          },
+          "applicationPolicy": {
+            "type": "string",
+            "enum": [
+              "CLOSED",
+              "OPEN",
+              "INVITE_ONLY"
+            ],
+            "description": "Whether users can apply: CLOSED, OPEN, or INVITE_ONLY."
+          },
+          "preferredSkillTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Skills that improve fit beyond required skillTags."
+          },
+          "requiredCredentialTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Credentials, licenses, or qualifications required."
+          },
+          "preferredCredentialTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Credentials that improve fit."
+          },
+          "requiredLanguageTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Languages required."
+          },
+          "preferredLanguageTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Languages that improve fit."
+          },
+          "requiredToolTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Tools, platforms, or software required."
+          },
+          "preferredToolTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Tools that improve fit."
+          },
+          "requiredAccessTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Accounts, clearance, location, network, or social access required."
+          },
+          "preferredAccessTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Access that improves fit."
+          },
+          "ownerOrganizationId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Organization that owns/reviews this opening or task."
+          },
+          "compensationKind": {
+            "type": "string",
+            "enum": [
+              "UNSPECIFIED",
+              "VOLUNTEER",
+              "PAID",
+              "BOUNTY",
+              "EQUITY",
+              "OTHER"
+            ],
+            "description": "Compensation category."
+          },
+          "compensationCadence": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "FIXED",
+              "HOURLY",
+              "WEEKLY",
+              "MONTHLY",
+              "ANNUAL",
+              null
+            ],
+            "description": "Compensation cadence. Null clears it."
+          },
+          "compensationCurrency": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Lowercase currency code, usually usd."
+          },
+          "compensationMinAmountMinorUnits": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Minimum compensation in currency minor units."
+          },
+          "compensationMaxAmountMinorUnits": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Maximum compensation in currency minor units."
+          },
+          "compensationMinAmountUsd": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Minimum compensation in whole US dollars; the server converts to minor units (cents). USD alternative to compensationMinAmountMinorUnits."
+          },
+          "compensationMaxAmountUsd": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Maximum compensation in whole US dollars; the server converts to minor units (cents). USD alternative to compensationMaxAmountMinorUnits."
+          },
+          "compensationPaymentRails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Acceptable payment rails, such as stripe, ach, usdc, wire."
+          },
+          "estimatedHoursPerWeekMin": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Minimum weekly hours for ongoing work."
+          },
+          "estimatedHoursPerWeekMax": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Maximum weekly hours for ongoing work."
+          },
+          "remotePolicy": {
+            "type": "string",
+            "enum": [
+              "UNSPECIFIED",
+              "REMOTE",
+              "HYBRID",
+              "ONSITE"
+            ],
+            "description": "UNSPECIFIED, REMOTE, HYBRID, or ONSITE."
+          },
+          "locationText": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable location constraint."
+          },
+          "workLocationCountryCode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "workLocationRegionCode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "workLocationCity": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "workLocationPostalCode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "workLocationLatitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "workLocationLongitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "workLocationRadiusKm": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "workTimeZone": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "IANA time zone preferred for the work."
+          },
+          "applicationQuestionsJson": {
+            "type": [
+              "object",
+              "array",
+              "null"
+            ],
+            "description": "Structured questions for applicants. Null clears it."
+          },
+          "executionMode": {
+            "type": "string",
+            "enum": [
+              "HUMAN_OR_AGENT",
+              "HUMAN_ONLY",
+              "AGENT_ONLY"
+            ],
+            "description": "HUMAN_OR_AGENT, HUMAN_ONLY, or AGENT_ONLY."
+          },
+          "maxClaims": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Max simultaneous claims when claimPolicy is OPEN_MANY."
+          },
+          "taskKey": {
+            "type": "string",
+            "description": "Stable dedup key"
+          },
+          "assigneePersonId": {
+            "type": "string",
+            "description": "Person ID to assign (use empty string to clear)"
+          },
+          "assigneeOrganizationId": {
+            "type": "string",
+            "description": "Organization ID to assign (use empty string to clear)"
+          },
+          "roleTitle": {
+            "type": "string",
+            "description": "Role of the assignee"
+          },
+          "sourceUrl": {
+            "type": "string",
+            "description": "URL to the source/evidence"
+          },
+          "available_at": {
+            "type": "string",
+            "description": "Earliest time this task should appear in active queues (ISO 8601), use empty string to clear"
+          },
+          "dueAt": {
+            "type": "string",
+            "description": "Due date (ISO 8601), use empty string to clear"
+          },
+          "due_at": {
+            "type": "string",
+            "description": "Alias for dueAt, use empty string to clear"
+          },
+          "deadline_policy": {
+            "type": "string",
+            "enum": [
+              "NONE",
+              "SOFT",
+              "EXPIRES",
+              "REQUIRED"
+            ],
+            "description": "Whether dueAt is ignored, a soft target, an expiring opportunity, or required work."
+          },
+          "deadline_rationale": {
+            "type": "string",
+            "description": "Freeform rationale for the deadline policy."
+          },
+          "contextJson": {
+            "type": "object",
+            "description": "Optional advanced task metadata merged with existing contextJson.",
+            "additionalProperties": true
+          },
+          "depends_on": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Replace blocker dependencies with this exact list of task IDs. Blockers must be completed/VERIFIED before this task appears in active queues."
+          },
+          "blockerTaskRefs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Replace blockers using task IDs or exact taskKeys."
+          },
+          "blockerTaskIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Replace blocker dependencies with this exact list of task IDs."
+          },
+          "hours": {
+            "type": "number",
+            "description": "Alias for estimatedEffortHours. Keep this current when task scope changes."
+          },
+          "value": {
+            "type": "number",
+            "description": "Gross conditional value if the task succeeds. Update when the upside/downside estimate changes."
+          },
+          "p_success": {
+            "type": "number",
+            "description": "Success probability, 0-1. Update after new information changes the odds."
+          },
+          "cash_cost": {
+            "type": "number",
+            "description": "Cash cost in USD. Update if execution cost changes."
+          },
+          "executor_type": {
+            "type": "string",
+            "enum": [
+              "Self",
+              "AI Agent"
+            ],
+            "description": "Who should execute this task. Use Self for normal user tasks even with AI assistance; AI Agent means autonomous assistant work."
+          },
+          "ev_math": {
+            "type": "string",
+            "description": "Freeform rationale for value/probability/hour assumptions"
+          },
+          "can_delegate": {
+            "type": "boolean",
+            "description": "Whether an agent or contractor can do this task"
+          },
+          "best_route": {
+            "type": "string",
+            "description": "Best execution route, e.g. self, agent, contractor"
+          },
+          "acceptanceCriteria": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Structured acceptance criteria. If omitted while description is updated, updateTask can extract checklist bullets under a markdown 'Acceptance criteria' heading."
+          },
+          "sortOrder": {
+            "type": "number",
+            "description": "Manual display order for public/task-tree views (lower = earlier). Not the computed personal priority score."
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "updateTask",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Search published parameters used by Optimitron calculations.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Key, display name, or description text."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Maximum results (default 20, max 100)."
+          }
+        }
+      },
+      "name": "searchParameters",
+      "requiredScopes": [
+        "tasks:personal",
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Get one exact parameter revision with formula, uncertainty, pinned input revisions, source metadata, inert calculation code, assumptions, and publication state.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "revisionId": {
+            "type": "string",
+            "description": "Exact revision id. Preferred for reproducible traces."
+          },
+          "key": {
+            "type": "string",
+            "description": "Parameter key when looking up the current revision."
+          }
+        }
+      },
+      "name": "getParameterTrace",
+      "requiredScopes": [
+        "tasks:personal",
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create one or more immutable parameter revision drafts. Returns numerical diffs, formulas or inert calculation code, exact input revisions, and provenance for human review. This never publishes revisions.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "parameters": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 100,
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "number"
+                },
+                "unit": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "displayName": {
+                  "type": "string"
+                },
+                "displayValue": {
+                  "type": "string"
+                },
+                "sourceType": {
+                  "type": "string",
+                  "enum": [
+                    "EXTERNAL",
+                    "CALCULATED",
+                    "DEFINITION",
+                    "AI_ESTIMATED",
+                    "CURATED"
+                  ]
+                },
+                "sourceRef": {
+                  "type": "string"
+                },
+                "sourceUrls": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "calculationSource": {
+                  "type": "object",
+                  "description": "Exact Python, notebook, or other calculation source to retain as inert content-addressed data. Optimitron stores but never executes it.",
+                  "properties": {
+                    "language": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    },
+                    "runtime": {
+                      "type": "object"
+                    },
+                    "dependencies": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "entrypoint": {
+                      "type": "string"
+                    },
+                    "inputs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "outputs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "notes": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "language",
+                    "source"
+                  ]
+                },
+                "formulaText": {
+                  "type": "string"
+                },
+                "formulaLatex": {
+                  "type": "string"
+                },
+                "manualRef": {
+                  "type": "string"
+                },
+                "latexSymbol": {
+                  "type": "string"
+                },
+                "confidence": {
+                  "type": "string"
+                },
+                "sourceLastUpdated": {
+                  "type": "string"
+                },
+                "peerReviewed": {
+                  "type": "boolean"
+                },
+                "conservative": {
+                  "type": "boolean"
+                },
+                "sensitivity": {
+                  "type": "number"
+                },
+                "confidenceIntervalLow": {
+                  "type": "number"
+                },
+                "confidenceIntervalHigh": {
+                  "type": "number"
+                },
+                "stdError": {
+                  "type": "number"
+                },
+                "distributionType": {
+                  "type": "string",
+                  "enum": [
+                    "FIXED",
+                    "NORMAL",
+                    "LOGNORMAL",
+                    "BETA",
+                    "GAMMA",
+                    "TRIANGULAR",
+                    "UNIFORM"
+                  ]
+                },
+                "distributionParameters": {
+                  "type": "object"
+                },
+                "summaryStats": {
+                  "type": "object"
+                },
+                "validationMin": {
+                  "type": "number"
+                },
+                "validationMax": {
+                  "type": "number"
+                },
+                "rationale": {
+                  "type": "string"
+                },
+                "assumptions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "inputs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "symbol": {
+                        "type": "string"
+                      },
+                      "parameterKey": {
+                        "type": "string"
+                      },
+                      "revisionId": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "symbol",
+                      "parameterKey"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "key",
+                "value",
+                "unit",
+                "description",
+                "rationale"
+              ]
+            }
+          }
+        },
+        "required": [
+          "parameters"
+        ]
+      },
+      "name": "proposeParameterBundle",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Publish or reject one reviewed parameter revision.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "revisionId": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "publish",
+              "reject"
+            ]
+          }
+        },
+        "required": [
+          "revisionId",
+          "action"
+        ]
+      },
+      "name": "reviewParameterRevision",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create an immutable task-impact draft with materialized values, formulas or inert calculation code, assumptions, and sources. Public drafts require admin review before use.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string"
+          },
+          "frameKey": {
+            "type": "string",
+            "enum": [
+              "IMMEDIATE",
+              "ONE_YEAR",
+              "FIVE_YEAR",
+              "TWENTY_YEAR",
+              "LIFETIME"
+            ]
+          },
+          "frame": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "assumptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "formulaText": {
+            "type": "string"
+          },
+          "formulaLatex": {
+            "type": "string"
+          },
+          "calculationCode": {
+            "type": "string"
+          },
+          "calculationLanguage": {
+            "type": "string"
+          },
+          "sourceUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "calculationSource": {
+            "type": "object",
+            "description": "Exact Python, notebook, or other calculation source to retain as inert content-addressed data. Optimitron stores but never executes it.",
+            "properties": {
+              "language": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "runtime": {
+                "type": "object"
+              },
+              "dependencies": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "entrypoint": {
+                "type": "string"
+              },
+              "inputs": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "outputs": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "notes": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "language",
+              "source"
+            ]
+          },
+          "estimateNotes": {
+            "type": "string"
+          },
+          "calculationVersion": {
+            "type": "string"
+          },
+          "methodologyKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "proposeTaskImpact",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Trace the current or specified task-impact estimate through its formula, materialized values, recursive parameter tree, and source metadata.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string"
+          },
+          "estimateSetId": {
+            "type": "string"
+          }
+        }
+      },
+      "name": "getTaskImpactTrace",
+      "requiredScopes": [
+        "tasks:personal",
+        "earthdata:write"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Create or replace a task impact estimate. Values are USD-equivalent welfare; expectedEconomicValueUsd* fields must already be probability-weighted. Include low/base/high ranges, assumptions, and sourceUrls for subjective or high-value estimates. Negative values represent harm caused.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID to attach impact to"
+          },
+          "frameKey": {
+            "type": "string",
+            "enum": [
+              "IMMEDIATE",
+              "ONE_YEAR",
+              "FIVE_YEAR",
+              "TWENTY_YEAR",
+              "LIFETIME"
+            ],
+            "description": "Time horizon for evaluation (default: FIVE_YEAR)"
+          },
+          "frame": {
+            "type": "object",
+            "description": "Low/base/high impact frame. expectedEconomicValueUsd* is already probability-weighted; for Notion imports use P(success) * Value.",
+            "properties": {
+              "evaluationHorizonYears": {
+                "type": "number",
+                "description": "Years covered by this estimate"
+              },
+              "successProbabilityLow": {
+                "type": "number",
+                "description": "Low success probability, 0-1"
+              },
+              "successProbabilityBase": {
+                "type": "number",
+                "description": "Base success probability, 0-1"
+              },
+              "successProbabilityHigh": {
+                "type": "number",
+                "description": "High success probability, 0-1"
+              },
+              "delayDalysLostPerDayLow": {
+                "type": "number"
+              },
+              "delayDalysLostPerDayBase": {
+                "type": "number"
+              },
+              "delayDalysLostPerDayHigh": {
+                "type": "number"
+              },
+              "delayEconomicValueUsdLostPerDayLow": {
+                "type": "number"
+              },
+              "delayEconomicValueUsdLostPerDayBase": {
+                "type": "number"
+              },
+              "delayEconomicValueUsdLostPerDayHigh": {
+                "type": "number"
+              },
+              "expectedDalysAvertedLow": {
+                "type": "number"
+              },
+              "expectedDalysAvertedBase": {
+                "type": "number"
+              },
+              "expectedDalysAvertedHigh": {
+                "type": "number"
+              },
+              "expectedEconomicValueUsdLow": {
+                "type": "number",
+                "description": "Low probability-weighted USD-equivalent welfare"
+              },
+              "expectedEconomicValueUsdBase": {
+                "type": "number",
+                "description": "Base probability-weighted USD-equivalent welfare"
+              },
+              "expectedEconomicValueUsdHigh": {
+                "type": "number",
+                "description": "High probability-weighted USD-equivalent welfare"
+              },
+              "estimatedCashCostUsdLow": {
+                "type": "number"
+              },
+              "estimatedCashCostUsdBase": {
+                "type": "number"
+              },
+              "estimatedCashCostUsdHigh": {
+                "type": "number"
+              },
+              "estimatedEffortHoursLow": {
+                "type": "number"
+              },
+              "estimatedEffortHoursBase": {
+                "type": "number"
+              },
+              "estimatedEffortHoursHigh": {
+                "type": "number"
+              }
+            }
+          },
+          "metrics": {
+            "type": "array",
+            "description": "Custom impact metrics (lives lost, taxpayer cost, suffering hours, etc.)",
+            "items": {
+              "type": "object",
+              "properties": {
+                "metricKey": {
+                  "type": "string",
+                  "description": "Stable key (e.g. lives_lost, taxpayer_cost_usd)"
+                },
+                "baseValue": {
+                  "type": "number",
+                  "description": "Primary estimate (negative = harm)"
+                },
+                "lowValue": {
+                  "type": "number"
+                },
+                "highValue": {
+                  "type": "number"
+                },
+                "unit": {
+                  "type": "string",
+                  "description": "Unit label (e.g. lives, USD, hours)"
+                },
+                "displayGroup": {
+                  "type": "string",
+                  "description": "UI grouping label"
+                }
+              },
+              "required": [
+                "metricKey",
+                "baseValue",
+                "unit"
+              ]
+            }
+          },
+          "assumptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Human-readable assumptions, including probability gates and why subjective values are plausible"
+          },
+          "sourceUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Sources/citations for the value, probability, deadline, or conversion assumptions"
+          },
+          "estimateNotes": {
+            "type": "string",
+            "description": "Short explanation of the calculation and what would change the estimate"
+          },
+          "formulaText": {
+            "type": "string",
+            "description": "The arithmetic behind the number, in plain text, so a reader can check it without running anything"
+          },
+          "formulaLatex": {
+            "type": "string",
+            "description": "Same formula as LaTeX, rendered on the task page"
+          },
+          "calculationVersion": {
+            "type": "string",
+            "description": "Version tag for the calculation method"
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "setTaskImpact",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Claim a task as the authenticated user.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID to claim"
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "claimTask",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Commit to reminding a specific head of state (or other 1% Treaty signer) to sign. Creates a private reminder subtask for you, parented to the signer task. The subtask carries an actionLink to a Google search for the signer's official contact, plus an outreach message template with your referral code embedded so any signer click-through credits you. Idempotent: calling twice with the same signer returns the existing subtask. The subtask auto-VERIFIES when the signer signs the treaty via your referral.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "signerTaskId": {
+            "type": "string",
+            "description": "Task ID of the parent signer task (e.g. 1-pct-treaty-signer-us). Use listTasks or searchTasks with status=ACTIVE to find candidates."
+          }
+        },
+        "required": [
+          "signerTaskId"
+        ]
+      },
+      "name": "claimSignerReminder",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Mark one private Self task you own VERIFIED in a single call so it leaves your active queue. This owner-attestation shortcut is only for uncompensated, childless personal tasks that are unassigned or assigned only to you and have no formal work history. Use the submission-and-verification workflow for OPEN_MANY, delegated, shared, paid, public, organization, or agent work. If a one-person task was incorrectly stored as OPEN_MANY and has no formal history, update its claimPolicy to OPEN_SINGLE first.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Private Self task ID"
+          },
+          "completionEvidence": {
+            "type": "string",
+            "description": "A short factual description of what was completed"
+          }
+        },
+        "required": [
+          "taskId",
+          "completionEvidence"
+        ]
+      },
+      "name": "completeTask",
+      "requiredScopes": [
+        "tasks:personal"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Claim an open task if needed, then mark only the authenticated user's claim completed. This does not itself complete the task. An authorized reviewer may later verify the claim; OPEN_SINGLE then resolves the task, while OPEN_MANY remains active for more contributions. Safe to retry after claim completion.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID"
+          },
+          "completionEvidence": {
+            "type": "string",
+            "description": "What was done and proof it worked"
+          }
+        },
+        "required": [
+          "taskId",
+          "completionEvidence"
+        ]
+      },
+      "name": "completeTaskClaim",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Add a dependency between tasks. The blocked task cannot proceed until the blocker is done. Optional edge metadata can estimate how much the blocker raises downstream success probability or accelerates downstream value.",
+      "inputSchema": {
+        "type": "object",
+        "allOf": [
+          {
+            "anyOf": [
+              {
+                "required": [
+                  "blockedTaskRef"
+                ]
+              },
+              {
+                "required": [
+                  "blockedTaskId"
+                ]
+              }
+            ]
+          },
+          {
+            "anyOf": [
+              {
+                "required": [
+                  "blockerTaskRef"
+                ]
+              },
+              {
+                "required": [
+                  "blockerTaskId"
+                ]
+              }
+            ]
+          }
+        ],
+        "properties": {
+          "blockedTaskRef": {
+            "type": "string",
+            "description": "Canonical task ID or exact taskKey for the task that is blocked."
+          },
+          "blockedTaskId": {
+            "type": "string",
+            "description": "Task that is blocked"
+          },
+          "blockerTaskRef": {
+            "type": "string",
+            "description": "Canonical task ID or exact taskKey for the task that must complete first."
+          },
+          "blockerTaskId": {
+            "type": "string",
+            "description": "Task that must complete first"
+          },
+          "probabilityDeltaBase": {
+            "type": "number",
+            "description": "Base probability lift, 0-1, produced by completing blockerTaskId for blockedTaskId."
+          },
+          "increases_p_success": {
+            "type": "number",
+            "description": "Alias for probabilityDeltaBase. Use for Notion-style 'this prerequisite raises downstream P(success)' estimates."
+          },
+          "timeDeltaDaysBase": {
+            "type": "number",
+            "description": "Base days of acceleration produced by completing blockerTaskId for blockedTaskId."
+          },
+          "time_delta_days": {
+            "type": "number",
+            "description": "Alias for timeDeltaDaysBase."
+          },
+          "assumptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Short assumptions behind the edge lift estimate."
+          },
+          "calculationVersion": {
+            "type": "string",
+            "description": "Optional version tag for the edge-lift calculation."
+          },
+          "label": {
+            "type": "string",
+            "description": "Optional note describing the dependency"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional note describing the dependency"
+          }
+        }
+      },
+      "name": "addDependency",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Get all tasks blocking a given task, and all tasks this task blocks.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID"
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "getBlockers",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Log an agent's work — what it did, what it cost, what task it advanced.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "runId": {
+            "type": "string",
+            "description": "Unique run identifier"
+          },
+          "provider": {
+            "type": "string",
+            "description": "AI provider (gemini, anthropic, openai)"
+          },
+          "costUsd": {
+            "type": "number",
+            "description": "Total cost in USD"
+          },
+          "apiCalls": {
+            "type": "number",
+            "description": "Number of API calls"
+          },
+          "taskId": {
+            "type": "string",
+            "description": "Task this run worked on"
+          },
+          "agentId": {
+            "type": "string",
+            "description": "Stable agent identifier, usually matching the lease agentId"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "RUNNING",
+              "COMPLETED",
+              "FAILED",
+              "PARTIAL"
+            ]
+          },
+          "outputSummary": {
+            "type": "string",
+            "description": "What the run produced"
+          }
+        },
+        "required": [
+          "runId",
+          "provider",
+          "costUsd",
+          "apiCalls",
+          "taskId"
+        ]
+      },
+      "name": "logAgentRun",
+      "requiredScopes": [
+        "agent:run"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Acquire a short-lived lease on a task to prevent other agents from working it simultaneously.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID to lease"
+          },
+          "agentId": {
+            "type": "string",
+            "description": "Unique agent identifier"
+          },
+          "leaseSeconds": {
+            "type": "number",
+            "description": "Lease duration in seconds (default 600)"
+          }
+        },
+        "required": [
+          "taskId",
+          "agentId"
+        ]
+      },
+      "name": "acquireLease",
+      "requiredScopes": [
+        "agent:run"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Extend an active lease. Call periodically to prevent expiry while working.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID"
+          },
+          "agentId": {
+            "type": "string",
+            "description": "Agent identifier"
+          },
+          "leaseSeconds": {
+            "type": "number",
+            "description": "New lease duration in seconds (default 600)"
+          }
+        },
+        "required": [
+          "taskId",
+          "agentId"
+        ]
+      },
+      "name": "heartbeatLease",
+      "requiredScopes": [
+        "agent:run"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Voluntarily release a lease so another agent can pick up the task.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID"
+          },
+          "agentId": {
+            "type": "string",
+            "description": "Agent identifier"
+          }
+        },
+        "required": [
+          "taskId",
+          "agentId"
+        ]
+      },
+      "name": "releaseLease",
+      "requiredScopes": [
+        "agent:run"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List Optimitron referendums. Public callers see active referendums by default; admins can filter by DRAFT, ACTIVE, or CLOSED.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "ACTIVE",
+              "CLOSED"
+            ],
+            "description": "Referendum status filter. Defaults to ACTIVE."
+          },
+          "query": {
+            "type": "string",
+            "description": "Optional search over title, slug, and description."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max referendums to return (default 20, max 100)."
+          }
+        }
+      },
+      "name": "listReferendums",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": true,
+      "description": "Create a new referendum row. Defaults to DRAFT so a new question does not start accepting votes until intentionally activated.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Human-readable referendum title."
+          },
+          "slug": {
+            "type": "string",
+            "description": "Optional URL slug. Defaults to a slugified title."
+          },
+          "description": {
+            "type": "string",
+            "description": "Short public summary for cards, lists, and metadata."
+          },
+          "question": {
+            "type": "string",
+            "description": "Canonical yes/no ballot question voters answer."
+          },
+          "bodyMarkdown": {
+            "type": "string",
+            "description": "Full public referendum detail text in Markdown."
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "GENERAL",
+              "DECLARATION",
+              "TREATY",
+              "MEMBERSHIP",
+              "COURT_CASE",
+              "AMENDMENT",
+              "BUDGET"
+            ],
+            "description": "Referendum kind. Defaults to GENERAL."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "ACTIVE",
+              "CLOSED"
+            ],
+            "description": "Initial status. Defaults to DRAFT."
+          },
+          "jurisdictionId": {
+            "type": "string",
+            "description": "Optional jurisdiction ID if this referendum is scoped."
+          }
+        },
+        "required": [
+          "title",
+          "question"
+        ]
+      },
+      "name": "createReferendum",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Search allowed GitHub repositories through the server-side GitHub API token. Returns matching files and text-match snippets without exposing the token.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search string, e.g. a function name, symbol, or code fragment."
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name or owner/repo. Default: the configured Optimitron repo."
+          },
+          "path": {
+            "type": "string",
+            "description": "Optional directory path qualifier, e.g. apps/optimitron/src/lib."
+          },
+          "fileType": {
+            "type": "string",
+            "description": "Optional file extension without a dot, e.g. ts or tsx."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max GitHub code-search results to return (default 10, max 25)."
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "name": "searchRepo",
+      "requiredScopes": [
+        "github"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Fetch one allowed GitHub repository file through the server-side GitHub Contents API.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repo": {
+            "type": "string",
+            "description": "Repository name or owner/repo."
+          },
+          "path": {
+            "type": "string",
+            "description": "File path within the repo."
+          },
+          "ref": {
+            "type": "string",
+            "description": "Optional branch, tag, or commit SHA. Default: main."
+          }
+        },
+        "required": [
+          "repo",
+          "path"
+        ]
+      },
+      "name": "getFileContent",
+      "requiredScopes": [
+        "github"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "List files/directories from an allowed GitHub repository directory through the server-side GitHub Contents API.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repo": {
+            "type": "string",
+            "description": "Repository name or owner/repo."
+          },
+          "path": {
+            "type": "string",
+            "description": "Directory path within the repo. Default: repo root."
+          },
+          "ref": {
+            "type": "string",
+            "description": "Optional branch, tag, or commit SHA. Default: main."
+          }
+        },
+        "required": [
+          "repo"
+        ]
+      },
+      "name": "listRepoFiles",
+      "requiredScopes": [
+        "github"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Admin-only generic pass-through to api.github.com using the server-side token. Use this for issues, PRs, discussions, commit statuses, workflow runs, agent tasks, etc. — anything the dedicated tools don't already cover. Repo-allowlist is enforced on /repos/<owner>/<repo>/* paths; non-repo paths (/user, /search/code, /octocat) rely on the token's fine-grained scopes for safety. Returns { status, ok, body }.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "method": {
+            "type": "string",
+            "enum": [
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "description": "HTTP method. Default: GET."
+          },
+          "path": {
+            "type": "string",
+            "description": "Path on api.github.com starting with '/', e.g. '/repos/mikepsinn/optimitron/issues' or '/search/code'."
+          },
+          "query": {
+            "type": "object",
+            "description": "Optional query-string params, e.g. { per_page: 50, state: 'open' }.",
+            "additionalProperties": true
+          },
+          "body": {
+            "description": "Optional request body for non-GET requests. Pass an object (auto-JSON.stringify'd) or a raw string."
+          }
+        },
+        "required": [
+          "path"
+        ]
+      },
+      "name": "githubApi",
+      "requiredScopes": [
+        "github"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Return a structured inventory of pages for configured Optimitron-owned domains. Agents should call this before creating a new page.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "site": {
+            "type": "string",
+            "description": "Optional domain filter, e.g. optimitron.com, warondisease.org, dfda.earth, dih.earth, or manual.warondisease.org."
+          }
+        }
+      },
+      "name": "listSitePages",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "Return the fully rendered logged-out text for an Optimitron-owned page as clean markdown, with its title, section headings, and last-modified metadata. Checked-in rendered snapshots are preferred so client-side loading shells are never mistaken for page content; this public reader does not expose authenticated page text.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Full URL of an allowed page."
+          }
+        },
+        "required": [
+          "url"
+        ]
+      },
+      "name": "getPageContent",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "Search the Optimitron manual, disease eradication plan, and related documentation. Returns relevant context with citations.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search query (e.g. 'FDA approval timeline', 'RAPPA preference aggregation')"
+          },
+          "maxResults": {
+            "type": "number",
+            "description": "Max results to return (default 5)"
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "name": "searchManual",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "Ask Wishonia a question — she answers in character using retrieved documentation from the Optimitron manual and disease eradication plan.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "question": {
+            "type": "string",
+            "description": "Your question for Wishonia"
+          }
+        },
+        "required": [
+          "question"
+        ]
+      },
+      "name": "askWishonia",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "Fuzzy-search your accessible tasks by title, description, impact statement, task key, assignee, or organization. Signed-in results may include public tasks and private tasks you created, manage, are assigned, claimed, or can access through an organization; other users' private work remains excluded. Use this before createTask/updateTask to find parents, duplicates, blockerTaskIds, or blockedTaskIds. Long snippets are capped at 200 characters and include a getTask instruction for reading the full description. For Optimitron code or documentation work, query the stable key 'optimitron:dev', select that exact result, and call createTask with parentTaskKey='optimitron:dev'. Returns the legacy result array unless paginated=true or cursor is supplied. Paginated inventory uses immutable task-ID order, not relevance order.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search query text."
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Opaque cursor returned as nextCursor by the preceding page. Copy it verbatim and keep query and filters unchanged."
+          },
+          "paginated": {
+            "type": "boolean",
+            "description": "Return {tasks,nextCursor}. Omit for the legacy result-array response."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results to return (default 20, max 100)"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "all",
+              "public",
+              "private"
+            ],
+            "description": "Which tasks to search: 'all' = public + your private work (default when signed in), 'public' = public only (default for anonymous callers), 'private' = only your non-public tasks."
+          },
+          "scope": {
+            "type": "string",
+            "enum": [
+              "public",
+              "accessible"
+            ],
+            "description": "Deprecated alias of visibility ('accessible' = 'all'). Prefer visibility."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "ACTIVE",
+              "VERIFIED",
+              "STALE"
+            ],
+            "description": "Optional status filter to narrow dependency candidates."
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "name": "searchTasks",
+      "requiredScopes": []
+    },
+    {
+      "adminOnly": false,
+      "description": "Post a comment on a task. Message is GitHub-flavored markdown with these extensions:\n- Math: $inline$ or $$block$$ (rendered via KaTeX)\n- Diagrams: ```mermaid ... ``` fences (rendered via Mermaid)\n- Charts: ```chart { ...Chart.js config JSON... } ``` fences\n- Images: ![alt](url) inline\n- Tables, lists, strikethrough, code blocks, blockquotes — all standard\nMax length: 20,000 characters. Rate limit: 5 comments per task per hour.\nPosting a comment automatically sends comment notifications to task recipients and triggers a Wishonia auto-reply in the background.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID to comment on"
+          },
+          "parentCommentId": {
+            "type": "string",
+            "description": "Optional parent comment ID if this is a reply"
+          },
+          "message": {
+            "type": "string",
+            "description": "Markdown body (1-20000 chars, supports math/mermaid/chart fences)"
+          },
+          "mediaUrl": {
+            "type": "string",
+            "description": "Optional evidence URL (tweet, screenshot, article)"
+          }
+        },
+        "required": [
+          "taskId",
+          "message"
+        ]
+      },
+      "name": "postTaskComment",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Upvote (+1), downvote (-1), or remove vote (0) on a task comment.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "commentId": {
+            "type": "string",
+            "description": "Comment ID to vote on"
+          },
+          "value": {
+            "type": "number",
+            "description": "+1 upvote, -1 downvote, 0 remove vote"
+          }
+        },
+        "required": [
+          "commentId",
+          "value"
+        ]
+      },
+      "name": "voteTaskComment",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Soft-delete your own comment (or any comment if you are a curator).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "commentId": {
+            "type": "string",
+            "description": "Comment ID to delete"
+          }
+        },
+        "required": [
+          "commentId"
+        ]
+      },
+      "name": "deleteTaskComment",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Fetch paginated comments for a task. Returns comments with vote scores, nested replies, and recent activity events.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Task ID to read comments for"
+          },
+          "sort": {
+            "type": "string",
+            "description": "'new' (default) or 'top'",
+            "enum": [
+              "new",
+              "top"
+            ]
+          },
+          "cursor": {
+            "type": "string",
+            "description": "ISO timestamp cursor from a previous response's nextCursor"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Default 50, max 100"
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "getTaskComments",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Create a reusable task template backed by TaskTrigger. Use this when a task should be stamped out for many people/orgs or fired by an event such as user.signup. Defaults to eventName='manual' and disabled until previewed/enabled.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "templateKey": {
+            "type": "string",
+            "description": "Stable unique key for this template, e.g. mission:first-hour."
+          },
+          "eventName": {
+            "type": "string",
+            "description": "Event that fires this template. Defaults to manual. Use user.signup for everyone-on-signup tasks."
+          },
+          "idempotencyKeyTemplate": {
+            "type": "string",
+            "description": "Template producing one stable task-key base per target. Defaults to '<templateKey>:{{target.kind}}:{{target.id}}', or '<templateKey>:user:{{user.id}}' for user.* events."
+          },
+          "eventFilter": {
+            "type": "object"
+          },
+          "completionGate": {
+            "type": "object"
+          },
+          "jurisdictionId": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Defaults to false. Preview first, then enable when the template is right."
+          },
+          "spawnSpecs": {
+            "type": "array",
+            "description": "One spawned task per spec. Use assigneePersonResolver='context.target.id' for person targets, assigneeOrganizationResolver='context.target.id' for organization targets, or resolver='actor' for the calling user.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "description": "Suffix used in spawned taskKey."
+                },
+                "isParent": {
+                  "type": "boolean"
+                },
+                "sortOrder": {
+                  "type": "number"
+                },
+                "titleTemplate": {
+                  "type": "string"
+                },
+                "descriptionTemplate": {
+                  "type": "string"
+                },
+                "impactStatementTemplate": {
+                  "type": "string"
+                },
+                "roleTitleTemplate": {
+                  "type": "string"
+                },
+                "category": {
+                  "type": "string"
+                },
+                "estimatedEffortHours": {
+                  "type": "number"
+                },
+                "dueDays": {
+                  "type": "number"
+                },
+                "availableInDays": {
+                  "type": "number"
+                },
+                "deadlinePolicy": {
+                  "type": "string",
+                  "enum": [
+                    "NONE",
+                    "SOFT",
+                    "EXPIRES",
+                    "REQUIRED"
+                  ]
+                },
+                "claimPolicy": {
+                  "type": "string"
+                },
+                "isPublic": {
+                  "type": "boolean"
+                },
+                "skillTagTemplates": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "interestTagTemplates": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "actionLinkUrlTemplate": {
+                  "type": "string"
+                },
+                "actionLinkLabelTemplate": {
+                  "type": "string"
+                },
+                "actionLinkInstructionsTemplate": {
+                  "type": "string"
+                },
+                "creatorResolver": {
+                  "type": "string"
+                },
+                "assigneePersonResolver": {
+                  "type": "string"
+                },
+                "assigneeOrganizationResolver": {
+                  "type": "string"
+                },
+                "parentResolver": {
+                  "type": "string"
+                },
+                "contributesToGate": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "kind",
+                "titleTemplate",
+                "descriptionTemplate"
+              ]
+            }
+          },
+          "metadata": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "templateKey",
+          "spawnSpecs"
+        ]
+      },
+      "name": "createTaskTemplate",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List reusable task templates. This is a friendly view over TaskTrigger rows.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "eventName": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "jurisdictionId": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Default 100, max 500"
+          }
+        }
+      },
+      "name": "listTaskTemplates",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Get one task template, including spawned task specs and recent fires.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "templateKey": {
+            "type": "string"
+          },
+          "recentFires": {
+            "type": "number",
+            "description": "How many recent fires to include. Default 10, max 100."
+          }
+        },
+        "required": [
+          "templateKey"
+        ]
+      },
+      "name": "getTaskTemplate",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Render a task template for a target/context without writing anything. Use before enabling or assigning a template.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "templateKey": {
+            "type": "string"
+          },
+          "targetPersonId": {
+            "type": "string",
+            "description": "Person ID to assign/render for. Adds context.target={kind:'person',id} and context.recipientPersonId."
+          },
+          "targetOrganizationId": {
+            "type": "string",
+            "description": "Organization ID to assign/render for. Adds context.target={kind:'organization',id} and context.organizationId."
+          },
+          "targetUserId": {
+            "type": "string",
+            "description": "User ID to render for. Adds context.target={kind:'user',id} and context.user.id."
+          },
+          "context": {
+            "type": "object",
+            "description": "Extra template context. Explicit fields here are preserved unless a target helper fills a missing field."
+          }
+        },
+        "required": [
+          "templateKey"
+        ]
+      },
+      "name": "previewTaskTemplate",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Stamp out a task template for one target. Writes are idempotent through the template's idempotencyKeyTemplate and the spawned taskKey values.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "templateKey": {
+            "type": "string"
+          },
+          "targetPersonId": {
+            "type": "string",
+            "description": "Person ID to assign/render for. Adds context.target={kind:'person',id} and context.recipientPersonId."
+          },
+          "targetOrganizationId": {
+            "type": "string",
+            "description": "Organization ID to assign/render for. Adds context.target={kind:'organization',id} and context.organizationId."
+          },
+          "targetUserId": {
+            "type": "string",
+            "description": "User ID to render for. Adds context.target={kind:'user',id} and context.user.id."
+          },
+          "context": {
+            "type": "object",
+            "description": "Extra template context. Explicit fields here are preserved unless a target helper fills a missing field."
+          }
+        },
+        "required": [
+          "templateKey"
+        ]
+      },
+      "name": "assignTaskTemplate",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Create a new TaskTrigger blueprint. The trigger fires on a named event (e.g. 'user.signup', 'referral.sent', 'cron.<name>') and either spawns tasks, verifies a task on a completion gate, or spawns a communication. Templates use {{path.to.field}} substitution against the event context. This is the data-driven way to add new onboarding flows / reminder cadences / task spawners without a code commit. Returns the created trigger row.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "triggerKey": {
+            "type": "string",
+            "description": "Stable unique key, e.g. 'user-onboarding:treaty'."
+          },
+          "eventName": {
+            "type": "string",
+            "description": "Event that fires this trigger."
+          },
+          "triggerKind": {
+            "type": "string",
+            "enum": [
+              "spawnTasks",
+              "verifyTask",
+              "spawnCommunication"
+            ],
+            "description": "What the trigger does. Defaults to spawnTasks."
+          },
+          "idempotencyKeyTemplate": {
+            "type": "string",
+            "description": "Template producing a unique key per logical fire, e.g. 'user-onboarding:treaty:{{user.id}}'."
+          },
+          "eventFilter": {
+            "type": "object",
+            "description": "Optional JSON filter (equals/matches/and/or/not/exists)."
+          },
+          "completionGate": {
+            "type": "object",
+            "description": "Optional gate spec (allOf/anyOf/count/always). Add inputScope: 'siblings' to gate against the verify target's siblings instead of its children."
+          },
+          "jurisdictionId": {
+            "type": "string",
+            "description": "Optional jurisdiction scope."
+          },
+          "notes": {
+            "type": "string",
+            "description": "Free-form notes."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Defaults to false for MCP-authored triggers."
+          },
+          "schedule": {
+            "type": "string",
+            "description": "Optional cron expression (e.g. '30 * * * *'). When set, /api/cron/run-due-triggers fires this trigger when the schedule is due since its last successful fire. Omit for triggers that fire only on application events (user.signup, referral.sent, etc.)."
+          },
+          "iterationSource": {
+            "type": "string",
+            "enum": [
+              "none",
+              "overdue-tasks"
+            ],
+            "description": "Optional resolver key for the data the cron handler iterates over before firing. 'overdue-tasks' fires the trigger once per overdue Task; 'none' fires once with no record. Omit for non-cron triggers."
+          },
+          "spawnSpecs": {
+            "type": "array",
+            "description": "For triggerKind=spawnTasks: one spec per task to create. At most one isParent=true. Children get taskKey '<idempotencyKey>:<kind>'; parent gets just '<idempotencyKey>'.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "description": "Suffix used in spawned taskKey."
+                },
+                "isParent": {
+                  "type": "boolean"
+                },
+                "sortOrder": {
+                  "type": "number"
+                },
+                "titleTemplate": {
+                  "type": "string"
+                },
+                "descriptionTemplate": {
+                  "type": "string"
+                },
+                "impactStatementTemplate": {
+                  "type": "string"
+                },
+                "roleTitleTemplate": {
+                  "type": "string"
+                },
+                "category": {
+                  "type": "string"
+                },
+                "estimatedEffortHours": {
+                  "type": "number"
+                },
+                "dueDays": {
+                  "type": "number"
+                },
+                "availableInDays": {
+                  "type": "number"
+                },
+                "deadlinePolicy": {
+                  "type": "string",
+                  "enum": [
+                    "NONE",
+                    "SOFT",
+                    "EXPIRES",
+                    "REQUIRED"
+                  ]
+                },
+                "claimPolicy": {
+                  "type": "string"
+                },
+                "isPublic": {
+                  "type": "boolean"
+                },
+                "skillTagTemplates": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "interestTagTemplates": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "actionLinkUrlTemplate": {
+                  "type": "string"
+                },
+                "actionLinkLabelTemplate": {
+                  "type": "string"
+                },
+                "actionLinkInstructionsTemplate": {
+                  "type": "string"
+                },
+                "creatorResolver": {
+                  "type": "string"
+                },
+                "assigneePersonResolver": {
+                  "type": "string"
+                },
+                "assigneeOrganizationResolver": {
+                  "type": "string"
+                },
+                "parentResolver": {
+                  "type": "string"
+                },
+                "contributesToGate": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "kind",
+                "titleTemplate",
+                "descriptionTemplate"
+              ]
+            }
+          },
+          "communicationSpawnSpecs": {
+            "type": "array",
+            "description": "For triggerKind=spawnCommunication: one spec per outbound message.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                },
+                "subjectTemplate": {
+                  "type": "string"
+                },
+                "bodyTextTemplate": {
+                  "type": "string"
+                },
+                "bodyHtmlTemplate": {
+                  "type": "string"
+                },
+                "commentTemplate": {
+                  "type": "string"
+                },
+                "channel": {
+                  "type": "string"
+                },
+                "audienceResolver": {
+                  "type": "string"
+                },
+                "purpose": {
+                  "type": "string"
+                },
+                "emailScope": {
+                  "type": "string"
+                },
+                "dedupeKeyTemplate": {
+                  "type": "string"
+                },
+                "minHoursBetweenSends": {
+                  "type": "number"
+                },
+                "maxSendsPerTask": {
+                  "type": "number"
+                },
+                "minSendCount": {
+                  "type": "number",
+                  "description": "Inclusive lower bound on the prior-send count at which this spec is active. Lets one trigger carry escalating-tone variants — week-1 spec at 0/0, week-2 at 1/1, etc. Default 0."
+                },
+                "maxSendCount": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "description": "Inclusive upper bound on the prior-send count. null = open-ended (this spec keeps firing once minSendCount is reached, until maxSendsPerTask runs out)."
+                }
+              },
+              "required": [
+                "kind",
+                "subjectTemplate",
+                "bodyTextTemplate",
+                "dedupeKeyTemplate"
+              ]
+            }
+          }
+        },
+        "required": [
+          "triggerKey",
+          "eventName",
+          "idempotencyKeyTemplate"
+        ]
+      },
+      "name": "createTaskTrigger",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Update an existing TaskTrigger by triggerKey. Pass only the fields you want to change. spawnSpecs / communicationSpawnSpecs, when supplied, REPLACE the existing specs (delete + recreate).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "triggerKey": {
+            "type": "string"
+          },
+          "eventName": {
+            "type": "string"
+          },
+          "triggerKind": {
+            "type": "string",
+            "enum": [
+              "spawnTasks",
+              "verifyTask",
+              "spawnCommunication"
+            ]
+          },
+          "idempotencyKeyTemplate": {
+            "type": "string"
+          },
+          "eventFilter": {
+            "type": "object"
+          },
+          "completionGate": {
+            "type": "object"
+          },
+          "jurisdictionId": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "schedule": {
+            "type": "string",
+            "description": "Cron expression. See createTaskTrigger."
+          },
+          "iterationSource": {
+            "type": "string",
+            "enum": [
+              "none",
+              "overdue-tasks"
+            ],
+            "description": "Resolver key. See createTaskTrigger."
+          },
+          "spawnSpecs": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "communicationSpawnSpecs": {
+            "type": "array",
+            "description": "Replaces existing communication specs. Each item supports the same fields as in createTaskTrigger, including minSendCount / maxSendCount for escalating-tone variants.",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "required": [
+          "triggerKey"
+        ]
+      },
+      "name": "updateTaskTrigger",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": true,
+      "description": "Soft-disable a TaskTrigger. Sets enabled=false with an optional reason. Re-enable by calling updateTaskTrigger with enabled:true.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "triggerKey": {
+            "type": "string"
+          },
+          "disabledReason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "triggerKey"
+        ]
+      },
+      "name": "disableTaskTrigger",
+      "requiredScopes": [
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List TaskTriggers, optionally filtered by eventName, enabled, or jurisdictionId. Returns triggerKey + summary fields, no specs.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "eventName": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "jurisdictionId": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Default 100, max 500"
+          }
+        }
+      },
+      "name": "listTaskTriggers",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Get full details of a TaskTrigger by triggerKey, including all spec rows and the most recent fires.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "triggerKey": {
+            "type": "string"
+          },
+          "recentFires": {
+            "type": "number",
+            "description": "How many recent fires to include. Default 10, max 100."
+          }
+        },
+        "required": [
+          "triggerKey"
+        ]
+      },
+      "name": "getTaskTrigger",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Fire a TaskTrigger manually with arbitrary context. Use dryRun:true to render templates and return the planned spawn without committing — critical for iterating on a template before it goes live. Without dryRun: writes are committed and idempotent (re-firing the same idempotencyKey returns the cached result).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "triggerKey": {
+            "type": "string"
+          },
+          "context": {
+            "type": "object",
+            "description": "Arbitrary event context. Templates and resolvers read from this."
+          },
+          "dryRun": {
+            "type": "boolean",
+            "description": "Default false. True = render-only, no writes."
+          }
+        },
+        "required": [
+          "triggerKey",
+          "context"
+        ]
+      },
+      "name": "fireTaskTrigger",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Validate and import a lossless Notion export bundle. Dry-run is the default; set dryRun to false only after reviewing the returned create, update, unchanged, and error items. Imported tasks remain private drafts, and formula or rollup definitions are preserved without execution.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "bundle": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "dryRun": {
+            "type": "boolean",
+            "default": true
+          }
+        },
+        "required": [
+          "bundle"
+        ]
+      },
+      "name": "importNotionBundle",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create a private structured collection with stable fields. Formula and rollup fields preserve imported definitions and outputs but are not executed.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "organizationId": {
+            "type": "string"
+          },
+          "jurisdictionId": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "PRIVATE",
+              "PUBLIC"
+            ]
+          },
+          "idempotencyKey": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "TEXT",
+                    "RICH_TEXT",
+                    "NUMBER",
+                    "BOOLEAN",
+                    "DATE",
+                    "SELECT",
+                    "MULTI_SELECT",
+                    "URL",
+                    "EMAIL",
+                    "FILE",
+                    "RELATION",
+                    "TASK",
+                    "PERSON",
+                    "ORGANIZATION",
+                    "DOCUMENT",
+                    "FORMULA",
+                    "ROLLUP"
+                  ]
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "position": {
+                  "type": "number"
+                },
+                "targetCollectionId": {
+                  "type": "string"
+                },
+                "optionsJson": {
+                  "type": "object"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "type"
+              ]
+            }
+          }
+        },
+        "required": [
+          "name",
+          "idempotencyKey"
+        ]
+      },
+      "name": "createCollection",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Update collection metadata with optimistic concurrency. Sharing and ownership still require full access.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "collectionId": {
+            "type": "string"
+          },
+          "expectedVersion": {
+            "type": "number"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "TEXT",
+                    "RICH_TEXT",
+                    "NUMBER",
+                    "BOOLEAN",
+                    "DATE",
+                    "SELECT",
+                    "MULTI_SELECT",
+                    "URL",
+                    "EMAIL",
+                    "FILE",
+                    "RELATION",
+                    "TASK",
+                    "PERSON",
+                    "ORGANIZATION",
+                    "DOCUMENT",
+                    "FORMULA",
+                    "ROLLUP"
+                  ]
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "position": {
+                  "type": "number"
+                },
+                "targetCollectionId": {
+                  "type": "string"
+                },
+                "optionsJson": {
+                  "type": "object"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "type"
+              ]
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "organizationId": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "PRIVATE",
+              "PUBLIC"
+            ]
+          }
+        },
+        "required": [
+          "collectionId",
+          "expectedVersion"
+        ]
+      },
+      "name": "updateCollection",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Get a collection schema, saved views, and effective permission.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "collectionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "collectionId"
+        ]
+      },
+      "name": "getCollection",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List collections the current user can see.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number"
+          }
+        }
+      },
+      "name": "listCollections",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create a collection record. Normal edits cannot write file, relation, formula, rollup, or canonical-entity fields through values; use relations for links.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "collectionId": {
+            "type": "string"
+          },
+          "values": {
+            "type": "object"
+          },
+          "relations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "fieldKey": {
+                  "type": "string"
+                },
+                "position": {
+                  "type": "number"
+                },
+                "targetRecordId": {
+                  "type": "string"
+                },
+                "targetTaskId": {
+                  "type": "string"
+                },
+                "targetPersonId": {
+                  "type": "string"
+                },
+                "targetOrganizationId": {
+                  "type": "string"
+                },
+                "targetDocumentId": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "fieldKey"
+              ]
+            }
+          },
+          "taskId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "personId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "organizationId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "documentId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "idempotencyKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "collectionId",
+          "values",
+          "idempotencyKey"
+        ]
+      },
+      "name": "createCollectionRecord",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Update record values or relations and reject stale versions.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "recordId": {
+            "type": "string"
+          },
+          "expectedVersion": {
+            "type": "number"
+          },
+          "values": {
+            "type": "object"
+          },
+          "relations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "fieldKey": {
+                  "type": "string"
+                },
+                "position": {
+                  "type": "number"
+                },
+                "targetRecordId": {
+                  "type": "string"
+                },
+                "targetTaskId": {
+                  "type": "string"
+                },
+                "targetPersonId": {
+                  "type": "string"
+                },
+                "targetOrganizationId": {
+                  "type": "string"
+                },
+                "targetDocumentId": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "fieldKey"
+              ]
+            }
+          },
+          "taskId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "personId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "organizationId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "documentId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "recordId",
+          "expectedVersion"
+        ]
+      },
+      "name": "updateCollectionRecord",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Atomically create or update up to 100 collection records. Creates require stable idempotency keys; updates require the expected record version. Any invalid or stale operation rolls back the entire batch.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "collectionId": {
+            "type": "string"
+          },
+          "operations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "operation": {
+                  "type": "string",
+                  "enum": [
+                    "create",
+                    "update"
+                  ]
+                },
+                "idempotencyKey": {
+                  "type": "string"
+                },
+                "recordId": {
+                  "type": "string"
+                },
+                "expectedVersion": {
+                  "type": "number"
+                },
+                "values": {
+                  "type": "object"
+                },
+                "relations": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "fieldKey": {
+                        "type": "string"
+                      },
+                      "position": {
+                        "type": "number"
+                      },
+                      "targetRecordId": {
+                        "type": "string"
+                      },
+                      "targetTaskId": {
+                        "type": "string"
+                      },
+                      "targetPersonId": {
+                        "type": "string"
+                      },
+                      "targetOrganizationId": {
+                        "type": "string"
+                      },
+                      "targetDocumentId": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldKey"
+                    ]
+                  }
+                },
+                "taskId": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "personId": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "organizationId": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "documentId": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "operation"
+              ]
+            }
+          }
+        },
+        "required": [
+          "collectionId",
+          "operations"
+        ]
+      },
+      "name": "upsertCollectionRecordsBatch",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Query collection records with bounded filters, ordered sorts, cursor pagination, and linked-entity authorization.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "collectionId": {
+            "type": "string"
+          },
+          "cursor": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "query": {
+            "type": "string"
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "sorts": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "required": [
+          "collectionId"
+        ]
+      },
+      "name": "queryCollectionRecords",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Search authorized Markdown documents and collection records without exposing inaccessible matches.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "name": "searchContent",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create or update a saved table view with visible fields, filters, and sorts.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "collectionId": {
+            "type": "string"
+          },
+          "viewId": {
+            "type": "string"
+          },
+          "expectedVersion": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "visibleFieldIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "sorts": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "collectionId",
+          "name"
+        ]
+      },
+      "name": "saveCollectionView",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create a markdown document (version 1). Private by default. Optionally attach it to a task you can view.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Document title"
+          },
+          "body": {
+            "type": "string",
+            "description": "Markdown body"
+          },
+          "taskId": {
+            "type": "string",
+            "description": "Optional task to attach the document to"
+          },
+          "jurisdictionId": {
+            "type": "string",
+            "description": "Optional jurisdiction. Defaults to the attached task's jurisdiction."
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "Optional organization that owns the document"
+          },
+          "parentDocumentId": {
+            "type": "string",
+            "description": "Optional parent document"
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "description": "Stable retry key for this create request"
+          },
+          "visibility": {
+            "type": "string",
+            "description": "PRIVATE (default) or PUBLIC.",
+            "enum": [
+              "PRIVATE",
+              "PUBLIC"
+            ]
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "idempotencyKey"
+        ]
+      },
+      "name": "createDocument",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Update a document. Writes an immutable revision and rejects stale edits. Omitted fields carry forward.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "description": "Stable document ID"
+          },
+          "expectedVersion": {
+            "type": "number",
+            "description": "Version returned by getDocument"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string",
+            "description": "Full replacement markdown body"
+          },
+          "organizationId": {
+            "description": "Organization owner, or null to remove it",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "parentDocumentId": {
+            "description": "Parent document, or null to move it to the root",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "taskId": {
+            "description": "Linked task, or null to remove the task link",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "visibility": {
+            "type": "string",
+            "description": "PRIVATE (default) or PUBLIC.",
+            "enum": [
+              "PRIVATE",
+              "PUBLIC"
+            ]
+          }
+        },
+        "required": [
+          "documentId",
+          "expectedVersion"
+        ]
+      },
+      "name": "updateDocument",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Read a document or historical revision plus its revision list when you have access.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "description": "Stable document ID or historical revision ID"
+          }
+        },
+        "required": [
+          "documentId"
+        ]
+      },
+      "name": "getDocument",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List documents you can see. Filter by taskId to see a task's documents.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "Only documents on this task"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Default 100, max 500"
+          }
+        }
+      },
+      "name": "listDocuments",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Read the exact document revision and instructions assigned to the authenticated reviewer.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "reviewTaskId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "reviewTaskId"
+        ]
+      },
+      "name": "getDocumentReview",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create a separate private proposal document from selected comments on one exact document revision.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "authorityTaskId": {
+            "type": "string"
+          },
+          "baseDocumentRevisionId": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "description": "Stable retry key for this operation."
+          },
+          "sourceCommentIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "uniqueItems": true
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authorityTaskId",
+          "baseDocumentRevisionId",
+          "body",
+          "idempotencyKey",
+          "sourceCommentIds",
+          "summary",
+          "title"
+        ]
+      },
+      "name": "createDocumentProposal",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Apply a pinned proposal artifact to its unchanged base document as a new immutable revision.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "authorityTaskId": {
+            "type": "string"
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "description": "Stable retry key for this operation."
+          },
+          "proposalArtifactId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authorityTaskId",
+          "idempotencyKey",
+          "proposalArtifactId"
+        ]
+      },
+      "name": "applyDocumentProposal",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create a private assigned review task pinned to one exact immutable document revision.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "authorityTaskId": {
+            "type": "string"
+          },
+          "documentRevisionId": {
+            "type": "string"
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "description": "Stable retry key for this operation."
+          },
+          "instructions": {
+            "type": "string"
+          },
+          "reviewerPersonId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authorityTaskId",
+          "documentRevisionId",
+          "idempotencyKey",
+          "instructions",
+          "reviewerPersonId"
+        ]
+      },
+      "name": "requestDocumentReview",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Submit an explained verdict for the exact revision assigned to the authenticated reviewer.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "explanation": {
+            "type": "string"
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "description": "Stable retry key for this operation."
+          },
+          "reviewTaskId": {
+            "type": "string"
+          },
+          "verdict": {
+            "type": "string",
+            "enum": [
+              "APPROVE",
+              "CHANGES_REQUESTED",
+              "REJECT",
+              "ABSTAIN"
+            ]
+          }
+        },
+        "required": [
+          "explanation",
+          "idempotencyKey",
+          "reviewTaskId",
+          "verdict"
+        ]
+      },
+      "name": "submitDocumentReview",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Record an authorized immutable internal ADOPT or REJECT decision on one exact current revision.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "ADOPT",
+              "REJECT"
+            ]
+          },
+          "authorityTaskId": {
+            "type": "string"
+          },
+          "documentRevisionId": {
+            "type": "string"
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "description": "Stable retry key for this operation."
+          },
+          "reason": {
+            "type": "string"
+          },
+          "reviewArtifactId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "action",
+          "authorityTaskId",
+          "documentRevisionId",
+          "idempotencyKey",
+          "reviewArtifactId"
+        ]
+      },
+      "name": "decideDocumentRevision",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List, grant, or revoke access to a document or collection. Grant and revoke require full access. A user may be identified by Optimitron user ID or account email.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "list",
+              "grant",
+              "revoke"
+            ]
+          },
+          "resourceId": {
+            "type": "string"
+          },
+          "resourceType": {
+            "type": "string",
+            "enum": [
+              "document",
+              "collection"
+            ]
+          },
+          "granteeType": {
+            "type": "string",
+            "enum": [
+              "user",
+              "organization"
+            ]
+          },
+          "granteeId": {
+            "type": "string"
+          },
+          "granteeEmail": {
+            "type": "string"
+          },
+          "accessLevel": {
+            "type": "string",
+            "enum": [
+              "FULL_ACCESS",
+              "EDIT",
+              "EDIT_CONTENT",
+              "COMMENT",
+              "VIEW"
+            ]
+          }
+        },
+        "required": [
+          "action",
+          "resourceType",
+          "resourceId"
+        ]
+      },
+      "name": "manageContentAccess",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "List files, prepare or complete an upload, obtain a short-lived authorized download URL, or delete a private document/collection-record file.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "list",
+              "prepare",
+              "complete",
+              "open",
+              "delete"
+            ]
+          },
+          "attachmentId": {
+            "type": "string"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "collectionRecordId": {
+            "type": "string"
+          },
+          "checksumSha256": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "sizeBytes": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "action"
+        ]
+      },
+      "name": "manageContentFiles",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Export an authorized document snapshot or one cursor-paginated collection page. Private file metadata is included, but storage keys and unsigned object URLs are never returned.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "resourceId": {
+            "type": "string"
+          },
+          "resourceType": {
+            "type": "string",
+            "enum": [
+              "document",
+              "collection"
+            ]
+          },
+          "cursor": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "resourceType",
+          "resourceId"
+        ]
+      },
+      "name": "exportContent",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:admin"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Validate, normalize, deduplicate, and hash a user-selected private conversation-to-work batch without writing tasks. Review every returned error and action before applyPrivateTaskBundle.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "rootTaskId": {
+            "type": "string",
+            "description": "Private personal or organization root/container task ID."
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "approvedExcerpts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "anchor": {
+                      "type": "string"
+                    },
+                    "excerpt": {
+                      "type": "string"
+                    },
+                    "timestamp": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "anchor",
+                    "excerpt"
+                  ]
+                }
+              },
+              "capturedAt": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "channel": {
+                "type": "string",
+                "enum": [
+                  "DISCORD",
+                  "EMAIL",
+                  "GITHUB",
+                  "MEETING_NOTES",
+                  "NOTION",
+                  "SLACK",
+                  "TELEGRAM",
+                  "WHATSAPP",
+                  "OTHER"
+                ]
+              },
+              "messageAnchors": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "participantAliases": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "selectionHash": {
+                "type": "string",
+                "description": "SHA-256 or equivalent hash of the selected source batch."
+              },
+              "selectionId": {
+                "type": "string",
+                "description": "Stable local identifier for this explicit selection."
+              },
+              "sourceUrl": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "title": {
+                "type": "string"
+              },
+              "userSelected": {
+                "type": "boolean",
+                "const": true,
+                "description": "Must be true. Ambient or whole-account imports are rejected."
+              }
+            },
+            "required": [
+              "channel",
+              "messageAnchors",
+              "selectionHash",
+              "selectionId",
+              "title",
+              "userSelected"
+            ]
+          },
+          "candidates": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 100,
+            "items": {
+              "type": "object",
+              "properties": {
+                "acceptanceCriteria": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "category": {
+                  "type": "string",
+                  "enum": [
+                    "ADVOCACY",
+                    "RESEARCH",
+                    "COMMUNICATION",
+                    "ENGINEERING",
+                    "ORGANIZING",
+                    "OUTREACH",
+                    "GOVERNANCE",
+                    "SCIENCE",
+                    "LEGAL",
+                    "CREATIVE",
+                    "OTHER"
+                  ]
+                },
+                "clarificationNeeded": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "dependencyRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "description": {
+                  "type": "string"
+                },
+                "dueAt": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "eligibleExecutorTypes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "AGENT",
+                      "HUMAN"
+                    ]
+                  }
+                },
+                "estimatedCostUsd": {
+                  "type": "object",
+                  "properties": {
+                    "base": {
+                      "type": "number"
+                    },
+                    "high": {
+                      "type": "number"
+                    },
+                    "low": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "low",
+                    "base",
+                    "high"
+                  ]
+                },
+                "estimatedDurationSeconds": {
+                  "type": "object",
+                  "properties": {
+                    "base": {
+                      "type": "number"
+                    },
+                    "high": {
+                      "type": "number"
+                    },
+                    "low": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "low",
+                    "base",
+                    "high"
+                  ]
+                },
+                "expectedDeliverable": {
+                  "type": "string"
+                },
+                "expectedValueUsd": {
+                  "type": "object",
+                  "properties": {
+                    "base": {
+                      "type": "number"
+                    },
+                    "high": {
+                      "type": "number"
+                    },
+                    "low": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "low",
+                    "base",
+                    "high"
+                  ]
+                },
+                "groundedByAnchors": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "objectiveServed": {
+                  "type": "string"
+                },
+                "parentRef": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Candidate ref or existing accessible task ID."
+                },
+                "privacyClassification": {
+                  "type": "string",
+                  "enum": [
+                    "ORGANIZATION_CONFIDENTIAL",
+                    "PERSONAL_PRIVATE"
+                  ]
+                },
+                "projectOrWorkflow": {
+                  "type": "string"
+                },
+                "ref": {
+                  "type": "string"
+                },
+                "requiredObligation": {
+                  "type": "boolean"
+                },
+                "safetyGuardrail": {
+                  "type": "boolean"
+                },
+                "successProbability": {
+                  "type": "object",
+                  "properties": {
+                    "base": {
+                      "type": "number"
+                    },
+                    "high": {
+                      "type": "number"
+                    },
+                    "low": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "low",
+                    "base",
+                    "high"
+                  ]
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "acceptanceCriteria",
+                "description",
+                "eligibleExecutorTypes",
+                "estimatedCostUsd",
+                "estimatedDurationSeconds",
+                "expectedDeliverable",
+                "expectedValueUsd",
+                "groundedByAnchors",
+                "objectiveServed",
+                "privacyClassification",
+                "projectOrWorkflow",
+                "ref",
+                "successProbability",
+                "title"
+              ]
+            }
+          }
+        },
+        "required": [
+          "rootTaskId",
+          "source",
+          "candidates"
+        ]
+      },
+      "name": "reviewPrivateTaskBundle",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Atomically apply a previously reviewed private task bundle as ACTIVE tasks. The server recomputes reviewHash; changed or invalid bundles are rejected. Raw transcript text is not accepted.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "rootTaskId": {
+            "type": "string",
+            "description": "Private personal or organization root/container task ID."
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "approvedExcerpts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "anchor": {
+                      "type": "string"
+                    },
+                    "excerpt": {
+                      "type": "string"
+                    },
+                    "timestamp": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "anchor",
+                    "excerpt"
+                  ]
+                }
+              },
+              "capturedAt": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "channel": {
+                "type": "string",
+                "enum": [
+                  "DISCORD",
+                  "EMAIL",
+                  "GITHUB",
+                  "MEETING_NOTES",
+                  "NOTION",
+                  "SLACK",
+                  "TELEGRAM",
+                  "WHATSAPP",
+                  "OTHER"
+                ]
+              },
+              "messageAnchors": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "participantAliases": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "selectionHash": {
+                "type": "string",
+                "description": "SHA-256 or equivalent hash of the selected source batch."
+              },
+              "selectionId": {
+                "type": "string",
+                "description": "Stable local identifier for this explicit selection."
+              },
+              "sourceUrl": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "title": {
+                "type": "string"
+              },
+              "userSelected": {
+                "type": "boolean",
+                "const": true,
+                "description": "Must be true. Ambient or whole-account imports are rejected."
+              }
+            },
+            "required": [
+              "channel",
+              "messageAnchors",
+              "selectionHash",
+              "selectionId",
+              "title",
+              "userSelected"
+            ]
+          },
+          "candidates": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 100,
+            "items": {
+              "type": "object",
+              "properties": {
+                "acceptanceCriteria": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "category": {
+                  "type": "string",
+                  "enum": [
+                    "ADVOCACY",
+                    "RESEARCH",
+                    "COMMUNICATION",
+                    "ENGINEERING",
+                    "ORGANIZING",
+                    "OUTREACH",
+                    "GOVERNANCE",
+                    "SCIENCE",
+                    "LEGAL",
+                    "CREATIVE",
+                    "OTHER"
+                  ]
+                },
+                "clarificationNeeded": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "dependencyRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "description": {
+                  "type": "string"
+                },
+                "dueAt": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "eligibleExecutorTypes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "AGENT",
+                      "HUMAN"
+                    ]
+                  }
+                },
+                "estimatedCostUsd": {
+                  "type": "object",
+                  "properties": {
+                    "base": {
+                      "type": "number"
+                    },
+                    "high": {
+                      "type": "number"
+                    },
+                    "low": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "low",
+                    "base",
+                    "high"
+                  ]
+                },
+                "estimatedDurationSeconds": {
+                  "type": "object",
+                  "properties": {
+                    "base": {
+                      "type": "number"
+                    },
+                    "high": {
+                      "type": "number"
+                    },
+                    "low": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "low",
+                    "base",
+                    "high"
+                  ]
+                },
+                "expectedDeliverable": {
+                  "type": "string"
+                },
+                "expectedValueUsd": {
+                  "type": "object",
+                  "properties": {
+                    "base": {
+                      "type": "number"
+                    },
+                    "high": {
+                      "type": "number"
+                    },
+                    "low": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "low",
+                    "base",
+                    "high"
+                  ]
+                },
+                "groundedByAnchors": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "objectiveServed": {
+                  "type": "string"
+                },
+                "parentRef": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Candidate ref or existing accessible task ID."
+                },
+                "privacyClassification": {
+                  "type": "string",
+                  "enum": [
+                    "ORGANIZATION_CONFIDENTIAL",
+                    "PERSONAL_PRIVATE"
+                  ]
+                },
+                "projectOrWorkflow": {
+                  "type": "string"
+                },
+                "ref": {
+                  "type": "string"
+                },
+                "requiredObligation": {
+                  "type": "boolean"
+                },
+                "safetyGuardrail": {
+                  "type": "boolean"
+                },
+                "successProbability": {
+                  "type": "object",
+                  "properties": {
+                    "base": {
+                      "type": "number"
+                    },
+                    "high": {
+                      "type": "number"
+                    },
+                    "low": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "low",
+                    "base",
+                    "high"
+                  ]
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "acceptanceCriteria",
+                "description",
+                "eligibleExecutorTypes",
+                "estimatedCostUsd",
+                "estimatedDurationSeconds",
+                "expectedDeliverable",
+                "expectedValueUsd",
+                "groundedByAnchors",
+                "objectiveServed",
+                "privacyClassification",
+                "projectOrWorkflow",
+                "ref",
+                "successProbability",
+                "title"
+              ]
+            }
+          },
+          "reviewHash": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "rootTaskId",
+          "source",
+          "candidates",
+          "reviewHash"
+        ]
+      },
+      "name": "applyPrivateTaskBundle",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Start the canonical execution attempt for an accessible active, unblocked leaf task. Reserved roots, containers, and tasks with active or pending-verification attempts are rejected.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "agentExecutorId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "confidence": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "estimatedCost": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "currency": {
+                "type": "string",
+                "description": "Three-letter currency code, such as usd."
+              },
+              "minorUnits": {
+                "type": "number",
+                "description": "Nonnegative integer."
+              }
+            },
+            "required": [
+              "currency",
+              "minorUnits"
+            ]
+          },
+          "estimatedDurationSeconds": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "runContext": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "agentRunId": {
+                "type": "string"
+              },
+              "baseCommit": {
+                "type": "string"
+              },
+              "branch": {
+                "type": "string"
+              },
+              "isolationMode": {
+                "type": "string",
+                "enum": [
+                  "NO_WORKTREE",
+                  "SHARED_ONE_PR",
+                  "ISOLATED_WORKTREE"
+                ]
+              },
+              "ownedFileGlobs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "worktreePath": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "isolationMode"
+            ]
+          },
+          "taskId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "startTaskExecution",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Submit exactly one immutable artifact for a running execution attempt: a task-linked document revision, content attachment, task-comment attachment, external URL, or structured result.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "contentAttachmentId": {
+            "type": "string"
+          },
+          "documentRevisionId": {
+            "type": "string"
+          },
+          "externalUrl": {
+            "type": "string"
+          },
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "metadata": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "structuredResult": {},
+          "taskCommentAttachmentId": {
+            "type": "string"
+          },
+          "taskExecutionAttemptId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "taskExecutionAttemptId"
+        ]
+      },
+      "name": "submitTaskArtifact",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Finish a running attempt, snapshot the task's acceptance criteria, record actual duration/cost, and create a pending typed verification. At least one artifact is required.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "actualCost": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "currency": {
+                "type": "string",
+                "description": "Three-letter currency code, such as usd."
+              },
+              "minorUnits": {
+                "type": "number",
+                "description": "Nonnegative integer."
+              }
+            },
+            "required": [
+              "currency",
+              "minorUnits"
+            ]
+          },
+          "actualDurationSeconds": {
+            "type": "number"
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "DETERMINISTIC",
+              "RULE_BASED",
+              "REVIEWER",
+              "OUTCOME"
+            ]
+          },
+          "outputSummary": {
+            "type": "string"
+          },
+          "taskExecutionAttemptId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "actualDurationSeconds",
+          "outputSummary",
+          "taskExecutionAttemptId"
+        ]
+      },
+      "name": "submitTaskForVerification",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Accept or reject one pending execution verification against its immutable criteria snapshot. Acceptance verifies the task; rejection preserves evidence and requeues it as ACTIVE.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "criterionResults": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "criterion": {
+                  "type": "string"
+                },
+                "evidence": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "passed": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "criterion",
+                "passed"
+              ]
+            }
+          },
+          "evidence": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "ACCEPTED",
+              "REJECTED"
+            ]
+          },
+          "taskVerificationId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "criterionResults",
+          "result",
+          "taskVerificationId"
+        ]
+      },
+      "name": "verifyTaskExecution",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Read the accessible task's provenance, claims, comments, execution attempts, artifact hashes, and verification history without exposing raw private source content.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "name": "getTaskAuditTrail",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Create an immutable outbound message or browser-action request for human approval. This does not approve or execute anything; editing requires a new idempotency key and request.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "destination": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "string"
+          },
+          "idempotencyKey": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object"
+          },
+          "taskExecutionAttemptId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "taskId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "destination",
+          "idempotencyKey",
+          "operation",
+          "payload",
+          "taskId"
+        ]
+      },
+      "name": "proposeExternalAction",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Record one terminal execution receipt for an already human-approved external action. The exact approved payload cannot be changed or replayed through this tool.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "externalActionRequestId": {
+            "type": "string"
+          },
+          "failureMessage": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "receipt": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "EXECUTED",
+              "FAILED"
+            ]
+          }
+        },
+        "required": [
+          "externalActionRequestId",
+          "result"
+        ]
+      },
+      "name": "recordExternalActionResult",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Export one private root subtree you manage, including tasks, internal comments, safe attachment metadata, source provenance, execution evidence, linked current documents, and internal dependency edges.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "rootTaskId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "rootTaskId"
+        ]
+      },
+      "name": "exportPrivateWork",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Scrub and unlink one reviewed private source selection you own or administer. Derived tasks remain; approved excerpts, anchors, aliases, URLs, and external identifiers are removed.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "sourceArtifactId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sourceArtifactId"
+        ]
+      },
+      "name": "deletePrivateSourceSelection",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Find reusable reviewed text answers for one person or organization.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "subject": {
+            "type": "object",
+            "properties": {
+              "organizationId": {
+                "type": "string"
+              },
+              "personId": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false,
+            "oneOf": [
+              {
+                "required": [
+                  "organizationId"
+                ]
+              },
+              {
+                "required": [
+                  "personId"
+                ]
+              }
+            ]
+          },
+          "question": {
+            "type": "string"
+          },
+          "knowledgeKey": {
+            "type": "string"
+          },
+          "contextTags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "asOf": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "limit": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "subject",
+          "question"
+        ]
+      },
+      "name": "findReviewedAnswers",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Capture a form's narrative fields, prepare reusable responses, and create one shared review task for each unresolved answer.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "formKey": {
+            "type": "string"
+          },
+          "formTitle": {
+            "type": "string"
+          },
+          "formSourceUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "formPurpose": {
+            "type": "string",
+            "enum": [
+              "SURVEY",
+              "APPLICATION",
+              "INTAKE",
+              "ASSESSMENT",
+              "QUESTIONNAIRE"
+            ]
+          },
+          "formTaskId": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "object",
+            "properties": {
+              "organizationId": {
+                "type": "string"
+              },
+              "personId": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false,
+            "oneOf": [
+              {
+                "required": [
+                  "organizationId"
+                ]
+              },
+              {
+                "required": [
+                  "personId"
+                ]
+              }
+            ]
+          },
+          "questions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 200,
+            "items": {
+              "type": "object",
+              "properties": {
+                "fieldKey": {
+                  "type": "string"
+                },
+                "knowledgeKey": {
+                  "type": "string"
+                },
+                "prompt": {
+                  "type": "string"
+                },
+                "contextTags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "answerRevisionId": {
+                  "type": "string"
+                },
+                "proposedAnswer": {
+                  "type": "string"
+                },
+                "sensitivity": {
+                  "type": "string",
+                  "enum": [
+                    "PUBLIC",
+                    "INTERNAL",
+                    "CONFIDENTIAL",
+                    "RESTRICTED"
+                  ]
+                },
+                "sourceArtifactIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "validUntil": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                }
+              },
+              "required": [
+                "fieldKey",
+                "prompt"
+              ]
+            }
+          },
+          "idempotencyKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "formTaskId",
+          "subject",
+          "questions",
+          "idempotencyKey"
+        ]
+      },
+      "name": "prepareFormResponses",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    },
+    {
+      "adminOnly": false,
+      "description": "Propose the exact prepared form submission for human approval without executing it.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "formSubmissionId": {
+            "type": "string"
+          },
+          "taskExecutionAttemptId": {
+            "type": "string"
+          },
+          "destination": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "formSubmissionId",
+          "taskExecutionAttemptId",
+          "destination"
+        ]
+      },
+      "name": "proposeFormSubmission",
+      "requiredScopes": [
+        "tasks:personal",
+        "tasks:organization"
+      ]
+    }
+  ],
+  "transport": "Streamable HTTP (MCP 2025-03-26)"
+}

--- a/packages/site-kit/src/lib/routes.ts
+++ b/packages/site-kit/src/lib/routes.ts
@@ -90,6 +90,8 @@ export const ROUTES = {
   wishocracy: '/wishocracy',
   dfda: '/dfda',
   mcp: '/mcp',
+  developers: '/developers',
+  developersTools: '/developers/tools',
   surveyDemo: '/survey/demo',
 
   // Studies (dfda)

--- a/scripts/generate-mcp-catalog.ts
+++ b/scripts/generate-mcp-catalog.ts
@@ -1,0 +1,51 @@
+/**
+ * Regenerate the MCP catalog the campaign developer pages render.
+ *
+ *   pnpm mcp:catalog
+ *
+ * The MCP server itself stays on optimitron.com, and its tool registry lives in
+ * `apps/optimitron/src/lib/mcp-server.ts` — 14k lines whose tool definitions are
+ * interleaved with handlers that talk to Prisma. warondisease.org cannot import
+ * that, and importing an app from a package would invert the dependency graph,
+ * so the catalog is snapshotted here into a JSON file that site-kit reads.
+ *
+ * Rerun this whenever a tool, description, scope, or admin gate changes. The
+ * output is the same payload `GET /api/mcp/tools` serves, so the page shows what
+ * the live server enforces as of the last regeneration.
+ */
+
+import { writeFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { getToolCatalog } from "../apps/optimitron/src/lib/mcp-server"
+import {
+  ALL_SCOPES,
+  MCP_SCOPE_DESCRIPTIONS,
+  scopeToWire,
+} from "../apps/optimitron/src/lib/mcp-scopes"
+
+const OUTPUT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../packages/site-kit/src/lib/mcp/catalog.generated.json",
+)
+
+const catalog = {
+  endpoint: "/api/mcp",
+  scopes: ALL_SCOPES.map((scope) => ({
+    description: MCP_SCOPE_DESCRIPTIONS[scope],
+    wire: scopeToWire(scope),
+  })),
+  tools: getToolCatalog().map((tool) => ({
+    adminOnly: tool.adminOnly,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    name: tool.name,
+    requiredScopes: (tool.scopes ?? []).map((scope) => scopeToWire(scope)),
+  })),
+  transport: "Streamable HTTP (MCP 2025-03-26)",
+}
+
+writeFileSync(OUTPUT, `${JSON.stringify(catalog, null, 2)}\n`, "utf8")
+console.log(
+  `Wrote ${catalog.tools.length} tools and ${catalog.scopes.length} scopes to ${OUTPUT}`,
+)

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -427,6 +427,40 @@ export const publicSiteAppRoutes = Object.freeze({
       sourcePage: "apps/warondisease/app/employees/page.tsx",
     },
     {
+      covers: [
+        "apps/warondisease/app/mcp/page.tsx",
+        "packages/site-kit/src/components/shared/CopyableCode.tsx",
+        "packages/site-kit/src/lib/mcp-catalog.ts",
+        "packages/site-kit/src/lib/mcp/catalog.generated.json",
+      ],
+      label: "MCP setup",
+      routeName: "mcp",
+      routePath: "/mcp",
+      sourcePage: "apps/warondisease/app/mcp/page.tsx",
+    },
+    {
+      covers: [
+        "apps/warondisease/app/developers/page.tsx",
+        "packages/site-kit/src/components/shared/CopyableCode.tsx",
+        "packages/site-kit/src/lib/mcp-catalog.ts",
+      ],
+      label: "Earth Optimization API",
+      routeName: "developers",
+      routePath: "/developers",
+      sourcePage: "apps/warondisease/app/developers/page.tsx",
+    },
+    {
+      covers: [
+        "apps/warondisease/app/developers/tools/page.tsx",
+        "packages/site-kit/src/lib/mcp-catalog.ts",
+        "packages/site-kit/src/lib/mcp/catalog.generated.json",
+      ],
+      label: "MCP tool reference",
+      routeName: "developers-tools",
+      routePath: "/developers/tools",
+      sourcePage: "apps/warondisease/app/developers/tools/page.tsx",
+    },
+    {
       covers: ["apps/warondisease/app/survey/demo/page.tsx"],
       label: "Survey embed demo",
       routeName: "survey-demo",


### PR DESCRIPTION
## Summary

`/mcp`, `/developers`, and `/developers/tools` existed only on optimitron.com, so all three returned 404 on warondisease.org. This ports them into `apps/warondisease` in the campaign shell. Copy is unchanged from the source pages except where the domain move made it wrong.

## What changed

**New campaign pages**
- `apps/warondisease/app/mcp/page.tsx` — MCP setup and install instructions. The OAuth consent flow (`/mcp/authorize`) is deliberately not ported: optimitron.com hosts the MCP server and stays the authorization surface.
- `apps/warondisease/app/developers/page.tsx` — Earth Optimization API overview.
- `apps/warondisease/app/developers/tools/page.tsx` — the full 171-tool MCP reference.

**Cross-domain URLs.** The MCP server, its OAuth endpoints, `/openapi.json`, and the REST API all stay on optimitron.com. Every URL these pages print now goes through `optimitronUrl()`, so a reader who copies the MCP server URL or an endpoint gets `https://optimitron.com/...` instead of a root-relative path that would resolve against warondisease.org and 404. The `/developers` REST section keeps its compact `GET /api/tasks` chips and gains one copyable **Base URL** panel above them, so the paths are still unambiguous.

**Tool catalog.** `/developers/tools` previously imported `getToolCatalog()` from `apps/optimitron/src/lib/mcp-server.ts` (14,569 lines, tool definitions interleaved with Prisma handlers across ~12 modules). A package cannot import an app, and splitting definitions out of every one of those modules is a large refactor of the live MCP server for a docs page. Instead the catalog is snapshotted:
- `scripts/generate-mcp-catalog.ts` + `pnpm mcp:catalog` regenerates it from that same registry.
- `packages/site-kit/src/lib/mcp/catalog.generated.json` is the committed output — verified byte-identical to what `https://optimitron.com/api/mcp/tools` serves today (171 tools, 32 admin-gated, 8 scopes).
- `packages/site-kit/src/lib/mcp-catalog.ts` types it and does the grouping. Rerun `pnpm mcp:catalog` after any tool, description, scope, or admin-gate change; the `/developers/tools` copy snapshot makes the drift visible in review.

**Shared UI.** `packages/site-kit/src/components/shared/CopyableCode.tsx` — the copy-button code block the optimitron pages used, restyled to the campaign app's flat border style and backed by site-kit's existing `copyTextToClipboard` fallback. AGENTS.md requires a copy affordance next to values users paste elsewhere, and every one of these pages is such values.

**Registration.** `ROUTES.developers` / `ROUTES.developersTools` added to site-kit routes (`mcp` already existed); all three routes registered in `publicSiteAppRoutes.warondisease` and in `CAMPAIGN_PAGES` under a new "Build on it" section.

## Deviations

- `apps/optimitron/src/lib/mcp-scopes.ts` was **not** moved into site-kit. `apps/optimitron` has no dependency on `@optimitron/site-kit` and does not list it in `transpilePackages`; adding both to the largest app in the repo to relocate one data file is a bigger change than this port warrants and risks its build. The scope names and descriptions the campaign pages need ride along in the generated catalog instead, so there is still one source of truth and no hand-maintained copy.
- The tool page's claim that it "cannot drift from reality" was dropped, because a snapshot can. The regeneration command is documented in the module header and the script header.
- `/developers/tools` overflowed horizontally at 390px on the original page — long tool identifiers such as `upsertVariableRelationshipEvidenceEstimate` are single unbreakable words wider than a phone viewport. Fixed with `break-words`; verified `scrollWidth === clientWidth` at 390 / 768 / 1280.
- Only the three new `page.logged-out.md` snapshots are committed. `pnpm copy warondisease` also rewrote 20 unrelated snapshots (parameter values now render as links; the footer gained nav entries) — pre-existing drift on `main`, unrelated to this change and likely to collide with other in-flight port PRs, so those were reverted.

## Pages to review

- `/mcp?logout=1`
- `/developers?logout=1`
- `/developers/tools?logout=1`

Preview root is in the Vercel comment.

## Verification

- `pnpm --filter @apps/warondisease typecheck` — pass
- `pnpm --filter @apps/warondisease lint` — pass
- `pnpm --filter @apps/warondisease test` — 19 files / 75 tests pass. The default invocation fails every file in a fresh worktree at the `beforeAll` DB hook (no local test database); rerunning with `SKIP_DB_TEST_SETUP=1` passes all 75. Environmental, not caused by this change.
- `pnpm test:site-app-navigation` — 19/19 pass
- `tsc --noEmit` for `@apps/dfda`, `@apps/courtofhumanity`, `@apps/wishocracy` — pass (the `ROUTES` additions are additive)
- Before/after screenshots captured at 1280 and 390 for all three routes and inspected locally.

No lockfile change; no dependency added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added public documentation for the Earth Optimization API, including OAuth/PKCE setup, REST endpoints, permissions, examples, and supported use cases.
  - Added an MCP setup guide with connection instructions for popular clients and details about available capabilities.
  - Added a searchable MCP Tool Reference covering tools, scopes, parameters, and administrative access requirements.
  - Added copy buttons to code examples for easier setup.
  - Added developer resources to campaign search and public routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->