### PR TITLE
Improve survey results navigation and dashboard sharing

### DIFF
--- a/apps/trialabundancesurvey/app/page.logged-out.md
+++ b/apps/trialabundancesurvey/app/page.logged-out.md
@@ -25,6 +25,7 @@
 #### ABOUT
 - [ABOUT](/about)
 - [RESEARCH & EVIDENCE](/research)
+- [SURVEY RESULTS](/results)
 - [FAQ](/faq)
 #### CONTACT
 - [hello@trialabundancesurvey.org](mailto:hello@trialabundancesurvey.org)

--- a/apps/trialabundancesurvey/app/page.tsx
+++ b/apps/trialabundancesurvey/app/page.tsx
@@ -1,6 +1,7 @@
 import Layout from "../components/layout"
 import TrialAbundanceSurveySection from "@/components/landing/trial-abundance-survey-section"
 import { parseTrialAbundanceVisualState } from "@optimitron/site-kit/lib/trial-abundance-visual"
+import { ROUTES } from "@optimitron/site-kit/lib/routes"
 
 interface HomePageProps {
   searchParams?: Promise<{ visual?: string }>
@@ -19,6 +20,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
       <TrialAbundanceSurveySection
         disableIntroAnimation={Boolean(visualState)}
         visualState={visualState}
+        resultsHref={ROUTES.surveyResults}
       />
     </Layout>
   )

--- a/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
+++ b/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
@@ -144,10 +144,14 @@ test("an authenticated response stays in the browser after a failed save and ret
   await expect(page.getByText("We could not save your response. Your answers are still in this browser.")).toBeVisible()
   expect(await savedSubmissions(email)).toHaveLength(0)
   await expect(page.getByRole("button", { name: "COPY SURVEY LINK", exact: true })).toHaveCount(0)
+  await expect(page.getByRole("link", { name: "View survey results", exact: true })).toHaveCount(0)
   await capture(page, "survey-save-retry")
   await page.getByRole("button", { name: "Retry save", exact: true }).click()
   await expect(page.getByRole("button", { name: "COPY SURVEY LINK", exact: true })).toBeVisible()
   expect(await savedSubmissions(email)).toHaveLength(1)
+  if (AUTH_E2E_APP === "trialabundancesurvey") {
+    await expect(page.getByRole("link", { name: "View survey results", exact: true })).toHaveAttribute("href", "/results")
+  }
   await page.reload()
   expect(await savedSubmissions(email)).toHaveLength(1)
 })

