### PR TITLE
Fail Vercel builds with missing app configuration

### DIFF
--- a/.github/scripts/vercel-app-build-scope.mjs
+++ b/.github/scripts/vercel-app-build-scope.mjs
@@ -14,6 +14,7 @@ const dependencyFields = [
   "peerDependencies",
 ];
 const globalBuildFiles = new Set([
+  ".github/scripts/vercel-app-env.mjs",
   ".npmrc",
   "package.json",
   "pnpm-lock.yaml",

--- a/.github/scripts/vercel-app-build-scope.test.mjs
+++ b/.github/scripts/vercel-app-build-scope.test.mjs
@@ -103,7 +103,12 @@ test("ignores global review and documentation changes", () => {
 });
 
 test("rebuilds every app for root dependency inputs", () => {
-  const files = ["package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml"];
+  const files = [
+    ".github/scripts/vercel-app-env.mjs",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+  ];
 
   for (const app of apps) {
     assert.deepEqual(getVercelAppBuildMatches(app, files), files);

--- a/.github/scripts/vercel-app-env.mjs
+++ b/.github/scripts/vercel-app-env.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+const AUTH_ENVIRONMENT_VARIABLES = Object.freeze([
+  "DATABASE_URL",
+  "NEXTAUTH_SECRET",
+]);
+
+const AUTH_PRODUCTION_ENVIRONMENT_VARIABLES = Object.freeze([
+  "NEXTAUTH_URL",
+  "RESEND_API_KEY",
+  "GOOGLE_CLIENT_ID",
+  "GOOGLE_CLIENT_SECRET",
+]);
+
+function requirements(required = [], requiredInProduction = []) {
+  return Object.freeze({
+    required: Object.freeze([...required]),
+    requiredInProduction: Object.freeze([...requiredInProduction]),
+  });
+}
+
+function authRequirements(requiredInProduction = []) {
+  return requirements(AUTH_ENVIRONMENT_VARIABLES, [
+    ...AUTH_PRODUCTION_ENVIRONMENT_VARIABLES,
+    ...requiredInProduction,
+  ]);
+}
+
+export const VERCEL_APP_ENV_REQUIREMENTS = Object.freeze({
+  optimitron: authRequirements(["CRON_SECRET"]),
+  warondisease: authRequirements(["CRON_SECRET"]),
+  dfda: authRequirements(["GOOGLE_GENERATIVE_AI_API_KEY"]),
+  wishocracy: authRequirements(),
+  trialabundancesurvey: authRequirements(),
+  curedao: requirements(),
+  acceleratedmedicine: authRequirements(["RIGHT_TO_TRY_RATE_LIMIT_SECRET"]),
+  courtofhumanity: authRequirements(),
+});
+
+export function getMissingVercelAppEnvironmentVariables(
+  appName,
+  environment = process.env,
+) {
+  const appRequirements = VERCEL_APP_ENV_REQUIREMENTS[appName];
+  if (!appRequirements) {
+    throw new Error(`Unknown Vercel app: ${appName}`);
+  }
+
+  const names = [
+    ...appRequirements.required,
+    ...(environment.VERCEL_ENV === "production"
+      ? appRequirements.requiredInProduction
+      : []),
+  ];
+  return names.filter((name) => !environment[name]?.trim());
+}
+
+export function validateVercelAppEnvironment(
+  appName,
+  environment = process.env,
+) {
+  const missing = getMissingVercelAppEnvironmentVariables(appName, environment);
+  if (missing.length > 0) {
+    const target = environment.VERCEL_ENV?.trim() || "deployment";
+    throw new Error(
+      `${appName} cannot build for ${target}. Missing required environment variables: ${missing.join(", ")}`,
+    );
+  }
+  console.log(`${appName}: required deployment environment variables are set.`);
+}
+
+function main() {
+  const appName = process.argv[2];
+  if (!appName) {
+    throw new Error("Usage: vercel-app-env.mjs <app-name>");
+  }
+  validateVercelAppEnvironment(appName);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/vercel-app-projects.test.mjs
+++ b/.github/scripts/vercel-app-projects.test.mjs
@@ -8,6 +8,11 @@ import {
   VERCEL_APP_PROJECTS,
 } from "./vercel-app-projects.mjs";
 import {
+  getMissingVercelAppEnvironmentVariables,
+  validateVercelAppEnvironment,
+  VERCEL_APP_ENV_REQUIREMENTS,
+} from "./vercel-app-env.mjs";
+import {
   getVercelAppBuildMatches,
   loadWorkspacePackages,
   shouldAutoBuildPreview,
@@ -84,11 +89,83 @@ test("declares one Vercel project for every deployed app", () => {
       vercelJson.buildCommand,
       `${project.rootDirectory} needs a Vercel build command`,
     );
+    assert.match(
+      vercelJson.buildCommand,
+      new RegExp(
+        `^node \.\.\/\.\.\/\.github\/scripts\/vercel-app-env\.mjs ${project.appName} &&`,
+        "u",
+      ),
+      `${project.rootDirectory} must validate its deployment environment before the build`,
+    );
     assert.equal(
       vercelJson.ignoreCommand,
       `node ../../.github/scripts/vercel-ignore-build.mjs ${project.appName}`,
     );
   }
+});
+
+test("declares environment requirements for every Vercel app", () => {
+  assert.deepEqual(
+    Object.keys(VERCEL_APP_ENV_REQUIREMENTS).sort(),
+    VERCEL_APP_PROJECTS.map(({ appName }) => appName).sort(),
+  );
+});
+
+test("reports all missing variables without exposing values", () => {
+  const environment = {
+    VERCEL_ENV: "production",
+    DATABASE_URL: "postgresql://example",
+    NEXTAUTH_SECRET: "secret",
+    RESEND_API_KEY: "resend",
+    RIGHT_TO_TRY_RATE_LIMIT_SECRET: "rate-limit-secret",
+  };
+  assert.deepEqual(
+    getMissingVercelAppEnvironmentVariables("acceleratedmedicine", environment),
+    ["NEXTAUTH_URL", "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
+  );
+  assert.throws(
+    () => validateVercelAppEnvironment("acceleratedmedicine", environment),
+    (error) =>
+      error.message.includes("GOOGLE_CLIENT_ID") &&
+      !error.message.includes("postgresql://example") &&
+      !error.message.includes("rate-limit-secret"),
+  );
+});
+
+test("requires provider credentials and the canonical auth URL only in production", () => {
+  const previewEnvironment = {
+    VERCEL_ENV: "preview",
+    DATABASE_URL: "postgresql://example",
+    NEXTAUTH_SECRET: "secret",
+  };
+  assert.deepEqual(
+    getMissingVercelAppEnvironmentVariables(
+      "trialabundancesurvey",
+      previewEnvironment,
+    ),
+    [],
+  );
+  assert.deepEqual(
+    getMissingVercelAppEnvironmentVariables("trialabundancesurvey", {
+      ...previewEnvironment,
+      VERCEL_ENV: "production",
+    }),
+    [
+      "NEXTAUTH_URL",
+      "RESEND_API_KEY",
+      "GOOGLE_CLIENT_ID",
+      "GOOGLE_CLIENT_SECRET",
+    ],
+  );
+});
+
+test("allows an app with no required environment variables", () => {
+  assert.deepEqual(
+    getMissingVercelAppEnvironmentVariables("curedao", {
+      VERCEL_ENV: "production",
+    }),
+    [],
+  );
 });
 
 test("classifies custom domains and Vercel deployment URLs", () => {

--- a/.github/scripts/vercel-app-projects.test.mjs
+++ b/.github/scripts/vercel-app-projects.test.mjs
@@ -159,6 +159,19 @@ test("requires provider credentials and the canonical auth URL only in productio
   );
 });
 
+test("names the app when asked about one it does not manage", () => {
+  // The Vercel build command passes the app name as a string argument, so a
+  // typo there surfaces here. Failing with the offending name is what makes
+  // that diagnosable from a build log.
+  assert.throws(
+    () =>
+      getMissingVercelAppEnvironmentVariables("warondiseas", {
+        VERCEL_ENV: "production",
+      }),
+    (error) => error.message.includes("warondiseas"),
+  );
+});
+
 test("allows an app with no required environment variables", () => {
   assert.deepEqual(
     getMissingVercelAppEnvironmentVariables("curedao", {

--- a/apps/DEPLOYMENT.md
+++ b/apps/DEPLOYMENT.md
@@ -111,6 +111,17 @@ Provider credentials can be shared only when the provider configuration includes
 every required callback URL. Separate credentials are safer when an app does not
 need the provider.
 
+Each app's Vercel build command runs `.github/scripts/vercel-app-env.mjs`
+before compilation. The preflight fails the deployment and lists every missing
+required variable. It never prints variable values. Authentication apps require
+their database and session secret in every deployment. Production also requires
+the app's canonical `NEXTAUTH_URL`, Resend key, and Google OAuth credentials
+because its sign-in page offers both email and Google. Apps with active scheduled
+jobs require `CRON_SECRET` in production. Accelerated Medicine also requires
+`RIGHT_TO_TRY_RATE_LIMIT_SECRET` for its public support form. dFDA requires
+`GOOGLE_GENERATIVE_AI_API_KEY` for its shipped evidence tools. Provider and
+feature credentials stay production-only unless a preview explicitly needs them.
+
 The current donation page uses checked-in Stripe Payment Links, so it does not
 need Stripe API secrets. The legacy checkout, session, and webhook routes were
 removed; nothing reacts to a completed donation server-side. Payment Links are
@@ -123,11 +134,10 @@ production schema because votes, people, and referrals are shared records.
 
 ## Source of truth
 
-Each app's `.env.example` lists only the variables its shipped capabilities
-need. Vercel remains the value store. The example files are the reviewable
-contract and contain no real secrets. Accelerated Medicine ships the shared
-survey and sign-in, so it receives `DATABASE_URL`, its own `NEXTAUTH_SECRET`,
-and a production `NEXTAUTH_URL`. CureDAO does not receive database or
+Each app's `.env.example` lists the variables its shipped capabilities need.
+Vercel remains the value store. The preflight manifest is the executable
+required-variable contract. The example files document required and optional
+variables without real secrets. CureDAO does not receive database or
 authentication secrets because it does not ship those capabilities.
 
 Vercel sets `NODE_ENV`, `VERCEL_URL`, and related platform variables. Do not add

--- a/apps/acceleratedmedicine/.env.example
+++ b/apps/acceleratedmedicine/.env.example
@@ -3,12 +3,15 @@ DATABASE_URL="postgresql://user:password@host-pooler/database?sslmode=require"
 NEXTAUTH_SECRET="generate-a-random-32-byte-secret"
 NEXTAUTH_URL="http://localhost:3016"
 
-# Optional sign-in and email providers
+# Required in production: sign-in and email providers
 RESEND_API_KEY="re_your_api_key"
 EMAIL_FROM_ADDRESS="no-reply@acceleratedmedicine.org"
 EMAIL_FROM_NAME="Institute for Accelerated Medicine"
 GOOGLE_CLIENT_ID="your-google-client-id"
 GOOGLE_CLIENT_SECRET="your-google-client-secret"
+
+# Required in production: public-form rate limiting
+RIGHT_TO_TRY_RATE_LIMIT_SECRET="generate-a-random-rate-limit-secret"
 
 # Canonical survey iframe host
 NEXT_PUBLIC_SURVEY_ORIGIN="https://trialabundancesurvey.org"

--- a/apps/acceleratedmedicine/vercel.json
+++ b/apps/acceleratedmedicine/vercel.json
@@ -8,5 +8,5 @@
     }
   },
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "buildCommand": "cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/acceleratedmedicine run build"
+  "buildCommand": "node ../../.github/scripts/vercel-app-env.mjs acceleratedmedicine && cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/acceleratedmedicine run build"
 }

--- a/apps/courtofhumanity/.env.example
+++ b/apps/courtofhumanity/.env.example
@@ -3,7 +3,7 @@ DATABASE_URL="postgresql://user:password@host-pooler/database?sslmode=require"
 NEXTAUTH_SECRET="generate-a-random-32-byte-secret"
 NEXTAUTH_URL="http://localhost:3017"
 
-# Optional sign-in and email providers
+# Required in production: sign-in and email providers
 RESEND_API_KEY="re_your_api_key"
 EMAIL_FROM_ADDRESS="no-reply@courtofhumanity.org"
 EMAIL_FROM_NAME="Court of Humanity"

--- a/apps/courtofhumanity/vercel.json
+++ b/apps/courtofhumanity/vercel.json
@@ -11,5 +11,5 @@
     }
   },
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "buildCommand": "cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/courtofhumanity run build"
+  "buildCommand": "node ../../.github/scripts/vercel-app-env.mjs courtofhumanity && cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/courtofhumanity run build"
 }

--- a/apps/curedao/vercel.json
+++ b/apps/curedao/vercel.json
@@ -11,5 +11,5 @@
     }
   },
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "buildCommand": "cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/curedao run build"
+  "buildCommand": "node ../../.github/scripts/vercel-app-env.mjs curedao && cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/curedao run build"
 }

--- a/apps/dfda/.env.example
+++ b/apps/dfda/.env.example
@@ -7,7 +7,7 @@ DATABASE_URL="postgresql://user:password@host-pooler/database?sslmode=require"
 NEXTAUTH_SECRET="generate-a-random-32-byte-secret"
 NEXTAUTH_URL="http://localhost:3011"
 
-# Optional sign-in and email providers
+# Required in production: sign-in and email providers
 RESEND_API_KEY="re_your_api_key"
 EMAIL_FROM_ADDRESS="no-reply@dfda.earth"
 EMAIL_FROM_NAME="dFDA"

--- a/apps/dfda/vercel.json
+++ b/apps/dfda/vercel.json
@@ -11,5 +11,5 @@
     }
   },
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "buildCommand": "cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/dfda run build"
+  "buildCommand": "node ../../.github/scripts/vercel-app-env.mjs dfda && cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/dfda run build"
 }

