### PR TITLE
Survey: state select and US default

### DIFF
--- a/apps/acceleratedmedicine/app/montana/page.tsx
+++ b/apps/acceleratedmedicine/app/montana/page.tsx
@@ -225,7 +225,7 @@ export default function MontanaPage() {
         </Container>
       </SectionContainer>
 
-      <StateSupportSection initialState="Montana" />
+      <StateSupportSection initialStateCode="MT" />
     </Layout>
   );
 }

--- a/apps/acceleratedmedicine/app/survey/page.tsx
+++ b/apps/acceleratedmedicine/app/survey/page.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from "next";
 import { StateSupportSection } from "@/components/landing/right-to-try-sections";
 import Layout from "@/components/layout";
 import { parseTrialAbundanceVisualState } from "@optimitron/site-kit/lib/trial-abundance-visual";
+import { normalizeUsRegionCode } from "@optimitron/site-kit/lib/us-states";
 import {
-  stateSlug,
   SUPPORTER_ROLES,
   US_STATES,
   type StateAbbreviation,
@@ -20,16 +20,16 @@ export const metadata: Metadata = {
   },
 };
 
+/**
+ * `?state=` accepts every form the survey itself accepts ("MO", "US-MO",
+ * "Missouri") plus the campaign-page slug ("new-york"), narrowed to the 50
+ * states that have campaign pages.
+ */
 function matchState(value: string | undefined): StateAbbreviation | undefined {
-  if (!value) return undefined;
-  const normalized = value.trim().toLowerCase();
-  const match = US_STATES.find(
-    ([name, abbreviation]) =>
-      name.toLowerCase() === normalized ||
-      stateSlug(name) === normalized ||
-      abbreviation.toLowerCase() === normalized,
-  );
-  return match?.[1];
+  const code =
+    normalizeUsRegionCode(value) ??
+    normalizeUsRegionCode(value?.replaceAll("-", " "));
+  return US_STATES.find(([, abbreviation]) => abbreviation === code)?.[1];
 }
 
 function matchRole(value: string | undefined): SupporterRole | undefined {

--- a/apps/acceleratedmedicine/app/survey/page.tsx
+++ b/apps/acceleratedmedicine/app/survey/page.tsx
@@ -7,7 +7,7 @@ import {
   stateSlug,
   SUPPORTER_ROLES,
   US_STATES,
-  type StateName,
+  type StateAbbreviation,
   type SupporterRole,
 } from "@/lib/right-to-try";
 
@@ -20,14 +20,16 @@ export const metadata: Metadata = {
   },
 };
 
