### PR TITLE
Update campaign and survey navigation

### DIFF
--- a/apps/trialabundancesurvey/app/page.logged-out.md
+++ b/apps/trialabundancesurvey/app/page.logged-out.md
@@ -21,7 +21,6 @@
 - YES
 - NOT SURE
 - NO
-- [View current survey results](/results)
 - AN INDEPENDENT RESEARCH INITIATIVE
 #### ABOUT
 - [ABOUT](/about)

--- a/apps/trialabundancesurvey/app/page.tsx
+++ b/apps/trialabundancesurvey/app/page.tsx
@@ -1,8 +1,6 @@
 import Layout from "../components/layout"
 import TrialAbundanceSurveySection from "@/components/landing/trial-abundance-survey-section"
 import { parseTrialAbundanceVisualState } from "@optimitron/site-kit/lib/trial-abundance-visual"
-import Link from "next/link"
-import { ROUTES } from "@optimitron/site-kit/lib/routes"
 
 interface HomePageProps {
   searchParams?: Promise<{ visual?: string }>
@@ -22,9 +20,6 @@ export default async function HomePage({ searchParams }: HomePageProps) {
         disableIntroAnimation={Boolean(visualState)}
         visualState={visualState}
       />
-      <p className="px-6 py-8 text-center font-bold">
-        <Link href={ROUTES.surveyResults} className="underline underline-offset-4">View current survey results</Link>
-      </p>
     </Layout>
   )
 }

--- a/packages/site-kit/src/lib/nav-items.ts
+++ b/packages/site-kit/src/lib/nav-items.ts
@@ -151,7 +151,7 @@ export const NAV_ITEMS_MAP = {
   },
   employees: {
     id: "employees",
-    label: "Remind Presidents",
+    label: "President Management System",
     path: ROUTES.employees,
     description:
       "See which presidents are late and remind them to sign the 1% Treaty",

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -88,7 +88,11 @@ function getAuthenticatedMenuRoute(appName) {
     authenticated: true,
     authRole: "user",
     captureSelector: '[role="dialog"]',
-    covers: [sourcePage, "packages/site-kit/src/components/layout.tsx"],
+    covers: [
+      sourcePage,
+      "packages/site-kit/src/components/layout.tsx",
+      "packages/site-kit/src/lib/nav-items.ts",
+    ],
     label: "Navigation menu — signed-in user",
     openMenu: true,
     routeName: "navigation-menu-authenticated",


### PR DESCRIPTION
Rename the War on Disease menu entry from “Remind Presidents” to “President Management System.” The shared footer entry uses the same label and still links to `/employees`.

Remove the “View current survey results” link and its spacing below the Trial Abundance homepage survey. Regenerate the homepage copy snapshot from the rendered page.

Validation: Trial Abundance homepage ESLint, both affected app typechecks, all 19 navigation/coverage checks, and `git diff --check` pass. Menu review coverage now includes the navigation label source. Desktop and mobile before/after screenshots were captured and inspected locally. The longer menu label wraps cleanly. The survey is followed directly by the footer. Fixed survey state, clock, fonts, and hydration kept the comparison stable. Footer viewport captures corrected a fixed-header overlap in full-element screenshots. Screenshot artifacts are excluded from this PR.

CI verification: all checks pass on f83c1eda0. Trial Abundance initially failed while GitHub finalized its screenshot artifact (HTTP 403), after its build and all 12 browser tests passed. A targeted retry and the dependent checks succeeded. The hosted visual review has complete coverage, with no missing screenshots or capture errors. No source changes were required for this CI failure.

Review routes:
- [War on Disease shared menu and footer](https://warondisease-git-feature-warondise-24a934-mike-p-sinns-projects.vercel.app/contact?logout=1). Open the menu to inspect the renamed entry.
- Trial Abundance `/?logout=1` (local screenshot state `/?visual=question`). This branch's existing Vercel configuration disables Trial Abundance previews; the CI visual review supplies the route screenshots.

- [ ] Review the President Management System label.
- [ ] Review the homepage link removal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the “View current survey results” link from the Trial Abundance Survey home page for both logged-in and logged-out visitors.
  * Updated the navigation label from “Remind Presidents” to “President Management System.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->