--- a/apps/optimitron/vercel.json
+++ b/apps/optimitron/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm run build:vercel",
+  "buildCommand": "node ../../.github/scripts/vercel-app-env.mjs optimitron && pnpm run build:vercel",
   "ignoreCommand": "node ../../.github/scripts/vercel-ignore-build.mjs optimitron",
   "git": {
     "deploymentEnabled": {

--- a/apps/trialabundancesurvey/.env.example
+++ b/apps/trialabundancesurvey/.env.example
@@ -3,7 +3,7 @@ DATABASE_URL="postgresql://user:password@host-pooler/database?sslmode=require"
 NEXTAUTH_SECRET="generate-a-random-32-byte-secret"
 NEXTAUTH_URL="http://localhost:3014"
 
-# Optional sign-in and email providers
+# Required in production: sign-in and email providers
 RESEND_API_KEY="re_your_api_key"
 EMAIL_FROM_ADDRESS="no-reply@trialabundancesurvey.org"
 EMAIL_FROM_NAME="Global Clinical Trial Abundance Survey"

--- a/apps/trialabundancesurvey/vercel.json
+++ b/apps/trialabundancesurvey/vercel.json
@@ -11,5 +11,5 @@
     }
   },
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "buildCommand": "cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/trialabundancesurvey run build"
+  "buildCommand": "node ../../.github/scripts/vercel-app-env.mjs trialabundancesurvey && cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/trialabundancesurvey run build"
 }