--- a/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
+++ b/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
@@ -149,7 +149,7 @@ test("an authenticated response stays in the browser after a failed save and ret
   await page.getByRole("button", { name: "Retry save", exact: true }).click()
   await expect(page.getByRole("button", { name: "COPY SURVEY LINK", exact: true })).toBeVisible()
   expect(await savedSubmissions(email)).toHaveLength(1)
-  if (AUTH_E2E_APP === "trialabundancesurvey") {
+  if (process.env.AUTH_E2E_APP === "trialabundancesurvey") {
     await expect(page.getByRole("link", { name: "View survey results", exact: true })).toHaveAttribute("href", "/results")
   }
   await page.reload()

--- a/apps/trialabundancesurvey/tests/unit/pending-response-recovery.test.tsx
+++ b/apps/trialabundancesurvey/tests/unit/pending-response-recovery.test.tsx
@@ -42,12 +42,15 @@ describe("pending Trial Abundance response recovery", () => {
     })
     syncPendingTrialAbundanceResponse.mockResolvedValue(true)
 
-    render(<PendingResponseRecovery />)
+    const { rerender } = render(<PendingResponseRecovery />)
 
     expect(
       screen.getByText("Saving the response from this browser…"),
     ).toBeInTheDocument()
     await waitFor(() => expect(refresh).toHaveBeenCalledOnce())
+    expect(screen.getByText("Response saved. Loading it now…")).toBeInTheDocument()
+    rerender(<PendingResponseRecovery hasRecordedResponse />)
+    expect(screen.queryByText("Response saved. Loading it now…")).not.toBeInTheDocument()
     expect(
       screen.queryByText(/No response on file yet/u),
     ).not.toBeInTheDocument()
@@ -74,7 +77,7 @@ describe("pending Trial Abundance response recovery", () => {
       .mockResolvedValueOnce(false)
       .mockResolvedValueOnce(true)
 
-    render(<PendingResponseRecovery />)
+    render(<PendingResponseRecovery hasRecordedResponse />)
 
     const retry = await screen.findByRole("button", { name: "Retry save" })
     expect(screen.getByText(/still saved in this browser/u)).toBeInTheDocument()

--- a/apps/trialabundancesurvey/tests/unit/survey-results-visual.test.ts
+++ b/apps/trialabundancesurvey/tests/unit/survey-results-visual.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { getSurveyResultsVisualFixture } from "@optimitron/site-kit/lib/survey-results-visual"
+import { parseTrialAbundanceVisualState } from "@optimitron/site-kit/lib/trial-abundance-visual"
 
 afterEach(() => vi.unstubAllEnvs())
 
@@ -9,6 +10,7 @@ describe("survey results previews", () => {
     vi.stubEnv("SITE_APP_VISUAL_FIXTURES", "")
     expect(getSurveyResultsVisualFixture("1")).toBeUndefined()
     expect(getSurveyResultsVisualFixture("empty")).toBeUndefined()
+    expect(parseTrialAbundanceVisualState("saved")).toBeUndefined()
   })
 
   it("keeps ordinary development requests on real data", () => {

--- a/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
+++ b/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
@@ -12,6 +12,7 @@ import confetti from "canvas-confetti"
 import { AnimatePresence, motion } from "framer-motion"
 import { CheckSquare, Square } from "lucide-react"
 import { useSession } from "next-auth/react"
+import Link from "next/link"
 import { useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
@@ -47,6 +48,7 @@ interface TrialAbundanceSurveySectionProps {
   headingAs?: "h1" | "h2"
   title?: string
   description?: string
+  resultsHref?: string
 }
 
 const answerOptions: Array<{
@@ -111,6 +113,7 @@ export default function TrialAbundanceSurveySection({
   headingAs: Heading = "h1",
   title,
   description,
+  resultsHref,
 }: TrialAbundanceSurveySectionProps) {
   const { data: session, status } = useSession()
   const searchParams = useSearchParams()
@@ -455,6 +458,11 @@ export default function TrialAbundanceSurveySection({
             {saveStatus === "saved" && session?.user ? (
               <>
                 <StepHeading className="sr-only">Survey complete</StepHeading>
+                {resultsHref ? (
+                  <Link href={resultsHref} className="block text-center font-bold underline underline-offset-4">
+                    View survey results
+                  </Link>
+                ) : null}
                 <ReferralLinkCard
                   referralLink={shareUrl}
                   shareTemplates={shareTemplates}

--- a/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
+++ b/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
@@ -86,7 +86,7 @@ function getInitialStage(
   if (visualState === "allocation") return "allocation"
   if (visualState === "details") return "details"
   if (visualState === "save-error") return "complete"
-  if (visualState === "complete") return "complete"
+  if (visualState === "complete" || visualState === "saved") return "complete"
   return "patient-access"
 }
 
@@ -144,7 +144,7 @@ export default function TrialAbundanceSurveySection({
   const saveInFlight = useRef(false)
   const [participantError, setParticipantError] = useState<string | null>(null)
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">(
-    visualState === "save-error" ? "error" : "idle",
+    visualState === "save-error" ? "error" : visualState === "saved" ? "saved" : "idle",
   )
 
   const saveResponse = useCallback(async () => {

--- a/packages/site-kit/src/components/shared/ReferralLinkCard.tsx
+++ b/packages/site-kit/src/components/shared/ReferralLinkCard.tsx
@@ -97,7 +97,7 @@ export function ReferralLinkCard({
 
           <div className="mb-3 border-4 border-primary bg-brutal-yellow/10 p-4">
             <p className="text-xs font-black uppercase text-muted-foreground mb-2">Share Text</p>
-            <p className="text-sm text-foreground/80 whitespace-pre-wrap">{selectedTemplate.text}</p>
+            <p className="text-sm text-foreground/80 whitespace-pre-wrap [overflow-wrap:anywhere]">{selectedTemplate.text}</p>
           </div>
 
           <Button

--- a/packages/site-kit/src/components/survey/pending-response-recovery.tsx
+++ b/packages/site-kit/src/components/survey/pending-response-recovery.tsx
@@ -53,6 +53,8 @@ export function PendingResponseRecovery({
   }
 
   if (state === "saved") {
+    if (hasRecordedResponse) return null
+
     return (
       <p className="text-lg font-bold" aria-live="polite">
         Response saved. Loading it now…

--- a/packages/site-kit/src/lib/site-config.ts
+++ b/packages/site-kit/src/lib/site-config.ts
@@ -1225,7 +1225,7 @@ const siteConfigs: Record<SiteVariant, SiteConfig> = {
       {
         id: "about",
         label: "ABOUT",
-        items: ["about", "research", "faq"],
+        items: ["about", "research", "surveyResults", "faq"],
       },
     ],
     contactInfo: {

--- a/packages/site-kit/src/lib/trial-abundance-visual.ts
+++ b/packages/site-kit/src/lib/trial-abundance-visual.ts
@@ -4,9 +4,14 @@ export type TrialAbundanceVisualState =
   | "allocation"
   | "details"
   | "complete"
+  | "saved"
   | "save-error"
 
 export function parseTrialAbundanceVisualState(value?: string): TrialAbundanceVisualState | undefined {
+  if (value === "saved") {
+    return process.env.NODE_ENV === "development" || process.env.SITE_APP_VISUAL_FIXTURES === "1"
+      ? "saved" : undefined
+  }
   return value === "question" || value === "self-funded" || value === "allocation" ||
     value === "details" || value === "complete" || value === "save-error" ? value : undefined
 }

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -1098,6 +1098,18 @@ export function getSiteAppScreenshotRoutes(appName, siteVariant) {
         surveyComponent,
       ],
     });
+    if (siteVariant === VARIANTS.SURVEY) routes.push({
+      authenticated: true,
+      authRole: "user",
+      label: "Saved response and results link",
+      routeName: "home-saved",
+      routePath: "/?visual=saved",
+      covers: [
+        surveyComponent,
+        "packages/site-kit/src/lib/trial-abundance-visual.ts",
+        "packages/site-kit/src/components/shared/ReferralLinkCard.tsx",
+      ],
+    });
     for (const [routeName, routePath, component] of [
       ["auth-signin", "/auth/signin", "auth/SurveySignInPage.tsx"],
       ["auth-error", "/auth/error?error=Verification", "auth/SurveyAuthErrorPage.tsx"],

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -1032,6 +1032,9 @@ export function getSiteAppScreenshotRoutes(appName, siteVariant) {
     const landingRoute = routes.find(({ routePath }) => routePath === "/");
     if (landingRoute) {
       landingRoute.covers = [...(landingRoute.covers ?? []), surveyComponent];
+      if (siteVariant === VARIANTS.SURVEY) {
+        landingRoute.covers.push("packages/site-kit/src/lib/site-config.ts");
+      }
     }
     routes.push(
       {


### PR DESCRIPTION
Survey dashboards now clear the recovered-response loading message once a recorded answer is present. Long referral URLs wrap inside Share Text without changing the message copied to the clipboard. Trial Abundance Survey also links to current results from the footer and after a signed-in response saves successfully.

Save errors still offer a retry even when an older response exists. The completion link appears only after a successful save; the questionnaire has no aggregate percentages or counts. A deterministic authenticated saved-state capture now covers that link in CI, with the fixture disabled in production.

Validation: six focused recovery and visual-fixture tests, all 19 navigation/copy checks, Trial Abundance lint and typecheck, and Accelerated Medicine typecheck passed. The recovery regression failed before the fix and passed afterward. Desktop/mobile browser checks verified the dashboard refresh, URL containment, unchanged clipboard text, and the saved-state fixture. Before/after screenshots were captured and inspected locally; no unrelated visual noise was found. The existing auth browser test's missing environment-variable qualifier is corrected. CI is rerunning.

Review states for the preview/CI gallery:

- /?visual=question&logout=1 — footer results navigation.
- /?visual=saved&login=demo — authenticated saved response and results link, in development or CI fixtures.
- /dashboard?visual=1&login=demo — recorded response and referral share box.
- /results?visual=1&logout=1 — existing public results destination.

- [ ] Review the navigation, dashboard, and saved-response screenshots.
- [ ] Review the diff and CI results before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “SURVEY RESULTS” link to the logged-out landing page’s About section.
  - Added a “View survey results” link after a survey response is successfully saved.
  - The link appears only for authenticated users with a successfully saved response and directs to the survey results page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
