### PR TITLE
Fix Vercel monorepo command overrides

### DIFF
--- a/.github/scripts/vercel-app-projects.mjs
+++ b/.github/scripts/vercel-app-projects.mjs
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const API_ORIGIN = "https://api.vercel.com";
 const GITHUB_REPOSITORY = "mikepsinn/optimitron";
+const VERCEL_COMMAND_KEYS = Object.freeze([
+  ["buildCommand", "buildCommand"],
+  ["ignoreCommand", "commandForIgnoringBuildStep"],
+  ["installCommand", "installCommand"],
+]);
 
 export const VERCEL_APP_PROJECTS = Object.freeze([
   project("optimitron", "optimitron-web", "optimitron.com", [
@@ -53,11 +59,23 @@ function project(
   smokePaths = ["/"],
   { previewPending = false } = {},
 ) {
+  const rootDirectory = `apps/${appName}`;
+  const vercelConfig = JSON.parse(
+    readFileSync(
+      new URL(`../../${rootDirectory}/vercel.json`, import.meta.url),
+      "utf8",
+    ),
+  );
   return Object.freeze({
     appName,
     projectName,
     productionDomain,
-    rootDirectory: `apps/${appName}`,
+    rootDirectory,
+    projectCommandOverrides: Object.freeze(
+      VERCEL_COMMAND_KEYS.filter(
+        ([configKey]) => vercelConfig[configKey] != null,
+      ).map(([, projectKey]) => projectKey),
+    ),
     deploymentPrefixes: Object.freeze(deploymentPrefixes),
     smokePaths: Object.freeze(smokePaths),
     previewPending,
@@ -105,11 +123,7 @@ export function getProjectPatch(current, desired) {
   );
   // Keep commands in each app's vercel.json. Project-level copies run from
   // the repository root and break the app-relative ../../ paths.
-  for (const key of [
-    "buildCommand",
-    "commandForIgnoringBuildStep",
-    "installCommand",
-  ]) {
+  for (const key of desired.projectCommandOverrides) {
     const currentValue = Object.hasOwn(current ?? {}, key)
       ? current[key]
       : current?.settings?.[key];

--- a/.github/scripts/vercel-app-projects.mjs
+++ b/.github/scripts/vercel-app-projects.mjs
@@ -103,6 +103,18 @@ export function getProjectPatch(current, desired) {
       return currentValue !== value;
     }),
   );
+  // Keep commands in each app's vercel.json. Project-level copies run from
+  // the repository root and break the app-relative ../../ paths.
+  for (const key of [
+    "buildCommand",
+    "commandForIgnoringBuildStep",
+    "installCommand",
+  ]) {
+    const currentValue = Object.hasOwn(current ?? {}, key)
+      ? current[key]
+      : current?.settings?.[key];
+    if (currentValue != null) patch[key] = null;
+  }
   const currentResourceConfig =
     current?.resourceConfig ?? current?.settings?.resourceConfig ?? {};
   const expectedResourceConfig = {

--- a/.github/scripts/vercel-app-projects.test.mjs
+++ b/.github/scripts/vercel-app-projects.test.mjs
@@ -230,6 +230,41 @@ test("repairs only deployment settings that drift", () => {
   );
 });
 
+test("clears only command overrides replaced by the app config", () => {
+  const desired = VERCEL_APP_PROJECTS[0];
+  assert.deepEqual(desired.projectCommandOverrides, [
+    "buildCommand",
+    "commandForIgnoringBuildStep",
+  ]);
+  assert.deepEqual(
+    getProjectPatch(
+      {
+        buildCommand: "pnpm run build:vercel",
+        commandForIgnoringBuildStep: "git diff HEAD^ HEAD --quiet",
+        installCommand: "pnpm install --frozen-lockfile",
+        settings: {
+          enableAffectedProjectsDeployments: true,
+          framework: "nextjs",
+          nodeVersion: "24.x",
+          productionDeploymentsFastLane: true,
+          resourceConfig: {
+            buildMachineSelection: "fixed",
+            buildMachineType: "standard",
+            elasticConcurrencyEnabled: false,
+          },
+          rootDirectory: desired.rootDirectory,
+          sourceFilesOutsideRootDirectory: true,
+        },
+      },
+      desired,
+    ),
+    {
+      buildCommand: null,
+      commandForIgnoringBuildStep: null,
+    },
+  );
+});
+
 test("requires the expected GitHub repository link", () => {
   assert.equal(
     getGitLinkProblem({

--- a/.github/scripts/vercel-app-projects.test.mjs
+++ b/.github/scripts/vercel-app-projects.test.mjs
@@ -174,7 +174,11 @@ test("repairs only deployment settings that drift", () => {
     getProjectPatch(
       {
         enableAffectedProjectsDeployments: false,
+        buildCommand: "cd ../.. && pnpm --filter @apps/warondisease run build",
+        commandForIgnoringBuildStep:
+          "node ../../.github/scripts/vercel-ignore-build.mjs warondisease",
         framework: "nextjs",
+        installCommand: "cd ../.. && pnpm install --frozen-lockfile",
         nodeVersion: "20.x",
         productionDeploymentsFastLane: false,
         resourceConfig: {
@@ -188,7 +192,10 @@ test("repairs only deployment settings that drift", () => {
       desired,
     ),
     {
+      buildCommand: null,
+      commandForIgnoringBuildStep: null,
       enableAffectedProjectsDeployments: true,
+      installCommand: null,
       nodeVersion: "24.x",
       productionDeploymentsFastLane: true,
       resourceConfig: {


### PR DESCRIPTION
## Summary
- clear project-level Vercel command overrides during app-project reconciliation
- keep app-relative install, build, and ignore commands sourced from each checked-in vercel.json
- cover the regression that broke the new Court of Humanity project

## Verification
- node --test .github/scripts/vercel-app-projects.test.mjs
- git diff --check
- applied the three-field correction to the live courtofhumanity project
- added the production DATABASE_URL from the canonical optimitron-web database
- triggered a production build from main commit fe62d6b1f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vercel deployments now honor build, install, and build-ignore commands defined in each app’s configuration.
  * Project-level command settings are cleared when applicable, preventing them from overriding app-specific deployment settings.

* **Tests**
  * Updated deployment configuration coverage to verify the corrected command precedence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->