--- a/apps/warondisease/.env.example
+++ b/apps/warondisease/.env.example
@@ -3,7 +3,7 @@ DATABASE_URL="postgresql://user:password@host-pooler/database?sslmode=require"
 NEXTAUTH_SECRET="generate-a-random-32-byte-secret"
 NEXTAUTH_URL="http://localhost:3010"
 
-# Optional sign-in and email providers
+# Required in production: sign-in and email providers
 RESEND_API_KEY="re_your_api_key"
 EMAIL_FROM_ADDRESS="no-reply@warondisease.org"
 EMAIL_FROM_NAME="War on Disease"

--- a/apps/warondisease/vercel.json
+++ b/apps/warondisease/vercel.json
@@ -8,5 +8,5 @@
     }
   },
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "buildCommand": "cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/warondisease run build"
+  "buildCommand": "node ../../.github/scripts/vercel-app-env.mjs warondisease && cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/warondisease run build"
 }

--- a/apps/wishocracy/.env.example
+++ b/apps/wishocracy/.env.example
@@ -3,7 +3,7 @@ DATABASE_URL="postgresql://user:password@host-pooler/database?sslmode=require"
 NEXTAUTH_SECRET="generate-a-random-32-byte-secret"
 NEXTAUTH_URL="http://localhost:3013"
 
