### PR TITLE
Make survey profiles optional and keep trial explanations easy to close

### DIFF
--- a/apps/acceleratedmedicine/app/api/survey/profile/route.ts
+++ b/apps/acceleratedmedicine/app/api/survey/profile/route.ts
@@ -1,1 +1,1 @@
-export { GET } from "@optimitron/site-kit/lib/trial-abundance-profile-route"
+export { GET, PUT } from "@optimitron/site-kit/lib/trial-abundance-profile-route"

--- a/apps/acceleratedmedicine/tests/integration/shared-survey.test.ts
+++ b/apps/acceleratedmedicine/tests/integration/shared-survey.test.ts
@@ -6,7 +6,8 @@ import {
   TRIAL_ABUNDANCE_SELF_FUNDED_ACCESS_REFERENDUM_SLUG,
 } from "@optimitron/db"
 import { POST } from "../../app/api/votes/sync/route"
-import { GET } from "../../app/api/survey/profile/route"
+import { GET, PUT } from "../../app/api/survey/profile/route"
+import { PUT as putTrialAbundanceProfile } from "../../../trialabundancesurvey/app/api/survey/profile/route"
 import { POST as postTrialAbundance } from "../../../trialabundancesurvey/app/api/votes/sync/route"
 import { prisma } from "../../lib/prisma"
 import { createAuthAdapter } from "@optimitron/site-kit/lib/auth-adapter"
@@ -35,7 +36,7 @@ const input = {
 }
 const createdReferendums: string[] = []
 
-function submit(body = input, handler = POST) {
+function submit(body: Record<string, unknown> = input, handler = POST) {
   return handler(new Request("http://localhost/api/votes/sync", {
     method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
   }))
@@ -110,7 +111,7 @@ describe("both survey routes with PostgreSQL", () => {
     expect(await prisma.referendumVote.count({ where: { userId } })).toBe(2)
     expect(await prisma.wishocraticAllocation.findFirst({ where: { userId } }))
       .toMatchObject({ allocationA: 35, allocationB: 65 })
-    expect(await (await GET()).json()).toEqual({ countryCode: "US", regionCode: "MO", role: "patient-or-caregiver" })
+    expect(await (await GET()).json()).toEqual({ ...input.participant, regionCode: "MO", hasProfile: true })
 
     // A new response changes the reusable profile; replaying an old request must not undo it.
     const changed = { ...input, submissionKey: randomUUID(), participant: { ...input.participant, countryCode: "CA", regionCode: "Ontario", updates: true } }
@@ -126,5 +127,49 @@ describe("both survey routes with PostgreSQL", () => {
     expect(await prisma.user.findUnique({ where: { id: userId } })).toMatchObject({ countryCode: "CA" })
     const vote = await prisma.referendumVote.findFirst({ where: { userId, referendum: { slug: TRIAL_ABUNDANCE_REFERENDUM_SLUG } } })
     expect(vote?.answer).toBe("YES")
+  })
+
+  it("saves an optional profile without changing answers, then preserves it after an answer-only response", async () => {
+    const { participant: _, ...answers } = input
+    expect((await submit(answers)).status).toBe(200)
+    const votes = await prisma.referendumVote.findMany({ where: { userId }, orderBy: { id: "asc" } })
+    const allocations = await prisma.wishocraticAllocation.findMany({ where: { userId } })
+    const originalSubmission = await prisma.formSubmission.findFirstOrThrow({ where: { respondentUserId: userId } })
+    const profile = { countryCode: "", regionCode: "", role: "clinician", story: "", updates: true }
+    for (const handler of [PUT, putTrialAbundanceProfile]) {
+      const response = await handler(new Request("http://localhost/api/survey/profile", {
+        method: "PUT", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...profile, userId: "not-the-session-user" }),
+      }))
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ ...profile, hasProfile: true })
+      expect(await (await GET()).json()).toEqual({ ...profile, hasProfile: true })
+    }
+    expect(await prisma.referendumVote.findMany({ where: { userId }, orderBy: { id: "asc" } })).toEqual(votes)
+    expect(await prisma.wishocraticAllocation.findMany({ where: { userId } })).toEqual(allocations)
+    expect(await prisma.formSubmission.findUnique({ where: { id: originalSubmission.id } })).toEqual(originalSubmission)
+    expect(await prisma.activity.count({ where: { userId, type: "VOTED_REFERENDUM" } })).toBe(1)
+    expect((await submit({ ...answers, submissionKey: randomUUID() })).status).toBe(200)
+    expect(await (await GET()).json()).toEqual({ ...profile, hasProfile: true })
+
+    const cleared = { ...profile, role: "", updates: false }
+    expect((await PUT(new Request("http://localhost/api/survey/profile", {
+      method: "PUT", body: JSON.stringify(cleared),
+    }))).status).toBe(200)
+    expect(await (await GET()).json()).toEqual({ ...cleared, hasProfile: true })
+    expect(await prisma.user.findUnique({ where: { id: userId } })).toMatchObject({ newsletterSubscribed: false })
+  })
+
+  it("rejects anonymous profile access and invalid updates without a saved profile", async () => {
+    const profileRequest = (body: unknown) => new Request("http://localhost/api/survey/profile", { method: "PUT", body: JSON.stringify(body) })
+    const profile = { ...input.participant, regionCode: "unknown-state" }
+    expect((await PUT(profileRequest(profile))).status).toBe(400)
+    expect(await prisma.formSubmission.count({ where: { respondentUserId: userId } })).toBe(0)
+    vi.mocked(getServerSession).mockResolvedValue(null)
+    expect((await GET()).status).toBe(401)
+    for (const handler of [PUT, putTrialAbundanceProfile]) {
+      expect((await handler(profileRequest(input.participant))).status).toBe(401)
+    }
+    expect(await prisma.formSubmission.count({ where: { respondentUserId: userId } })).toBe(0)
   })
 })

