### PR TITLE
Clarify trial survey and Court of Humanity pages

### DIFF
--- a/apps/acceleratedmedicine/app/model-act/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/model-act/page.logged-out.md
@@ -39,8 +39,6 @@
 - The framework above is an educational outline. Montana's enrolled bill and final rules provide the official enacted language, definitions, licensing structure, and implementation detail.
 - [OPEN SB 535](https://docs.legmt.gov/download-ticket?ticketId=404bf910-6276-4d4a-b3d3-56b7cac4b5f9)
 - [READ THE MONTANA GUIDE](/montana)
-### TRIAL ABUNDANCE SURVEY
-- Three questions about patient access, who may fund trial participation, and public priorities.
 - QUESTION 1 OF 3
 ### Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
 - Pragmatic trials compare treatments during routine care. Participation remains voluntary and requires informed consent and appropriate safety oversight.
@@ -58,7 +56,6 @@
 - [RESEARCH & EVIDENCE](https://warondisease.org/research)
 - [FAQ](/faq)
 #### SUPPORT
-- [DONATE](/donate)
 - [VOLUNTEER](/contact)
 - [GET EMAIL UPDATES](/survey)
 #### CONTACT

--- a/apps/acceleratedmedicine/app/model-act/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/model-act/page.logged-out.md
@@ -40,7 +40,7 @@
 - [OPEN SB 535](https://docs.legmt.gov/download-ticket?ticketId=404bf910-6276-4d4a-b3d3-56b7cac4b5f9)
 - [READ THE MONTANA GUIDE](/montana)
 - QUESTION 1 OF 3
-### Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
+### Should patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
 - Pragmatic trials compare treatments during routine care. Participation remains voluntary and requires informed consent and appropriate safety oversight.
 - YES
 - NOT SURE

--- a/apps/acceleratedmedicine/app/montana/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/montana/page.logged-out.md
@@ -65,8 +65,6 @@
 - [FINAL 2026 RULES](https://dphhs.mt.gov/assets/rules/2026-427-Adp-Arm.pdf)
 - [CURRENT MONTANA CODE](https://mca.legmt.gov/bills/mca/title_0500/chapter_0120/part_0010/sections_index.html)
 - [TREATMENT CENTER LICENSING](https://dphhs.mt.gov/oig/licensure/healthcarefacilitylicensure/lbfacilityapplications/lbexperimentaltreatmentcenters)
-### TRIAL ABUNDANCE SURVEY
-- Three questions about patient access, who may fund trial participation, and public priorities.
 - QUESTION 1 OF 3
 ### Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
 - Pragmatic trials compare treatments during routine care. Participation remains voluntary and requires informed consent and appropriate safety oversight.
@@ -84,7 +82,6 @@
 - [RESEARCH & EVIDENCE](https://warondisease.org/research)
 - [FAQ](/faq)
 #### SUPPORT
-- [DONATE](/donate)
 - [VOLUNTEER](/contact)
 - [GET EMAIL UPDATES](/survey)
 #### CONTACT

--- a/apps/acceleratedmedicine/app/montana/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/montana/page.logged-out.md
@@ -66,7 +66,7 @@
 - [CURRENT MONTANA CODE](https://mca.legmt.gov/bills/mca/title_0500/chapter_0120/part_0010/sections_index.html)
 - [TREATMENT CENTER LICENSING](https://dphhs.mt.gov/oig/licensure/healthcarefacilitylicensure/lbfacilityapplications/lbexperimentaltreatmentcenters)
 - QUESTION 1 OF 3
-### Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
+### Should patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
 - Pragmatic trials compare treatments during routine care. Participation remains voluntary and requires informed consent and appropriate safety oversight.
 - YES
 - NOT SURE

--- a/apps/acceleratedmedicine/app/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/page.logged-out.md
@@ -15,8 +15,6 @@
 
 - [RIGHT TO TRIAL INITIATIVE](/)
 - [Go to Dashboard](/dashboard)
-## TRIAL ABUNDANCE SURVEY
-- Three questions about patient access, who may fund trial participation, and public priorities.
 - QUESTION 1 OF 3
 ### Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
 - Pragmatic trials compare treatments during routine care. Participation remains voluntary and requires informed consent and appropriate safety oversight.
@@ -138,16 +136,16 @@
 - [FL](/states/florida)
 ### PATIENTS ARE READY.
 ### THE TRIAL SYSTEM ISN'T.
-- 44.8%
+- [44.8%](https://manual.WarOnDisease.org/knowledge/problem/nih-fails-2-institute-health.html)
 - Patients say yes when asked.
-- 0.06%
+- [0.06%](https://manual.WarOnDisease.org/knowledge/solution/dfda.html)
 - The system mostly never asks.
-- 1.9M
+- [1.9M](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
 - For the entire world.
-- 1.08B
+- [1.08B](https://manual.WarOnDisease.org/knowledge/economics/gdp-trajectories.html)
 - PEOPLE WITH CHRONIC DISEASE ARE WILLING TO PARTICIPATE
 - Click any underlined number to inspect its source, assumptions, and uncertainty.
-### 2.4B PEOPLE ARE
+### [2.4B](https://manual.WarOnDisease.org/knowledge/solution/dfda.html) PEOPLE ARE
 ### LIVING
 ### WITH CHRONIC DISEASE
 #### FOR 2 REASONS:
@@ -185,7 +183,7 @@
 - No major disease has been cured in over 44 years, highlighting the need for new research paradigms.
 ### THE OTHER PROBLEM.
 #### When patients try treatments, the rest of us learn almost nothing.
-- There are about 7K rare diseases. Roughly 6.65K still lack an effective treatment.
+- There are about [7K](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) rare diseases. Roughly [6.65K](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) still lack an effective treatment.
 - Right to Try creates access. Standardized outcomes turn isolated treatment decisions into comparable evidence about what works.
 ##### GET ANOTHER OPTION
 - When approved treatments have failed, informed adults can still make a choice with their clinician.
@@ -195,20 +193,20 @@
 - De-identified results show which treatments helped, which failed, and for whom.
 ### GIVE PATIENTS ACCESS. MEASURE EVERY OUTCOME.
 ### OXFORD'S RECOVERY TRIAL PROVED RESEARCH CAN COST DRAMATICALLY LESS
-- $500
+- [$500](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
 - Per patient in a real pragmatic trial.
-- $929
+- [$929](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
 - Reference cost per participant.
-- $41K
+- [$41K](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
 - Median cost per participant.
-- 82x
-- 44.1x
-- 97.7%
+- [82x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- [44.1x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- [97.7%](https://manual.WarOnDisease.org/knowledge/appendix/dfda-impact-paper.html)
 ### WHY THE BOTTLENECK IS CLINICAL TRIALS, NOT BASIC SCIENCE
 #### THE VAST UNEXPLORED THERAPEUTIC FRONTIER
-- 9.5K
-- 9.5M
-- 32.5K
+- [9.5K](https://manual.WarOnDisease.org/knowledge/problem/untapped-therapeutic-frontier.html)
+- [9.5M](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- [32.5K](https://manual.WarOnDisease.org/knowledge/problem/untapped-therapeutic-frontier.html)
 - Exploration Ratio=32.5K tested 9.5M possible=0.34%Exploration Ratio=9.5M possible 32.5K tested​=0.34%
 - TESTED (0.34%)
 - UNEXPLORED (99.7%)
@@ -216,15 +214,15 @@
 - You cannot have "diminishing returns" when you haven't even started.
 - Wait, it gets worse: The FULL therapeutic frontier
 - The 9.5M figure above only counts single drugs against diseases. Modern medicine increasingly uses combination therapies (standard in oncology, HIV, cardiology).
-- 10M
-- 45B
-- 42M
+- [10M](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- [45B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- [42M](https://manual.WarOnDisease.org/knowledge/problem/untapped-therapeutic-frontier.html)
 - 45.1B
 - Note: We use the conservative 9.5M figure in our main calculations because single-drug trials are more straightforward. But the combination therapy space shows the true scale of unexplored medicine.
 #### YEARS TO UNIVERSAL TREATMENT COVERAGE
 - Clinical trials are how we discover which treatments work for which diseases. At current trial capacity, we find first effective treatments for only ~15 diseases per year.
-- Reference funding supports 40.7K pragmatic trials per year and 185 first treatments per year.
-- 36.0
+- Reference funding supports [40.7K](https://manual.WarOnDisease.org/knowledge/problem/untapped-therapeutic-frontier.html) pragmatic trials per year and [185](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html) first treatments per year.
+- [36.0](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
 - Addressing the "Diminishing Returns" Argument
 - Critics argue: "Just funding more trials won't proportionally increase discoveries - we've picked the low-hanging fruit."
 - This is wrong for six reasons:
@@ -236,17 +234,17 @@
 - 6.
 - Diminishing returns apply to repeated attempts at the same problem. We're proposing to attempt problems we've never tried.
 #### WHAT MORE TRIAL CAPACITY COULD PRODUCE
-- 40.7K
+- [40.7K](https://manual.WarOnDisease.org/knowledge/problem/untapped-therapeutic-frontier.html)
 - Pragmatic trials per year under reference funding.
-- 185
+- [185](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
 - First treatments found per year.
 - Time to cover the untreated-disease queue.
 - Treatments exist. Safe compounds exist. Patients are waiting.
 - The missing ingredient is trial capacity. That's a logistics problem, not a scientific frontier.
 ### WHAT HAPPENS WHEN EVERY PATIENT CAN PARTICIPATE
-- 23.4M
-- 12.3x
-- $58.6B
+- [23.4M](https://manual.WarOnDisease.org/knowledge/appendix/dfda-impact-paper.html)
+- [12.3x](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
+- [$58.6B](https://manual.WarOnDisease.org/knowledge/economics/1-pct-treaty-impact.html)
 ### HOW PATIENTS, CLINICIANS, AND RESEARCHERS FIND WHAT WORKS
 - Patients find trials. Clinicians compare options. Researchers learn from every result. Here is how a decentralized FDA makes all three easier.
 #### How it Works For Patients
@@ -460,7 +458,6 @@
 - [RESEARCH & EVIDENCE](https://warondisease.org/research)
 - [FAQ](/faq)
 #### SUPPORT
-- [DONATE](/donate)
 - [VOLUNTEER](/contact)
 - [GET EMAIL UPDATES](/survey)
 #### CONTACT

--- a/apps/acceleratedmedicine/app/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/page.logged-out.md
@@ -16,7 +16,7 @@
 - [RIGHT TO TRIAL INITIATIVE](/)
 - [Go to Dashboard](/dashboard)
 - QUESTION 1 OF 3
-### Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
+## Should patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
 - Pragmatic trials compare treatments during routine care. Participation remains voluntary and requires informed consent and appropriate safety oversight.
 - YES
 - NOT SURE

--- a/apps/acceleratedmedicine/app/states/missouri/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/states/missouri/page.logged-out.md
@@ -18,7 +18,7 @@
 ## SHOULD EVERY PATIENT IN MISSOURI HAVE THE RIGHT TO JOIN A CLINICAL TRIAL FOR THE MOST PROMISING TREATMENTS?
 - Help bring pragmatic trials, shared results, and more treatment options to patients in Missouri.
 - QUESTION 1 OF 3
-### Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
+### Should patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
 - Pragmatic trials compare treatments during routine care. Participation remains voluntary and requires informed consent and appropriate safety oversight.
 - YES
 - NOT SURE

--- a/apps/acceleratedmedicine/app/survey/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/survey/page.logged-out.md
@@ -16,7 +16,7 @@
 - [RIGHT TO TRIAL INITIATIVE](/)
 - [Go to Dashboard](/dashboard)
 - QUESTION 1 OF 3
-### Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
+## Should patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
 - Pragmatic trials compare treatments during routine care. Participation remains voluntary and requires informed consent and appropriate safety oversight.
 - YES
 - NOT SURE

--- a/apps/acceleratedmedicine/app/survey/page.logged-out.md
+++ b/apps/acceleratedmedicine/app/survey/page.logged-out.md
@@ -15,8 +15,6 @@
 
 - [RIGHT TO TRIAL INITIATIVE](/)
 - [Go to Dashboard](/dashboard)
-## TRIAL ABUNDANCE SURVEY
-- Three questions about patient access, who may fund trial participation, and public priorities.
 - QUESTION 1 OF 3
 ### Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
 - Pragmatic trials compare treatments during routine care. Participation remains voluntary and requires informed consent and appropriate safety oversight.
@@ -34,7 +32,6 @@
 - [RESEARCH & EVIDENCE](https://warondisease.org/research)
 - [FAQ](/faq)
 #### SUPPORT
-- [DONATE](/donate)
 - [VOLUNTEER](/contact)
 - [GET EMAIL UPDATES](/survey)
 #### CONTACT

--- a/apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx
+++ b/apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx
@@ -438,8 +438,8 @@ export function RightToTrialImpactPreviewSection() {
 export function StateSupportSection({
   initialRole,
   initialState,
-  heading = "Trial Abundance Survey",
-  body = "Three questions about patient access, who may fund trial participation, and public priorities.",
+  heading,
+  body,
   headingAs = "h2",
   visualState,
 }: {

--- a/apps/courtofhumanity/app/about/page.logged-out.md
+++ b/apps/courtofhumanity/app/about/page.logged-out.md
@@ -3,18 +3,18 @@
 ## Metadata
 
 - Page title: The Court of Humanity
-- Meta description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Meta description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - Canonical: https://courtofhumanity.org
 - Open Graph title: The Court of Humanity
-- Open Graph description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Open Graph description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - Open Graph image: https://courtofhumanity.org/assets/courtofhumanity/courtofhumanity-og-1200x630.png
 - Twitter title: The Court of Humanity
-- Twitter description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Twitter description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 
 ## Visible Page Copy
 
 ## ABOUT COURT OF HUMANITY
-- Read Humanity v. Government — the public case for redirecting 1% of military spending from weapons to cures — and put your name on the record as a plaintiff.
+- Read Humanity v. Government, inspect its cited evidence, add affected people to the public plaintiff register, and render a verified verdict.
 ### WHAT SHOULD YOU DO NEXT?
-- The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - [READ THE CASE](/humanity-v-government)

--- a/apps/courtofhumanity/app/contact/page.logged-out.md
+++ b/apps/courtofhumanity/app/contact/page.logged-out.md
@@ -3,13 +3,13 @@
 ## Metadata
 
 - Page title: The Court of Humanity
-- Meta description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Meta description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - Canonical: https://courtofhumanity.org
 - Open Graph title: The Court of Humanity
-- Open Graph description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Open Graph description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - Open Graph image: https://courtofhumanity.org/assets/courtofhumanity/courtofhumanity-og-1200x630.png
 - Twitter title: The Court of Humanity
-- Twitter description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Twitter description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 
 ## Visible Page Copy
 

--- a/apps/courtofhumanity/app/court/CourtJoinSignatureBox.tsx
+++ b/apps/courtofhumanity/app/court/CourtJoinSignatureBox.tsx
@@ -30,7 +30,7 @@ import { cn } from "@/lib/utils";
 
 const SIGNED_TITLE = "You are a member of the Court of Humanity.";
 const SIGNED_BODY =
-  "For each human you bring into the Court with your link, the jury grows by one and sovereign immunity weakens by an amount your governments' lawyers will quietly notice.";
+  "Share your link with anyone who should be able to inspect the cases and cast a verified verdict.";
 
 async function postCourtVote(input: {
   displayName?: string;
@@ -254,9 +254,8 @@ export function CourtJoinSignatureBox({
   return (
     <div className="mx-auto w-full max-w-md">
       <p className="mb-6 text-center text-xl font-bold text-foreground">
-        Joined this day,{" "}
-        <span data-volatile="signature date">{today ?? ""}</span>, in the year
-        of our ongoing confusion.
+        Add your name to the membership record. Today is{" "}
+        <span data-volatile="signature date">{today ?? ""}</span>.
       </p>
       <div className="flex flex-col gap-3 sm:flex-row">
         <input
@@ -282,7 +281,7 @@ export function CourtJoinSignatureBox({
             "px-8 text-lg disabled:opacity-40",
           )}
         >
-          {submitting ? "..." : "Sign"}
+          {submitting ? "..." : "Join the Court"}
         </button>
       </div>
       <label className="mt-4 flex cursor-pointer items-start gap-2 text-sm font-bold text-foreground">
@@ -293,8 +292,7 @@ export function CourtJoinSignatureBox({
           className="mt-1 h-4 w-4 cursor-pointer accent-foreground"
         />
         <span>
-          Display my name publicly on the signer list and leaderboards{" "}
-          <span className="opacity-70">(recommended)</span>.
+          Display my name publicly on the Court membership list.
         </span>
       </label>
       {error ? (

--- a/apps/courtofhumanity/app/court/court-case-text.test.ts
+++ b/apps/courtofhumanity/app/court/court-case-text.test.ts
@@ -15,11 +15,14 @@ describe("Court of Humanity case body", () => {
     );
   });
 
-  it("keeps the joinable Articles and the membership question intact", () => {
+  it("keeps the membership declaration and its safeguards intact", () => {
     expect(COURT_OF_HUMANITY_TEXT.markdown).toContain("**Article I**");
-    expect(COURT_OF_HUMANITY_TEXT.markdown).toContain("**Article VI**");
+    expect(COURT_OF_HUMANITY_TEXT.markdown).toContain("**Article IV**");
     expect(COURT_OF_HUMANITY_TEXT.markdown).toContain(
-      "hereby join the Court of Humanity",
+      "I join the Court of Humanity",
+    );
+    expect(COURT_OF_HUMANITY_TEXT.markdown).toContain(
+      "operates independently of governments",
     );
   });
 });

--- a/apps/courtofhumanity/app/court/page.logged-out.md
+++ b/apps/courtofhumanity/app/court/page.logged-out.md
@@ -2,44 +2,26 @@
 
 ## Metadata
 
-- Page title: Court of Humanity
-- Meta description: Should humans be able to sue a government that kills, injures, or ruins their family?
+- Page title: Join the Court of Humanity
+- Meta description: Join the Court of Humanity to inspect cases and evidence and cast verified human verdicts.
 - Canonical: https://courtofhumanity.org/court
-- Open Graph title: Court of Humanity
-- Open Graph description: Should humans be able to sue a government that kills, injures, or ruins their family?
+- Open Graph title: Join the Court of Humanity
+- Open Graph description: Join the Court of Humanity to inspect cases and evidence and cast verified human verdicts.
 - Open Graph image: https://courtofhumanity.org/assets/courtofhumanity/courtofhumanity-og-1200x630.png
-- Twitter title: Court of Humanity
-- Twitter description: Should humans be able to sue a government that kills, injures, or ruins their family?
+- Twitter title: Join the Court of Humanity
+- Twitter description: Join the Court of Humanity to inspect cases and evidence and cast verified human verdicts.
 
 ## Visible Page Copy
 
-- COURT OF HUMANITY - MEMBERSHIP REFERENDUM
-## If a government kills, injures, or harms you or your family, should you have the same right to sue it that you would have if a corporation did the same?
-- This is the question your species never put to itself. The reason is structural: the people who would have called the vote are the people who would have lost it.
-- WHEREAS, if a hospital kills your mother through negligence, you can sue. If a drug company hides safety data, you can sue. If a private security contractor shoots a child by accident, you can sue. If a government does the exact same thing, you cannot;
-- WHEREAS, the legal doctrine that protects governments is called sovereign immunity, and it descends, without architectural modification, from the principle that the king can do no wrong;
-- WHEREAS, your species abolished the divine right of kings in the 18th century. You retained the one part of it that needed abolishing;
-- WHEREAS, sovereign immunity is waivable. Governments can give it up at any time. The United States has waived it for postal-truck collisions, malpractice at federal hospitals, and slip-and-falls in federal buildings. It has not waived it for invading the wrong country, droning the wrong wedding, or imprisoning the wrong person for thirty years. The exclusion is structural, not accidental;
-- WHEREAS, governments killed approximately [310 million](https://manual.WarOnDisease.org/knowledge/problem/cost-of-war.html) of their own and other governments' citizens in the last century, including approximately [102 million](https://manual.WarOnDisease.org/knowledge/problem/cost-of-war.html) children, and the families of these humans were collectively awarded approximately zero dollars;
-- WHEREAS, your governments' own actuaries value a statistical human life at $13.7 million (DOT) to $10 million (other agencies). The wrongful-death exposure on those 310 million humans alone runs to roughly $3.1 quadrillion before you count the people they would have grown up to become;
-- WHEREAS, this number is large because the harm is large, not because the math is wrong;
-- WHEREAS, allowing governments to kill people without consequence is not a feature of democracy. It is the structural form of organized crime, with the addition of a flag;
-- WHEREAS, the question for you is not whether sovereign immunity is correct. The question is whether you noticed it exists, and whether, having noticed, you are willing to leave it in place;
-- WHEREAS, the Court of Humanity does not require any government to consent to its existence. It derives its jurisdiction from human consent — specifically, the consent of any verified human who chooses to join. There are approximately 8 billion of those;
-- WHEREAS, a court whose jurisdiction is human consent rather than sovereign consent has no problem getting humans to show up. The hard part has always been the other one;
-- WHEREAS, the [International Criminal Court](https://manual.WarOnDisease.org/knowledge/solution/court-of-humanity.html) does not work because it requires the offending governments to either cooperate with prosecutions of themselves or be ignored when they refuse. The Court of Humanity skips the cooperation problem. Bondholders, insurers, treaty parties, and procurement officers recognize its judgments first. Governments follow because their borrowing rates depend on it, and their own bondholders' lawyers — who are very good — point themselves at them in their own domestic courts;
-- WHEREAS, those bondholders are aligned with the judgments because the judgments are the asset. Compliance pays. Non-compliance is a default event. Default events trigger cross-default clauses on every other instrument the same government has issued. Sovereign immunity stops at the bond market, where the king has been bowing for centuries;
-- WHEREAS, the [1% Treaty](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html) becomes the standing settlement offer. A government facing approximately $104 quadrillion in cumulative wrongful-death exposure can accept the Treaty's redirect-1%-to-clinical-trials terms in exchange for capped, prospective liability. This is what your species calls a deal;
-- WHEREAS, voting no requires saying out loud "I believe my government should be allowed to kill my family with no consequences," which almost no human will say when asked, which is why the question, once asked, wins;
-- WHEREAS, this also seems suboptimal to leave in place;
-- NOW, THEREFORE, the undersigned humans, having noticed, hereby join the Court of Humanity, as follows:
-- Article I: The Court of Humanity is composed of the verified humans who have joined it. Membership is the act of recording your name as a member; no further training, dues, or robes are required. As of joining, you are simultaneously the plaintiff class, the jury pool, and the body whose collective consent constitutes the court's jurisdiction.
-- Article II: Each member, by joining, declares that the doctrine of sovereign immunity is hereby waived as to any government that has killed, injured, or unlawfully harmed them or their family without due process. Members may bring claims in any forum that will hear them — domestic courts, international tribunals, the Court of Humanity itself — and shall not have those claims dismissed on sovereign-immunity grounds within the Court's jurisdiction.
-- Article III: Standing extends to any verified human, anywhere, against any government, anywhere, for any wrongful act of killing, injuring, or unlawfully detaining a person. Verification uses proof of personhood. One human, one membership, one vote on cases brought before the jury.
-- Article IV: Judgments are enforced through capital markets, not coercion. Governments that fail to honor judgments find their compliant political opponents funded via the [Political Incentive Fund](https://manual.WarOnDisease.org/knowledge/solution/aligning-incentives.html), and find the [Incentive Alignment Bonds](https://manual.WarOnDisease.org/knowledge/appendix/incentive-alignment-bonds-paper.html) issued against their wrongful conduct selling at a price that reflects the market's view of their continued non-compliance. The court does not need an army; it needs only that bondholders have lawyers, which they do.
-- Article V: The [1% Treaty](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html) is hereby established as the standing settlement offer. Governments may accept the Treaty's terms — redirecting 1% of annual military spending to pragmatic clinical trials, with bondholder and political-incentive structures attached — in exchange for prospective liability caps on Court of Humanity claims arising from acts predating Treaty ratification. Signing gives them a settlement price. Refusing keeps the claims, judgments, and bondholder lawyers pointed at them.
-- Article VI: Membership in the Court of Humanity is irrevocable for the lifetime of the member, but no member may bind their heirs or descendants. Each subsequent generation joins by their own consent. The Court has no head of state, no annual budget, no dues, and no way to be voted out by anyone other than its own members. In this respect it resembles every other institution your species has ever built that actually works.
-- IN WITNESS WHEREOF, the undersigned humans, being of sound mind (debatable) and tired of watching their governments kill their families with no consequences, hereby join the Court of Humanity.
-- Joined this day, [signature date], in the year of our ongoing confusion.
-- SIGN
-- Display my name publicly on the signer list and leaderboards (recommended).
+- PUBLIC MEMBERSHIP
+## Join the Court of Humanity
+- The Court of Humanity is a public court for claims against institutions that affect human welfare. It operates independently of governments.
+- By joining, you support a process in which people can inspect claims and evidence, register affected humans as plaintiffs, and cast one verified verdict per person.
+- Article I: Each case must state its claims, cite its evidence, and give named defendants a clear opportunity to respond.
+- Article II: Any verified human may join the Court. One human may hold one membership and cast one vote on each case.
+- Article III: Verdicts record the verified opinions of participating members. They do not create legal liability or replace proceedings in a court with lawful jurisdiction.
+- Article IV: Joining does not file a lawsuit, create an attorney-client relationship, waive legal rights, or enroll a member in another campaign.
+- By adding my name below, I join the Court of Humanity and support public cases decided through open evidence and verified human votes.
+- Add your name to the membership record. Today is [signature date].
+- JOIN THE COURT
+- Display my name publicly on the Court membership list.

--- a/apps/courtofhumanity/app/court/page.tsx
+++ b/apps/courtofhumanity/app/court/page.tsx
@@ -1,8 +1,5 @@
 import type { Metadata } from "next";
-import {
-  COURT_OF_HUMANITY_QUESTION,
-  COURT_OF_HUMANITY_TEXT,
-} from "@optimitron/data/referendums";
+import { COURT_OF_HUMANITY_TEXT } from "@optimitron/data/referendums";
 import Layout from "@/components/layout";
 import { JsonLdScript } from "@/components/site/JsonLdScript";
 import { buildCourtStructuredData } from "@/lib/campaign-structured-data";
@@ -13,9 +10,9 @@ import { CourtJoinSignatureBox } from "./CourtJoinSignatureBox";
 
 export const dynamic = "force-dynamic";
 
-const COURT_PAGE_TITLE = "Court of Humanity";
+const COURT_PAGE_TITLE = "Join the Court of Humanity";
 const COURT_PAGE_DESCRIPTION =
-  "Should humans be able to sue a government that kills, injures, or ruins their family?";
+  "Join the Court of Humanity to inspect cases and evidence and cast verified human verdicts.";
 
 const siteOg = getSiteConfig().ogMetadata;
 
@@ -50,10 +47,7 @@ interface CourtPageProps {
 }
 
 /**
- * `/court` — the read-and-join surface for the Court of Humanity
- * referendum: the membership question, the full case body, and one
- * signature box. Ported from the monolith's stepper page in the same
- * skim-and-sign shape the peer apps use for `/treaty`.
+ * `/court` — the Court of Humanity membership declaration and join form.
  */
 export default async function CourtPage({ searchParams }: CourtPageProps) {
   const params = await searchParams;
@@ -65,10 +59,10 @@ export default async function CourtPage({ searchParams }: CourtPageProps) {
         <JsonLdScript data={buildCourtStructuredData()} />
         <main className="mx-auto max-w-3xl px-4 py-14 sm:px-6">
           <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-            Court of Humanity - Membership referendum
+            Public membership
           </p>
           <h1 className="mt-3 text-3xl font-black leading-[1.15] text-foreground sm:text-4xl">
-            {COURT_OF_HUMANITY_QUESTION}
+            Join the Court of Humanity
           </h1>
 
           <article className="mt-8 border-2 border-foreground bg-background p-5 sm:p-8">

--- a/apps/courtofhumanity/app/dashboard/page.tsx
+++ b/apps/courtofhumanity/app/dashboard/page.tsx
@@ -45,12 +45,11 @@ export default async function CourtDashboardPage() {
               <p className="text-lg font-bold">
                 You are not on the plaintiff register yet.{" "}
                 <a
-                  href="https://warondisease.org/humanity-v-government"
+                  href="https://warondisease.org/plaintiffs"
                   className="underline"
                 >
-                  Read the case
-                </a>{" "}
-                and sign the 1% Treaty to join it.
+                  Register a plaintiff
+                </a>.
               </p>
             )}
           </Card>
@@ -71,7 +70,7 @@ export default async function CourtDashboardPage() {
                 Register a plaintiff
               </a>
               <a
-                href="https://warondisease.org/court"
+                href="/humanity-v-government#verdict"
                 className="inline-block border-4 border-primary bg-brutal-cyan px-4 py-2 font-black uppercase shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]"
               >
                 Render your verdict

--- a/apps/courtofhumanity/app/faq/page.logged-out.md
+++ b/apps/courtofhumanity/app/faq/page.logged-out.md
@@ -3,37 +3,35 @@
 ## Metadata
 
 - Page title: The Court of Humanity
-- Meta description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Meta description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - Canonical: https://courtofhumanity.org
 - Open Graph title: The Court of Humanity
-- Open Graph description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Open Graph description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - Open Graph image: https://courtofhumanity.org/assets/courtofhumanity/courtofhumanity-og-1200x630.png
 - Twitter title: The Court of Humanity
-- Twitter description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Twitter description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 
 ## Visible Page Copy
 
-## FREQUENTLY ASKED QUESTIONS
-- What the Court of Humanity is, and how to join the case
+## COURT QUESTIONS
+- How cases, plaintiffs, membership, and verdicts work
 ### THE COURT
 #### WHAT IS THE COURT OF HUMANITY?
-- A public court where humanity brings claims against the institutions that injure it. First on the docket: Humanity v. Government. Your governments spend $604 on weapons for every $1 testing which medicines work, while two billion humans live with untreated disease. The Court counts the plaintiffs, files the evidence, and records humanity's verdict.
-#### IS THIS A REAL COURT?
-- It is a court of public record, not a government tribunal. No sheriff enforces its verdicts. Its power is the register: named plaintiffs, documented harms, and a verdict rendered by the humans every government is paid to serve. Chemical weapons, landmines, and nuclear tests were banned by treaties that started with less.
-#### HOW DO I BECOME A PLAINTIFF?
-- Sign the 1% Treaty — every YES vote registers you as a plaintiff on Humanity v. Government. You can also register someone you love who can no longer sign for themselves.
+- A public court where humanity brings cases against institutions that harm people. The Court publishes each claim, its cited evidence, a plaintiff register, and verified member verdicts.
+#### WHAT KIND OF COURT IS THIS?
+- The Court operates independently of governments. Its verdicts form a public record; they are not orders issued by a government court.
+#### WHAT CAN MEMBERS DO?
+- Members can inspect case records and cast one verified verdict per case. Joining the Court is separate from registering a plaintiff or supporting another campaign.
+### THE CASE RECORD
+#### WHAT IS HUMANITY V. GOVERNMENT?
+- It is the first case on the docket. It alleges that governments caused preventable deaths and economic harm after accepting a duty to promote the general welfare. The case page presents the claim, evidence, damages model, and verdict.
+#### HOW DO I REGISTER A PLAINTIFF?
+- Use Register a Plaintiff to add yourself or another affected person to the public case record. Plaintiff registration is separate from Court membership and verdict voting.
+#### WHAT DOES A VERDICT DO?
+- A verdict records the verified opinion of participating members. It does not file a lawsuit, create legal liability, or guarantee compensation.
 #### WHO OPERATES THE COURT?
-- The Institute for Accelerated Medicine, a 501(c)(3) nonprofit. Every case file, piece of evidence, and vote tally is public, so you can check the record instead of trusting the operator.
-### THE 1% TREATY
-#### WHAT IS THE 1% TREATY?
-- The 1% Treaty is a global agreement where nations redirect just 1% of their military spending to fund pragmatic clinical trials integrated into standard healthcare. This gives everyone 1% more security (fewer nuclear weapons pointed at them) while accelerating access to life-saving treatments by years.
-#### WHY 1%? WHY NOT MORE OR LESS?
-- 1% is strategically chosen because it's small enough to be feasible (doesn't compromise national defense) but large enough to be transformative ($27.2B annually). It's also psychologically powerful: everyone gets 1% more security while gaining years of life through faster medical progress.
-#### WHAT HAPPENS TO MILITARY CAPABILITIES WITH 1% LESS FUNDING?
-- Virtually nothing. Modern militaries have massive redundancy and waste. A 1% reduction is easily absorbed through efficiency improvements, reduced procurement waste, or delayed upgrades. No country loses meaningful defensive capability, but everyone gains health security.
-#### WHICH COUNTRIES WOULD PARTICIPATE?
-- The treaty is designed for universal participation, but the top 15 military spenders (US, China, Russia, India, Saudi Arabia, UK, Germany, France, Japan, South Korea, Italy, Australia, Canada, Israel, Spain) account for 81% of global military spending. Their participation alone would fund the entire system.
-### READY TO JOIN THE CASE?
-- Read the filing, then put your name on the record
+- The Institute for Accelerated Medicine, a 501(c)(3) nonprofit, operates the site. Case records, cited evidence, and vote totals are published for public inspection.
+### REVIEW THE FIRST CASE
+- Read the claim and cited evidence before voting
 - [READ THE CASE](/humanity-v-government)
-- [CONTACT US](/contact)
+- [REGISTER A PLAINTIFF](https://warondisease.org/plaintiffs)

--- a/apps/courtofhumanity/app/page.logged-out.md
+++ b/apps/courtofhumanity/app/page.logged-out.md
@@ -3,13 +3,13 @@
 ## Metadata
 
 - Page title: The Court of Humanity
-- Meta description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Meta description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - Canonical: https://courtofhumanity.org
 - Open Graph title: The Court of Humanity
-- Open Graph description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Open Graph description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - Open Graph image: https://courtofhumanity.org/assets/courtofhumanity/courtofhumanity-og-1200x630.png
 - Twitter title: The Court of Humanity
-- Twitter description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Twitter description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 
 ## Visible Page Copy
 
@@ -19,10 +19,10 @@
 - Where humanity brings its case against the institutions it pays to protect it. Court is in session.
 - NOW ON THE DOCKET
 ### HUMANITY V. GOVERNMENT
-- The defendants collect $[604](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html) for weapons for every $1 they spend testing which medicines work, while [150K](https://manual.WarOnDisease.org/knowledge/strategy/questions.html) humans die of disease every day. The plaintiffs are the humans who pay them to promote the general welfare. The remedy sought: redirect 1% of military spending to pragmatic clinical trials.
+- The case alleges that governments breached their duty to promote the general welfare, causing preventable deaths and economic harm. Read the claim and cited evidence, add affected people to the public plaintiff register, then render a verdict.
 - [READ THE CASE](/humanity-v-government)
 - [REGISTER A PLAINTIFF](https://warondisease.org/plaintiffs)
-- [RENDER YOUR VERDICT](/court)
+- [RENDER YOUR VERDICT](/humanity-v-government#verdict)
 #### THE CASE
 - [HUMANITY V. GOVERNMENT](/humanity-v-government)
 - [JOIN THE COURT](/court)

--- a/apps/courtofhumanity/app/privacy/page.logged-out.md
+++ b/apps/courtofhumanity/app/privacy/page.logged-out.md
@@ -3,13 +3,13 @@
 ## Metadata
 
 - Page title: The Court of Humanity
-- Meta description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Meta description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - Canonical: https://courtofhumanity.org
 - Open Graph title: The Court of Humanity
-- Open Graph description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Open Graph description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - Open Graph image: https://courtofhumanity.org/assets/courtofhumanity/courtofhumanity-og-1200x630.png
 - Twitter title: The Court of Humanity
-- Twitter description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Twitter description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 
 ## Visible Page Copy
 

--- a/apps/courtofhumanity/app/terms/page.logged-out.md
+++ b/apps/courtofhumanity/app/terms/page.logged-out.md
@@ -3,13 +3,13 @@
 ## Metadata
 
 - Page title: The Court of Humanity
-- Meta description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Meta description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - Canonical: https://courtofhumanity.org
 - Open Graph title: The Court of Humanity
-- Open Graph description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Open Graph description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 - Open Graph image: https://courtofhumanity.org/assets/courtofhumanity/courtofhumanity-og-1200x630.png
 - Twitter title: The Court of Humanity
-- Twitter description: The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.
+- Twitter description: The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.
 
 ## Visible Page Copy
 

--- a/apps/courtofhumanity/lib/campaign-structured-data.ts
+++ b/apps/courtofhumanity/lib/campaign-structured-data.ts
@@ -60,13 +60,8 @@ export function buildCourtStructuredData() {
     webPage(ROUTES.court, "Court of Humanity"),
     claim(
       ROUTES.court,
-      "Human consent claim",
-      "Humans can join a public jury and hold governments accountable for killing, injuring, or ruining families.",
-    ),
-    claim(
-      ROUTES.court,
-      "Settlement claim",
-      "The 1% Treaty is the proposed settlement mechanism for the Court of Humanity campaign.",
+      "Public membership claim",
+      "Verified humans can join the Court of Humanity, inspect case evidence, and cast one verdict per case.",
     ),
   ]);
 }

--- a/apps/trialabundancesurvey/app/page.logged-out.md
+++ b/apps/trialabundancesurvey/app/page.logged-out.md
@@ -15,10 +15,8 @@
 
 - [GLOBAL CLINICAL TRIAL ABUNDANCE SURVEY](/)
 - [Go to Dashboard](/dashboard)
-## TRIAL ABUNDANCE SURVEY
-- Three questions about patient access, who may fund trial participation, and public priorities.
 - QUESTION 1 OF 3
-### Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
+## Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
 - Pragmatic trials compare treatments during routine care. Participation remains voluntary and requires informed consent and appropriate safety oversight.
 - YES
 - NOT SURE

--- a/apps/trialabundancesurvey/app/page.logged-out.md
+++ b/apps/trialabundancesurvey/app/page.logged-out.md
@@ -16,7 +16,7 @@
 - [GLOBAL CLINICAL TRIAL ABUNDANCE SURVEY](/)
 - [Go to Dashboard](/dashboard)
 - QUESTION 1 OF 3
-## Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
+## Should patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?
 - Pragmatic trials compare treatments during routine care. Participation remains voluntary and requires informed consent and appropriate safety oversight.
 - YES
 - NOT SURE

--- a/packages/data/src/referendums/court-of-humanity.ts
+++ b/packages/data/src/referendums/court-of-humanity.ts
@@ -20,55 +20,19 @@ export const COURT_OF_HUMANITY_QUESTION =
   "If a government kills, injures, or harms you or your family, should you have the same right to sue it that you would have if a corporation did the same?";
 
 export const COURT_OF_HUMANITY_TEXT = {
-  markdown: `This is the question your species never put to itself. The reason is structural: the people who would have called the vote are the people who would have lost it.
+  markdown: `The Court of Humanity is a public court for claims against institutions that affect human welfare. It operates independently of governments.
 
-WHEREAS, if a hospital kills your mother through negligence, you can sue. If a drug company hides safety data, you can sue. If a private security contractor shoots a child by accident, you can sue. If a government does the exact same thing, you cannot;
+By joining, you support a process in which people can inspect claims and evidence, register affected humans as plaintiffs, and cast one verified verdict per person.
 
-WHEREAS, the legal doctrine that protects governments is called sovereign immunity, and it descends, without architectural modification, from the principle that the king can do no wrong;
+**Article I**: Each case must state its claims, cite its evidence, and give named defendants a clear opportunity to respond.
 
-WHEREAS, your species abolished the divine right of kings in the 18th century. You retained the one part of it that needed abolishing;
+**Article II**: Any verified human may join the Court. One human may hold one membership and cast one vote on each case.
 
-WHEREAS, sovereign immunity is waivable. Governments can give it up at any time. The United States has waived it for postal-truck collisions, malpractice at federal hospitals, and slip-and-falls in federal buildings. It has not waived it for invading the wrong country, droning the wrong wedding, or imprisoning the wrong person for thirty years. The exclusion is structural, not accidental;
+**Article III**: Verdicts record the verified opinions of participating members. They do not create legal liability or replace proceedings in a court with lawful jurisdiction.
 
-WHEREAS, governments killed approximately [310 million](https://manual.WarOnDisease.org/knowledge/problem/cost-of-war.html) of their own and other governments' citizens in the last century, including approximately [102 million](https://manual.WarOnDisease.org/knowledge/problem/cost-of-war.html) children, and the families of these humans were collectively awarded approximately zero dollars;
+**Article IV**: Joining does not file a lawsuit, create an attorney-client relationship, waive legal rights, or enroll a member in another campaign.
 
-WHEREAS, your governments' own actuaries value a statistical human life at \\$13.7 million (DOT) to \\$10 million (other agencies). The wrongful-death exposure on those 310 million humans alone runs to roughly \\$3.1 quadrillion before you count the people they would have grown up to become;
-
-WHEREAS, this number is large because the harm is large, not because the math is wrong;
-
-WHEREAS, allowing governments to kill people without consequence is not a feature of democracy. It is the structural form of organized crime, with the addition of a flag;
-
-WHEREAS, the question for you is not whether sovereign immunity is correct. The question is whether you noticed it exists, and whether, having noticed, you are willing to leave it in place;
-
-WHEREAS, the Court of Humanity does not require any government to consent to its existence. It derives its jurisdiction from human consent — specifically, the consent of any verified human who chooses to join. There are approximately 8 billion of those;
-
-WHEREAS, a court whose jurisdiction is human consent rather than sovereign consent has no problem getting humans to show up. The hard part has always been the other one;
-
-WHEREAS, the [International Criminal Court](https://manual.WarOnDisease.org/knowledge/solution/court-of-humanity.html) does not work because it requires the offending governments to either cooperate with prosecutions of themselves or be ignored when they refuse. The Court of Humanity skips the cooperation problem. Bondholders, insurers, treaty parties, and procurement officers recognize its judgments first. Governments follow because their borrowing rates depend on it, and their own bondholders' lawyers — who are very good — point themselves at them in their own domestic courts;
-
-WHEREAS, those bondholders are aligned with the judgments because the judgments are the asset. Compliance pays. Non-compliance is a default event. Default events trigger cross-default clauses on every other instrument the same government has issued. Sovereign immunity stops at the bond market, where the king has been bowing for centuries;
-
-WHEREAS, the [1% Treaty](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html) becomes the standing settlement offer. A government facing approximately \\$104 quadrillion in cumulative wrongful-death exposure can accept the Treaty's redirect-1%-to-clinical-trials terms in exchange for capped, prospective liability. This is what your species calls a deal;
-
-WHEREAS, voting no requires saying out loud "I believe my government should be allowed to kill my family with no consequences," which almost no human will say when asked, which is why the question, once asked, wins;
-
-WHEREAS, this also seems suboptimal to leave in place;
-
-NOW, THEREFORE, the undersigned humans, having noticed, hereby join the Court of Humanity, as follows:
-
-**Article I**: The Court of Humanity is composed of the verified humans who have joined it. Membership is the act of recording your name as a member; no further training, dues, or robes are required. As of joining, you are simultaneously the plaintiff class, the jury pool, and the body whose collective consent constitutes the court's jurisdiction.
-
-**Article II**: Each member, by joining, declares that the doctrine of sovereign immunity is hereby waived as to any government that has killed, injured, or unlawfully harmed them or their family without due process. Members may bring claims in any forum that will hear them — domestic courts, international tribunals, the Court of Humanity itself — and shall not have those claims dismissed on sovereign-immunity grounds within the Court's jurisdiction.
-
-**Article III**: Standing extends to any verified human, anywhere, against any government, anywhere, for any wrongful act of killing, injuring, or unlawfully detaining a person. Verification uses proof of personhood. One human, one membership, one vote on cases brought before the jury.
-
-**Article IV**: Judgments are enforced through capital markets, not coercion. Governments that fail to honor judgments find their compliant political opponents funded via the [Political Incentive Fund](https://manual.WarOnDisease.org/knowledge/solution/aligning-incentives.html), and find the [Incentive Alignment Bonds](https://manual.WarOnDisease.org/knowledge/appendix/incentive-alignment-bonds-paper.html) issued against their wrongful conduct selling at a price that reflects the market's view of their continued non-compliance. The court does not need an army; it needs only that bondholders have lawyers, which they do.
-
-**Article V**: The [1% Treaty](https://manual.WarOnDisease.org/knowledge/solution/1-percent-treaty.html) is hereby established as the standing settlement offer. Governments may accept the Treaty's terms — redirecting 1% of annual military spending to pragmatic clinical trials, with bondholder and political-incentive structures attached — in exchange for prospective liability caps on Court of Humanity claims arising from acts predating Treaty ratification. Signing gives them a settlement price. Refusing keeps the claims, judgments, and bondholder lawyers pointed at them.
-
-**Article VI**: Membership in the Court of Humanity is irrevocable for the lifetime of the member, but no member may bind their heirs or descendants. Each subsequent generation joins by their own consent. The Court has no head of state, no annual budget, no dues, and no way to be voted out by anyone other than its own members. In this respect it resembles every other institution your species has ever built that actually works.
-
-IN WITNESS WHEREOF, the undersigned humans, being of sound mind (debatable) and tired of watching their governments kill their families with no consequences, hereby join the Court of Humanity.
+By adding my name below, I join the Court of Humanity and support public cases decided through open evidence and verified human votes.
 `,
   sourceFile: "knowledge/solution/court-of-humanity.qmd",
   originalName: "court-of-humanity-text",

--- a/packages/db/src/__tests__/seed.integration.test.ts
+++ b/packages/db/src/__tests__/seed.integration.test.ts
@@ -863,7 +863,7 @@ describeIfDatabase("syncManagedData", () => {
           slug: "court-of-humanity",
           kind: ReferendumKind.MEMBERSHIP,
           question: expect.stringContaining("same right to sue"),
-          bodyMarkdown: expect.stringContaining("sovereign immunity"),
+          bodyMarkdown: expect.stringContaining("I join the Court of Humanity"),
           contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
         }),
         expect.objectContaining({

--- a/packages/db/src/constants.ts
+++ b/packages/db/src/constants.ts
@@ -9,7 +9,7 @@ export const TREATY_REFERENDUM_SLUG = "one-percent-treaty";
 export const TRIAL_ABUNDANCE_REFERENDUM_SLUG =
   "patient-access-to-pragmatic-clinical-trials";
 export const TRIAL_ABUNDANCE_REFERENDUM_QUESTION =
-  "Should eligible patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?";
+  "Should patients have the right to join a pragmatic clinical trial for a promising treatment through their physician?";
 export const TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_SLUG =
   "patient-funded-access-to-pragmatic-clinical-trials";
 export const TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_QUESTION =

--- a/packages/db/src/managed-data/managed-referendums.ts
+++ b/packages/db/src/managed-data/managed-referendums.ts
@@ -58,7 +58,7 @@ export const MANAGED_REFERENDUMS: readonly ManagedReferendumRecord[] = [
     question: TRIAL_ABUNDANCE_REFERENDUM_QUESTION,
     kind: ReferendumKind.GENERAL,
     description:
-      "Measures public support for eligible patients joining pragmatic clinical trials through their regular physician.",
+      "Measures public support for patients joining pragmatic clinical trials through their regular physician.",
     bodyMarkdown:
       "Pragmatic clinical trials compare treatments during routine medical care. Participation is voluntary and requires informed consent and appropriate safety oversight.",
     status: ReferendumStatus.ACTIVE,

--- a/packages/site-kit/src/components/brand-about-page.tsx
+++ b/packages/site-kit/src/components/brand-about-page.tsx
@@ -18,7 +18,7 @@ const ABOUT_CONTENT: Partial<Record<SiteVariant, {
 }>> = {
   "courtofhumanity.org": {
     outcome:
-      "Read Humanity v. Government — the public case for redirecting 1% of military spending from weapons to cures — and put your name on the record as a plaintiff.",
+      "Read Humanity v. Government, inspect its cited evidence, add affected people to the public plaintiff register, and render a verified verdict.",
     action: "Read the case",
     href: "/humanity-v-government",
   },

--- a/packages/site-kit/src/components/court-home-page.tsx
+++ b/packages/site-kit/src/components/court-home-page.tsx
@@ -1,17 +1,12 @@
 import { Card } from "@optimitron/neobrutalist-ui/ui/card"
 import { Container } from "@optimitron/neobrutalist-ui/ui/container"
 import { SectionContainer } from "@optimitron/neobrutalist-ui/ui/section-container"
-import {
-  GLOBAL_DISEASE_DEATHS_DAILY,
-  MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO,
-} from "@optimitron/data/parameters"
-import { ParameterValue } from "./shared/ParameterValue"
 
 // The case and verdict surfaces live in this app (issue #254). Plaintiff
 // registration still lives on warondisease.org until it migrates too.
 const CASE_URL = "/humanity-v-government"
 const PLAINTIFFS_URL = "https://warondisease.org/plaintiffs"
-const VERDICT_URL = "/court"
+const VERDICT_URL = "/humanity-v-government#verdict"
 
 const actionButtonClassName =
   "inline-block border-4 border-primary px-6 py-3 text-center text-lg font-black uppercase shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all hover:translate-x-1 hover:translate-y-1 hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]"
@@ -47,22 +42,10 @@ export function CourtHomePage() {
               Humanity v. Government
             </h2>
             <p className="mt-6 text-lg font-medium leading-relaxed">
-              The defendants collect $
-              <ParameterValue
-                param={MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO}
-                display="integer"
-                className="font-black text-brutal-pink"
-              />{" "}
-              for weapons for every $1 they spend testing which medicines work,
-              while{" "}
-              <ParameterValue
-                param={GLOBAL_DISEASE_DEATHS_DAILY}
-                format={{ precision: 0 }}
-                className="font-black text-brutal-pink"
-              />{" "}
-              humans die of disease every day. The plaintiffs are the humans
-              who pay them to promote the general welfare. The remedy sought:
-              redirect 1% of military spending to pragmatic clinical trials.
+              The case alleges that governments breached their duty to promote
+              the general welfare, causing preventable deaths and economic harm.
+              Read the claim and cited evidence, add affected people to the
+              public plaintiff register, then render a verdict.
             </p>
             <div className="mt-8 grid gap-4 sm:grid-cols-3">
               <a href={CASE_URL} className={`${actionButtonClassName} bg-brutal-cyan text-foreground`}>

--- a/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
+++ b/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
@@ -92,13 +92,13 @@ export default function TrialAbundanceSurveySection({
   title,
   description,
 }: TrialAbundanceSurveySectionProps) {
-  const PatientAccessHeading = title ? "h2" : Heading
   const { data: session, status } = useSession()
   const searchParams = useSearchParams()
   const referralCode = searchParams?.get("ref") ?? null
   const inviteToken = searchParams?.get("invite") ?? null
   const isVisualCapture = visualState !== undefined
   const [stage, setStage] = useState<SurveyStage>(getInitialStage(visualState))
+  const StepHeading = stage === "patient-access" && title ? "h2" : Heading
   const [patientAccessAnswer, setPatientAccessAnswer] =
     useState<TrialAbundanceAnswer | null>(
       visualState === "complete" ? "YES" : null,
@@ -300,9 +300,9 @@ export default function TrialAbundanceSurveySection({
                 <p className="text-sm font-black uppercase text-brutal-pink">
                   Question 1 of 3
                 </p>
-                <PatientAccessHeading className="text-xl font-black leading-snug sm:text-3xl">
+                <StepHeading className="text-xl font-black leading-snug sm:text-3xl">
                   {TRIAL_ABUNDANCE_REFERENDUM_QUESTION}
-                </PatientAccessHeading>
+                </StepHeading>
                 <p className="font-bold text-muted-foreground">
                   Pragmatic trials compare treatments during routine care.
                   Participation remains voluntary and requires informed consent
@@ -327,9 +327,9 @@ export default function TrialAbundanceSurveySection({
                 <p className="text-sm font-black uppercase text-brutal-pink">
                   Question 2 of 3
                 </p>
-                <h2 className="text-xl font-black leading-snug sm:text-3xl">
+                <StepHeading className="text-xl font-black leading-snug sm:text-3xl">
                   {TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_QUESTION}
-                </h2>
+                </StepHeading>
                 <p className="font-bold text-muted-foreground">
                   This asks whether the patient may cover trial costs. It does
                   not waive informed consent or safety oversight.
@@ -356,14 +356,14 @@ export default function TrialAbundanceSurveySection({
                 <p className="text-sm font-black uppercase text-brutal-pink">
                   Question 3 of 3
                 </p>
-                <p className="text-center text-lg font-bold leading-snug sm:text-2xl">
+                <StepHeading className="text-center text-lg font-bold leading-snug sm:text-2xl">
                   Considering only these two priorities, how would you split
                   public spending between military and weapons and{" "}
                   <PragmaticTrialsDialog triggerClassName="inline text-brutal-pink underline decoration-dotted underline-offset-2">
                     pragmatic clinical trials
                   </PragmaticTrialsDialog>
                   ?
-                </p>
+                </StepHeading>
 
                 <AllocationDisplay
                   clinicalTrialsAllocation={clinicalTrialsAllocation}
@@ -407,7 +407,7 @@ export default function TrialAbundanceSurveySection({
 
         {stage === "details" ? (
           <SurveyCard>
-            <h2 className="text-2xl font-black uppercase">About you</h2>
+            <StepHeading className="text-2xl font-black uppercase">About you</StepHeading>
             <form className="flex flex-col gap-5" onSubmit={(event) => { event.preventDefault(); void handleComplete() }}>
               <SurveyParticipantFields value={participant} onChange={(value) => {
                 participantEdited.current = true
@@ -425,16 +425,20 @@ export default function TrialAbundanceSurveySection({
         {stage === "complete" ? (
           <div ref={completionRef} className="space-y-8">
             {saveStatus === "saved" && session?.user ? (
-              <ReferralLinkCard
-                referralLink={shareUrl}
-                shareTemplates={shareTemplates}
-                hashtags="PragmaticTrials,ClinicalResearch"
-                introText="Invite someone else to answer the same three questions. Their response will be attributed to your referral link."
-                copyLinkLabel="COPY SURVEY LINK"
-                linkContentType="trial_abundance_referral"
-              />
+              <>
+                <StepHeading className="sr-only">Survey complete</StepHeading>
+                <ReferralLinkCard
+                  referralLink={shareUrl}
+                  shareTemplates={shareTemplates}
+                  hashtags="PragmaticTrials,ClinicalResearch"
+                  introText="Invite someone else to answer the same three questions. Their response will be attributed to your referral link."
+                  copyLinkLabel="COPY SURVEY LINK"
+                  linkContentType="trial_abundance_referral"
+                />
+              </>
             ) : status === "authenticated" || visualState === "save-error" ? (
               <SurveyCard>
+                <StepHeading className="sr-only">Save your response</StepHeading>
                 {saveStatus === "error" ? <>
                   <AlertCard type="error" message="We could not save your response. Your answers are still in this browser." />
                   <Button onClick={() => void saveResponse()}>Retry save</Button>
@@ -442,9 +446,9 @@ export default function TrialAbundanceSurveySection({
               </SurveyCard>
             ) : (
               <Card className="mx-auto max-w-3xl border-4 border-primary bg-background p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sm:p-8">
-                <h2 className="mb-2 text-2xl font-black uppercase">
+                <StepHeading className="mb-2 text-2xl font-black uppercase">
                   Save your response
-                </h2>
+                </StepHeading>
                 <p className="mb-6 font-bold">
                   Verify once to store this response and get a personal survey
                   link for referrals.

--- a/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
+++ b/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
@@ -89,9 +89,10 @@ export default function TrialAbundanceSurveySection({
   visualState,
   initialParticipant,
   headingAs: Heading = "h1",
-  title = "Trial Abundance Survey",
-  description = "Three questions about patient access, who may fund trial participation, and public priorities.",
+  title,
+  description,
 }: TrialAbundanceSurveySectionProps) {
+  const PatientAccessHeading = title ? "h2" : Heading
   const { data: session, status } = useSession()
   const searchParams = useSearchParams()
   const referralCode = searchParams?.get("ref") ?? null
@@ -272,15 +273,19 @@ export default function TrialAbundanceSurveySection({
       className="pb-24"
     >
       <Container>
-        {stage === "patient-access" ? (
-          <>
-            <Heading className="mb-3 text-center text-3xl font-black uppercase sm:text-4xl md:text-6xl">
-              {title}
-            </Heading>
-            <p className="mx-auto mb-10 max-w-2xl text-center text-base font-bold sm:text-lg">
-              {description}
-            </p>
-          </>
+        {stage === "patient-access" && (title || description) ? (
+          <div className="mb-10 text-center">
+            {title ? (
+              <Heading className="mb-3 text-3xl font-black uppercase sm:text-4xl md:text-6xl">
+                {title}
+              </Heading>
+            ) : null}
+            {description ? (
+              <p className="mx-auto max-w-2xl text-base font-bold sm:text-lg">
+                {description}
+              </p>
+            ) : null}
+          </div>
         ) : null}
 
         <AnimatePresence mode="wait">
@@ -295,9 +300,9 @@ export default function TrialAbundanceSurveySection({
                 <p className="text-sm font-black uppercase text-brutal-pink">
                   Question 1 of 3
                 </p>
-                <h2 className="text-xl font-black leading-snug sm:text-3xl">
+                <PatientAccessHeading className="text-xl font-black leading-snug sm:text-3xl">
                   {TRIAL_ABUNDANCE_REFERENDUM_QUESTION}
-                </h2>
+                </PatientAccessHeading>
                 <p className="font-bold text-muted-foreground">
                   Pragmatic trials compare treatments during routine care.
                   Participation remains voluntary and requires informed consent

--- a/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
+++ b/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
@@ -57,6 +57,25 @@ const answerOptions: Array<{
   { answer: "NO", label: "No" },
 ]
 
+const pragmaticTrialPattern = /pragmatic clinical trials?/i
+const pragmaticTrialTriggerClassName =
+  "inline text-brutal-pink underline decoration-dotted underline-offset-2"
+
+function PragmaticTrialQuestion({ question }: { question: string }) {
+  const match = pragmaticTrialPattern.exec(question)
+  if (!match || match.index === undefined) return question
+
+  return (
+    <>
+      {question.slice(0, match.index)}
+      <PragmaticTrialsDialog triggerClassName={pragmaticTrialTriggerClassName}>
+        {match[0]}
+      </PragmaticTrialsDialog>
+      {question.slice(match.index + match[0].length)}
+    </>
+  )
+}
+
 function getInitialStage(
   visualState: TrialAbundanceVisualState | undefined,
 ): SurveyStage {
@@ -301,7 +320,9 @@ export default function TrialAbundanceSurveySection({
                   Question 1 of 3
                 </p>
                 <StepHeading className="text-xl font-black leading-snug sm:text-3xl">
-                  {TRIAL_ABUNDANCE_REFERENDUM_QUESTION}
+                  <PragmaticTrialQuestion
+                    question={TRIAL_ABUNDANCE_REFERENDUM_QUESTION}
+                  />
                 </StepHeading>
                 <p className="font-bold text-muted-foreground">
                   Pragmatic trials compare treatments during routine care.
@@ -328,7 +349,9 @@ export default function TrialAbundanceSurveySection({
                   Question 2 of 3
                 </p>
                 <StepHeading className="text-xl font-black leading-snug sm:text-3xl">
-                  {TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_QUESTION}
+                  <PragmaticTrialQuestion
+                    question={TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_QUESTION}
+                  />
                 </StepHeading>
                 <p className="font-bold text-muted-foreground">
                   This asks whether the patient may cover trial costs. It does
@@ -359,7 +382,7 @@ export default function TrialAbundanceSurveySection({
                 <StepHeading className="text-center text-lg font-bold leading-snug sm:text-2xl">
                   Considering only these two priorities, how would you split
                   public spending between military and weapons and{" "}
-                  <PragmaticTrialsDialog triggerClassName="inline text-brutal-pink underline decoration-dotted underline-offset-2">
+                  <PragmaticTrialsDialog triggerClassName={pragmaticTrialTriggerClassName}>
                     pragmatic clinical trials
                   </PragmaticTrialsDialog>
                   ?

--- a/packages/site-kit/src/lib/faq.ts
+++ b/packages/site-kit/src/lib/faq.ts
@@ -8,7 +8,6 @@
 import type { FaqConfig } from './site-config'
 import { formatParameter } from "@optimitron/data/parameters/compact-format"
 import {
-  MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO,
   RECOVERY_TRIAL_COST_REDUCTION_FACTOR,
   PEACE_DIVIDEND_ANNUAL_SOCIETAL_BENEFIT,
   GLOBAL_REGISTERED_VOTERS,
@@ -203,40 +202,54 @@ export const WAR_ON_DISEASE_FAQ: FaqConfig = {
  * Court of Humanity FAQ (Judicial variant)
  */
 export const COURT_OF_HUMANITY_FAQ: FaqConfig = {
-  title: 'FREQUENTLY ASKED QUESTIONS',
-  subtitle: 'What the Court of Humanity is, and how to join the case',
+  title: 'COURT QUESTIONS',
+  subtitle: 'How cases, plaintiffs, membership, and verdicts work',
   sections: [
     {
       category: 'THE COURT',
       questions: [
         {
           q: 'What is the Court of Humanity?',
-          a: `A public court where humanity brings claims against the institutions that injure it. First on the docket: Humanity v. Government. Your governments spend $${Math.round(MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO.value)} on weapons for every $1 testing which medicines work, while two billion humans live with untreated disease. The Court counts the plaintiffs, files the evidence, and records humanity's verdict.`,
+          a: 'A public court where humanity brings cases against institutions that harm people. The Court publishes each claim, its cited evidence, a plaintiff register, and verified member verdicts.',
         },
         {
-          q: 'Is this a real court?',
-          a: 'It is a court of public record, not a government tribunal. No sheriff enforces its verdicts. Its power is the register: named plaintiffs, documented harms, and a verdict rendered by the humans every government is paid to serve. Chemical weapons, landmines, and nuclear tests were banned by treaties that started with less.',
+          q: 'What kind of court is this?',
+          a: 'The Court operates independently of governments. Its verdicts form a public record; they are not orders issued by a government court.',
         },
         {
-          q: 'How do I become a plaintiff?',
-          a: 'Sign the 1% Treaty — every YES vote registers you as a plaintiff on Humanity v. Government. You can also register someone you love who can no longer sign for themselves.',
-        },
-        {
-          q: 'Who operates the Court?',
-          a: 'The Institute for Accelerated Medicine, a 501(c)(3) nonprofit. Every case file, piece of evidence, and vote tally is public, so you can check the record instead of trusting the operator.',
+          q: 'What can members do?',
+          a: 'Members can inspect case records and cast one verified verdict per case. Joining the Court is separate from registering a plaintiff or supporting another campaign.',
         },
       ],
     },
-    FAQ_SECTIONS.treaty,
+    {
+      category: 'THE CASE RECORD',
+      questions: [
+        {
+          q: 'What is Humanity v. Government?',
+          a: 'It is the first case on the docket. It alleges that governments caused preventable deaths and economic harm after accepting a duty to promote the general welfare. The case page presents the claim, evidence, damages model, and verdict.',
+        },
+        {
+          q: 'How do I register a plaintiff?',
+          a: 'Use Register a Plaintiff to add yourself or another affected person to the public case record. Plaintiff registration is separate from Court membership and verdict voting.',
+        },
+        {
+          q: 'What does a verdict do?',
+          a: 'A verdict records the verified opinion of participating members. It does not file a lawsuit, create legal liability, or guarantee compensation.',
+        },
+        {
+          q: 'Who operates the Court?',
+          a: 'The Institute for Accelerated Medicine, a 501(c)(3) nonprofit, operates the site. Case records, cited evidence, and vote totals are published for public inspection.',
+        },
+      ],
+    },
   ],
   ctaSection: {
-    title: 'READY TO JOIN THE CASE?',
-    subtitle: 'Read the filing, then put your name on the record',
+    title: 'REVIEW THE FIRST CASE',
+    subtitle: 'Read the claim and cited evidence before voting',
     buttons: [
-      // These point at the case surfaces on warondisease.org until the court
-      // routes land in this app (issue #254), then they become local paths.
       { label: 'READ THE CASE', href: '/humanity-v-government', variant: 'primary' },
-      { label: 'CONTACT US', href: '/contact', variant: 'secondary' },
+      { label: 'REGISTER A PLAINTIFF', href: 'https://warondisease.org/plaintiffs', variant: 'secondary' },
     ],
   },
 }

--- a/packages/site-kit/src/lib/site-config.ts
+++ b/packages/site-kit/src/lib/site-config.ts
@@ -1404,7 +1404,7 @@ const siteConfigs: Record<SiteVariant, SiteConfig> = {
     name: "Court of Humanity",
     title: "The Court of Humanity",
     description:
-      "The public court where humanity brings its case against the governments it pays to protect it. First on the docket: Humanity v. Government.",
+      "The public court where humanity brings cases against institutions that harm people. Inspect the evidence, register plaintiffs, and render a verified verdict.",
     domains: ["courtofhumanity.org", "www.courtofhumanity.org"],
     baseUrl: "https://courtofhumanity.org",
     domain: "courtofhumanity.org",


### PR DESCRIPTION
## Summary

- remove the redundant Trial Abundance Survey introduction and make Question 1 the page heading
- remove "eligible" from the shared patient-access question
- open the pragmatic-trial explainer when visitors click the term in any of the three questions
- refocus the Court of Humanity shell on cases, plaintiffs, membership, and verdicts
- remove 1% Treaty, Political Incentive Fund, and Incentive Alignment Bond promotion from the Court membership route and FAQ
- make `/court` an explicit membership declaration instead of placing a signature form beneath a referendum question
- send "Render your verdict" to the verdict section of `Humanity v. Government`
- refresh the affected public-copy snapshots

The separate `Humanity v. Government` case still names the 1% Treaty as that case's proposed remedy. The generic Court pages do not promote it.

## Verification

- `pnpm --filter @apps/courtofhumanity typecheck`
- `pnpm --filter @apps/trialabundancesurvey typecheck`
- `pnpm --filter @apps/acceleratedmedicine typecheck`
- `pnpm --filter @optimitron/data run build`
- `pnpm --filter @apps/courtofhumanity test:unit` — 15 tests passed
- ESLint passed for Court of Humanity, Trial Abundance Survey, and Accelerated Medicine
- `git diff --check`
- regenerated affected copy snapshots
- clicked the pragmatic-trial term in all three survey questions and verified the modal opened
- captured and inspected mobile before/after screenshots for the survey, Court membership route, FAQ, homepage, and about page

## Human review

- [ ] Confirm the standalone survey should begin directly with Question 1.
- [ ] Confirm the Court FAQ should remain as a focused explanation of cases, plaintiffs, membership, and verdicts.
- [ ] Confirm the 1% Treaty should remain only inside `Humanity v. Government` as that case's proposed remedy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Removed Trial Abundance Survey introductions and updated patient-access questions to refer to patients.
  - Added source links to key numeric claims on the main landing page.
  - Removed the Donate link from footer support navigation.
  - Reframed Court of Humanity pages around public membership, evidence review, plaintiff registration, and verified verdicts.

- **Accessibility & Presentation**
  - Improved survey heading structure and display behavior when introductory content is unavailable.
  - Updated Court of Humanity membership, FAQ, and sharing copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->