### PR TITLE
Share the pnpm content store across worktrees

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
-store-dir=.pnpm-store
 virtual-store-dir=.pnpm-store/virtual-store
 # Single next@15.5.15 + next-auth identity across monorepo
 public-hoist-pattern[]=next


### PR DESCRIPTION
## Summary
- stop overriding pnpm's shared content store with a worktree-local store
- keep the virtual store local to each worktree

## Verification
- pnpm store path resolves to the configured global store (E:\\.pnpm-store\\v3 on this machine)
- git diff --cached --check

## Impact
This prevents each new worktree from duplicating the full pnpm content-addressed store. Existing installed dependency trees remain worktree-local as required.

## Review
- [ ] Human review complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager configuration while preserving existing dependency resolution and hoisting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->