-function matchState(value: string | undefined): StateName | undefined {
+function matchState(value: string | undefined): StateAbbreviation | undefined {
   if (!value) return undefined;
   const normalized = value.trim().toLowerCase();
   const match = US_STATES.find(
-    ([name]) =>
-      name.toLowerCase() === normalized || stateSlug(name) === normalized,
+    ([name, abbreviation]) =>
+      name.toLowerCase() === normalized ||
+      stateSlug(name) === normalized ||
+      abbreviation.toLowerCase() === normalized,
   );
-  return match?.[0];
+  return match?.[1];
 }
 
 function matchRole(value: string | undefined): SupporterRole | undefined {
@@ -47,7 +49,7 @@ export default async function SurveyPage({
         headingAs="h1"
         visualState={parseTrialAbundanceVisualState(visual)}
         initialRole={matchRole(role)}
-        initialState={matchState(state)}
+        initialStateCode={matchState(state)}
       />
     </Layout>
   );

--- a/apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx
+++ b/apps/acceleratedmedicine/components/landing/right-to-try-sections.tsx
@@ -437,14 +437,15 @@ export function RightToTrialImpactPreviewSection() {
 
 export function StateSupportSection({
   initialRole,
-  initialState,
+  initialStateCode,
   heading,
   body,
   headingAs = "h2",
   visualState,
 }: {
   initialRole?: SupporterRole;
-  initialState?: string;
+  /** Stored as `User.regionCode`; a name like "Missouri" would not match the select. */
+  initialStateCode?: StateAbbreviation;
   heading?: string;
   body?: string;
   headingAs?: "h1" | "h2";
@@ -459,7 +460,7 @@ export function StateSupportSection({
       visualState={visualState}
       disableIntroAnimation={Boolean(visualState)}
       initialParticipant={{
-        ...(initialState ? { countryCode: "US", regionCode: initialState } : {}),
+        ...(initialStateCode ? { countryCode: "US", regionCode: initialStateCode } : {}),
         role: initialRole ?? "",
       }}
     />

--- a/apps/acceleratedmedicine/components/state-campaign-page.tsx
+++ b/apps/acceleratedmedicine/components/state-campaign-page.tsx
@@ -72,7 +72,7 @@ export function StateCampaignPage({
         heading={campaign.headline}
         headingAs="h1"
         initialRole={initialRole}
-        initialState={campaign.name}
+        initialStateCode={campaign.abbreviation}
       />
 
       <SectionContainer bgColor="pink" borderPosition="bottom">

--- a/apps/acceleratedmedicine/lib/right-to-try.ts
+++ b/apps/acceleratedmedicine/lib/right-to-try.ts
@@ -1,3 +1,9 @@
+import {
+  US_STATES,
+  type StateAbbreviation,
+  type StateName,
+} from "@optimitron/site-kit/lib/us-states";
+
 export const RIGHT_TO_TRY_SOURCES = {
   montanaSb535:
     "https://docs.legmt.gov/download-ticket?ticketId=404bf910-6276-4d4a-b3d3-56b7cac4b5f9",
@@ -9,62 +15,10 @@ export const RIGHT_TO_TRY_SOURCES = {
     "https://dphhs.mt.gov/oig/licensure/healthcarefacilitylicensure/lbfacilityapplications/lbexperimentaltreatmentcenters",
 } as const;
 
-export const US_STATES = [
-  ["Alabama", "AL"],
-  ["Alaska", "AK"],
-  ["Arizona", "AZ"],
-  ["Arkansas", "AR"],
-  ["California", "CA"],
-  ["Colorado", "CO"],
-  ["Connecticut", "CT"],
-  ["Delaware", "DE"],
-  ["Florida", "FL"],
-  ["Georgia", "GA"],
-  ["Hawaii", "HI"],
-  ["Idaho", "ID"],
-  ["Illinois", "IL"],
-  ["Indiana", "IN"],
-  ["Iowa", "IA"],
-  ["Kansas", "KS"],
-  ["Kentucky", "KY"],
-  ["Louisiana", "LA"],
-  ["Maine", "ME"],
-  ["Maryland", "MD"],
-  ["Massachusetts", "MA"],
-  ["Michigan", "MI"],
-  ["Minnesota", "MN"],
-  ["Mississippi", "MS"],
-  ["Missouri", "MO"],
-  ["Montana", "MT"],
-  ["Nebraska", "NE"],
-  ["Nevada", "NV"],
-  ["New Hampshire", "NH"],
-  ["New Jersey", "NJ"],
-  ["New Mexico", "NM"],
-  ["New York", "NY"],
-  ["North Carolina", "NC"],
-  ["North Dakota", "ND"],
-  ["Ohio", "OH"],
-  ["Oklahoma", "OK"],
-  ["Oregon", "OR"],
-  ["Pennsylvania", "PA"],
-  ["Rhode Island", "RI"],
-  ["South Carolina", "SC"],
-  ["South Dakota", "SD"],
-  ["Tennessee", "TN"],
-  ["Texas", "TX"],
-  ["Utah", "UT"],
-  ["Vermont", "VT"],
-  ["Virginia", "VA"],
-  ["Washington", "WA"],
-  ["West Virginia", "WV"],
-  ["Wisconsin", "WI"],
-  ["Wyoming", "WY"],
-] as const;
-
-export type StateName = (typeof US_STATES)[number][0];
-
-export type StateAbbreviation = (typeof US_STATES)[number][1];
+// The list lives in site-kit so the shared survey's state select and these
+// campaign pages cannot drift apart.
+export { US_STATES };
+export type { StateAbbreviation, StateName };
 
 export const SUPPORTER_ROLES = [
   "patient-or-caregiver",

--- a/apps/acceleratedmedicine/tests/integration/shared-survey.test.ts
+++ b/apps/acceleratedmedicine/tests/integration/shared-survey.test.ts
@@ -28,6 +28,7 @@ const input = {
   sourceUrl: "https://acceleratedmedicine.org/survey",
   timestamp: "2026-09-02T12:00:00.000Z",
   participant: {
+    // Sent as a name on purpose: the route must store the bare code.
     countryCode: "US", regionCode: "Missouri", role: "patient-or-caregiver",
     story: "Local integration test", updates: false,
   },
@@ -96,7 +97,7 @@ describe("both survey routes with PostgreSQL", () => {
   it("saves answers, consent and profile together; retries preserve the original submission", async () => {
     expect((await submit()).status).toBe(200)
     const user = await prisma.user.findUniqueOrThrow({ where: { id: userId }, include: { person: true } })
-    expect(user).toMatchObject({ countryCode: "US", regionCode: "Missouri", newsletterSubscribed: false })
+    expect(user).toMatchObject({ countryCode: "US", regionCode: "MO", newsletterSubscribed: false })
     expect(user.person?.countryCode).toBe("US")
     const submission = await prisma.formSubmission.findFirstOrThrow({
       where: { respondentUserId: userId, idempotencyKey: input.submissionKey },
@@ -105,11 +106,11 @@ describe("both survey routes with PostgreSQL", () => {
     expect(submission.subject?.personId).toBe(user.personId)
     expect(submission.submittedAt).toBeInstanceOf(Date)
     expect(Object.fromEntries(submission.responses.map((response) => [response.field.key, response.valueJson])))
-      .toMatchObject({ ...input.participant, email, patientAccessAnswer: "YES", selfFundedAccessAnswer: "ABSTAIN", militaryAllocationPercent: 35 })
+      .toMatchObject({ ...input.participant, regionCode: "MO", email, patientAccessAnswer: "YES", selfFundedAccessAnswer: "ABSTAIN", militaryAllocationPercent: 35 })
     expect(await prisma.referendumVote.count({ where: { userId } })).toBe(2)
     expect(await prisma.wishocraticAllocation.findFirst({ where: { userId } }))
       .toMatchObject({ allocationA: 35, allocationB: 65 })
-    expect(await (await GET()).json()).toEqual({ countryCode: "US", regionCode: "Missouri", role: "patient-or-caregiver" })
+    expect(await (await GET()).json()).toEqual({ countryCode: "US", regionCode: "MO", role: "patient-or-caregiver" })
 
     // A new response changes the reusable profile; replaying an old request must not undo it.
     const changed = { ...input, submissionKey: randomUUID(), participant: { ...input.participant, countryCode: "CA", regionCode: "Ontario", updates: true } }
@@ -121,6 +122,7 @@ describe("both survey routes with PostgreSQL", () => {
       .toMatchObject({ countryCode: "CA", regionCode: "Ontario", newsletterSubscribed: false })
     // Invalid details must not change either the profile or existing votes.
     expect((await submit({ ...input, submissionKey: randomUUID(), patientAccessAnswer: "NO", participant: { ...input.participant, regionCode: "" } })).status).toBe(400)
+    expect((await submit({ ...input, submissionKey: randomUUID(), patientAccessAnswer: "NO", participant: { ...input.participant, regionCode: "Show Me State" } })).status).toBe(400)
     expect(await prisma.user.findUnique({ where: { id: userId } })).toMatchObject({ countryCode: "CA" })
     const vote = await prisma.referendumVote.findFirst({ where: { userId, referendum: { slug: TRIAL_ABUNDANCE_REFERENDUM_SLUG } } })
     expect(vote?.answer).toBe("YES")

--- a/apps/acceleratedmedicine/tests/unit/survey-participant.test.ts
+++ b/apps/acceleratedmedicine/tests/unit/survey-participant.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { surveyParticipantSchema } from "@optimitron/site-kit/lib/survey-participant";
+import { normalizeUsRegionCode } from "@optimitron/site-kit/lib/us-states";
+
+const base = {
+  countryCode: "US",
+  regionCode: "MO",
+  role: "patient-or-caregiver",
+  story: "",
+  updates: false,
+};
+
+describe("normalizeUsRegionCode", () => {
+  it.each([
+    ["MO", "MO"],
+    ["mo", "MO"],
+    ["US-MO", "MO"],
+    ["Missouri", "MO"],
+    [" missouri ", "MO"],
+    ["District of Columbia", "DC"],
+    ["Puerto Rico", "PR"],
+  ])("maps %j to %s", (input, expected) => {
+    expect(normalizeUsRegionCode(input)).toBe(expected);
+  });
+
+  it("returns null for anything that is not a US region", () => {
+    for (const value of [
+      "",
+      "   ",
+      "Show Me State",
+      "Ontario",
+      "US-",
+      "ZZ",
+      undefined,
+      null,
+    ]) {
+      expect(normalizeUsRegionCode(value)).toBeNull();
+    }
+  });
+});
+
+describe("surveyParticipantSchema regionCode", () => {
+  it("stores the bare code when a US answer arrives as a name or prefixed code", () => {
+    expect(
+      surveyParticipantSchema.parse({ ...base, regionCode: "Missouri" })
+        .regionCode,
+    ).toBe("MO");
+    expect(
+      surveyParticipantSchema.parse({ ...base, regionCode: "US-MO" })
+        .regionCode,
+    ).toBe("MO");
+  });
+
+  it("rejects a US answer without a known region, on the regionCode path", () => {
+    for (const regionCode of ["", "Show Me State"]) {
+      const result = surveyParticipantSchema.safeParse({ ...base, regionCode });
+      expect(result.success).toBe(false);
+      if (!result.success)
+        expect(result.error.issues[0]?.path).toEqual(["regionCode"]);
+    }
+  });
+
+  it("keeps free text for other countries and leaves it optional", () => {
+    expect(
+      surveyParticipantSchema.parse({
+        ...base,
+        countryCode: "CA",
+        regionCode: "Ontario",
+      }).regionCode,
+    ).toBe("Ontario");
+    expect(
+      surveyParticipantSchema.safeParse({
+        ...base,
+        countryCode: "CA",
+        regionCode: "",
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
+++ b/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
@@ -63,7 +63,7 @@ async function answerSurvey(page: Page) {
   await survey.getByRole("slider").press("ArrowRight")
   await survey.getByRole("button", { name: "Continue", exact: true }).click()
   await survey.getByRole("combobox", { name: "Country", exact: true }).selectOption("US")
-  await survey.getByLabel("State", { exact: true }).selectOption("MO")
+  await survey.getByRole("combobox", { name: "State", exact: true }).selectOption("MO")
   await survey.getByRole("combobox", { name: "Your role", exact: true }).selectOption("patient-or-caregiver")
   await survey.getByRole("textbox", { name: "Why does this matter to you?", exact: false }).fill("I want more treatment options.")
   await expect(survey.getByRole("checkbox")).not.toBeChecked()

--- a/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
+++ b/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
@@ -63,7 +63,7 @@ async function answerSurvey(page: Page) {
   await survey.getByRole("slider").press("ArrowRight")
   await survey.getByRole("button", { name: "Continue", exact: true }).click()
   await survey.getByRole("combobox", { name: "Country", exact: true }).selectOption("US")
-  await survey.getByLabel("State", { exact: true }).fill("Missouri")
+  await survey.getByLabel("State", { exact: true }).selectOption("MO")
   await survey.getByRole("combobox", { name: "Your role", exact: true }).selectOption("patient-or-caregiver")
   await survey.getByRole("textbox", { name: "Why does this matter to you?", exact: false }).fill("I want more treatment options.")
   await expect(survey.getByRole("checkbox")).not.toBeChecked()
@@ -108,9 +108,9 @@ test("survey email link saves the answers and lands on the dashboard", async ({ 
   expect(await savedSubmissions(email)).toHaveLength(1)
   expect(submission.personId).toBe(submission.userPersonId)
   expect(submission.emailVerified).toBeTruthy()
-  expect(submission).toMatchObject({ countryCode: "US", regionCode: "Missouri", newsletterSubscribed: false })
+  expect(submission).toMatchObject({ countryCode: "US", regionCode: "MO", newsletterSubscribed: false })
   expect(submission.answers).toMatchObject({
-    countryCode: "US", regionCode: "Missouri", role: "patient-or-caregiver",
+    countryCode: "US", regionCode: "MO", role: "patient-or-caregiver",
     story: "I want more treatment options.", updates: false, email,
     patientAccessAnswer: "YES", selfFundedAccessAnswer: "ABSTAIN", militaryAllocationPercent: 49,
   })

--- a/packages/site-kit/src/components/landing/survey-participant-fields.tsx
+++ b/packages/site-kit/src/components/landing/survey-participant-fields.tsx
@@ -2,6 +2,7 @@
 
 import { SURVEY_COUNTRIES, SURVEY_ROLES, SURVEY_UPDATES_LABEL } from "../../lib/survey-participant"
 import type { SurveyParticipant } from "../../lib/survey-participant"
+import { US_REGION_OPTIONS } from "../../lib/us-states"
 
 export type ParticipantDraft = Omit<SurveyParticipant, "role"> & { role: string }
 
@@ -22,11 +23,19 @@ export function SurveyParticipantFields({ value, onChange }: {
             {SURVEY_COUNTRIES.map(({ code, name }) => <option key={code} value={code}>{name}</option>)}
           </select>
         </label>
-        {value.countryCode ? (
+        {value.countryCode === "US" ? (
           <label className="font-black">
-            {value.countryCode === "US" ? "State" : "State / region (optional)"}
-            <input className={inputClass} autoComplete="address-level1" maxLength={100}
-              required={value.countryCode === "US"} value={value.regionCode}
+            State
+            <select className={inputClass} autoComplete="address-level1" required value={value.regionCode}
+              onChange={(event) => onChange({ ...value, regionCode: event.target.value })}>
+              <option value="">Choose a state</option>
+              {US_REGION_OPTIONS.map(({ code, name }) => <option key={code} value={code}>{name}</option>)}
+            </select>
+          </label>
+        ) : value.countryCode ? (
+          <label className="font-black">
+            State / region (optional)
+            <input className={inputClass} autoComplete="address-level1" maxLength={100} value={value.regionCode}
               onChange={(event) => onChange({ ...value, regionCode: event.target.value })} />
           </label>
         ) : null}

--- a/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
+++ b/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
@@ -26,6 +26,7 @@ import { PragmaticTrialsDialog } from "./PragmaticTrialsDialog"
 import { SurveyParticipantFields } from "./survey-participant-fields"
 import type { ParticipantDraft } from "./survey-participant-fields"
 import { surveyParticipantSchema } from "../../lib/survey-participant"
+import { normalizeUsRegionCode } from "../../lib/us-states"
 import { AlertCard } from "@optimitron/neobrutalist-ui/ui/alert-card"
 
 type SurveyStage =
@@ -133,7 +134,7 @@ export default function TrialAbundanceSurveySection({
   const completionRef = useRef<HTMLDivElement>(null)
   const hasRetriedSync = useRef(false)
   const [participant, setParticipant] = useState<ParticipantDraft>({
-    countryCode: "", regionCode: "", role: "", story: "", updates: false,
+    countryCode: "US", regionCode: "", role: "", story: "", updates: false,
     ...initialParticipant,
   })
   const participantEdited = useRef(false)
@@ -164,11 +165,15 @@ export default function TrialAbundanceSurveySection({
       .then(async (response) => response.ok ? response.json() : null)
       .then((profile: Partial<ParticipantDraft> | null) => {
         if (!profile || participantEdited.current) return
-        setParticipant((current) => ({ ...current,
-          countryCode: profile.countryCode || current.countryCode,
-          regionCode: profile.regionCode || current.regionCode,
-          role: profile.role || current.role,
-        }))
+        setParticipant((current) => {
+          const countryCode = profile.countryCode || current.countryCode
+          const regionCode = profile.regionCode || current.regionCode
+          return { ...current, countryCode,
+            // Profiles saved before the state select hold names like "Missouri".
+            regionCode: countryCode === "US" ? normalizeUsRegionCode(regionCode) ?? regionCode : regionCode,
+            role: profile.role || current.role,
+          }
+        })
       }).catch(() => { /* The user can enter details if profile loading fails. */ })
     return () => controller.abort()
   }, [isVisualCapture, status])

--- a/packages/site-kit/src/lib/survey-participant.ts
+++ b/packages/site-kit/src/lib/survey-participant.ts
@@ -1,5 +1,6 @@
 import countries from "world-countries"
 import { z } from "zod"
+import { normalizeUsRegionCode, US_REGIONS } from "./us-states"
 
 export const SURVEY_COUNTRIES = countries
   .map((country) => ({ code: country.cca2, name: country.name.common }))
@@ -14,6 +15,8 @@ export const SURVEY_ROLES = [
   ["other", "Other"],
 ] as const
 
+const US_REGION_CODES = new Set<string>(US_REGIONS.map(([, code]) => code))
+
 export const surveyParticipantSchema = z.object({
   countryCode: z.string().refine(
     (value) => SURVEY_COUNTRIES.some(({ code }) => code === value),
@@ -26,10 +29,16 @@ export const surveyParticipantSchema = z.object({
   ]),
   story: z.string().trim().max(2000),
   updates: z.boolean(),
-}).refine((value) => value.countryCode !== "US" || Boolean(value.regionCode), {
-  message: "Enter your state.",
-  path: ["regionCode"],
 })
+  // Older clients and prefilled links send "Missouri" or "US-MO"; store the
+  // bare code so every US answer for one state lands on one regionCode.
+  .transform((value) => value.countryCode !== "US" ? value
+    : { ...value, regionCode: normalizeUsRegionCode(value.regionCode) ?? value.regionCode })
+  .superRefine((value, ctx) => {
+    if (value.countryCode === "US" && !US_REGION_CODES.has(value.regionCode)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["regionCode"], message: "Choose your state." })
+    }
+  })
 
 export type SurveyParticipant = z.infer<typeof surveyParticipantSchema>
 

--- a/packages/site-kit/src/lib/us-states.ts
+++ b/packages/site-kit/src/lib/us-states.ts
@@ -1,0 +1,115 @@
+/**
+ * US first-level subdivisions keyed by their ISO 3166-2:US code without the
+ * "US-" prefix. That bare two-letter form is what Vercel's
+ * `x-vercel-ip-country-region` header and the signup geo path already write
+ * into `User.regionCode`, so survey answers stored the same way group with
+ * geo-detected profiles on the `[countryCode, regionCode]` index instead of
+ * splitting one state across "MO", "Missouri", and "US-MO".
+ */
+
+export const US_STATES = [
+  ["Alabama", "AL"],
+  ["Alaska", "AK"],
+  ["Arizona", "AZ"],
+  ["Arkansas", "AR"],
+  ["California", "CA"],
+  ["Colorado", "CO"],
+  ["Connecticut", "CT"],
+  ["Delaware", "DE"],
+  ["Florida", "FL"],
+  ["Georgia", "GA"],
+  ["Hawaii", "HI"],
+  ["Idaho", "ID"],
+  ["Illinois", "IL"],
+  ["Indiana", "IN"],
+  ["Iowa", "IA"],
+  ["Kansas", "KS"],
+  ["Kentucky", "KY"],
+  ["Louisiana", "LA"],
+  ["Maine", "ME"],
+  ["Maryland", "MD"],
+  ["Massachusetts", "MA"],
+  ["Michigan", "MI"],
+  ["Minnesota", "MN"],
+  ["Mississippi", "MS"],
+  ["Missouri", "MO"],
+  ["Montana", "MT"],
+  ["Nebraska", "NE"],
+  ["Nevada", "NV"],
+  ["New Hampshire", "NH"],
+  ["New Jersey", "NJ"],
+  ["New Mexico", "NM"],
+  ["New York", "NY"],
+  ["North Carolina", "NC"],
+  ["North Dakota", "ND"],
+  ["Ohio", "OH"],
+  ["Oklahoma", "OK"],
+  ["Oregon", "OR"],
+  ["Pennsylvania", "PA"],
+  ["Rhode Island", "RI"],
+  ["South Carolina", "SC"],
+  ["South Dakota", "SD"],
+  ["Tennessee", "TN"],
+  ["Texas", "TX"],
+  ["Utah", "UT"],
+  ["Vermont", "VT"],
+  ["Virginia", "VA"],
+  ["Washington", "WA"],
+  ["West Virginia", "WV"],
+  ["Wisconsin", "WI"],
+  ["Wyoming", "WY"],
+] as const;
+
+export type StateName = (typeof US_STATES)[number][0];
+
+export type StateAbbreviation = (typeof US_STATES)[number][1];
+
+/**
+ * Inhabited subdivisions that are not states. The survey accepts them because
+ * their residents are US patients too; state campaign pages are not generated
+ * for them.
+ */
+export const US_NON_STATE_REGIONS = [
+  ["American Samoa", "AS"],
+  ["District of Columbia", "DC"],
+  ["Guam", "GU"],
+  ["Northern Mariana Islands", "MP"],
+  ["Puerto Rico", "PR"],
+  ["U.S. Virgin Islands", "VI"],
+] as const;
+
+export const US_REGIONS = [...US_STATES, ...US_NON_STATE_REGIONS] as const;
+
+export type UsRegionCode = (typeof US_REGIONS)[number][1];
+
+/** `US_REGIONS` in display order for a select. */
+export const US_REGION_OPTIONS: ReadonlyArray<{
+  code: UsRegionCode;
+  name: string;
+}> = [...US_REGIONS]
+  .map(([name, code]) => ({ code, name }))
+  .sort((a, b) => a.name.localeCompare(b.name, "en"));
+
+const REGION_CODE_BY_KEY = new Map<string, UsRegionCode>();
+for (const [name, code] of US_REGIONS) {
+  REGION_CODE_BY_KEY.set(code, code);
+  REGION_CODE_BY_KEY.set(name.toLowerCase(), code);
+}
+
+/**
+ * Canonicalize whatever a human, an older client, or a prefilled link sends
+ * for a US region — "MO", "mo", "US-MO", "Missouri", " missouri " — to the
+ * stored code. Returns null when nothing matches so the caller can reject it
+ * instead of storing free text.
+ */
+export function normalizeUsRegionCode(
+  value: string | null | undefined,
+): UsRegionCode | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return (
+    REGION_CODE_BY_KEY.get(trimmed.toUpperCase().replace(/^US-/, "")) ??
+    REGION_CODE_BY_KEY.get(trimmed.toLowerCase()) ??
+    null
+  );
+}


### PR DESCRIPTION
When the country was United States, the Trial Abundance Survey asked for "State" in a free-text input and accepted anything non-empty. `User.regionCode` was collecting "MO", "Missouri", "misouri", and worse. That column is indexed with `countryCode` for census grouping and drives the flyer-hang "nearby" match, so one state was splitting across several keys.

## What changed

- **Country defaults to United States**, so the state field is visible immediately.
- **State is a select** of the 50 states, DC, and the five inhabited territories (56 options). Territories are included because the free-text field let residents of Puerto Rico etc. answer before; dropping them would have been a regression. Native `<select>` rather than a typeahead: it matches the Country control next to it, works on mobile pickers, supports type-to-jump, and adds no component or dependency.
- **Stored value is the bare two-letter code** ("MO"). That is what Vercel's `x-vercel-ip-country-region` header and the signup geo path already write, so survey answers group with geo-detected profiles instead of splitting.
- **Schema normalizes and then validates.** "Missouri", "US-MO", and "mo" all become "MO" server-side, so older cached clients and prefilled links keep working; anything else for a US answer is rejected on the `regionCode` path with "Choose your state." Other countries keep the optional free-text region.
- **Saved profiles that still hold a name** are normalized when they load into the form, so the select shows the right state instead of blank.
- **The state list moved to site-kit** (`packages/site-kit/src/lib/us-states.ts`). `apps/acceleratedmedicine/lib/right-to-try.ts` re-exports it so the campaign pages and the shared survey read one table.
- **Prefill bug fixed on the way.** The state campaign pages, `/montana`, and `/survey?state=` passed the state *name* into `regionCode`; with a code-valued select that would have rendered blank on exactly the pages meant to funnel state signups. They now pass the abbreviation, and the prop is typed `StateAbbreviation` so passing a name again fails typecheck. `/survey?state=MO` also works now, alongside `?state=Missouri` and `?state=missouri`.

## Not changed, flagged

- Existing `User.regionCode` rows written by the old free-text field still hold names. Normalizing them is a data migration and needs a separate go-ahead; the read-side normalization above means those users see the correct state in the form and get corrected on their next submit.
- `apps/optimitron/src/components/profile/ProfileSnapshotForm.tsx` still has a free-text region input with placeholder `US-TX` — a third format. Worth aligning with the same select and code, separately.

## Verification

- Before/after screenshots of `/?visual=details` at 1280px and 375px captured and inspected locally (not attached, per repo policy): before shows "Choose a country" and no state field; after shows United States selected and a State select with 56 options. No layout change to the rest of the form.
- The details step is not in any `page.logged-out.md`, so no copy snapshots change.
- `@apps/acceleratedmedicine`: typecheck clean, lint clean, 37 unit tests pass (7 files) — includes a new `survey-participant.test.ts` covering normalization inputs, the US-only rejection path, and the non-US free-text path.
- `@apps/trialabundancesurvey` (embeds the same component): typecheck clean.
- `shared-survey.test.ts` (integration) updated: it still sends `"Missouri"` on purpose and now asserts `"MO"` is what gets stored and returned by `/api/survey/profile`, plus a 400 for a junk state. I could not run it locally — the local Postgres was unreachable from this session — so it runs in CI's "Accelerated Medicine survey database regression tests" step.
- Seven touched files were already failing `prettier --check` on `main`; their formatting was left alone so the diff stays limited to this change. Only the two new files were formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