-# Optional sign-in and email providers
+# Required in production: sign-in and email providers
 RESEND_API_KEY="re_your_api_key"
 EMAIL_FROM_ADDRESS="no-reply@wishocracy.org"
 EMAIL_FROM_NAME="Wishocracy"

--- a/apps/wishocracy/vercel.json
+++ b/apps/wishocracy/vercel.json
@@ -11,5 +11,5 @@
     }
   },
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "buildCommand": "cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/wishocracy run build"
+  "buildCommand": "node ../../.github/scripts/vercel-app-env.mjs wishocracy && cd ../.. && pnpm --filter @optimitron/db run prisma:generate && pnpm build:app-dependencies && pnpm --filter @apps/wishocracy run build"
 }


### PR DESCRIPTION
## Summary

- run an app-specific environment preflight before every Vercel build
- require core auth configuration for all deployments and production provider/feature configuration for shipped capabilities
- rebuild every app when the shared requirements manifest changes
- document the executable contract without logging secret values

## Current Vercel audit

- Accelerated Medicine production is missing `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
- Court of Humanity production is missing `RESEND_API_KEY`, `GOOGLE_CLIENT_ID`, and `GOOGLE_CLIENT_SECRET`
- the other six production projects satisfy this contract

## Verification

- [ ] Human reviewed the required-variable contract
- [x] 94 deployment and preview-script tests pass
- [x] Prettier check passes
- [x] `git diff --check` passes
- [x] No UI changed, so screenshots are not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-deployment validation for required Vercel environment variables across applications.
  * Production deployments now verify required authentication, email, OAuth, rate-limiting, and AI provider credentials before building.
  * Deployment checks report all missing variable names without exposing secret values.

* **Bug Fixes**
  * Changes to environment validation now trigger rebuilds for all affected applications.

* **Documentation**
  * Updated environment templates and deployment guidance to identify production-required settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->