--- a/apps/acceleratedmedicine/tests/unit/survey-participant.test.ts
+++ b/apps/acceleratedmedicine/tests/unit/survey-participant.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { surveyParticipantSchema } from "@optimitron/site-kit/lib/survey-participant";
+import { surveyParticipantSchema, surveyProfileSchema } from "@optimitron/site-kit/lib/survey-participant";
 import { normalizeUsRegionCode } from "@optimitron/site-kit/lib/us-states";
 
 const base = {
@@ -10,6 +10,22 @@ const base = {
   story: "",
   updates: false,
 };
+
+describe("optional dashboard profile", () => {
+  it("accepts a role or country without the other details", () => {
+    const empty = { countryCode: "", regionCode: "", role: "", story: "", updates: false };
+    for (const profile of [empty, { ...empty, role: "clinician" }, { ...empty, countryCode: "US" }]) {
+      expect(surveyProfileSchema.parse(profile)).toEqual(profile);
+    }
+  });
+
+  it("normalizes a supplied state and rejects invalid values", () => {
+    expect(surveyProfileSchema.parse({ ...base, regionCode: "Missouri" }).regionCode).toBe("MO");
+    expect(surveyProfileSchema.safeParse({ ...base, regionCode: "unknown" }).success).toBe(false);
+    expect(surveyProfileSchema.safeParse({ ...base, role: "unknown" }).success).toBe(false);
+    expect(surveyProfileSchema.safeParse({ ...base, story: "a".repeat(2001) }).success).toBe(false);
+  });
+});
 
 describe("normalizeUsRegionCode", () => {
   it.each([

--- a/apps/trialabundancesurvey/app/api/survey/profile/route.ts
+++ b/apps/trialabundancesurvey/app/api/survey/profile/route.ts
@@ -1,1 +1,1 @@
-export { GET } from "@optimitron/site-kit/lib/trial-abundance-profile-route"
+export { GET, PUT } from "@optimitron/site-kit/lib/trial-abundance-profile-route"

--- a/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
+++ b/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
@@ -61,12 +61,8 @@ async function answerSurvey(page: Page) {
   await expect(survey.getByText("Question 2 of 3", { exact: true })).toBeVisible()
   await survey.getByRole("button", { name: "Not sure", exact: true }).click()
   await survey.getByRole("slider").press("ArrowRight")
-  await survey.getByRole("button", { name: "Continue", exact: true }).click()
-  await survey.getByRole("combobox", { name: "Country", exact: true }).selectOption("US")
-  await survey.getByRole("combobox", { name: "State", exact: true }).selectOption("MO")
-  await survey.getByRole("combobox", { name: "Your role", exact: true }).selectOption("patient-or-caregiver")
-  await survey.getByRole("textbox", { name: "Why does this matter to you?", exact: false }).fill("I want more treatment options.")
-  await expect(survey.getByRole("checkbox")).not.toBeChecked()
+  await expect(survey.getByText("Question 3 of 3", { exact: true })).toBeVisible()
+  await expect(survey.getByRole("combobox")).toHaveCount(0)
 }
 
 async function savedSubmissions(email: string) {
@@ -108,13 +104,31 @@ test("survey email link saves the answers and lands on the dashboard", async ({ 
   expect(await savedSubmissions(email)).toHaveLength(1)
   expect(submission.personId).toBe(submission.userPersonId)
   expect(submission.emailVerified).toBeTruthy()
-  expect(submission).toMatchObject({ countryCode: "US", regionCode: "MO", newsletterSubscribed: false })
+  expect(submission).toMatchObject({ countryCode: null, regionCode: null, newsletterSubscribed: false })
   expect(submission.answers).toMatchObject({
-    countryCode: "US", regionCode: "MO", role: "patient-or-caregiver",
-    story: "I want more treatment options.", updates: false, email,
+    countryCode: null, regionCode: null, role: null, story: null, updates: null, email,
     patientAccessAnswer: "YES", selfFundedAccessAnswer: "ABSTAIN", militaryAllocationPercent: 49,
   })
   await capture(page, "survey-auth-dashboard")
+
+  const profile = page.locator("#survey-profile")
+  await expect(profile).not.toHaveAttribute("open")
+  await profile.getByText("About you (optional)", { exact: true }).click()
+  await expect(profile.getByRole("combobox", { name: /^Country/ })).toHaveValue("")
+  await expect(profile.getByRole("checkbox")).not.toBeChecked()
+  await profile.getByRole("combobox", { name: /^Your role/ }).selectOption("patient-or-caregiver")
+  await profile.getByRole("button", { name: "Save details", exact: true }).click()
+  await expect(profile.getByRole("status")).toHaveText("Details saved.")
+  await page.reload()
+  await profile.getByText("About you (optional)", { exact: true }).click()
+  await expect(profile.getByRole("combobox", { name: /^Your role/ })).toHaveValue("patient-or-caregiver")
+  await expect(profile.getByRole("combobox", { name: /^Country/ })).toHaveValue("")
+  const submissionsWithProfile = await savedSubmissions(email)
+  expect(submissionsWithProfile).toHaveLength(2)
+  expect(submissionsWithProfile.find(({ id }) => id === submission.id)?.answers).toEqual(submission.answers)
+  expect(submissionsWithProfile.find(({ id }) => id !== submission.id)?.answers).toMatchObject({
+    countryCode: "", regionCode: "", role: "patient-or-caregiver", story: "", updates: false,
+  })
 
   await page.getByRole("button", { name: "Toggle menu" }).click()
   await page.getByRole("button", { name: "Log Out", exact: true }).click()

--- a/apps/trialabundancesurvey/tests/unit/survey-profile-preview.test.tsx
+++ b/apps/trialabundancesurvey/tests/unit/survey-profile-preview.test.tsx
@@ -1,0 +1,21 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { SurveyProfileSection } from "@optimitron/site-kit/components/survey/SurveyProfileSection"
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("survey profile visual preview", () => {
+  it("cannot write synthetic profile values to the signed-in account", () => {
+    const fetch = vi.fn()
+    vi.stubGlobal("fetch", fetch)
+    const { container } = render(<SurveyProfileSection visualPreview defaultOpen />)
+
+    expect(screen.getByRole("button", { name: "Save details" })).toBeDisabled()
+    expect(screen.getByRole("combobox", { name: /^Country/ })).toBeDisabled()
+    expect(screen.getByRole("combobox", { name: /^Your role/ })).toBeDisabled()
+    // A form submission must also be inert if it bypasses the disabled button.
+    fireEvent.submit(container.querySelector("form")!)
+    expect(fetch).not.toHaveBeenCalled()
+    expect(screen.queryByText("Details saved.")).not.toBeInTheDocument()
+  })
+})

--- a/packages/db/src/wishocracy-catalog.ts
+++ b/packages/db/src/wishocracy-catalog.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_WISHOCRATIC_ITEMS,
 } from "@optimitron/data/wishocratic-items-registry"
 import type { PrismaClient } from "./generated/prisma/client.js"
-import { JurisdictionType } from "./generated/prisma/client.js"
+import { JurisdictionType, Prisma } from "./generated/prisma/client.js"
 
 const ALL_WISHOCRATIC_ITEM_IDS = Object.keys(DEFAULT_WISHOCRATIC_ITEMS) as DefaultWishocraticItemId[]
 
@@ -35,9 +35,9 @@ export async function ensureWishocraticItemsExist(
     select: { id: true },
   })
 
-  await Promise.all(uniqueIds.map((itemId) => {
+  await Promise.all(uniqueIds.map(async (itemId) => {
     const record = getDefaultWishocraticCatalogRecord(itemId)
-    return prisma.wishocraticItem.upsert({
+    const upsert = () => prisma.wishocraticItem.upsert({
       where: { id: itemId },
       create: {
         id: record.id,
@@ -59,5 +59,12 @@ export async function ensureWishocraticItemsExist(
         deletedAt: null,
       },
     })
+    try {
+      await upsert()
+    } catch (error) {
+      if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2002") throw error
+      // A concurrent insert can win the jurisdiction/name constraint before the ID conflict is handled.
+      await upsert()
+    }
   }))
 }

--- a/packages/neobrutalist-ui/src/ui/dialog.tsx
+++ b/packages/neobrutalist-ui/src/ui/dialog.tsx
@@ -31,8 +31,10 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    showCloseButton?: boolean
+  }
+>(({ className, children, showCloseButton = true, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -44,10 +46,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {showCloseButton ? (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      ) : null}
     </DialogPrimitive.Content>
   </DialogPortal>
 ))

--- a/packages/site-kit/src/components/landing/PragmaticTrialsDialog.tsx
+++ b/packages/site-kit/src/components/landing/PragmaticTrialsDialog.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react"
+import { X } from "lucide-react"
 import { ParameterInline } from "../shared/ParameterValue"
 import { Button } from "@optimitron/neobrutalist-ui/ui/button"
 import {
@@ -33,7 +34,8 @@ export function PragmaticTrialsDialog({
         </button>
       </DialogTrigger>
       <DialogContent
-        className="!inset-0 !h-[100dvh] !w-screen !max-w-none !translate-x-0 !translate-y-0 gap-0 overflow-y-auto overscroll-y-contain border-0 p-0 shadow-none sm:rounded-none"
+        showCloseButton={false}
+        className="block !inset-0 !h-[100dvh] !w-screen !max-w-none !translate-x-0 !translate-y-0 gap-0 overflow-y-auto overscroll-y-contain border-0 p-0 shadow-none sm:rounded-none"
         style={{ WebkitOverflowScrolling: "touch" }}
       >
         <div className="min-h-full bg-background">
@@ -49,6 +51,17 @@ export function PragmaticTrialsDialog({
                 </DialogDescription>
               </DialogHeader>
             </div>
+            <DialogClose asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                aria-label="Close explanation"
+                className="absolute right-5 top-5 size-11 rounded-none border-2 border-primary sm:right-8 sm:top-6"
+              >
+                <X className="size-5" aria-hidden="true" />
+              </Button>
+            </DialogClose>
           </div>
 
           <div className="mx-auto max-w-6xl space-y-6 p-5 pb-8 sm:p-8">

--- a/packages/site-kit/src/components/landing/survey-participant-fields.tsx
+++ b/packages/site-kit/src/components/landing/survey-participant-fields.tsx
@@ -8,16 +8,17 @@ export type ParticipantDraft = Omit<SurveyParticipant, "role"> & { role: string 
 
 const inputClass = "mt-2 w-full border-4 border-primary bg-background p-3 font-bold"
 
-export function SurveyParticipantFields({ value, onChange }: {
+export function SurveyParticipantFields({ value, onChange, optional = false }: {
   value: ParticipantDraft
   onChange: (value: ParticipantDraft) => void
+  optional?: boolean
 }) {
   return (
     <>
       <div className="grid gap-5 sm:grid-cols-2">
         <label className="font-black">
-          Country
-          <select className={inputClass} autoComplete="country" required value={value.countryCode}
+          Country{optional ? " (optional)" : ""}
+          <select className={inputClass} autoComplete="country" required={!optional} value={value.countryCode}
             onChange={(event) => onChange({ ...value, countryCode: event.target.value, regionCode: "" })}>
             <option value="">Choose a country</option>
             {SURVEY_COUNTRIES.map(({ code, name }) => <option key={code} value={code}>{name}</option>)}
@@ -25,8 +26,8 @@ export function SurveyParticipantFields({ value, onChange }: {
         </label>
         {value.countryCode === "US" ? (
           <label className="font-black">
-            State
-            <select className={inputClass} autoComplete="address-level1" required value={value.regionCode}
+            State{optional ? " (optional)" : ""}
+            <select className={inputClass} autoComplete="address-level1" required={!optional} value={value.regionCode}
               onChange={(event) => onChange({ ...value, regionCode: event.target.value })}>
               <option value="">Choose a state</option>
               {US_REGION_OPTIONS.map(({ code, name }) => <option key={code} value={code}>{name}</option>)}
@@ -41,8 +42,8 @@ export function SurveyParticipantFields({ value, onChange }: {
         ) : null}
       </div>
       <label className="font-black">
-        Your role
-        <select className={inputClass} required value={value.role}
+        Your role{optional ? " (optional)" : ""}
+        <select className={inputClass} required={!optional} value={value.role}
           onChange={(event) => onChange({ ...value, role: event.target.value })}>
           <option value="">Choose a role</option>
           {SURVEY_ROLES.map(([key, label]) => <option key={key} value={key}>{label}</option>)}

--- a/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
+++ b/packages/site-kit/src/components/landing/trial-abundance-survey-section.tsx
@@ -24,17 +24,14 @@ import { buildUserReferralUrl, getBaseUrl } from "../../lib/url"
 import { AuthForm } from "../auth/AuthForm"
 import { ReferralLinkCard } from "../shared/ReferralLinkCard"
 import { PragmaticTrialsDialog } from "./PragmaticTrialsDialog"
-import { SurveyParticipantFields } from "./survey-participant-fields"
 import type { ParticipantDraft } from "./survey-participant-fields"
-import { surveyParticipantSchema } from "../../lib/survey-participant"
-import { normalizeUsRegionCode } from "../../lib/us-states"
+import { surveyProfileSchema } from "../../lib/survey-participant"
 import { AlertCard } from "@optimitron/neobrutalist-ui/ui/alert-card"
 
 type SurveyStage =
   | "patient-access"
   | "self-funded-access"
   | "allocation"
-  | "details"
   | "complete"
 export type { TrialAbundanceVisualState } from "../../lib/trial-abundance-visual"
 import type { TrialAbundanceVisualState } from "../../lib/trial-abundance-visual"
@@ -84,7 +81,6 @@ function getInitialStage(
 ): SurveyStage {
   if (visualState === "self-funded") return "self-funded-access"
   if (visualState === "allocation") return "allocation"
-  if (visualState === "details") return "details"
   if (visualState === "save-error") return "complete"
   if (visualState === "complete" || visualState === "saved") return "complete"
   return "patient-access"
@@ -136,13 +132,7 @@ export default function TrialAbundanceSurveySection({
   )
   const completionRef = useRef<HTMLDivElement>(null)
   const hasRetriedSync = useRef(false)
-  const [participant, setParticipant] = useState<ParticipantDraft>({
-    countryCode: "US", regionCode: "", role: "", story: "", updates: false,
-    ...initialParticipant,
-  })
-  const participantEdited = useRef(false)
   const saveInFlight = useRef(false)
-  const [participantError, setParticipantError] = useState<string | null>(null)
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">(
     visualState === "save-error" ? "error" : visualState === "saved" ? "saved" : "idle",
   )
@@ -162,26 +152,6 @@ export default function TrialAbundanceSurveySection({
   }, [])
 
   useEffect(() => {
-    if (isVisualCapture || status !== "authenticated") return
-    const controller = new AbortController()
-    void fetch("/api/survey/profile", { signal: controller.signal })
-      .then(async (response) => response.ok ? response.json() : null)
-      .then((profile: Partial<ParticipantDraft> | null) => {
-        if (!profile || participantEdited.current) return
-        setParticipant((current) => {
-          const countryCode = profile.countryCode || current.countryCode
-          const regionCode = profile.regionCode || current.regionCode
-          return { ...current, countryCode,
-            // Profiles saved before the state select hold names like "Missouri".
-            regionCode: countryCode === "US" ? normalizeUsRegionCode(regionCode) ?? regionCode : regionCode,
-            role: profile.role || current.role,
-          }
-        })
-      }).catch(() => { /* The user can enter details if profile loading fails. */ })
-    return () => controller.abort()
-  }, [isVisualCapture, status])
-
-  useEffect(() => {
     if (isVisualCapture) return
 
     const pending = storage.getPendingTrialAbundanceResponse()
@@ -195,10 +165,6 @@ export default function TrialAbundanceSurveySection({
     setMilitaryAllocation(pending.militaryAllocationPercent)
     setPatientAccessAnswer(pending.patientAccessAnswer)
     setSelfFundedAccessAnswer(pending.selfFundedAccessAnswer)
-    if (pending.participant) {
-      participantEdited.current = true
-      setParticipant(pending.participant)
-    }
     setStage("complete")
     setUserHasDragged(true)
   }, [isVisualCapture])
@@ -255,18 +221,19 @@ export default function TrialAbundanceSurveySection({
 
   const handleComplete = async () => {
     if (!patientAccessAnswer || !selfFundedAccessAnswer) return
-    const parsed = surveyParticipantSchema.safeParse(participant)
-    if (!parsed.success) {
-      setParticipantError(parsed.error.issues[0]?.message ?? "Please check your details.")
-      return
+    if (initialParticipant) {
+      // State/role links can prefill the optional dashboard form. They are not
+      // respondent-confirmed details and must not be submitted with the answers.
+      const hints = surveyProfileSchema.safeParse({
+        countryCode: "", regionCode: "", role: "", story: "", updates: false, ...initialParticipant,
+      })
+      if (hints.success) storage.setSurveyProfileHints(hints.data)
     }
-    setParticipantError(null)
 
     setStage("complete")
 
     const response = {
       submissionKey: crypto.randomUUID(),
-      participant: parsed.data,
       inviteToken,
       militaryAllocationPercent: militaryAllocation,
       organizationId: organizationId ?? null,
@@ -422,10 +389,10 @@ export default function TrialAbundanceSurveySection({
 
                 {userHasDragged ? (
                   <Button
-                    onClick={() => setStage("details")}
-                    className="h-16 w-full border-4 border-primary bg-brutal-cyan text-xl font-black uppercase text-foreground shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]"
+                    onClick={() => void handleComplete()}
+                    className="min-h-16 h-auto w-full whitespace-normal border-4 border-primary bg-brutal-cyan py-3 text-lg sm:text-xl font-black uppercase text-foreground shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]"
                   >
-                    Continue
+                    {status === "authenticated" ? "Save my response" : "Continue to verification"}
                   </Button>
                 ) : null}
                 <BackButton onClick={() => setStage("self-funded-access")}>
@@ -435,23 +402,6 @@ export default function TrialAbundanceSurveySection({
             </motion.div>
           ) : null}
         </AnimatePresence>
-
-        {stage === "details" ? (
-          <SurveyCard>
-            <StepHeading className="text-2xl font-black uppercase">About you</StepHeading>
-            <form className="flex flex-col gap-5" onSubmit={(event) => { event.preventDefault(); void handleComplete() }}>
-              <SurveyParticipantFields value={participant} onChange={(value) => {
-                participantEdited.current = true
-                setParticipant(value)
-              }} />
-              {participantError ? <AlertCard type="error" message={participantError} /> : null}
-              <Button type="submit" className="h-14 text-lg font-black uppercase">
-                {status === "authenticated" ? "Save my response" : "Continue to verification"}
-              </Button>
-            </form>
-            <BackButton onClick={() => setStage("allocation")}>Back to allocation</BackButton>
-          </SurveyCard>
-        ) : null}
 
         {stage === "complete" ? (
           <div ref={completionRef} className="space-y-8">
@@ -471,6 +421,9 @@ export default function TrialAbundanceSurveySection({
                   copyLinkLabel="COPY SURVEY LINK"
                   linkContentType="trial_abundance_referral"
                 />
+                <p className="text-center font-bold">
+                  <Link href="/dashboard" className="underline underline-offset-4">Your survey dashboard</Link>
+                </p>
               </>
             ) : status === "authenticated" || visualState === "save-error" ? (
               <SurveyCard>

--- a/packages/site-kit/src/components/survey/SurveyDashboardPage.tsx
+++ b/packages/site-kit/src/components/survey/SurveyDashboardPage.tsx
@@ -20,11 +20,12 @@ import { getTrialAbundanceSurveyResults } from "../../lib/survey-results.server"
 import { getSurveyResultsVisualFixture } from "../../lib/survey-results-visual"
 import { getSiteConfig } from "../../lib/site-config"
 import { ROUTES } from "../../lib/routes"
+import { SurveyProfileSection } from "./SurveyProfileSection"
 
 export const dynamic = "force-dynamic"
 
 interface LiteDashboardPageProps {
-  searchParams?: Promise<{ recovery?: string; visual?: string }>
+  searchParams?: Promise<{ recovery?: string; visual?: string; profile?: string }>
 }
 
 /**
@@ -136,6 +137,10 @@ export default async function LiteDashboardPage({
             copyLinkLabel="COPY SURVEY LINK"
             linkContentType="trial_abundance_referral"
             className="mb-6"
+          />
+          <SurveyProfileSection
+            initialProfile={visualPreview ? { countryCode: "", regionCode: "", role: "", story: "", updates: false } : undefined}
+            defaultOpen={visualPreview && resolvedSearchParams?.profile === "1"}
           />
         </Container>
       </SectionContainer>

--- a/packages/site-kit/src/components/survey/SurveyDashboardPage.tsx
+++ b/packages/site-kit/src/components/survey/SurveyDashboardPage.tsx
@@ -139,7 +139,7 @@ export default async function LiteDashboardPage({
             className="mb-6"
           />
           <SurveyProfileSection
-            initialProfile={visualPreview ? { countryCode: "", regionCode: "", role: "", story: "", updates: false } : undefined}
+            visualPreview={visualPreview}
             defaultOpen={visualPreview && resolvedSearchParams?.profile === "1"}
           />
         </Container>

--- a/packages/site-kit/src/components/survey/SurveyProfileSection.tsx
+++ b/packages/site-kit/src/components/survey/SurveyProfileSection.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { Button } from "@optimitron/neobrutalist-ui/ui/button"
+import { AlertCard } from "@optimitron/neobrutalist-ui/ui/alert-card"
+import { SurveyParticipantFields } from "../landing/survey-participant-fields"
+import type { ParticipantDraft } from "../landing/survey-participant-fields"
+import { surveyProfileSchema } from "../../lib/survey-participant"
+import type { SurveyProfile } from "../../lib/survey-participant"
+import { storage } from "../../lib/storage"
+
+export const EMPTY_SURVEY_PROFILE: SurveyProfile = {
+  countryCode: "", regionCode: "", role: "", story: "", updates: false,
+}
+
+export function SurveyProfileSection({ initialProfile, defaultOpen = false }: {
+  initialProfile?: SurveyProfile
+  defaultOpen?: boolean
+}) {
+  const [profile, setProfile] = useState<ParticipantDraft>(initialProfile ?? EMPTY_SURVEY_PROFILE)
+  const [loaded, setLoaded] = useState(Boolean(initialProfile))
+  const [status, setStatus] = useState<"idle" | "loading" | "saving" | "saved">("idle")
+  const [error, setError] = useState<string | null>(null)
+  const inFlight = useRef(false)
+
+  async function loadProfile() {
+    if (inFlight.current) return
+    inFlight.current = true
+    setStatus("loading")
+    setError(null)
+    try {
+      const response = await fetch("/api/survey/profile", { cache: "no-store" })
+      if (!response.ok) throw new Error("Profile unavailable")
+      const saved = await response.json()
+      const hints = !saved.hasProfile ? storage.getSurveyProfileHints() : null
+      const parsed = surveyProfileSchema.parse({ ...EMPTY_SURVEY_PROFILE, ...saved,
+        countryCode: saved.countryCode || hints?.countryCode || "",
+        regionCode: saved.countryCode ? saved.regionCode : hints?.regionCode || "",
+        role: saved.role || hints?.role || "",
+      })
+      setProfile(parsed)
+      setLoaded(true)
+    } catch {
+      setError("We could not load your details. Please try again.")
+    } finally {
+      inFlight.current = false
+      setStatus("idle")
+    }
+  }
+
+  async function saveProfile() {
+    if (inFlight.current || !loaded) return
+    const parsed = surveyProfileSchema.safeParse(profile)
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? "Please check your details.")
+      return
+    }
+    inFlight.current = true
+    setStatus("saving")
+    setError(null)
+    try {
+      const response = await fetch("/api/survey/profile", {
+        method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(parsed.data),
+      })
+      if (!response.ok) throw new Error("Profile save failed")
+      setProfile(surveyProfileSchema.parse(await response.json()))
+      storage.removeSurveyProfileHints()
+      setStatus("saved")
+    } catch {
+      setError("We could not save your details. Please try again.")
+      setStatus("idle")
+    } finally {
+      inFlight.current = false
+    }
+  }
+
+  return (
+    <details id="survey-profile" open={defaultOpen || undefined}
+      className="border-4 border-primary bg-background p-6 mb-6"
+      onToggle={(event) => { if (event.currentTarget.open && !loaded) void loadProfile() }}>
+      <summary className="cursor-pointer text-xl font-black">About you (optional)</summary>
+      <div className="mt-6">
+        {error ? <AlertCard type="error" message={error} className="mb-4" /> : null}
+        {!loaded ? (
+          status === "loading" ? <p role="status">Loading your details…</p>
+            : <Button onClick={() => void loadProfile()}>Retry</Button>
+        ) : (
+          <form onSubmit={(event) => { event.preventDefault(); void saveProfile() }}>
+            <fieldset disabled={status === "saving"} className="flex min-w-0 flex-col gap-5">
+              <SurveyParticipantFields optional value={profile} onChange={(value) => {
+                setProfile(value); setStatus("idle"); setError(null)
+              }} />
+              <Button type="submit" className="self-start">{status === "saving" ? "Saving…" : "Save details"}</Button>
+            </fieldset>
+            {status === "saved" ? <p role="status" className="mt-4 font-bold">Details saved.</p> : null}
+          </form>
+        )}
+      </div>
+    </details>
+  )
+}

--- a/packages/site-kit/src/components/survey/SurveyProfileSection.tsx
+++ b/packages/site-kit/src/components/survey/SurveyProfileSection.tsx
@@ -13,12 +13,12 @@ export const EMPTY_SURVEY_PROFILE: SurveyProfile = {
   countryCode: "", regionCode: "", role: "", story: "", updates: false,
 }
 
-export function SurveyProfileSection({ initialProfile, defaultOpen = false }: {
-  initialProfile?: SurveyProfile
+export function SurveyProfileSection({ visualPreview = false, defaultOpen = false }: {
+  visualPreview?: boolean
   defaultOpen?: boolean
 }) {
-  const [profile, setProfile] = useState<ParticipantDraft>(initialProfile ?? EMPTY_SURVEY_PROFILE)
-  const [loaded, setLoaded] = useState(Boolean(initialProfile))
+  const [profile, setProfile] = useState<ParticipantDraft>(EMPTY_SURVEY_PROFILE)
+  const [loaded, setLoaded] = useState(visualPreview)
   const [status, setStatus] = useState<"idle" | "loading" | "saving" | "saved">("idle")
   const [error, setError] = useState<string | null>(null)
   const inFlight = useRef(false)
@@ -49,7 +49,7 @@ export function SurveyProfileSection({ initialProfile, defaultOpen = false }: {
   }
 
   async function saveProfile() {
-    if (inFlight.current || !loaded) return
+    if (visualPreview || inFlight.current || !loaded) return
     const parsed = surveyProfileSchema.safeParse(profile)
     if (!parsed.success) {
       setError(parsed.error.issues[0]?.message ?? "Please check your details.")
@@ -86,7 +86,7 @@ export function SurveyProfileSection({ initialProfile, defaultOpen = false }: {
             : <Button onClick={() => void loadProfile()}>Retry</Button>
         ) : (
           <form onSubmit={(event) => { event.preventDefault(); void saveProfile() }}>
-            <fieldset disabled={status === "saving"} className="flex min-w-0 flex-col gap-5">
+            <fieldset disabled={visualPreview || status === "saving"} className="flex min-w-0 flex-col gap-5">
               <SurveyParticipantFields optional value={profile} onChange={(value) => {
                 setProfile(value); setStatus("idle"); setError(null)
               }} />

--- a/packages/site-kit/src/lib/constants.ts
+++ b/packages/site-kit/src/lib/constants.ts
@@ -10,6 +10,7 @@ export const STORAGE_KEYS = {
   SIGNUP_INVITE_TOKEN: "signup_invite_token",
   PENDING_VOTE: "pendingVote",
   PENDING_TRIAL_ABUNDANCE_RESPONSE: "pendingTrialAbundanceResponse",
+  SURVEY_PROFILE_HINTS: "surveyProfileHints",
   MILITARY_ALLOCATION: "militaryAllocation",
   PENDING_ORGANIZATION: "pendingOrganization",
   PENDING_WISHOCRACY: "pendingWishocracy",

--- a/packages/site-kit/src/lib/storage.ts
+++ b/packages/site-kit/src/lib/storage.ts
@@ -1,5 +1,5 @@
 import { STORAGE_KEYS, type StorageKey } from "./constants"
-import type { SurveyParticipant } from "./survey-participant"
+import type { SurveyParticipant, SurveyProfile } from "./survey-participant"
 
 export type PendingOrganizationEndorsementDraft = {
   clientDraftId: string
@@ -301,6 +301,11 @@ export const storage = {
     setStorageItem(STORAGE_KEYS.PENDING_TRIAL_ABUNDANCE_RESPONSE, response),
   removePendingTrialAbundanceResponse: () =>
     removeStorageItem(STORAGE_KEYS.PENDING_TRIAL_ABUNDANCE_RESPONSE),
+
+  getSurveyProfileHints: () => getStorageItem<Partial<Pick<SurveyProfile, "countryCode" | "regionCode" | "role">>>(STORAGE_KEYS.SURVEY_PROFILE_HINTS),
+  setSurveyProfileHints: ({ countryCode, regionCode, role }: Partial<Pick<SurveyProfile, "countryCode" | "regionCode" | "role">>) =>
+    setStorageItem(STORAGE_KEYS.SURVEY_PROFILE_HINTS, { countryCode, regionCode, role }),
+  removeSurveyProfileHints: () => removeStorageItem(STORAGE_KEYS.SURVEY_PROFILE_HINTS),
 
   getPostVoteFlowState: () => getStorageItem<{ dismissedVerification?: boolean; screen?: number; sentCount?: number }>(STORAGE_KEYS.POST_VOTE_FLOW_STATE),
   setPostVoteFlowState: (data: { dismissedVerification?: boolean; screen?: number; sentCount?: number }) =>

--- a/packages/site-kit/src/lib/survey-participant.ts
+++ b/packages/site-kit/src/lib/survey-participant.ts
@@ -17,7 +17,7 @@ export const SURVEY_ROLES = [
 
 const US_REGION_CODES = new Set<string>(US_REGIONS.map(([, code]) => code))
 
-export const surveyParticipantSchema = z.object({
+const participantFieldsSchema = z.object({
   countryCode: z.string().refine(
     (value) => SURVEY_COUNTRIES.some(({ code }) => code === value),
     "Choose your country.",
@@ -30,6 +30,8 @@ export const surveyParticipantSchema = z.object({
   story: z.string().trim().max(2000),
   updates: z.boolean(),
 })
+
+export const surveyParticipantSchema = participantFieldsSchema
   // Older clients and prefilled links send "Missouri" or "US-MO"; store the
   // bare code so every US answer for one state lands on one regionCode.
   .transform((value) => value.countryCode !== "US" ? value
@@ -41,6 +43,23 @@ export const surveyParticipantSchema = z.object({
   })
 
 export type SurveyParticipant = z.infer<typeof surveyParticipantSchema>
+
+// Dashboard fields can be saved independently. Legacy survey drafts keep their
+// original validation above until their verification link has been used.
+export const surveyProfileSchema = participantFieldsSchema.extend({
+  countryCode: participantFieldsSchema.shape.countryCode.or(z.literal("")),
+  role: participantFieldsSchema.shape.role.or(z.literal("")),
+}).transform((value) => ({
+  ...value,
+  regionCode: !value.countryCode ? "" : value.countryCode === "US"
+    ? normalizeUsRegionCode(value.regionCode) ?? value.regionCode : value.regionCode,
+})).superRefine((value, ctx) => {
+  if (value.countryCode === "US" && value.regionCode && !US_REGION_CODES.has(value.regionCode)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["regionCode"], message: "Choose a state from the list." })
+  }
+})
+
+export type SurveyProfile = z.infer<typeof surveyProfileSchema>
 
 export const SURVEY_UPDATES_LABEL =
   "Send me occasional updates about clinical trials and patient access."

--- a/packages/site-kit/src/lib/trial-abundance-profile-route.ts
+++ b/packages/site-kit/src/lib/trial-abundance-profile-route.ts
@@ -1,27 +1,32 @@
 import { NextResponse } from "next/server"
+import { ZodError } from "zod"
 import { AuthenticationRequiredError, requireAuth } from "./auth-utils"
-import { prisma } from "./prisma"
-import { TRIAL_ABUNDANCE_FORM_KEY } from "./trial-abundance-submission.server"
+import { surveyProfileSchema } from "./survey-participant"
+import { getSurveyProfile, saveSurveyProfile } from "./trial-abundance-profile.server"
 
 export async function GET() {
   try {
     const { userId } = await requireAuth()
-    const [user, role] = await Promise.all([
-      prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { countryCode: true, regionCode: true } }),
-      prisma.formResponse.findFirst({
-        where: {
-          deletedAt: null, field: { key: "role" },
-          submission: { respondentUserId: userId, deletedAt: null, status: "SUBMITTED",
-            formRevision: { form: { sourceKey: TRIAL_ABUNDANCE_FORM_KEY } } },
-        },
-        orderBy: { createdAt: "desc" }, select: { valueJson: true },
-      }),
-    ])
-    return NextResponse.json({ ...user, role: typeof role?.valueJson === "string" ? role.valueJson : "" },
-      { headers: { "Cache-Control": "private, no-store" } })
+    return NextResponse.json(await getSurveyProfile(userId), { headers: { "Cache-Control": "private, no-store" } })
   } catch (error) {
-    if (error instanceof AuthenticationRequiredError) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-    console.error("Survey profile load failed", error)
-    return NextResponse.json({ error: "Profile unavailable" }, { status: 503 })
+    return profileError(error)
   }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const { userId } = await requireAuth()
+    const profile = surveyProfileSchema.parse(await request.json())
+    await saveSurveyProfile(userId, profile)
+    return NextResponse.json({ ...profile, hasProfile: true }, { headers: { "Cache-Control": "private, no-store" } })
+  } catch (error) {
+    return profileError(error)
+  }
+}
+
+function profileError(error: unknown) {
+  if (error instanceof AuthenticationRequiredError) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  if (error instanceof ZodError || error instanceof SyntaxError) return NextResponse.json({ error: "Please check your details." }, { status: 400 })
+  console.error("Survey profile request failed", error)
+  return NextResponse.json({ error: "We could not load or save your details. Please try again." }, { status: 503 })
 }

--- a/packages/site-kit/src/lib/trial-abundance-profile.server.ts
+++ b/packages/site-kit/src/lib/trial-abundance-profile.server.ts
@@ -1,0 +1,57 @@
+import { FormSubmissionStatus, Prisma, SubjectType } from "@optimitron/db"
+import { prisma } from "./prisma"
+import { ensurePersonForUser } from "./person.server"
+import type { SurveyProfile } from "./survey-participant"
+import {
+  getTrialAbundanceProfileFormRevision, TRIAL_ABUNDANCE_FORM_KEY,
+  TRIAL_ABUNDANCE_PROFILE_FORM_KEY,
+} from "./trial-abundance-submission.server"
+
+export async function getSurveyProfile(userId: string) {
+  const [user, submission] = await Promise.all([
+    prisma.user.findUniqueOrThrow({ where: { id: userId }, select: { countryCode: true, regionCode: true } }),
+    prisma.formSubmission.findFirst({
+      where: {
+        respondentUserId: userId, deletedAt: null, status: "SUBMITTED",
+        formRevision: { form: { sourceKey: { in: [TRIAL_ABUNDANCE_FORM_KEY, TRIAL_ABUNDANCE_PROFILE_FORM_KEY] } } },
+        // Answer-only submissions must not hide a previously saved profile.
+        responses: { some: { deletedAt: null, field: { key: "role" }, valueJson: { not: Prisma.DbNull } } },
+      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      select: { responses: { where: { deletedAt: null, field: { key: { in: ["role", "story", "updates"] } } }, select: { valueJson: true, field: { select: { key: true } } } } },
+    }),
+  ])
+  const values = Object.fromEntries(submission?.responses.map(({ field, valueJson }) => [field.key, valueJson]) ?? [])
+  return {
+    countryCode: user.countryCode ?? "", regionCode: user.regionCode ?? "",
+    role: typeof values.role === "string" ? values.role : "",
+    story: typeof values.story === "string" ? values.story : "",
+    updates: values.updates === true,
+    hasProfile: Boolean(submission),
+  }
+}
+
+export async function saveSurveyProfile(userId: string, profile: SurveyProfile) {
+  const person = await ensurePersonForUser(userId)
+  const revision = await getTrialAbundanceProfileFormRevision()
+  await prisma.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${`trial-abundance:${userId}`}, 0))`
+    const subject = await tx.subject.upsert({
+      where: { personId: person.id }, update: {},
+      create: { personId: person.id, displayName: person.displayName, subjectType: SubjectType.PERSON },
+    })
+    const submission = await tx.formSubmission.create({ data: {
+      formRevisionId: revision.id, createdByUserId: userId, respondentUserId: userId,
+      subjectId: subject.id, status: FormSubmissionStatus.SUBMITTED, submittedAt: new Date(),
+    } })
+    await tx.formResponse.createMany({ data: revision.fields.map((field) => ({
+      submissionId: submission.id, fieldId: field.id, formRevisionId: revision.id,
+      valueJson: profile[field.key as keyof SurveyProfile],
+    })) })
+    await tx.user.update({ where: { id: userId }, data: {
+      countryCode: profile.countryCode || null, regionCode: profile.regionCode || null,
+    } })
+    await tx.person.update({ where: { id: person.id }, data: { countryCode: profile.countryCode || null } })
+    // Survey consent never overrides the account's global email opt-out.
+  })
+}

--- a/packages/site-kit/src/lib/trial-abundance-submission.server.ts
+++ b/packages/site-kit/src/lib/trial-abundance-submission.server.ts
@@ -10,6 +10,7 @@ import type { TrialAbundanceResponseInput } from "./trial-abundance-response"
 import { SURVEY_UPDATES_LABEL } from "./survey-participant"
 
 export const TRIAL_ABUNDANCE_FORM_KEY = "trial-abundance:verified-response"
+export const TRIAL_ABUNDANCE_PROFILE_FORM_KEY = "trial-abundance:participant-profile"
 
 const fields = [
   ["patientAccessAnswer", TRIAL_ABUNDANCE_REFERENDUM_QUESTION, FormFieldType.SINGLE_SELECT],
@@ -28,15 +29,24 @@ function hash(value: unknown) {
   return createHash("sha256").update(JSON.stringify(value)).digest("hex")
 }
 
-export async function getTrialAbundanceFormRevision() {
+export function getTrialAbundanceFormRevision() {
+  return getSurveyFormRevision(TRIAL_ABUNDANCE_FORM_KEY, "Trial Abundance Survey", fields)
+}
+
+export function getTrialAbundanceProfileFormRevision() {
+  return getSurveyFormRevision(TRIAL_ABUNDANCE_PROFILE_FORM_KEY, "Trial Abundance Survey — About you",
+    fields.filter(([key]) => ["countryCode", "regionCode", "role", "story", "updates"].includes(key)))
+}
+
+async function getSurveyFormRevision(sourceKey: string, title: string, formFields: ReadonlyArray<(typeof fields)[number]>) {
   const { user } = await upsertWishoniaUser(prisma)
-  const contentHash = hash(fields)
+  const contentHash = hash(formFields)
   const form = await prisma.form.upsert({
-    where: { sourceKey: TRIAL_ABUNDANCE_FORM_KEY },
+    where: { sourceKey },
     // An empty update makes Prisma emulate upsert, which can race on the first responses.
-    update: { sourceKey: TRIAL_ABUNDANCE_FORM_KEY },
+    update: { sourceKey },
     create: {
-      sourceKey: TRIAL_ABUNDANCE_FORM_KEY, title: "Trial Abundance Survey",
+      sourceKey, title,
       createdByUserId: user.id, purpose: FormPurpose.SURVEY,
       status: FormStatus.OPEN, visibility: ContentVisibility.PRIVATE,
     },
@@ -52,7 +62,7 @@ export async function getTrialAbundanceFormRevision() {
         formId: form.id, contentHash, version: (latest._max.version ?? 0) + 1,
         title: form.title, createdByUserId: user.id,
         status: ModelRevisionStatus.PUBLISHED, publishedAt: new Date(),
-        fields: { create: fields.map(([key, prompt, type], position) => ({ key, prompt, type, position })) },
+        fields: { create: formFields.map(([key, prompt, type], position) => ({ key, prompt, type, position })) },
       } })
     }
     await tx.form.update({ where: { id: form.id }, data: { currentRevisionId: revision.id } })

--- a/packages/site-kit/src/lib/trial-abundance-visual.ts
+++ b/packages/site-kit/src/lib/trial-abundance-visual.ts
@@ -2,7 +2,6 @@ export type TrialAbundanceVisualState =
   | "question"
   | "self-funded"
   | "allocation"
-  | "details"
   | "complete"
   | "saved"
   | "save-error"
@@ -13,5 +12,5 @@ export function parseTrialAbundanceVisualState(value?: string): TrialAbundanceVi
       ? "saved" : undefined
   }
   return value === "question" || value === "self-funded" || value === "allocation" ||
-    value === "details" || value === "complete" || value === "save-error" ? value : undefined
+    value === "complete" || value === "save-error" ? value : undefined
 }

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -1056,12 +1056,6 @@ export function getSiteAppScreenshotRoutes(appName, siteVariant) {
         covers: [surveyComponent],
       },
       {
-        label: "Participant details and consent",
-        routeName: "home-details",
-        routePath: "/?visual=details",
-        covers: [surveyComponent, "packages/site-kit/src/components/landing/survey-participant-fields.tsx"],
-      },
-      {
         label: "Response save retry",
         routeName: "home-save-error",
         routePath: "/?visual=save-error",
@@ -1098,10 +1092,10 @@ export function getSiteAppScreenshotRoutes(appName, siteVariant) {
         surveyComponent,
       ],
     });
-    if (siteVariant === VARIANTS.SURVEY) routes.push({
+    routes.push({
       authenticated: true,
       authRole: "user",
-      label: "Saved response and results link",
+      label: "Saved response and dashboard link",
       routeName: "home-saved",
       routePath: "/?visual=saved",
       covers: [
@@ -1115,6 +1109,7 @@ export function getSiteAppScreenshotRoutes(appName, siteVariant) {
       ["auth-error", "/auth/error?error=Verification", "auth/SurveyAuthErrorPage.tsx"],
       ["auth-verify-request", "/auth/verify-request", "auth/SurveyVerifyRequestPage.tsx"],
       ["dashboard-saved-preview", "/dashboard?visual=1", "survey/SurveyDashboardPage.tsx"],
+      ["dashboard-profile-preview", "/dashboard?visual=1&profile=1", "survey/SurveyProfileSection.tsx"],
       ["dashboard-retry-preview", "/dashboard?visual=1&recovery=error", "survey/pending-response-recovery.tsx"],
     ]) {
       routes.push({
@@ -1122,6 +1117,12 @@ export function getSiteAppScreenshotRoutes(appName, siteVariant) {
         ...(routeName.startsWith("dashboard") ? { authenticated: true, authRole: "user" } : {}),
         covers: [
           `packages/site-kit/src/components/${component}`,
+          ...(routeName === "dashboard-profile-preview" ? [
+            "packages/site-kit/src/components/landing/survey-participant-fields.tsx",
+            "packages/site-kit/src/lib/survey-participant.ts",
+            "packages/site-kit/src/lib/trial-abundance-profile-route.ts",
+            "packages/site-kit/src/lib/trial-abundance-profile.server.ts",
+          ] : []),
           ...(routeName.startsWith("dashboard") ? [
             "packages/site-kit/src/components/survey/SurveyDashboardPage.tsx",
             ...surveyResultsFiles,

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -1139,6 +1139,20 @@ export function getSiteAppScreenshotRoutes(appName, siteVariant) {
     }
   }
 
+  if ([VARIANTS.WAR_ON_DISEASE, VARIANTS.SURVEY, VARIANTS.ACCELERATED_MEDICINE].includes(siteVariant)) {
+    routes.push({
+      label: "Pragmatic clinical trials explanation",
+      routeName: "pragmatic-trials-dialog",
+      routePath: siteVariant === VARIANTS.WAR_ON_DISEASE ? "/" : "/?visual=question",
+      openDialog: siteVariant === VARIANTS.WAR_ON_DISEASE ? "pragmatic clinical trials" : "pragmatic clinical trial",
+      captureSelector: '[role="dialog"]',
+      covers: [
+        "packages/site-kit/src/components/landing/PragmaticTrialsDialog.tsx",
+        "packages/neobrutalist-ui/src/ui/dialog.tsx",
+      ],
+    });
+  }
+
   const publicRoutes = getPublicSiteAppRoutes(appName);
   const publicRouteNames = new Set(publicRoutes.map(({ routeName }) => routeName));
   const screenshotRoutes = [

--- a/scripts/smoke-site-apps.mjs
+++ b/scripts/smoke-site-apps.mjs
@@ -284,6 +284,7 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
             routePath,
             captureSelector,
             openMenu,
+            openDialog,
           },
           lane,
         ) => {
@@ -347,6 +348,11 @@ async function captureScreenshots(appName, siteVariant, baseUrl) {
               await menuDialog
                 .getByRole("button", { name: "Log Out" })
                 .waitFor({ state: "visible" });
+              await forceAnimationsComplete(page);
+            }
+            if (openDialog) {
+              await page.getByRole("button", { name: openDialog, exact: true }).first().click();
+              await page.getByRole("dialog").waitFor({ state: "visible" });
               await forceAnimationsComplete(page);
             }
             const screenshotPath = path.join(


### PR DESCRIPTION
Respondents now finish the three Trial Abundance questions and proceed directly to verification or save. Country, state/region, role, story, and survey updates move to a collapsed **About you (optional)** section below the dashboard's results and sharing controls. Each field can be left blank. The shared flow covers Trial Abundance Survey and Accelerated Medicine, including embedded and state-specific survey entrypoints.

Profile saves use a separate private form submission and do not resubmit votes, change allocations, or add referral activity. Existing profile details and survey consent load for editing. Answer-only submissions do not hide an older profile, and older pending drafts can still complete verification. State and role links supply editable dashboard hints rather than submitted respondent details. Global email opt-outs remain unchanged. No database schema changes are required. Screenshot profile fixtures are read-only and cannot write synthetic values to the signed-in account; normal dashboard forms remain editable.

The same pull request also gives the pragmatic-trials explanation a visible 44×44 X in its sticky upper-right header. X, Escape, the bottom Close button, and focus return work throughout the mobile scroll.

Concurrent first responses also recover from an item catalog uniqueness race. The failed catalog upsert retries once; persistent conflicts still fail.

Validation:
- Both survey app typechecks and lint passed. A focused regression test also verifies that screenshot fixtures cannot submit profile updates.
- All 8 local PostgreSQL integration tests on a fresh database, 196 database unit tests, 13 participant-schema checks, 11 response sync/recovery checks, and 19 navigation/copy checks passed.
- Both production builds and all 24 desktop/mobile email authentication tests passed. The email suite follows the shorter survey and verifies a later optional profile save without changing the recorded answers.
- Desktop and mobile browser checks on both sites exercised anonymous answers → authenticated save → profile save → reload. Partial profiles, state/role hints, and failed load/save retries passed against an isolated local PostgreSQL database.
- Before/after screenshots and exact copy/flow diffs were captured and inspected locally. Changed dashboard, verification, saved-response, and profile retry states are covered. Document-coordinate captures removed sticky-header overlap from tall form screenshots. The removed details step uses an exact copy/flow diff. No screenshots or local artifact paths are published here.
- CI now captures the optional dashboard form and signed-in saved response on both survey sites. CI, deployment, smoke, visual-review, and preview-data-sync checks passed for d9e535542. All inline review threads are resolved.

Review routes on the branch previews after deployment:
- [War on Disease explanation](https://warondisease-git-feature-pragmatic-44470a-mike-p-sinns-projects.vercel.app/?logout=1#vote): open pragmatic clinical trials.
- [Accelerated Medicine survey](https://acceleratedmedicine-git-feature-pr-1fcf05-mike-p-sinns-projects.vercel.app/?logout=1), [Question 3](https://acceleratedmedicine-git-feature-pr-1fcf05-mike-p-sinns-projects.vercel.app/?visual=allocation&logout=1), and [saved response](https://acceleratedmedicine-git-feature-pr-1fcf05-mike-p-sinns-projects.vercel.app/?visual=saved&login=demo).
- [Accelerated Medicine dashboard](https://acceleratedmedicine-git-feature-pr-1fcf05-mike-p-sinns-projects.vercel.app/dashboard?login=demo) and [expanded profile preview](https://acceleratedmedicine-git-feature-pr-1fcf05-mike-p-sinns-projects.vercel.app/dashboard?visual=1&profile=1&login=demo).
- [State/role entrypoint](https://acceleratedmedicine-git-feature-pr-1fcf05-mike-p-sinns-projects.vercel.app/survey?state=MO&role=clinician&logout=1).
- Trial Abundance Survey branch deployments are disabled in this repository. Its local review covers /?logout=1, /?visual=allocation&logout=1, /?visual=complete&logout=1, /?visual=saved&login=demo, /embed, /dashboard?login=demo, and /dashboard?visual=1&profile=1&login=demo.

- [ ] Review the shorter survey and optional profile on desktop and mobile.
- [ ] Review the explanation close button at both scroll positions.
- [ ] Review the diff and CI results before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dialogs can optionally hide their default close button.
  - Clinical trials dialogs now include an accessible close button in the sticky header.
  - Survey respondents can save optional profile details from the dashboard and edit them later.
  - Survey completion no longer requires entering profile details inline.
  - Saved profile information persists across subsequent survey submissions.

- **Bug Fixes**
  - Improved reliability when saving concurrent catalog updates.

- **Tests**
  - Added visual coverage for dashboard profiles and clinical trials dialog variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

