### PR TITLE
Show survey results across public pages and dashboards

### DIFF
--- a/apps/trialabundancesurvey/app/page.logged-out.md
+++ b/apps/trialabundancesurvey/app/page.logged-out.md
@@ -21,6 +21,7 @@
 - YES
 - NOT SURE
 - NO
+- [View current survey results](/results)
 - AN INDEPENDENT RESEARCH INITIATIVE
 #### ABOUT
 - [ABOUT](/about)

--- a/apps/trialabundancesurvey/app/page.tsx
+++ b/apps/trialabundancesurvey/app/page.tsx
@@ -1,6 +1,8 @@
 import Layout from "../components/layout"
 import TrialAbundanceSurveySection from "@/components/landing/trial-abundance-survey-section"
 import { parseTrialAbundanceVisualState } from "@optimitron/site-kit/lib/trial-abundance-visual"
+import Link from "next/link"
+import { ROUTES } from "@optimitron/site-kit/lib/routes"
 
 interface HomePageProps {
   searchParams?: Promise<{ visual?: string }>
@@ -20,6 +22,9 @@ export default async function HomePage({ searchParams }: HomePageProps) {
         disableIntroAnimation={Boolean(visualState)}
         visualState={visualState}
       />
+      <p className="px-6 py-8 text-center font-bold">
+        <Link href={ROUTES.surveyResults} className="underline underline-offset-4">View current survey results</Link>
+      </p>
     </Layout>
   )
 }

--- a/apps/trialabundancesurvey/app/results/page.tsx
+++ b/apps/trialabundancesurvey/app/results/page.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link"
+import Layout from "../../components/layout"
+import { Button } from "@optimitron/neobrutalist-ui/ui/button"
+import { Container } from "@optimitron/neobrutalist-ui/ui/container"
+import { SectionContainer } from "@optimitron/neobrutalist-ui/ui/section-container"
+import { SurveyResultsCard } from "@optimitron/site-kit/components/dashboard/SurveyResultsCard"
+import { getPageMetadata } from "@optimitron/site-kit/lib/nav-items"
+import { ROUTES } from "@optimitron/site-kit/lib/routes"
+import { getTrialAbundanceSurveyResults } from "@optimitron/site-kit/lib/survey-results.server"
+import { getSurveyResultsVisualFixture } from "@optimitron/site-kit/lib/survey-results-visual"
+
+export const dynamic = "force-dynamic"
+
+export function generateMetadata() {
+  return getPageMetadata("surveyResults")
+}
+
+export default async function SurveyResultsPage({ searchParams }: {
+  searchParams?: Promise<{ visual?: string }>
+}) {
+  const visual = (await searchParams)?.visual
+  const results = getSurveyResultsVisualFixture(visual) ?? await getTrialAbundanceSurveyResults()
+  return (
+    <Layout>
+      <SectionContainer bgColor="background" borderPosition="none" padding="lg">
+        <Container>
+          <SurveyResultsCard results={results} headingAs="h1" />
+          <div className="mt-8">
+            <Button asChild><Link href={ROUTES.home}>Add your response</Link></Button>
+          </div>
+        </Container>
+      </SectionContainer>
+    </Layout>
+  )
+}

--- a/apps/trialabundancesurvey/tests/unit/survey-results-visual.test.ts
+++ b/apps/trialabundancesurvey/tests/unit/survey-results-visual.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { getSurveyResultsVisualFixture } from "@optimitron/site-kit/lib/survey-results-visual"
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe("survey results previews", () => {
+  it("cannot replace production results through a query parameter", () => {
+    vi.stubEnv("NODE_ENV", "production")
+    vi.stubEnv("SITE_APP_VISUAL_FIXTURES", "")
+    expect(getSurveyResultsVisualFixture("1")).toBeUndefined()
+    expect(getSurveyResultsVisualFixture("empty")).toBeUndefined()
+  })
+
+  it("keeps ordinary development requests on real data", () => {
+    vi.stubEnv("NODE_ENV", "development")
+    expect(getSurveyResultsVisualFixture()).toBeUndefined()
+    expect(getSurveyResultsVisualFixture("invalid")).toBeUndefined()
+  })
+
+  it("omits personal responses from public previews", () => {
+    vi.stubEnv("SITE_APP_VISUAL_FIXTURES", "1")
+    expect(getSurveyResultsVisualFixture("1")?.funding.user).toBeNull()
+    expect(getSurveyResultsVisualFixture("1", true)?.funding.user).toBe(35)
+    expect(getSurveyResultsVisualFixture("empty", true)?.funding).toEqual({ user: null, average: null, median: null })
+  })
+})

