### PR TITLE
Record that Accelerated Medicine ships authentication

### DIFF
--- a/apps/DEPLOYMENT.md
+++ b/apps/DEPLOYMENT.md
@@ -85,8 +85,9 @@ are truly shared. Link each shared variable to the projects that need it.
 Good shared candidates:
 
 - `DATABASE_URL` for War on Disease, dFDA, Wishocracy, Trial Abundance Survey,
-  and Court of Humanity. Court of Humanity authenticates against the same shared
-  database, so it needs this variable before its first production deploy.
+  Accelerated Medicine, and Court of Humanity. Accelerated Medicine and Court of
+  Humanity authenticate against the same shared database, so each needs this
+  variable before its first production deploy.
 - `NEXTAUTH_SECRET` for the optimitron web project and dFDA only. optimitron.com
   signs MCP Bearer tokens with it and dfda.earth/api/mcp verifies them, so those
   two projects must share one value (decided 2026-08-14: one secret, no separate
@@ -124,9 +125,10 @@ production schema because votes, people, and referrals are shared records.
 
 Each app's `.env.example` lists only the variables its shipped capabilities
 need. Vercel remains the value store. The example files are the reviewable
-contract and contain no real secrets. Accelerated Medicine and CureDAO do not
-receive database or authentication secrets because they do not ship those
-capabilities.
+contract and contain no real secrets. Accelerated Medicine ships the shared
+survey and sign-in, so it receives `DATABASE_URL`, its own `NEXTAUTH_SECRET`,
+and a production `NEXTAUTH_URL`. CureDAO does not receive database or
+authentication secrets because it does not ship those capabilities.
 
 Vercel sets `NODE_ENV`, `VERCEL_URL`, and related platform variables. Do not add
 them manually. `NEXT_PUBLIC_SITE_VARIANT` is fixed in each app's Next config.

--- a/apps/acceleratedmedicine/.env.example
+++ b/apps/acceleratedmedicine/.env.example
@@ -1,3 +1,15 @@
+# Database and authentication (the app ships the shared survey and sign-in)
+DATABASE_URL="postgresql://user:password@host-pooler/database?sslmode=require"
+NEXTAUTH_SECRET="generate-a-random-32-byte-secret"
+NEXTAUTH_URL="http://localhost:3016"
+
+# Optional sign-in and email providers
+RESEND_API_KEY="re_your_api_key"
+EMAIL_FROM_ADDRESS="no-reply@acceleratedmedicine.org"
+EMAIL_FROM_NAME="Institute for Accelerated Medicine"
+GOOGLE_CLIENT_ID="your-google-client-id"
+GOOGLE_CLIENT_SECRET="your-google-client-secret"
+
 # Canonical survey iframe host
 NEXT_PUBLIC_SURVEY_ORIGIN="https://trialabundancesurvey.org"
 


### PR DESCRIPTION
## Summary

Docs only. Since the shared Trial Abundance survey landed, the Accelerated Medicine app serves sign-in and survey routes, so its Vercel project needs `DATABASE_URL`, its own `NEXTAUTH_SECRET`, and a production `NEXTAUTH_URL`. The preview build fails without them, which is correct: an app that cannot authenticate should not deploy. This records the requirement where the next person will look.

## What changed

- `apps/DEPLOYMENT.md`: Accelerated Medicine joins the `DATABASE_URL` list, and the paragraph that said it receives no database or auth secrets now says it does; CureDAO keeps that sentence.
- `apps/acceleratedmedicine/.env.example`: adds the database and auth block and the optional provider block, matching the other auth-shipping apps. Port 3016.

## Verification

No build or screenshots: nothing renders. Diff review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)