### PR TITLE
Port /feedback and /missions into the campaign app

### DIFF
--- a/apps/warondisease/app/feedback/page.logged-out.md
+++ b/apps/warondisease/app/feedback/page.logged-out.md
@@ -1,0 +1,23 @@
+# /feedback
+
+## Metadata
+
+- Page title: Feedback
+- Meta description: Tell us what is confusing, irritating, broken, or missing so this becomes a better to-do list for humanity.
+- Canonical: https://warondisease.org
+- Open Graph title: The International Campaign to End War and Disease
+- Open Graph description: Click a glowing rectangle. 15 seconds. 2.6 lives saved + 53 years of suffering prevented.
+- Open Graph image: https://warondisease.org/assets/warondisease/war-on-disease-og-1200x630.png
+- Twitter title: The International Campaign to End War and Disease
+- Twitter description: Click a glowing rectangle. 15 seconds. 2.6 lives saved + 53 years of suffering prevented.
+
+## Visible Page Copy
+
+- FEEDBACK
+## HELP COORDINATE HUMANITY BETTER.
+- A decentralized to-do list for humanity. It coordinates the work to end war and disease, in the least irritating way possible. Tell us where it falls short.
+- Company website
+- WHAT SHOULD CHANGE?
+- PAGE URL
+- EMAIL
+- SEND.