--- a/apps/warondisease/app/api/referral-invitations/route.ts
+++ b/apps/warondisease/app/api/referral-invitations/route.ts
@@ -259,7 +259,6 @@ export async function PATCH(req: NextRequest) {
 
     const updateData: {
       status?: ReferralInvitationStatus
-      convertedAt?: Date | null
       copiedAt?: Date
       sentAt?: Date
       messageText?: string
@@ -274,7 +273,6 @@ export async function PATCH(req: NextRequest) {
       const validStatuses: ReferralInvitationStatus[] = [
         ReferralInvitationStatus.PENDING,
         ReferralInvitationStatus.SENT,
-        ReferralInvitationStatus.CONVERTED,
         ReferralInvitationStatus.DECLINED,
         ReferralInvitationStatus.COPIED,
         ReferralInvitationStatus.CANCELLED,
@@ -284,9 +282,7 @@ export async function PATCH(req: NextRequest) {
       }
 
       updateData.status = status as ReferralInvitationStatus
-      if (status === ReferralInvitationStatus.CONVERTED) {
-        updateData.convertedAt = existing.convertedAt ?? new Date()
-      } else if (status === ReferralInvitationStatus.SENT) {
+      if (status === ReferralInvitationStatus.SENT) {
         updateData.sentAt = existing.sentAt ?? new Date()
       }
     }

--- a/apps/warondisease/tests/unit/dashboard-invitations.test.tsx
+++ b/apps/warondisease/tests/unit/dashboard-invitations.test.tsx
@@ -31,12 +31,12 @@ describe("dashboard invitation controls through the API", () => {
     Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText: async () => {} } })
   })
 
-  it("saves the Voted control as a converted invitation", async () => {
-    render(<ReferralInvitationsCard invitations={[invitation]} referralLink={invitation.referralUrl} />)
-    fireEvent.click(screen.getByRole("button", { name: "Voted", exact: true }))
-    await waitFor(() => expect(boundary.saved.status).toBe("CONVERTED"))
-    expect(boundary.saved.convertedAt).toBeInstanceOf(Date)
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  it("rejects a manual conversion so the later verified vote can still link the invitation", async () => {
+    const response = await PATCH(new Request("https://warondisease.org/api/referral-invitations", {
+      method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ id: "invite", status: "CONVERTED" }),
+    }) as never)
+    expect(response.status).toBe(400)
+    expect(boundary.saved).toEqual({})
   })
 
   it("records a copied reminder with its copy timestamp", async () => {
@@ -49,7 +49,7 @@ describe("dashboard invitation controls through the API", () => {
   it("shows rejected updates instead of silently treating them as saved", async () => {
     vi.stubGlobal("fetch", async () => new Response(null, { status: 503 }))
     render(<ReferralInvitationsCard invitations={[invitation]} referralLink={invitation.referralUrl} />)
-    fireEvent.click(screen.getByRole("button", { name: "Voted", exact: true }))
+    fireEvent.click(screen.getByRole("button", { name: "Copy reminder" }))
     expect(await screen.findByRole("alert")).toHaveTextContent("We could not save that invitation update")
     expect(boundary.saved).toEqual({})
   })

--- a/apps/warondisease/tests/unit/dashboard-invitations.test.tsx
+++ b/apps/warondisease/tests/unit/dashboard-invitations.test.tsx
@@ -1,0 +1,56 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ReferralInvitationsCard } from "../../../../packages/site-kit/src/components/dashboard/ReferralInvitationsCard"
+import type { DashboardReferralInvitation } from "../../../../packages/site-kit/src/types/dashboard"
+
+const boundary = vi.hoisted(() => ({ saved: {} as Record<string, unknown> }))
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: () => {} }) }))
+vi.mock("@/lib/auth-utils", () => ({ requireAuth: async () => ({ userId: "sender" }) }))
+vi.mock("@/lib/email", () => ({ sendReferralInviteEmail: vi.fn() }))
+vi.mock("@/lib/prisma", () => ({ prisma: {
+  referralInvitation: {
+    findUnique: async () => ({ id: "invite", referrerUserId: "sender", status: "PENDING", convertedAt: null }),
+    update: async ({ data }: { data: Record<string, unknown> }) => { boundary.saved = data; return { id: "invite", ...data } },
+  },
+} }))
+
+import { PATCH } from "../../app/api/referral-invitations/route"
+
+const invitation: DashboardReferralInvitation = {
+  id: "invite", recipientName: "Demo Friend", inviteeContact: null, contactMethod: "IN_PERSON", inviteToken: "token",
+  referralUrl: "https://warondisease.org/vote/sender", messageText: null, status: "PENDING", votedAt: null,
+  copiedAt: null, sentAt: null, remindersSent: 0, lastRemindedAt: null, confirmedAt: null, createdAt: new Date("2026-01-01"),
+}
+
+describe("dashboard invitation controls through the API", () => {
+  afterEach(() => vi.unstubAllGlobals())
+  beforeEach(() => {
+    boundary.saved = {}
+    vi.stubGlobal("fetch", async (url: string, init: RequestInit) => PATCH(new Request(`https://warondisease.org${url}`, init) as never))
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText: async () => {} } })
+  })
+
+  it("saves the Voted control as a converted invitation", async () => {
+    render(<ReferralInvitationsCard invitations={[invitation]} referralLink={invitation.referralUrl} />)
+    fireEvent.click(screen.getByRole("button", { name: "Voted", exact: true }))
+    await waitFor(() => expect(boundary.saved.status).toBe("CONVERTED"))
+    expect(boundary.saved.convertedAt).toBeInstanceOf(Date)
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  })
+
+  it("records a copied reminder with its copy timestamp", async () => {
+    render(<ReferralInvitationsCard invitations={[invitation]} referralLink={invitation.referralUrl} />)
+    fireEvent.click(screen.getByRole("button", { name: "Copy reminder" }))
+    await waitFor(() => expect(boundary.saved.status).toBe("COPIED"))
+    expect(boundary.saved.copiedAt).toBeInstanceOf(Date)
+  })
+
+  it("shows rejected updates instead of silently treating them as saved", async () => {
+    vi.stubGlobal("fetch", async () => new Response(null, { status: 503 }))
+    render(<ReferralInvitationsCard invitations={[invitation]} referralLink={invitation.referralUrl} />)
+    fireEvent.click(screen.getByRole("button", { name: "Voted", exact: true }))
+    expect(await screen.findByRole("alert")).toHaveTextContent("We could not save that invitation update")
+    expect(boundary.saved).toEqual({})
+  })
+})

--- a/apps/warondisease/tests/unit/survey-results.test.ts
+++ b/apps/warondisease/tests/unit/survey-results.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import {
+  MILITARY_ALLOCATION_ITEM_ID as military,
+  TRIALS_ALLOCATION_ITEM_ID as trials,
+  summarizeFundingAllocations,
+  summarizeVotePercentages,
+} from "../../../../packages/site-kit/src/lib/survey-results"
+
+describe("survey result percentages", () => {
+  it("includes unsure responses in the denominator without returning counts", () => {
+    expect(summarizeVotePercentages([
+      { answer: "YES", _count: { _all: 3 } },
+      { answer: "NO", _count: { _all: 1 } },
+      { answer: "ABSTAIN", _count: { _all: 4 } },
+    ])).toEqual({ YES: 37.5, NO: 12.5, ABSTAIN: 50 })
+  })
+
+  it("keeps an unanswered question distinct from zero support", () => {
+    expect(summarizeVotePercentages([])).toBeNull()
+    expect(summarizeVotePercentages([{ answer: "NO", _count: { _all: 1 } }])).toEqual({ YES: 0, NO: 100, ABSTAIN: 0 })
+  })
+})
+
+const allocation = (userId: string, allocationA: number, reversed = false, day = 1) => ({
+  userId, itemAId: reversed ? trials : military, itemBId: reversed ? military : trials,
+  allocationA, allocationB: 100 - allocationA, updatedAt: new Date(`2026-01-0${day}T00:00:00Z`),
+})
+
+describe("funding results", () => {
+  it("uses each participant's latest answer, including reversed item order", () => {
+    const rows = [allocation("a", 10), allocation("a", 70, true, 2), allocation("b", 80), allocation("c", 10)]
+    const results = summarizeFundingAllocations(rows, "a")
+    expect(results).toEqual({ user: 30, average: 40, median: 30 })
+    expect(summarizeFundingAllocations([...rows].reverse(), "a")).toEqual(results)
+  })
+
+  it("retains genuine zero allocations and ignores invalid or unrelated comparisons", () => {
+    expect(summarizeFundingAllocations([
+      allocation("a", 0), allocation("b", 100),
+      { ...allocation("c", 70), allocationB: 70 },
+      { ...allocation("d", 40), itemBId: "EDUCATION" },
+      allocation("e", -1),
+    ], "a")).toEqual({ user: 0, average: 50, median: 50 })
+  })
+
+  it("does not invent an average or require the current user to have answered", () => {
+    expect(summarizeFundingAllocations([], "a")).toEqual({ user: null, average: null, median: null })
+    expect(summarizeFundingAllocations([allocation("b", 20)], "a")).toEqual({ user: null, average: 20, median: 20 })
+  })
+})

--- a/apps/warondisease/tests/unit/survey-results.test.ts
+++ b/apps/warondisease/tests/unit/survey-results.test.ts
@@ -47,4 +47,9 @@ describe("funding results", () => {
     expect(summarizeFundingAllocations([], "a")).toEqual({ user: null, average: null, median: null })
     expect(summarizeFundingAllocations([allocation("b", 20)], "a")).toEqual({ user: null, average: 20, median: 20 })
   })
+
+  it("returns only aggregate values when no participant is requested", () => {
+    expect(summarizeFundingAllocations([allocation("a", 20), allocation("b", 60)]))
+      .toEqual({ user: null, average: 40, median: 40 })
+  })
 })

--- a/packages/site-kit/src/components/dashboard/DashboardClient.tsx
+++ b/packages/site-kit/src/components/dashboard/DashboardClient.tsx
@@ -24,7 +24,7 @@ import { OrganizationsCard } from "@/components/dashboard/OrganizationsCard"
 import { ActivityFeed } from "@/components/dashboard/ActivityFeed"
 import { EmailSignatureCard } from "@/components/dashboard/EmailSignatureCard"
 import { StickyShareFooter } from "@/components/dashboard/StickyShareFooter"
-import { MilitaryVsClinicalTrialsAllocationCard } from "@/components/dashboard/MilitaryVsClinicalTrialsAllocationCard"
+import { SurveyResultsCard } from "@/components/dashboard/SurveyResultsCard"
 import type { DashboardData, LeaderboardEntry } from "@/types/dashboard"
 
 export function DashboardClient({
@@ -141,12 +141,8 @@ export function DashboardClient({
             </div>
           )}
 
-          {/* Allocation Comparison */}
-          <div className="mb-8">
-            <MilitaryVsClinicalTrialsAllocationCard
-              userAllocation={initialData.allocation.user}
-              averageAllocation={initialData.allocation.average}
-            />
+          <div className="mb-8" id="survey-results">
+            <SurveyResultsCard results={initialData.surveyResults} />
           </div>
 
           {(showPoliticalContent || hasActivity || hasBadges || hasOrganizations || hasLeaderboard) && (

--- a/packages/site-kit/src/components/dashboard/ReferralInvitationsCard.tsx
+++ b/packages/site-kit/src/components/dashboard/ReferralInvitationsCard.tsx
@@ -1,13 +1,14 @@
 "use client"
 
 import { useState } from "react"
-import { Card } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
+import { Card } from "@optimitron/neobrutalist-ui/ui/card"
+import { Button } from "@optimitron/neobrutalist-ui/ui/button"
 import { useRouter } from "next/navigation"
 import { Target, Check, Clock, X as XIcon, Send, Copy } from "lucide-react"
-import { cn } from "@/lib/utils"
+import { cn } from "@optimitron/neobrutalist-ui/cn"
 import type { DashboardReferralInvitation } from "@/types/dashboard"
 import { createLogger } from "@/lib/logger"
+import { ReferralInvitationStatus } from "@optimitron/db/enums"
 
 const log = createLogger("referral-invitations-card")
 
@@ -40,6 +41,7 @@ export function ReferralInvitationsCard({
   const router = useRouter()
   const [workingId, setWorkingId] = useState<string | null>(null)
   const [copiedId, setCopiedId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
 
   const votedCount = invitations.filter((c) => c.status === "VOTED").length
   const pendingCount = invitations.filter(
@@ -49,15 +51,22 @@ export function ReferralInvitationsCard({
 
   const updateStatus = async (id: string, status: DashboardReferralInvitation["status"]) => {
     setWorkingId(id)
+    setError(null)
     try {
-      await fetch("/api/referral-invitations", {
+      const savedStatus = status === "VOTED" ? ReferralInvitationStatus.CONVERTED
+        : status === "REMINDED" ? ReferralInvitationStatus.COPIED
+        : status === "DECLINED" ? ReferralInvitationStatus.DECLINED
+        : ReferralInvitationStatus.PENDING
+      const response = await fetch("/api/referral-invitations", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id, status }),
+        body: JSON.stringify({ id, status: savedStatus, ...(status === "REMINDED" ? { action: "markCopied" } : {}) }),
       })
+      if (!response.ok) throw new Error("We could not save that invitation update. Please try again.")
       router.refresh()
     } catch (err) {
       log.error("Failed to update referral invitation", { error: err })
+      setError("We could not save that invitation update. Please try again.")
     } finally {
       setWorkingId(null)
     }
@@ -81,6 +90,7 @@ export function ReferralInvitationsCard({
 
   const content = (
     <>
+      {error ? <p role="alert" className="mb-4 text-sm font-bold text-destructive">{error}</p> : null}
       {/* Summary bar */}
       <div className="grid grid-cols-3 gap-3 mb-6">
         <div className="border-4 border-primary bg-brutal-cyan p-3 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] text-center">

--- a/packages/site-kit/src/components/dashboard/ReferralInvitationsCard.tsx
+++ b/packages/site-kit/src/components/dashboard/ReferralInvitationsCard.tsx
@@ -49,12 +49,11 @@ export function ReferralInvitationsCard({
   ).length
   const totalCount = invitations.length
 
-  const updateStatus = async (id: string, status: DashboardReferralInvitation["status"]) => {
+  const updateStatus = async (id: string, status: Exclude<DashboardReferralInvitation["status"], "VOTED">) => {
     setWorkingId(id)
     setError(null)
     try {
-      const savedStatus = status === "VOTED" ? ReferralInvitationStatus.CONVERTED
-        : status === "REMINDED" ? ReferralInvitationStatus.COPIED
+      const savedStatus = status === "REMINDED" ? ReferralInvitationStatus.COPIED
         : status === "DECLINED" ? ReferralInvitationStatus.DECLINED
         : ReferralInvitationStatus.PENDING
       const response = await fetch("/api/referral-invitations", {
@@ -154,16 +153,6 @@ export function ReferralInvitationsCard({
                     >
                       <Copy className="w-3 h-3 mr-1" />
                       {copied ? "Copied!" : "Copy reminder"}
-                    </Button>
-                    <Button
-                      onClick={() => updateStatus(c.id, "VOTED")}
-                      disabled={working}
-                      size="sm"
-                      variant="outline"
-                      className="bg-background border-4 border-primary font-black uppercase text-xs shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-none transition-all"
-                    >
-                      <Check className="w-3 h-3 mr-1" />
-                      Voted
                     </Button>
                     <Button
                       onClick={() => updateStatus(c.id, "DECLINED")}

--- a/packages/site-kit/src/components/dashboard/StatsOverview.tsx
+++ b/packages/site-kit/src/components/dashboard/StatsOverview.tsx
@@ -60,7 +60,7 @@ export function StatsOverview({ stats, onMetricClick, className }: StatsOverview
               <CardContent className="pt-6">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="text-sm font-bold uppercase text-muted-foreground">Hearts & Minds Reached</p>
+                    <p className="text-sm font-bold uppercase text-muted-foreground">Referral Link Visits</p>
                     <p className="text-4xl font-black text-brutal-yellow">{stats.reach.toLocaleString()}</p>
                   </div>
                   <Globe className="h-12 w-12 text-brutal-yellow" />
@@ -70,8 +70,7 @@ export function StatsOverview({ stats, onMetricClick, className }: StatsOverview
           </TooltipTrigger>
           <TooltipContent className="bg-background border-4 border-primary p-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] max-w-sm">
             <p className="font-bold text-sm">
-              Estimated reach based on your referrals and shares. Each referral generates an average of 265 social media
-              impressions.
+              Recorded visits through your referral links. Repeat visits can count more than once.
             </p>
           </TooltipContent>
         </Tooltip>

--- a/packages/site-kit/src/components/dashboard/SurveyResultsCard.tsx
+++ b/packages/site-kit/src/components/dashboard/SurveyResultsCard.tsx
@@ -27,16 +27,20 @@ function FundingBar({ label, military }: { label: string; military: number }) {
   )
 }
 
-export function SurveyResultsCard({ results }: { results: DashboardSurveyResults }) {
+export function SurveyResultsCard({ results, headingAs: Heading = "h2" }: {
+  results: DashboardSurveyResults
+  headingAs?: "h1" | "h2"
+}) {
   const ratio = MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO.value
+  const QuestionHeading = Heading === "h1" ? "h2" : "h3"
   return (
     <Card className="border-4 border-primary bg-background p-5 sm:p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
       <section aria-labelledby="survey-results-heading">
-        <h2 id="survey-results-heading" className="text-2xl sm:text-3xl font-black uppercase mb-6">Survey results</h2>
-        <div className="grid gap-8 lg:grid-cols-3">
+        <Heading id="survey-results-heading" className="text-2xl sm:text-3xl font-black uppercase mb-6">Survey results</Heading>
+        <div className={`grid gap-8 ${results.questions.length === 2 ? "lg:grid-cols-2" : "lg:grid-cols-3"}`}>
           {results.questions.map(({ slug, title, question, percentages }) => (
             <div key={slug} className="flex flex-col gap-3">
-              <h3 className="text-lg font-black">{title}</h3>
+              <QuestionHeading className="text-lg font-black">{title}</QuestionHeading>
               <p className="text-sm font-bold leading-relaxed">{question}</p>
               {percentages ? (
                 <div className="mt-auto space-y-3 pt-2">
@@ -59,10 +63,10 @@ export function SurveyResultsCard({ results }: { results: DashboardSurveyResults
           ))}
         </div>
         <div className="mt-10">
-          <h3 className="text-lg font-black mb-2">Military or clinical trials?</h3>
+          <QuestionHeading className="text-lg font-black mb-2">Military or clinical trials?</QuestionHeading>
           <p className="text-sm font-bold mb-6">How survey respondents would divide funding between the two.</p>
           {results.funding.average !== null ? (
-            <div className="grid gap-6 lg:grid-cols-3">
+            <div className={`grid gap-6 ${results.funding.user === null ? "lg:grid-cols-2" : "lg:grid-cols-3"}`}>
               <FundingBar label="Average response" military={results.funding.average} />
               {results.funding.user !== null ? <FundingBar label="Your response" military={results.funding.user} /> : null}
               <FundingBar label="Current government spending" military={ratio / (ratio + 1) * 100} />

--- a/packages/site-kit/src/components/dashboard/SurveyResultsCard.tsx
+++ b/packages/site-kit/src/components/dashboard/SurveyResultsCard.tsx
@@ -1,0 +1,76 @@
+import { Card } from "@optimitron/neobrutalist-ui/ui/card"
+import { MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO } from "@optimitron/data/parameters"
+import type { DashboardSurveyResults } from "../../lib/survey-results"
+
+const answers = [
+  { answer: "YES", label: "Yes", color: "bg-brutal-cyan" },
+  { answer: "NO", label: "No", color: "bg-brutal-pink" },
+  { answer: "ABSTAIN", label: "Not sure", color: "bg-brutal-yellow" },
+] as const
+
+const percent = (value: number) => `${value.toLocaleString("en-US", { maximumFractionDigits: 1 })}%`
+
+function FundingBar({ label, military }: { label: string; military: number }) {
+  const trials = 100 - military
+  return (
+    <div className="space-y-2">
+      <h4 className="font-black">{label}</h4>
+      <div className="flex h-7 overflow-hidden border-2 border-primary" aria-hidden="true">
+        <div className="bg-brutal-cyan" style={{ width: `${trials}%` }} />
+        <div className="bg-brutal-pink" style={{ width: `${military}%` }} />
+      </div>
+      <div className="flex justify-between gap-4 text-sm font-bold">
+        <span>Clinical trials <span className="tabular-nums">{percent(trials)}</span></span>
+        <span className="text-right">Military <span className="tabular-nums">{percent(military)}</span></span>
+      </div>
+    </div>
+  )
+}
+
+export function SurveyResultsCard({ results }: { results: DashboardSurveyResults }) {
+  const ratio = MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO.value
+  return (
+    <Card className="border-4 border-primary bg-background p-5 sm:p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+      <section aria-labelledby="survey-results-heading">
+        <h2 id="survey-results-heading" className="text-2xl sm:text-3xl font-black uppercase mb-6">Survey results</h2>
+        <div className="grid gap-8 lg:grid-cols-3">
+          {results.questions.map(({ slug, title, question, percentages }) => (
+            <div key={slug} className="flex flex-col gap-3">
+              <h3 className="text-lg font-black">{title}</h3>
+              <p className="text-sm font-bold leading-relaxed">{question}</p>
+              {percentages ? (
+                <div className="mt-auto space-y-3 pt-2">
+                  <div className="flex h-7 overflow-hidden border-2 border-primary" aria-hidden="true">
+                    {answers.map(({ answer, color }) => <div key={answer} className={color} style={{ width: `${percentages[answer]}%` }} />)}
+                  </div>
+                  <dl className="grid grid-cols-3 gap-2">
+                    {answers.map(({ answer, label, color }) => (
+                      <div key={answer}>
+                        <dt className="flex items-center gap-1.5 text-xs font-bold">
+                          <span className={`h-2.5 w-2.5 shrink-0 ${color}`} aria-hidden="true" />{label}
+                        </dt>
+                        <dd className="text-xl font-black tabular-nums mt-1">{percent(percentages[answer])}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              ) : <p className="text-sm font-bold text-muted-foreground">Results will appear after a response is saved.</p>}
+            </div>
+          ))}
+        </div>
+        <div className="mt-10">
+          <h3 className="text-lg font-black mb-2">Military or clinical trials?</h3>
+          <p className="text-sm font-bold mb-6">How survey respondents would divide funding between the two.</p>
+          {results.funding.average !== null ? (
+            <div className="grid gap-6 lg:grid-cols-3">
+              <FundingBar label="Average response" military={results.funding.average} />
+              {results.funding.user !== null ? <FundingBar label="Your response" military={results.funding.user} /> : null}
+              <FundingBar label="Current government spending" military={ratio / (ratio + 1) * 100} />
+            </div>
+          ) : <p className="text-sm font-bold text-muted-foreground">Funding results will appear after a response is saved.</p>}
+          {results.funding.median !== null ? <p className="mt-4 text-sm font-bold text-muted-foreground">Median response: {percent(100 - results.funding.median)} to clinical trials.</p> : null}
+        </div>
+      </section>
+    </Card>
+  )
+}

--- a/packages/site-kit/src/components/survey/SurveyDashboardPage.tsx
+++ b/packages/site-kit/src/components/survey/SurveyDashboardPage.tsx
@@ -14,6 +14,12 @@ import { TRIAL_ABUNDANCE_REFERENDUM_QUESTION } from "@optimitron/db/constants"
 import { buildUserReferralUrl } from "../../lib/url"
 import { ReferralLinkCard } from "../shared/ReferralLinkCard"
 import { PendingResponseRecovery } from "./pending-response-recovery"
+import Link from "next/link"
+import { SurveyResultsCard } from "../dashboard/SurveyResultsCard"
+import { getTrialAbundanceSurveyResults } from "../../lib/survey-results.server"
+import { getSurveyResultsVisualFixture } from "../../lib/survey-results-visual"
+import { getSiteConfig } from "../../lib/site-config"
+import { ROUTES } from "../../lib/routes"
 
 export const dynamic = "force-dynamic"
 
@@ -41,7 +47,8 @@ export default async function LiteDashboardPage({
     redirect("/auth/signin?callbackUrl=/dashboard")
   }
 
-  const [vote, selfFundedAccessVote, allocation] = recoveryPreview
+  const [[vote, selfFundedAccessVote, allocation], results] = await Promise.all([
+    recoveryPreview
     ? [null, null, null]
     : visualPreview
     ? [
@@ -49,11 +56,18 @@ export default async function LiteDashboardPage({
         { answer: "ABSTAIN" as const },
         { allocationA: 35, allocationB: 65 },
       ]
-    : await Promise.all([
+    : Promise.all([
         getUserTrialAbundanceVote(sessionUser.id),
         getUserTrialAbundanceSelfFundedAccessVote(sessionUser.id),
         getUserTrialAbundanceAllocation(sessionUser.id),
-      ])
+      ]),
+    visualPreview
+      ? getSurveyResultsVisualFixture("1", !recoveryPreview)!
+      : getTrialAbundanceSurveyResults(sessionUser.id),
+  ])
+  const resultsUrl = getSiteConfig().domain === "trialabundancesurvey.org"
+    ? ROUTES.surveyResults
+    : `https://trialabundancesurvey.org${ROUTES.surveyResults}`
   const headersList = await headers()
   const host = headersList.get("host") ?? "trialabundancesurvey.org"
   const proto = /^(localhost|127\.0\.0\.1)(:|$)/.test(host) ? "http" : "https"
@@ -108,6 +122,11 @@ export default async function LiteDashboardPage({
               </div>
             ) : null}
           </Card>
+
+          <SurveyResultsCard results={results} />
+          <p className="my-6 font-bold">
+            <Link href={resultsUrl} className="underline underline-offset-4">View public survey results</Link>
+          </p>
 
           <ReferralLinkCard
             referralLink={surveyUrl}

--- a/packages/site-kit/src/lib/dashboard-actions.ts
+++ b/packages/site-kit/src/lib/dashboard-actions.ts
@@ -16,7 +16,10 @@ import { getReferralTreeStats } from "@/lib/referral.server"
 import { GLOBAL_COORDINATION_TARGET_PCT, GLOBAL_POPULATION_2024 } from "@/lib/parameters-calculations-citations"
 import { validateUsername } from "@/lib/username"
 import { buildUserInviteReferralUrl } from "@/lib/url"
-import { countTreatyVotes, getUserTreatyVote } from "@/lib/treaty-votes.server"
+import { countTreatyVotes } from "@/lib/treaty-votes.server"
+import { TREATY_REFERENDUM_SLUG } from "@/lib/treaty"
+import { buildOfficialReferendumVoteWhere } from "@/lib/referendum-vote-classification.server"
+import { getDashboardSurveyResults } from "@/lib/survey-results.server"
 import { ensurePersonForUser } from "@/lib/person.server"
 import {
   getUserDisplayAvatar,
@@ -104,7 +107,10 @@ export async function getDashboardData() {
           createdAt: true,
           _count: {
             select: {
-              referendumVotes: true,
+              referendumVotes: { where: {
+                ...buildOfficialReferendumVoteWhere(),
+                referendum: { slug: TREATY_REFERENDUM_SLUG, deletedAt: null },
+              } },
             },
           },
         },
@@ -121,18 +127,11 @@ export async function getDashboardData() {
     referredByUserId: userWithDashboardData.id,
   })
 
-  const organizationVotesCount = userWithDashboardData.createdOrganizations.reduce(
-    (total, org) => total + org._count.referendumVotes,
-    0,
-  )
-
   const shareCount = await prisma.shareAttempt.count({
     where: {
       userId: userWithDashboardData.id,
     },
   })
-
-  const totalImpact = referralCount + organizationVotesCount
 
   const referralTree = await getReferralTreeStats(userWithDashboardData.id, {
     publicRecruitsLimit: 20,
@@ -143,12 +142,12 @@ export async function getDashboardData() {
     orderBy: { createdAt: "desc" },
   })
 
-  const actualReach =
-    shareCount > 0 ? shareCount * 265 : totalImpact * 265
-
-  const rank = await calculateUserRank(totalImpact)
-  const totalVotes = await countTreatyVotes()
-  await getUserTreatyVote(user.id)
+  const [actualReach, rank, totalVotes, surveyResults] = await Promise.all([
+    prisma.referralClick.count({ where: { referrerUserId: user.id, deletedAt: null } }),
+    calculateUserRank(referralCount),
+    countTreatyVotes(),
+    getDashboardSurveyResults(user.id),
+  ])
 
   const enabledProviders = getEnabledProviders()
   const primaryMembership = userWithDashboardData.organizationMemberships[0]
@@ -182,7 +181,7 @@ export async function getDashboardData() {
     },
     stats: {
       referrals: referralCount,
-      shares: shareCount || referralCount * 3,
+      shares: shareCount,
       reach: actualReach,
       rank,
     },
@@ -246,10 +245,7 @@ export async function getDashboardData() {
       current: (totalVotes / GLOBAL_POPULATION_2024.value) * 100,
       target: GLOBAL_COORDINATION_TARGET_PCT.value * 100,
     },
-    allocation: {
-      user: null as number | null,
-      average: 50,
-    },
+    surveyResults,
     organizations: {
       created: userWithDashboardData.createdOrganizations.map((org) => ({
         id: org.id,
@@ -268,7 +264,8 @@ export async function getTopReferrers() {
     by: ["referredByUserId"],
     where: {
       referredByUserId: { not: null },
-      deletedAt: null,
+      ...buildOfficialReferendumVoteWhere(),
+      referendum: { slug: TREATY_REFERENDUM_SLUG, deletedAt: null },
     },
     _count: { _all: true },
     orderBy: { _count: { referredByUserId: "desc" } },

--- a/packages/site-kit/src/lib/nav-items.ts
+++ b/packages/site-kit/src/lib/nav-items.ts
@@ -53,6 +53,15 @@ export interface NavItem {
  * Each variant decides which items to show and how to organize them.
  */
 export const NAV_ITEMS_MAP = {
+  surveyResults: {
+    id: "surveyResults",
+    label: "Survey results",
+    path: ROUTES.surveyResults,
+    description: "Current survey results on patient access, patient-funded clinical trials, and research funding priorities.",
+    canonicalVariant: VARIANTS.SURVEY,
+    allowedVariants: [VARIANTS.SURVEY],
+    useSiteDefaultOg: true,
+  },
   // About section items
   home: {
     id: "home",

--- a/packages/site-kit/src/lib/referral.server.ts
+++ b/packages/site-kit/src/lib/referral.server.ts
@@ -2,6 +2,7 @@ import { prisma } from "./prisma"
 import { resolveUsernameAlias } from "./user"
 import { countTreatyVotes } from "./treaty-votes.server"
 import { TREATY_REFERENDUM_SLUG } from "./treaty"
+import { buildOfficialReferendumVoteWhere } from "./referendum-vote-classification.server"
 
 /**
  * Finds a user by Person.handle or referral code.
@@ -106,6 +107,8 @@ export async function getReferralTreeStats(
       WHERE v."referredByUserId" = ${userId}
         AND v."referendumId" = ${referendumId}
         AND v."deletedAt" IS NULL
+        AND v."voteSource" = 'SELF'
+        AND EXISTS (SELECT 1 FROM "Person" p WHERE p."id" = v."personId" AND p."deletedAt" IS NULL AND p."lifeStatus" = 'LIVING')
 
       UNION ALL
 
@@ -114,6 +117,8 @@ export async function getReferralTreeStats(
       INNER JOIN tree t ON v."referredByUserId" = t.voter_id
       WHERE v."referendumId" = ${referendumId}
         AND v."deletedAt" IS NULL
+        AND v."voteSource" = 'SELF'
+        AND EXISTS (SELECT 1 FROM "Person" p WHERE p."id" = v."personId" AND p."deletedAt" IS NULL AND p."lifeStatus" = 'LIVING')
         AND t.depth < 20
         AND NOT (v."userId" = ANY(t.visited))
     )
@@ -128,8 +133,7 @@ export async function getReferralTreeStats(
   const publicRecruits = await prisma.referendumVote.findMany({
     where: {
       referredByUserId: userId,
-      referendumId,
-      deletedAt: null,
+      ...buildOfficialReferendumVoteWhere({ referendumId }),
       user: {
         person: {
           OR: [{ isPublic: true }, { handle: { not: null } }],

--- a/packages/site-kit/src/lib/routes.ts
+++ b/packages/site-kit/src/lib/routes.ts
@@ -36,6 +36,7 @@ export const ROUTES = {
   // Research / Evidence
   impact: '/impact',
   research: '/research',
+  surveyResults: '/results',
   references: '/references',
 
   // Universal Right to Try education

--- a/packages/site-kit/src/lib/site-config.ts
+++ b/packages/site-kit/src/lib/site-config.ts
@@ -1214,7 +1214,7 @@ const siteConfigs: Record<SiteVariant, SiteConfig> = {
     },
 
     // Navigation - Ultra-minimal for nervous nonprofits
-    topLevelNavItems: ["vote", "faq"],
+    topLevelNavItems: ["vote", "surveyResults", "faq"],
     sidebarSections: [], // No sidebar sections - keep it simple
 
     footerBranding: {

--- a/packages/site-kit/src/lib/survey-results-visual.ts
+++ b/packages/site-kit/src/lib/survey-results-visual.ts
@@ -1,0 +1,31 @@
+import {
+  TRIAL_ABUNDANCE_REFERENDUM_QUESTION,
+  TRIAL_ABUNDANCE_REFERENDUM_SLUG,
+  TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_QUESTION,
+  TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_SLUG,
+} from "@optimitron/db/constants"
+import type { DashboardSurveyResults } from "./survey-results"
+
+/** Explicit layout previews; production requests always use the database. */
+export function getSurveyResultsVisualFixture(visual?: string, personal = false): DashboardSurveyResults | undefined {
+  if (process.env.NODE_ENV !== "development" && process.env.SITE_APP_VISUAL_FIXTURES !== "1") return undefined
+  if (visual !== "1" && visual !== "empty") return undefined
+  const empty = visual === "empty"
+  return {
+    questions: [
+      {
+        slug: TRIAL_ABUNDANCE_REFERENDUM_SLUG,
+        title: "Patient access",
+        question: TRIAL_ABUNDANCE_REFERENDUM_QUESTION,
+        percentages: empty ? null : { YES: 75, NO: 15, ABSTAIN: 10 },
+      },
+      {
+        slug: TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_SLUG,
+        title: "Patient-funded access",
+        question: TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_QUESTION,
+        percentages: empty ? null : { YES: 60, NO: 25, ABSTAIN: 15 },
+      },
+    ],
+    funding: { user: personal && !empty ? 35 : null, average: empty ? null : 30, median: empty ? null : 25 },
+  }
+}

--- a/packages/site-kit/src/lib/survey-results.server.ts
+++ b/packages/site-kit/src/lib/survey-results.server.ts
@@ -19,7 +19,15 @@ const questions = [
 ]
 
 export async function getDashboardSurveyResults(userId: string): Promise<DashboardSurveyResults> {
-  const slugs = questions.map(question => question.slug)
+  return getSurveyResults(questions, userId)
+}
+
+export async function getTrialAbundanceSurveyResults(userId?: string): Promise<DashboardSurveyResults> {
+  return getSurveyResults(questions.filter(question => question.slug !== TREATY_REFERENDUM_SLUG), userId)
+}
+
+async function getSurveyResults(selectedQuestions: typeof questions, userId?: string): Promise<DashboardSurveyResults> {
+  const slugs = selectedQuestions.map(question => question.slug)
   const [referendums, votes, allocations] = await Promise.all([
     prisma.referendum.findMany({
       where: { slug: { in: slugs }, deletedAt: null },
@@ -46,7 +54,7 @@ export async function getDashboardSurveyResults(userId: string): Promise<Dashboa
     }),
   ])
   return {
-    questions: questions.flatMap(question => {
+    questions: selectedQuestions.flatMap(question => {
       const referendum = referendums.find(item => item.slug === question.slug)
       return referendum ? [{
         ...question,

--- a/packages/site-kit/src/lib/survey-results.server.ts
+++ b/packages/site-kit/src/lib/survey-results.server.ts
@@ -1,0 +1,59 @@
+import "server-only"
+import {
+  TREATY_REFERENDUM_SLUG,
+  TRIAL_ABUNDANCE_REFERENDUM_SLUG,
+  TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_SLUG,
+} from "@optimitron/db/constants"
+import { prisma } from "./prisma"
+import { buildOfficialReferendumVoteWhere } from "./referendum-vote-classification.server"
+import {
+  MILITARY_ALLOCATION_ITEM_ID, TRIALS_ALLOCATION_ITEM_ID,
+  summarizeFundingAllocations, summarizeVotePercentages,
+} from "./survey-results"
+import type { DashboardSurveyResults } from "./survey-results"
+
+const questions = [
+  { slug: TREATY_REFERENDUM_SLUG, title: "The 1% Treaty" },
+  { slug: TRIAL_ABUNDANCE_REFERENDUM_SLUG, title: "Patient access" },
+  { slug: TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_SLUG, title: "Patient-funded access" },
+]
+
+export async function getDashboardSurveyResults(userId: string): Promise<DashboardSurveyResults> {
+  const slugs = questions.map(question => question.slug)
+  const [referendums, votes, allocations] = await Promise.all([
+    prisma.referendum.findMany({
+      where: { slug: { in: slugs }, deletedAt: null },
+      select: { id: true, slug: true, question: true },
+    }),
+    prisma.referendumVote.groupBy({
+      by: ["referendumId", "answer"],
+      where: {
+        ...buildOfficialReferendumVoteWhere(),
+        referendum: { slug: { in: slugs }, deletedAt: null },
+      },
+      _count: { _all: true },
+    }),
+    prisma.wishocraticAllocation.findMany({
+      where: {
+        deletedAt: null,
+        user: { deletedAt: null },
+        OR: [
+          { itemAId: MILITARY_ALLOCATION_ITEM_ID, itemBId: TRIALS_ALLOCATION_ITEM_ID },
+          { itemAId: TRIALS_ALLOCATION_ITEM_ID, itemBId: MILITARY_ALLOCATION_ITEM_ID },
+        ],
+      },
+      select: { userId: true, itemAId: true, itemBId: true, allocationA: true, allocationB: true, updatedAt: true },
+    }),
+  ])
+  return {
+    questions: questions.flatMap(question => {
+      const referendum = referendums.find(item => item.slug === question.slug)
+      return referendum ? [{
+        ...question,
+        question: referendum.question,
+        percentages: summarizeVotePercentages(votes.filter(vote => vote.referendumId === referendum.id)),
+      }] : []
+    }),
+    funding: summarizeFundingAllocations(allocations, userId),
+  }
+}

--- a/packages/site-kit/src/lib/survey-results.ts
+++ b/packages/site-kit/src/lib/survey-results.ts
@@ -19,7 +19,7 @@ export function summarizeFundingAllocations(allocations: {
   allocationA: number
   allocationB: number
   updatedAt: Date
-}[], userId: string) {
+}[], userId?: string) {
   const latest = new Map<string, { military: number; updatedAt: Date }>()
   for (const allocation of allocations) {
     const forward = allocation.itemAId === MILITARY_ALLOCATION_ITEM_ID && allocation.itemBId === TRIALS_ALLOCATION_ITEM_ID
@@ -35,7 +35,7 @@ export function summarizeFundingAllocations(allocations: {
   const values = [...latest.values()].map(value => value.military).sort((a, b) => a - b)
   const middle = Math.floor(values.length / 2)
   return {
-    user: latest.get(userId)?.military ?? null,
+    user: userId ? latest.get(userId)?.military ?? null : null,
     average: values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : null,
     median: values.length ? (values[middle]! + values[Math.floor((values.length - 1) / 2)]!) / 2 : null,
   }

--- a/packages/site-kit/src/lib/survey-results.ts
+++ b/packages/site-kit/src/lib/survey-results.ts
@@ -1,0 +1,48 @@
+import type { VotePosition } from "@optimitron/db"
+
+export function summarizeVotePercentages(groups: { answer: VotePosition; _count: { _all: number } }[]) {
+  const total = groups.reduce((sum, group) => sum + group._count._all, 0)
+  if (total === 0) return null
+  return groups.reduce((result, group) => {
+    result[group.answer] += group._count._all / total * 100
+    return result
+  }, { YES: 0, NO: 0, ABSTAIN: 0 })
+}
+
+export const MILITARY_ALLOCATION_ITEM_ID = "MILITARY_OPERATIONS"
+export const TRIALS_ALLOCATION_ITEM_ID = "PRAGMATIC_CLINICAL_TRIALS"
+
+export function summarizeFundingAllocations(allocations: {
+  userId: string
+  itemAId: string
+  itemBId: string
+  allocationA: number
+  allocationB: number
+  updatedAt: Date
+}[], userId: string) {
+  const latest = new Map<string, { military: number; updatedAt: Date }>()
+  for (const allocation of allocations) {
+    const forward = allocation.itemAId === MILITARY_ALLOCATION_ITEM_ID && allocation.itemBId === TRIALS_ALLOCATION_ITEM_ID
+    const reverse = allocation.itemBId === MILITARY_ALLOCATION_ITEM_ID && allocation.itemAId === TRIALS_ALLOCATION_ITEM_ID
+    if (!forward && !reverse) continue
+    const military = forward ? allocation.allocationA : allocation.allocationB
+    if (!Number.isFinite(military) || military < 0 || military > 100 || allocation.allocationA + allocation.allocationB !== 100) continue
+    const previous = latest.get(allocation.userId)
+    if (!previous || allocation.updatedAt > previous.updatedAt) {
+      latest.set(allocation.userId, { military, updatedAt: allocation.updatedAt })
+    }
+  }
+  const values = [...latest.values()].map(value => value.military).sort((a, b) => a - b)
+  const middle = Math.floor(values.length / 2)
+  return {
+    user: latest.get(userId)?.military ?? null,
+    average: values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : null,
+    median: values.length ? (values[middle]! + values[Math.floor((values.length - 1) / 2)]!) / 2 : null,
+  }
+}
+
+export type SurveyVotePercentages = NonNullable<ReturnType<typeof summarizeVotePercentages>>
+export interface DashboardSurveyResults {
+  questions: { slug: string; title: string; question: string; percentages: SurveyVotePercentages | null }[]
+  funding: ReturnType<typeof summarizeFundingAllocations>
+}

--- a/packages/site-kit/src/lib/treaty-votes.server.ts
+++ b/packages/site-kit/src/lib/treaty-votes.server.ts
@@ -6,6 +6,7 @@ import {
 import { prisma } from "./prisma"
 import { ensurePersonForUser } from "./person.server"
 import { TREATY_REFERENDUM_SLUG } from "./treaty"
+import { buildOfficialReferendumVoteWhere } from "./referendum-vote-classification.server"
 
 export async function getTreatyReferendum() {
   const referendum = await prisma.referendum.findUnique({
@@ -48,9 +49,7 @@ export async function countTreatyVotes(where: {
 
   return prisma.referendumVote.count({
     where: {
-      referendumId: referendum.id,
-      deletedAt: null,
-      voteSource: ReferendumVoteSource.SELF,
+      ...buildOfficialReferendumVoteWhere({ referendumId: referendum.id }),
       ...(where.referredByUserId
         ? { referredByUserId: where.referredByUserId }
         : {}),

--- a/packages/site-kit/src/lib/user.ts
+++ b/packages/site-kit/src/lib/user.ts
@@ -93,6 +93,8 @@ export async function calculateUserRank(referralCount: number): Promise<number> 
           ON v."referredByUserId" = u."id"
           AND v."referendumId" = r."id"
           AND v."deletedAt" IS NULL
+          AND v."voteSource" = 'SELF'
+          AND EXISTS (SELECT 1 FROM "Person" p WHERE p."id" = v."personId" AND p."deletedAt" IS NULL AND p."lifeStatus" = 'LIVING')
         GROUP BY u."id"
         HAVING COUNT(v."id") > ${referralCount}
       ) subquery
@@ -106,6 +108,8 @@ export async function calculateUserRank(referralCount: number): Promise<number> 
     FROM "ReferendumVote" v
     INNER JOIN "Referendum" r ON r."id" = v."referendumId" AND r."slug" = ${TREATY_REFERENDUM_SLUG}
     WHERE v."referredByUserId" IS NOT NULL AND v."deletedAt" IS NULL
+      AND v."voteSource" = 'SELF'
+      AND EXISTS (SELECT 1 FROM "Person" p WHERE p."id" = v."personId" AND p."deletedAt" IS NULL AND p."lifeStatus" = 'LIVING')
   `
   return Number(usersWithReferrals[0]?.count ?? 0) + 1
 }

--- a/packages/site-kit/src/lib/user.ts
+++ b/packages/site-kit/src/lib/user.ts
@@ -2,6 +2,7 @@ import "server-only"
 import type { Prisma } from "@optimitron/db"
 import { prisma } from "./prisma"
 import { TREATY_REFERENDUM_SLUG } from "./treaty"
+import { buildOfficialReferendumVoteWhere } from "./referendum-vote-classification.server"
 
 export type PublicProfileLink = {
   id: string
@@ -159,7 +160,7 @@ export async function getPublicUserProfile(handleOrUsername: string) {
   const referralCount = await prisma.referendumVote.count({
     where: {
       referredByUserId: user.id,
-      deletedAt: null,
+      ...buildOfficialReferendumVoteWhere(),
       referendum: { slug: TREATY_REFERENDUM_SLUG },
     },
   })

--- a/packages/site-kit/src/types/dashboard.ts
+++ b/packages/site-kit/src/types/dashboard.ts
@@ -1,4 +1,5 @@
 import type { EnabledProviders } from "@/lib/auth-utils"
+import type { DashboardSurveyResults } from "../lib/survey-results"
 
 export interface DashboardUser {
   id: string
@@ -68,11 +69,6 @@ export interface DashboardOrganizations {
   created: DashboardOrganization[]
 }
 
-export interface DashboardAllocation {
-  user: number | null
-  average: number
-}
-
 export interface DashboardPublicRecruit {
   id: string
   name: string | null
@@ -116,7 +112,7 @@ export interface DashboardData {
   enabledProviders: EnabledProviders
   activities: DashboardActivity[]
   globalProgress: DashboardProgress
-  allocation: DashboardAllocation
+  surveyResults: DashboardSurveyResults
   organizations: DashboardOrganizations
 }
 
@@ -127,4 +123,3 @@ export interface LeaderboardEntry {
   image: string | null
   referrals: number
 }
-

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -7,6 +7,12 @@ const campaignPlanPageFile =
   "packages/site-kit/src/components/campaign-plan-page.tsx";
 const researchPageFile =
   "packages/site-kit/src/components/research-page.tsx";
+const surveyResultsFiles = [
+  "packages/site-kit/src/components/dashboard/SurveyResultsCard.tsx",
+  "packages/site-kit/src/lib/survey-results.ts",
+  "packages/site-kit/src/lib/survey-results.server.ts",
+  "packages/site-kit/src/lib/survey-results-visual.ts",
+];
 const dfdaHowItWorksFiles = [
   "packages/site-kit/src/components/how-it-works/DfdaUserWorkflows.tsx",
   "packages/site-kit/src/components/how-it-works/HowItWorksStep.tsx",
@@ -680,6 +686,27 @@ export const publicSiteAppRoutes = Object.freeze({
       sourcePage: "apps/trialabundancesurvey/app/research/page.tsx",
     },
     {
+      covers: ["apps/trialabundancesurvey/app/results/page.tsx", ...surveyResultsFiles],
+      label: "Public survey results",
+      routeName: "results",
+      routePath: "/results",
+      sourcePage: "apps/trialabundancesurvey/app/results/page.tsx",
+    },
+    {
+      covers: ["apps/trialabundancesurvey/app/results/page.tsx", ...surveyResultsFiles],
+      label: "Survey results — populated preview",
+      routeName: "results-preview",
+      routePath: "/results?visual=1",
+      sourcePage: "apps/trialabundancesurvey/app/results/page.tsx",
+    },
+    {
+      covers: ["apps/trialabundancesurvey/app/results/page.tsx", ...surveyResultsFiles],
+      label: "Survey results — no saved answers",
+      routeName: "results-empty-preview",
+      routePath: "/results?visual=empty",
+      sourcePage: "apps/trialabundancesurvey/app/results/page.tsx",
+    },
+    {
       covers: ["apps/trialabundancesurvey/app/contact/page.tsx"],
       label: "Contact",
       routeName: "contact",
@@ -1073,6 +1100,10 @@ export function getSiteAppScreenshotRoutes(appName, siteVariant) {
         ...(routeName.startsWith("dashboard") ? { authenticated: true, authRole: "user" } : {}),
         covers: [
           `packages/site-kit/src/components/${component}`,
+          ...(routeName.startsWith("dashboard") ? [
+            "packages/site-kit/src/components/survey/SurveyDashboardPage.tsx",
+            ...surveyResultsFiles,
+          ] : []),
           ...(routeName === "auth-error" ? [
             "packages/site-kit/src/components/auth/SurveyAuthErrorContent.tsx",
             `apps/${appName}/app/auth/error/error-content.tsx`,

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -233,6 +233,8 @@ export const authenticatedSiteAppRoutes = Object.freeze({
       authRole: "user",
       covers: [
         "apps/trialabundancesurvey/app/dashboard/page.tsx",
+        "packages/site-kit/src/components/survey/SurveyDashboardPage.tsx",
+        ...surveyResultsFiles,
         "packages/site-kit/src/components/shared/ReferralLinkCard.tsx",
         "packages/site-kit/src/lib/trial-abundance-votes.server.ts",
       ],
@@ -261,6 +263,7 @@ export const authenticatedSiteAppRoutes = Object.freeze({
       covers: [
         "apps/acceleratedmedicine/app/dashboard/page.tsx",
         "packages/site-kit/src/components/survey/SurveyDashboardPage.tsx",
+        ...surveyResultsFiles,
       ],
       label: "Survey dashboard — signed-in user",
       routeName: "dashboard-authenticated",

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -62,6 +62,9 @@ function getCampaignHomeFiles(appName) {
 
 const warOnDiseaseDashboardFiles = [
   "packages/site-kit/src/components/dashboard/DashboardClient.tsx",
+  "packages/site-kit/src/components/dashboard/SurveyResultsCard.tsx",
+  "packages/site-kit/src/lib/survey-results.ts",
+  "packages/site-kit/src/lib/survey-results.server.ts",
   "packages/site-kit/src/components/dashboard/StatsOverview.tsx",
   "packages/site-kit/src/components/dashboard/ProfileCard.tsx",
   "packages/site-kit/src/components/dashboard/ReferralGoalCard.tsx",


### PR DESCRIPTION
Survey answers were saved, but the War on Disease dashboard showed no aggregate results and Trial Abundance showed only each participant's answers. This adds a public Trial Abundance `/results` page, links from its homepage and menu, and aggregate results in the Trial Abundance and Accelerated Medicine participant dashboards. War on Disease also shows the treaty question.

Results use Yes, No, and Not sure percentages, plus the funding average and median. Participant dashboards compare the person's saved funding answer with the aggregate and the existing government-spending parameter. Public results contain no personal answer. No response counts or survey-stage disclaimer appear. Empty results stay empty. The server returns percentages without respondent identities or counts.

The War on Disease dashboard also gains these fixes:
- Invitation reminders and declines use accepted API statuses and show save failures. Copy timestamps persist. A submitted vote confirms an invitation automatically; the API rejects manual conversion.
- Share totals use recorded share attempts. Referral-link visits replace the invented reach multiplier.
- Leaderboard, rank, organization totals, referral tree, and public-profile totals use the same official treaty-vote scope.

Local validation: 84 War on Disease tests, 38 Trial Abundance tests, 37 Accelerated Medicine tests, all 19 navigation/coverage checks, affected app typechecks, and Trial Abundance lint pass. Regression coverage includes anonymous funding summaries and rejection of production query parameters that request fixture data. Database types and schema are unchanged.

Desktop and mobile screenshots were captured and inspected locally for the homepage, menu, public results, empty results, participant dashboards, response-recovery state, campaign dashboard, and invitation failures. Fixed layout fixtures keep comparisons stable. Stale built question constants, incomplete hydration, development controls, and scroll-position noise were corrected before capture. The generated homepage copy diff contains only the new results link. Screenshot artifacts are excluded from this PR.

All required checks pass on `f457904c9bd6`, including all seven site-app builds and browser checks, web E2E, static validation, core validation, and visual-review coverage. Anonymous `/results` and the signed-in Trial Abundance dashboard render against seeded CI PostgreSQL. Those screenshots were inspected. Local PostgreSQL stalls prevented a local database-backed render. Preview deployments require Vercel sign-in.

The broad CI gallery also reports two unrelated baseline differences on unchanged routes: the leaders page's elapsed-day counters advanced one day, and the external manual search index returned a different result. Source diffs confirm neither page nor its data loader changed in this PR. The focused local before/after review contains the feature changes. These live-input differences remain visible in the broad CI gallery.

Review pages:
- [War on Disease dashboard](https://warondisease-git-feature-warondise-24a934-mike-p-sinns-projects.vercel.app/dashboard?login=demo)
- [Public-profile referral total](https://warondisease-git-feature-warondise-24a934-mike-p-sinns-projects.vercel.app/u/demo?login=demo)
- [Accelerated Medicine dashboard](https://acceleratedmedicine-git-feature-wa-c373db-mike-p-sinns-projects.vercel.app/dashboard?login=demo)
- Trial Abundance: `/results?logout=1`, `/?logout=1`, `/dashboard?login=demo`. Its existing Vercel configuration disables previews for this branch. Local and CI screenshots cover these routes; the production domain updates after merge.

- [ ] Review the percentage displays and public results links.
- [ ] Review the campaign invitation controls and referral totals.