--- a/apps/warondisease/app/feedback/page.tsx
+++ b/apps/warondisease/app/feedback/page.tsx
@@ -1,0 +1,169 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import Layout from "@/components/layout";
+import { getSessionUser } from "@/lib/auth-utils";
+import {
+  createFeedbackTask,
+  FEEDBACK_HONEYPOT_FIELD,
+  isFeedbackRejectedError,
+} from "@/lib/feedback.server";
+import { ROUTES } from "@/lib/routes";
+
+export const metadata: Metadata = {
+  title: "Feedback",
+  description:
+    "Tell us what is confusing, irritating, broken, or missing so this becomes a better to-do list for humanity.",
+};
+
+export const dynamic = "force-dynamic";
+
+type FeedbackSearchParams = Record<string, string | string[] | undefined>;
+
+function first(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+async function submitFeedback(formData: FormData) {
+  "use server";
+
+  const sessionUser = await getSessionUser();
+  let redirectPath = "";
+
+  try {
+    const result = await createFeedbackTask({
+      antiSpam: {
+        honeypot: String(formData.get(FEEDBACK_HONEYPOT_FIELD) ?? ""),
+      },
+      contactEmail: String(formData.get("contactEmail") ?? ""),
+      message: String(formData.get("message") ?? ""),
+      pageUrl: String(formData.get("pageUrl") ?? ""),
+      submitterEmail: sessionUser?.email ?? null,
+      submitterUserId: sessionUser?.id ?? null,
+    });
+    redirectPath = `${ROUTES.feedback}?sent=1&task=${encodeURIComponent(result.taskId)}`;
+  } catch (error) {
+    if (!isFeedbackRejectedError(error)) throw error;
+    redirectPath = `${ROUTES.feedback}?sent=1`;
+  }
+
+  redirect(redirectPath);
+}
+
+export default async function FeedbackPage({
+  searchParams,
+}: {
+  searchParams?: Promise<FeedbackSearchParams>;
+}) {
+  const params = (await searchParams) ?? {};
+  const sent = first(params.sent) === "1";
+  const pageUrl = first(params.url) ?? "";
+
+  return (
+    <Layout>
+      <main className="mx-auto max-w-3xl px-4 py-14 sm:px-6">
+        <header className="border-b-2 border-foreground pb-6">
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            Feedback
+          </p>
+          <h1 className="mt-3 text-4xl font-black uppercase leading-none text-foreground sm:text-6xl">
+            Help coordinate humanity better.
+          </h1>
+          <p className="mt-5 max-w-2xl text-base font-bold leading-7 text-muted-foreground">
+            A decentralized to-do list for humanity. It coordinates the work to
+            end war and disease, in the least irritating way possible. Tell us
+            where it falls short.
+          </p>
+        </header>
+
+        {sent ? (
+          <section className="mt-8 border-2 border-foreground bg-background p-5">
+            <p className="text-xl font-black uppercase text-foreground">
+              Feedback sent.
+            </p>
+            <p className="mt-2 font-bold leading-7 text-muted-foreground">
+              It became an internal task for review. Excellent use of the
+              complaint apparatus.
+            </p>
+          </section>
+        ) : null}
+
+        {!sent ? (
+          <form action={submitFeedback} className="mt-8 space-y-5">
+            <div
+              aria-hidden="true"
+              className="absolute -left-[10000px] top-auto"
+            >
+              <label htmlFor={FEEDBACK_HONEYPOT_FIELD}>Company website</label>
+              <input
+                autoComplete="off"
+                id={FEEDBACK_HONEYPOT_FIELD}
+                name={FEEDBACK_HONEYPOT_FIELD}
+                tabIndex={-1}
+                type="text"
+              />
+            </div>
+            <div>
+              <label
+                className="mb-2 block text-xs font-black uppercase tracking-[0.16em] text-muted-foreground"
+                htmlFor="message"
+              >
+                What should change?
+              </label>
+              <textarea
+                className="min-h-48 w-full border-2 border-foreground bg-background px-4 py-3 font-bold leading-7 text-foreground"
+                id="message"
+                maxLength={8000}
+                minLength={3}
+                name="message"
+                placeholder="Site improvements, missing tasks, copy complaints, confusing pages, irritating emails, better strategy, all useful."
+                required
+              />
+            </div>
+
+            <div>
+              <label
+                className="mb-2 block text-xs font-black uppercase tracking-[0.16em] text-muted-foreground"
+                htmlFor="pageUrl"
+              >
+                Page URL
+              </label>
+              <input
+                className="w-full border-2 border-foreground bg-background px-4 py-3 font-bold text-foreground"
+                defaultValue={pageUrl}
+                id="pageUrl"
+                maxLength={1000}
+                name="pageUrl"
+                placeholder="https://warondisease.org/..."
+                type="url"
+              />
+            </div>
+
+            <div>
+              <label
+                className="mb-2 block text-xs font-black uppercase tracking-[0.16em] text-muted-foreground"
+                htmlFor="contactEmail"
+              >
+                Email
+              </label>
+              <input
+                className="w-full border-2 border-foreground bg-background px-4 py-3 font-bold text-foreground"
+                id="contactEmail"
+                maxLength={254}
+                name="contactEmail"
+                placeholder="Optional, if you want a reply"
+                type="email"
+              />
+            </div>
+
+            <button
+              className="w-full border-2 border-foreground bg-foreground px-6 py-4 text-sm font-black uppercase tracking-[0.08em] text-background hover:bg-background hover:text-foreground sm:w-auto"
+              type="submit"
+            >
+              Send.
+            </button>
+          </form>
+        ) : null}
+      </main>
+    </Layout>
+  );
+}

--- a/apps/warondisease/app/missions/mission-safety-notice.tsx
+++ b/apps/warondisease/app/missions/mission-safety-notice.tsx
@@ -1,0 +1,21 @@
+import { MISSION_SAFETY_COPY } from "./mission-safety";
+
+export function MissionSafetyNotice({ compact = false }: { compact?: boolean }) {
+  return (
+    <section className="border-2 border-foreground p-5">
+      <h2 className="text-lg font-black uppercase">
+        {MISSION_SAFETY_COPY.title}
+      </h2>
+      <p className="mt-2 text-sm font-bold leading-relaxed text-muted-foreground">
+        {MISSION_SAFETY_COPY.body}
+      </p>
+      {!compact ? (
+        <ul className="mt-4 ml-4 list-disc space-y-2 text-sm font-bold leading-relaxed text-muted-foreground">
+          {MISSION_SAFETY_COPY.rules.map((rule) => (
+            <li key={rule}>{rule}</li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/warondisease/app/missions/mission-safety.ts
+++ b/apps/warondisease/app/missions/mission-safety.ts
@@ -1,0 +1,24 @@
+import { GLOBAL_DISEASE_DEATHS_DAILY } from "@optimitron/data/parameters";
+
+/**
+ * Safety copy for Earth Optimization Missions.
+ *
+ * Ported from Optimitron's `src/lib/dating-safety.ts`. Only the reader-facing
+ * copy came across; the acknowledgement version and its metadata helpers stayed
+ * on optimitron.com with the profile editor that writes them.
+ */
+
+const dailyDiseaseDeathsInThousands = Math.round(
+  GLOBAL_DISEASE_DEATHS_DAILY.value / 1000,
+);
+
+export const MISSION_SAFETY_COPY = {
+  title: "Mission Safety",
+  body: `Earth Optimization Missions are one-hour sessions for ending war and disease. You may fall madly in love if you insist. But keep in mind, ${dailyDiseaseDeathsInThousands} thousand people die of disease every day, so please spend the hour eradicating disease instead of hugging and/or kissing.`,
+  rules: [
+    "Choose the setting yourself: online, in public, or not at all. Leave whenever you want.",
+    "Do not send money, bank details, passwords, identity documents, or emergency favors to a match.",
+    "Report weird behavior. Block anyone who makes ending war and disease worse.",
+    "If you are in immediate danger, call local emergency services.",
+  ],
+} as const;

--- a/apps/warondisease/app/missions/missions.server.ts
+++ b/apps/warondisease/app/missions/missions.server.ts
@@ -1,0 +1,25 @@
+import type { DatingProfileStatus } from "@optimitron/db";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * The one slice of Optimitron's `src/lib/dating.server.ts` this page needs.
+ *
+ * Optimitron's `getOwnDatingProfile` returns the whole profile because its
+ * profile editor, discovery feed, and messaging all read from it. This page
+ * prints one line about whether the visitor's own missions are on, so it
+ * selects the status alone and leaves the rest — photos, blocks, matches,
+ * interactions — on optimitron.com with the surfaces that use them.
+ */
+export async function getOwnMissionProfileStatus(
+  userId: string,
+): Promise<DatingProfileStatus | null> {
+  const profile = await prisma.datingProfile.findFirst({
+    select: { status: true },
+    where: {
+      deletedAt: null,
+      userId,
+    },
+  });
+
+  return profile?.status ?? null;
+}

--- a/apps/warondisease/app/missions/page.logged-out.md
+++ b/apps/warondisease/app/missions/page.logged-out.md
@@ -1,0 +1,31 @@
+# /missions
+
+## Metadata
+
+- Page title: Earth Optimization Missions
+- Meta description: Find someone you would not mind ending war and disease with. Spend one useful hour optimizing Earth together. Love may occur. Flyers should occur first.
+- Canonical: https://warondisease.org
+- Open Graph title: The International Campaign to End War and Disease
+- Open Graph description: Click a glowing rectangle. 15 seconds. 2.6 lives saved + 53 years of suffering prevented.
+- Open Graph image: https://warondisease.org/assets/warondisease/war-on-disease-og-1200x630.png
+- Twitter title: The International Campaign to End War and Disease
+- Twitter description: Click a glowing rectangle. 15 seconds. 2.6 lives saved + 53 years of suffering prevented.
+
+## Visible Page Copy
+
+- EARTH OPTIMIZATION MISSIONS
+## FIND SOMEONE YOU WOULD NOT MIND SAVING THE WORLD WITH.
+- Spend one hour with a human you like. Figure out one useful thing to do for the campaign. Do it together. Have fun. Fall madly in love if you insist.
+- Disease kills about [150K](https://manual.WarOnDisease.org/knowledge/strategy/questions.html) humans a day. Love may reduce the urge to explode people and increase the urge to cure them. The scheduled activity is still optimizing Earth.
+- [SIGN IN TO START](/auth/signin?callbackUrl=%2Fmissions)
+- [FIND MISSION PEOPLE](https://optimitron.com/people?missions=1)
+### MISSION SAFETY
+- Earth Optimization Missions are one-hour sessions for ending war and disease. You may fall madly in love if you insist. But keep in mind, 150 thousand people die of disease every day, so please spend the hour eradicating disease instead of hugging and/or kissing.
+- [TURN ON MISSIONS Say what kind of human should find you, and which useful hour would not make you flee.](https://optimitron.com/profile#missions)
+- [FIND MISSION PEOPLE Filter people who turned on missions. Like, pass, or send one actual sentence before the species collapses.](https://optimitron.com/people?missions=1)
+- [OPEN MESSAGES Talk to mutual matches and propose a useful campaign session. No money requests. More posters.](https://optimitron.com/messages)
+### GOOD MISSIONS
+- [COFFEE PLUS QR FLYERS Acquire caffeine. Tape up evidence that your species can still coordinate.](https://optimitron.com/people?missions=1)
+- [WALK PLUS TWO VOTES Walk outside briefly. Text two humans the treaty vote before returning indoors.](https://optimitron.com/people?missions=1)
+- [VIDEO CALL PLUS TASK Pick one open task, do the first useful step, and leave a comment so the next human can continue.](https://optimitron.com/people?missions=1)
+- [MUSEUM PLUS POSTERS Look at civilization. Then help keep it from becoming a cautionary exhibit.](https://optimitron.com/people?missions=1)

--- a/apps/warondisease/app/missions/page.tsx
+++ b/apps/warondisease/app/missions/page.tsx
@@ -1,0 +1,223 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { GLOBAL_DISEASE_DEATHS_DAILY } from "@optimitron/data/parameters";
+import Layout from "@/components/layout";
+import { ParameterValue } from "@/components/shared/ParameterValue";
+import { getSessionUserId } from "@/lib/auth-utils";
+import { OPTIMITRON_LINKS, optimitronUrl } from "@/lib/optimitron-links";
+import { ROUTES } from "@/lib/routes";
+import { MissionSafetyNotice } from "./mission-safety-notice";
+import { getOwnMissionProfileStatus } from "./missions.server";
+
+export const metadata: Metadata = {
+  title: "Earth Optimization Missions",
+  description:
+    "Find someone you would not mind ending war and disease with. Spend one useful hour optimizing Earth together. Love may occur. Flyers should occur first.",
+};
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Mission profiles, discovery, and messaging stay on optimitron.com — this page
+ * is the campaign-side front door for them, so the three action cards and the
+ * sign-in target point back across the domain boundary.
+ */
+const MISSION_PEOPLE_URL = optimitronUrl("/people?missions=1");
+
+const MISSION_ACTIONS = [
+  {
+    href: OPTIMITRON_LINKS.profileMissions.url,
+    title: "Turn on missions",
+    body: "Say what kind of human should find you, and which useful hour would not make you flee.",
+  },
+  {
+    href: MISSION_PEOPLE_URL,
+    title: "Find mission people",
+    body: "Filter people who turned on missions. Like, pass, or send one actual sentence before the species collapses.",
+  },
+  {
+    href: OPTIMITRON_LINKS.messages.url,
+    title: "Open messages",
+    body: "Talk to mutual matches and propose a useful campaign session. No money requests. More posters.",
+  },
+] as const;
+
+const MISSION_EXAMPLES = [
+  {
+    title: "Coffee plus QR flyers",
+    body: "Acquire caffeine. Tape up evidence that your species can still coordinate.",
+  },
+  {
+    title: "Walk plus two votes",
+    body: "Walk outside briefly. Text two humans the treaty vote before returning indoors.",
+  },
+  {
+    title: "Video call plus task",
+    body: "Pick one open task, do the first useful step, and leave a comment so the next human can continue.",
+  },
+  {
+    title: "Museum plus posters",
+    body: "Look at civilization. Then help keep it from becoming a cautionary exhibit.",
+  },
+] as const;
+
+async function loadProfileStatus(userId: string) {
+  try {
+    return {
+      ready: true,
+      status: await getOwnMissionProfileStatus(userId),
+    };
+  } catch {
+    return {
+      ready: false,
+      status: null,
+    };
+  }
+}
+
+export default async function MissionsPage() {
+  const userId = await getSessionUserId();
+
+  if (!userId) {
+    return (
+      <Layout>
+        <main className="min-h-screen bg-background px-4 py-10 text-foreground [font-family:var(--v0-font-libre-baskerville)] sm:px-6 lg:px-8">
+          <MissionLanding signedIn={false} />
+        </main>
+      </Layout>
+    );
+  }
+
+  const { ready, status } = await loadProfileStatus(userId);
+
+  return (
+    <Layout>
+      <main className="min-h-screen bg-background px-4 py-10 text-foreground [font-family:var(--v0-font-libre-baskerville)] sm:px-6 lg:px-8">
+        <MissionLanding
+          profileStatus={
+            !ready
+              ? "unavailable"
+              : status
+                ? status.toLowerCase()
+                : "off"
+          }
+          signedIn
+        />
+      </main>
+    </Layout>
+  );
+}
+
+function MissionLanding({
+  profileStatus,
+  signedIn,
+}: {
+  profileStatus?: string;
+  signedIn: boolean;
+}) {
+  return (
+    <div className="mx-auto max-w-6xl">
+      <section className="grid gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.7fr)] lg:items-start">
+        <div className="max-w-3xl">
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            Earth Optimization Missions
+          </p>
+          <h1 className="mt-4 text-5xl font-black uppercase leading-none sm:text-7xl">
+            Find someone you would not mind saving the world with.
+          </h1>
+          <p className="mt-5 text-xl font-bold leading-9 text-muted-foreground">
+            Spend one hour with a human you like. Figure out one useful thing to
+            do for the campaign. Do it together. Have fun. Fall madly in love if
+            you insist.
+          </p>
+          <p className="mt-4 text-base font-bold leading-7 text-muted-foreground">
+            Disease kills about{" "}
+            <ParameterValue param={GLOBAL_DISEASE_DEATHS_DAILY} /> humans a day.
+            Love may reduce the urge to explode people and increase the urge to
+            cure them. The scheduled activity is still optimizing Earth.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            {signedIn ? (
+              <a
+                className="inline-flex min-h-12 items-center justify-center border-2 border-foreground bg-foreground px-5 text-sm font-black uppercase text-background transition-colors hover:bg-background hover:text-foreground"
+                href={OPTIMITRON_LINKS.profileMissions.url}
+              >
+                Turn on missions
+              </a>
+            ) : (
+              <Link
+                className="inline-flex min-h-12 items-center justify-center border-2 border-foreground bg-foreground px-5 text-sm font-black uppercase text-background transition-colors hover:bg-background hover:text-foreground"
+                href={`${ROUTES.signIn}?callbackUrl=${encodeURIComponent(ROUTES.missions)}`}
+              >
+                Sign in to start
+              </Link>
+            )}
+            <a
+              className="inline-flex min-h-12 items-center justify-center border-2 border-foreground bg-background px-5 text-sm font-black uppercase text-foreground transition-colors hover:bg-foreground hover:text-background"
+              href={MISSION_PEOPLE_URL}
+            >
+              Find mission people
+            </a>
+          </div>
+        </div>
+
+        <div className="grid gap-4">
+          <MissionSafetyNotice compact />
+          {profileStatus ? (
+            <div className="border-2 border-foreground p-5">
+              <h2 className="text-lg font-black uppercase">Mission status</h2>
+              <p className="mt-2 text-sm font-bold leading-relaxed text-muted-foreground">
+                {profileStatus === "active"
+                  ? "Active. Other opted-in humans can find you."
+                  : profileStatus === "off"
+                    ? "Off. Turn on missions and other humans can find you."
+                    : profileStatus === "unavailable"
+                      ? "Not ready yet. Try again in a moment."
+                      : `Current status: ${profileStatus}.`}
+              </p>
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="mt-12 grid gap-4 sm:grid-cols-3">
+        {MISSION_ACTIONS.map((route) => (
+          <a
+            className="border-2 border-foreground p-5 text-foreground transition-colors hover:bg-foreground hover:text-background"
+            href={route.href}
+            key={route.href}
+          >
+            <span className="block text-xl font-black uppercase">
+              {route.title}
+            </span>
+            <span className="mt-2 block text-sm font-bold leading-relaxed text-muted-foreground">
+              {route.body}
+            </span>
+          </a>
+        ))}
+      </section>
+
+      <section className="mt-12">
+        <h2 className="text-3xl font-black uppercase leading-none">
+          Good missions
+        </h2>
+        <div className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {MISSION_EXAMPLES.map((example) => (
+            <a
+              className="border-2 border-foreground p-5 text-foreground transition-colors hover:bg-foreground hover:text-background"
+              href={MISSION_PEOPLE_URL}
+              key={example.title}
+            >
+              <span className="block text-xl font-black uppercase">
+                {example.title}
+              </span>
+              <span className="mt-2 block text-sm font-bold leading-relaxed text-muted-foreground">
+                {example.body}
+              </span>
+            </a>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/warondisease/app/search/campaign-search.server.ts
+++ b/apps/warondisease/app/search/campaign-search.server.ts
@@ -160,6 +160,15 @@ const CAMPAIGN_PAGES: CampaignPageDocument[] = [
   },
   {
     description:
+      "Find someone you would not mind ending war and disease with, and spend one useful hour on it together.",
+    emoji: "❤️",
+    href: ROUTES.missions,
+    keywords: ["missions", "date", "dating", "match", "hour", "together"],
+    section: "Recruit",
+    title: "Earth Optimization Missions",
+  },
+  {
+    description:
       "Send one more 1% Treaty invitation to someone who has not voted.",
     emoji: "📨",
     href: ROUTES.send,
@@ -250,6 +259,15 @@ const CAMPAIGN_PAGES: CampaignPageDocument[] = [
     keywords: ["contact", "email", "reach", "support"],
     section: "About",
     title: "Contact",
+  },
+  {
+    description:
+      "Tell us what is confusing, irritating, broken, or missing on this site.",
+    emoji: "❗",
+    href: ROUTES.feedback,
+    keywords: ["feedback", "complaint", "bug", "broken", "confusing", "suggest"],
+    section: "About",
+    title: "Feedback",
   },
   {
     description: "What we collect and what we do not.",

--- a/packages/site-kit/src/lib/feedback.server.ts
+++ b/packages/site-kit/src/lib/feedback.server.ts
@@ -1,0 +1,257 @@
+/**
+ * Site feedback intake.
+ *
+ * Ported from Optimitron's `src/lib/feedback.server.ts`. A submission becomes a
+ * private task under the Optimitron engineering branch, so feedback lands in
+ * the same queue whichever site it was sent from.
+ *
+ * Optimitron builds the task through its generic `createTask`, which resolves a
+ * parent, a claim policy, and an assignee notification for every caller. This
+ * intake has one fixed shape — private, explicit parent, first-admin assignee —
+ * so it writes the resolved row directly, the way the other site-kit task
+ * writers do. The one behavior that does not carry over is the assignee email
+ * `createTask` sends: the task still shows up in the assignee's queue.
+ */
+
+import {
+  TaskCategory,
+  TaskClaimPolicy,
+  TaskStatus,
+  type Prisma,
+} from "@optimitron/db";
+import { WISHONIA_EMAIL } from "@optimitron/db/system-identities";
+import { OPTIMITRON_DEV_TASK_ID } from "@optimitron/db/task-keys";
+import { prisma } from "./prisma";
+
+const MAX_FEEDBACK_LENGTH = 8_000;
+const MAX_URL_LENGTH = 1_000;
+const MAX_EMAIL_LENGTH = 254;
+const FEEDBACK_TASK_TITLE_PREFIX = "Review site feedback:";
+const FEEDBACK_GLOBAL_BURST_LIMIT = 20;
+const FEEDBACK_GLOBAL_BURST_WINDOW_MS = 10 * 60 * 1000;
+export const FEEDBACK_HONEYPOT_FIELD = "companyWebsite";
+
+type FeedbackRejectionCode = "honeypot" | "rate_limited";
+
+export class FeedbackRejectedError extends Error {
+  readonly code: FeedbackRejectionCode;
+
+  constructor(code: FeedbackRejectionCode, message: string) {
+    super(message);
+    this.name = "FeedbackRejectedError";
+    this.code = code;
+  }
+}
+
+export function isFeedbackRejectedError(
+  error: unknown,
+): error is FeedbackRejectedError {
+  return error instanceof FeedbackRejectedError;
+}
+
+export interface CreateFeedbackTaskInput {
+  antiSpam?: {
+    honeypot?: string | null;
+  };
+  contactEmail?: string | null;
+  message: string;
+  pageUrl?: string | null;
+  submitterEmail?: string | null;
+  submitterUserId?: string | null;
+}
+
+function clean(value: string | null | undefined, maxLength: number) {
+  const trimmed = value?.trim() ?? "";
+  return trimmed ? trimmed.slice(0, maxLength) : null;
+}
+
+function makeTitle(message: string) {
+  const firstLine = message.replace(/\s+/g, " ").trim().slice(0, 72);
+  return `${FEEDBACK_TASK_TITLE_PREFIX} ${firstLine || "No summary"}`;
+}
+
+function cleanEmail(value: string | null | undefined) {
+  return clean(value, MAX_EMAIL_LENGTH);
+}
+
+function cleanHttpUrl(value: string | null | undefined) {
+  const cleaned = clean(value, MAX_URL_LENGTH);
+  if (!cleaned) return null;
+
+  try {
+    const parsed = new URL(cleaned);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+function assertHoneypotIsEmpty(input: CreateFeedbackTaskInput) {
+  const honeypot = clean(input.antiSpam?.honeypot, 500);
+  if (honeypot) {
+    throw new FeedbackRejectedError("honeypot", "Feedback accepted.");
+  }
+}
+
+/**
+ * Wishonia is the system user that owns work nobody else claimed. Cached in
+ * process because the row never changes.
+ */
+let cachedWishoniaUserId: string | null = null;
+
+async function getWishoniaUserId(): Promise<string> {
+  if (cachedWishoniaUserId) return cachedWishoniaUserId;
+
+  const user = await prisma.user.findUnique({
+    where: { email: WISHONIA_EMAIL },
+    select: { id: true },
+  });
+
+  if (!user) {
+    throw new Error(
+      "Wishonia user not seeded. Run: pnpm db:sync:managed-data -- --apply",
+    );
+  }
+
+  cachedWishoniaUserId = user.id;
+  return user.id;
+}
+
+async function getFeedbackTaskOwner() {
+  const admin = await prisma.user.findFirst({
+    where: {
+      deletedAt: null,
+      isAdmin: true,
+    },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      personId: true,
+    },
+  });
+
+  if (admin) {
+    return {
+      assigneePersonId: admin.personId,
+      creatorUserId: admin.id,
+    };
+  }
+
+  return {
+    assigneePersonId: null,
+    creatorUserId: await getWishoniaUserId(),
+  };
+}
+
+async function assertFeedbackWithinRateLimits(now = new Date()) {
+  const cutoff = new Date(now.getTime() - FEEDBACK_GLOBAL_BURST_WINDOW_MS);
+  const recentFeedbackTasks = await prisma.task.count({
+    where: {
+      createdAt: { gte: cutoff },
+      deletedAt: null,
+      isPublic: false,
+      title: { startsWith: FEEDBACK_TASK_TITLE_PREFIX },
+    },
+  });
+
+  if (recentFeedbackTasks >= FEEDBACK_GLOBAL_BURST_LIMIT) {
+    throw new FeedbackRejectedError(
+      "rate_limited",
+      "Feedback is temporarily rate limited.",
+    );
+  }
+}
+
+function buildFeedbackTaskDescription(input: {
+  contactEmail: string | null;
+  message: string;
+  pageUrl: string | null;
+  submitterEmail: string | null;
+  submitterUserId: string | null;
+}) {
+  return [
+    "A human sent feedback about how to better coordinate humanity to end war and disease.",
+    "",
+    "Feedback:",
+    input.message,
+    "",
+    input.pageUrl ? `Page URL: ${input.pageUrl}` : null,
+    input.contactEmail ? `Contact email: ${input.contactEmail}` : null,
+    input.submitterEmail ? `Signed-in email: ${input.submitterEmail}` : null,
+    input.submitterUserId
+      ? `Signed-in user ID: ${input.submitterUserId}`
+      : null,
+    "",
+    "Triage:",
+    "- If valid, turn it into the smallest useful site/task/email improvement.",
+    "- If it is irritation caused by our own copy or email behavior, fix the irritating thing.",
+    "- If they asked us to stop bothering them, handle that before doing anything clever.",
+  ]
+    .filter((line): line is string => line != null)
+    .join("\n");
+}
+
+export async function createFeedbackTask(input: CreateFeedbackTaskInput) {
+  assertHoneypotIsEmpty(input);
+
+  const message = clean(input.message, MAX_FEEDBACK_LENGTH);
+  if (!message || message.length < 3) {
+    throw new Error("Feedback is required.");
+  }
+  await assertFeedbackWithinRateLimits();
+
+  const contactEmail = cleanEmail(input.contactEmail);
+  const contactEmailNormalized = contactEmail?.toLowerCase() ?? null;
+  const submitterEmail = cleanEmail(input.submitterEmail);
+  const pageUrl = cleanHttpUrl(input.pageUrl);
+  const submitterUserId = clean(input.submitterUserId, 128);
+  const owner = await getFeedbackTaskOwner();
+  const metadata = {
+    contactEmail,
+    contactEmailNormalized,
+    pageUrl,
+    source: "feedback_page",
+    submitterEmail,
+    submitterUserId,
+  } satisfies Prisma.InputJsonObject;
+
+  const task = await prisma.task.create({
+    data: {
+      assigneePersonId: owner.assigneePersonId,
+      category: TaskCategory.OTHER,
+      // An assigned task is claimable only by its assignee; an unassigned one
+      // falls back to the single-claimer default, matching `createTask`.
+      claimPolicy: owner.assigneePersonId
+        ? TaskClaimPolicy.ASSIGNED_ONLY
+        : TaskClaimPolicy.OPEN_SINGLE,
+      contextJson: metadata,
+      createdByUserId: owner.creatorUserId,
+      description: buildFeedbackTaskDescription({
+        contactEmail,
+        message,
+        pageUrl,
+        submitterEmail,
+        submitterUserId,
+      }),
+      estimatedEffortHours: 0.25,
+      interestTags: ["feedback", "site improvement", "war and disease"],
+      // Product feedback belongs in the engineering branch, not the Optimize
+      // Earth root and not the feedback owner's personal queue (OPT-TASK-06).
+      // An explicit parent also makes the task private.
+      isPublic: false,
+      parentTaskId: OPTIMITRON_DEV_TASK_ID,
+      roleTitle: owner.assigneePersonId ? "Feedback triage" : null,
+      skillTags: ["triage", "copy", "product"],
+      status: TaskStatus.ACTIVE,
+      title: makeTitle(message),
+    },
+    select: { id: true },
+  });
+
+  return {
+    taskId: task.id,
+  };
+}

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -427,6 +427,28 @@ export const publicSiteAppRoutes = Object.freeze({
       sourcePage: "apps/warondisease/app/employees/page.tsx",
     },
     {
+      covers: [
+        "apps/warondisease/app/missions/page.tsx",
+        "apps/warondisease/app/missions/mission-safety.ts",
+        "apps/warondisease/app/missions/mission-safety-notice.tsx",
+        "apps/warondisease/app/missions/missions.server.ts",
+      ],
+      label: "Earth Optimization Missions",
+      routeName: "missions",
+      routePath: "/missions",
+      sourcePage: "apps/warondisease/app/missions/page.tsx",
+    },
+    {
+      covers: [
+        "apps/warondisease/app/feedback/page.tsx",
+        "packages/site-kit/src/lib/feedback.server.ts",
+      ],
+      label: "Feedback form",
+      routeName: "feedback",
+      routePath: "/feedback",
+      sourcePage: "apps/warondisease/app/feedback/page.tsx",
+    },
+    {
       covers: ["apps/warondisease/app/survey/demo/page.tsx"],
       label: "Survey embed demo",
       routeName: "survey-demo",


### PR DESCRIPTION
## Summary

`/feedback` and `/missions` were menu entries that still resolved only on optimitron.com and returned 404 on warondisease.org. This ports both pages into `apps/warondisease`. Copy, form fields, validation, and post-submit behavior are unchanged from the source pages.

## What changed

**Feedback**
- `apps/warondisease/app/feedback/page.tsx` — the form, wrapped in the campaign `Layout`. Same fields (message, page URL, email), same lengths, same honeypot, same `?sent=1` confirmation state.
- `packages/site-kit/src/lib/feedback.server.ts` — the intake, moved into site-kit so any site app can mount the form. Uses the site-kit Prisma shim. Optimitron builds the task through its generic `createTask`; this intake has one fixed shape (private, explicit parent, first-admin assignee), so it writes the resolved row directly, the way the other site-kit task writers do. Honeypot rejection, the 20-per-10-minutes global burst limit, URL/email cleaning, the task title prefix, the description template, and the `contextJson` metadata are all carried over unchanged.

**Missions**
- `apps/warondisease/app/missions/page.tsx` — the landing page, wrapped in `Layout`.
- `apps/warondisease/app/missions/missions.server.ts` — the one slice of Optimitron's 910-line `dating.server.ts` this page needs: the visitor's own mission-profile status. Profiles, photos, blocks, matches, and messaging stay on optimitron.com.
- `apps/warondisease/app/missions/mission-safety-notice.tsx` and `mission-safety.ts` — the safety notice and its copy.
- Profile, people, and messages links go through `OPTIMITRON_LINKS` / `optimitronUrl()` from `packages/site-kit/src/lib/optimitron-links.ts`.

**Registration**
- `scripts/site-app-visual-routes.mjs` — both routes added to `publicSiteAppRoutes.warondisease`.
- `apps/warondisease/app/search/campaign-search.server.ts` — both pages added to `CAMPAIGN_PAGES`.
- Generated `page.logged-out.md` snapshots for both routes via `pnpm copy warondisease`.

`packages/site-kit/src/lib/nav-items.ts` and `site-config.ts` are untouched; the menu is handled separately.

## Pages to review

The preview root is in the Vercel comment on this PR.

- `/feedback?logout=1`
- `/feedback?sent=1&logout=1` — the post-submit confirmation state
- `/missions?logout=1`
- `/missions?login=demo` — adds the mission-status card

## Verification

- `pnpm --filter @apps/warondisease typecheck` — passes
- `pnpm --filter @apps/warondisease lint` — passes
- `pnpm --filter @apps/warondisease test:unit` — 19 files, 75 tests, all pass
- `pnpm test:site-app-navigation` — 19/19 pass
- Server action smoke-tested end to end through the honeypot-rejection path, which returns before any database write, so no task was created.
- Screenshots captured and inspected locally at 1280 and 390 wide, before from optimitron.com and after from a local dev server. No layout breakage; both pages pick up the campaign shell cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
