### PR TITLE
Smoke each app's production deploy against its public domain

### DIFF
--- a/.github/scripts/preview-deploy-smoke.test.mjs
+++ b/.github/scripts/preview-deploy-smoke.test.mjs
@@ -198,7 +198,7 @@ test("skips unrelated production deployments without invoking failure handlers",
 
   assert.match(
     targetBlock,
-    /const smokeUrls = isProtectedVercelDeploymentUrl && app[\s\S]*?: \[targetUrl\];/u,
+    /const smokeUrls = smokesPublicDomain && app[\s\S]*?: \[targetUrl\];/u,
     "an unknown protected deployment must retain a URL long enough to emit app=unknown",
   );
   assert.doesNotMatch(

--- a/.github/scripts/vercel-app-projects.mjs
+++ b/.github/scripts/vercel-app-projects.mjs
@@ -82,6 +82,16 @@ function project(
   });
 }
 
+// Once a repository has more than one Vercel project, Vercel names each
+// project's GitHub deployment environment "Production <en dash> <project>"
+// rather than plain "Production", so an equality check against "Production"
+// classifies every split app's production deploy as a preview. Match the
+// leading word instead, which still excludes the "Preview <en dash> <project>"
+// names.
+export function isProductionDeploymentEnvironment(value) {
+  return /^production(?:\s|$)/i.test(String(value ?? "").trim());
+}
+
 export function getVercelAppByUrl(value) {
   let hostname;
   try {

--- a/.github/scripts/vercel-app-projects.test.mjs
+++ b/.github/scripts/vercel-app-projects.test.mjs
@@ -5,6 +5,7 @@ import {
   getGitLinkProblem,
   getProjectPatch,
   getVercelAppByUrl,
+  isProductionDeploymentEnvironment,
   VERCEL_APP_PROJECTS,
 } from "./vercel-app-projects.mjs";
 import {
@@ -20,6 +21,11 @@ import {
 
 const ciWorkflow = readFileSync(
   new URL("../workflows/ci.yml", import.meta.url),
+  "utf8",
+);
+
+const smokeDeployWorkflow = readFileSync(
+  new URL("../workflows/smoke-deploy.yml", import.meta.url),
   "utf8",
 );
 
@@ -196,6 +202,53 @@ test("classifies custom domains and Vercel deployment URLs", () => {
     "optimitron",
   );
   assert.equal(getVercelAppByUrl("https://dih-earth.vercel.app"), undefined);
+});
+
+test("recognizes the per-project production environment Vercel reports", () => {
+  // Vercel sends "Production \u2013 wishocracy" for every split app, so the
+  // deploy smoke used to treat seven of eight production deploys as previews
+  // and hit the protected *.vercel.app URL instead of the public domain.
+  for (const { projectName } of VERCEL_APP_PROJECTS) {
+    assert.equal(
+      isProductionDeploymentEnvironment(`Production \u2013 ${projectName}`),
+      true,
+    );
+    assert.equal(
+      isProductionDeploymentEnvironment(`Preview \u2013 ${projectName}`),
+      false,
+    );
+  }
+  assert.equal(isProductionDeploymentEnvironment("Production"), true);
+  assert.equal(isProductionDeploymentEnvironment("production"), true);
+  assert.equal(isProductionDeploymentEnvironment("Preview"), false);
+  assert.equal(isProductionDeploymentEnvironment("visual-review-web"), false);
+  assert.equal(isProductionDeploymentEnvironment(""), false);
+  assert.equal(isProductionDeploymentEnvironment(undefined), false);
+});
+
+test("keeps preview-only smoke off per-project production deployments", () => {
+  // The job-level expressions run before checkout, so they repeat the rule
+  // inline instead of importing the helper above. The Playwright job is
+  // preview-only: an equality check there let it run against every split app's
+  // production deployment, because those environments are named
+  // "Production <en dash> <project>" rather than "Production".
+  const playwrightGate = smokeDeployWorkflow.slice(
+    smokeDeployWorkflow.indexOf("name: Playwright preview smoke"),
+  );
+  assert.match(
+    playwrightGate,
+    /!startsWith\(github\.event\.deployment\.environment, 'Production'\)/u,
+  );
+  assert.match(
+    playwrightGate,
+    /!startsWith\(github\.event\.deployment_status\.environment, 'Production'\)/u,
+  );
+  assert.equal(
+    /github\.event\.deployment(?:_status)?\.environment != '[Pp]roduction'/u.test(
+      playwrightGate,
+    ),
+    false,
+  );
 });
 
 test("creates Git previews only for auto-build or explicit preview branches", () => {

--- a/.github/workflows/smoke-deploy.yml
+++ b/.github/workflows/smoke-deploy.yml
@@ -16,9 +16,12 @@ permissions:
 # 2. Add VERCEL_AUTOMATION_BYPASS_SECRET_<APPNAME> for each split app from
 #    Deployment Protection -> Protection Bypass for Automation. Optimitron uses
 #    the existing VERCEL_AUTOMATION_BYPASS_SECRET name.
-# 3. Add the same secret to Production if you want production smoke to hit the
-#    exact protected *.vercel.app deployment URL. Without it, production smoke
-#    uses the public production aliases so host-specific outages stay visible.
+# Preview smoke needs those secrets because preview deployment URLs are
+# protected. Production smoke does not: it always uses the public production
+# alias, which is the only target that catches a DNS, alias or host-routing
+# failure. Slack alerting for a production failure needs SLACK_WEBHOOK_URL
+# readable from this job, which runs under the Preview environment for every
+# per-project deployment (see the environment mapping below).
 
 jobs:
   smoke:
@@ -276,28 +279,6 @@ jobs:
 
             core.setFailed(`Deployment did not reach success with an environment URL before smoke timeout; last status: ${lastStatus}.`);
 
-      # Resolving the app first is what lets the step below read the same
-      # per-app bypass secret the smoke step uses. Reading the optimitron-only
-      # secret there made every app look unprotected, so the public-domain
-      # fallback never ran and protected deployment URLs were smoked instead.
-      - name: Resolve smoke app
-        id: smoke_app
-        if: steps.deployment_status.outputs.state != 'skipped'
-        env:
-          RESOLVED_DEPLOYMENT_URL: ${{ steps.deployment_status.outputs.environment_url }}
-        run: |
-          node --input-type=module <<'NODE'
-          import { appendFileSync } from "node:fs";
-          import { getVercelAppByUrl } from "./.github/scripts/vercel-app-projects.mjs";
-
-          const targetUrl = String(process.env.RESOLVED_DEPLOYMENT_URL || "").trim();
-          const app = getVercelAppByUrl(targetUrl);
-          appendFileSync(
-            process.env.GITHUB_OUTPUT,
-            `app=${app?.appName ?? "unknown"}\n`,
-          );
-          NODE
-
       - name: Resolve smoke target
         id: target
         if: steps.deployment_status.outputs.state != 'skipped'
@@ -306,9 +287,6 @@ jobs:
           DEPLOYMENT_STATUS_JSON: ${{ toJSON(github.event.deployment_status) }}
           RESOLVED_DEPLOYMENT_ENVIRONMENT: ${{ steps.deployment_status.outputs.environment }}
           RESOLVED_DEPLOYMENT_URL: ${{ steps.deployment_status.outputs.environment_url }}
-          # Same expression as the smoke step below; they must agree about
-          # whether this app can reach its protected deployment URL.
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets[format('VERCEL_AUTOMATION_BYPASS_SECRET_{0}', steps.smoke_app.outputs.app)] || (steps.smoke_app.outputs.app == 'optimitron' && secrets.VERCEL_AUTOMATION_BYPASS_SECRET) || '' }}
         run: |
           node --input-type=module <<'NODE'
           import { appendFileSync } from "node:fs";
@@ -336,9 +314,6 @@ jobs:
           const parsedUrl = new URL(targetUrl);
           const app = getVercelAppByUrl(targetUrl);
           const appName = app?.appName ?? "unknown";
-          const bypassSecret = String(
-            process.env.VERCEL_AUTOMATION_BYPASS_SECRET || "",
-          ).trim();
           const productionHosts = new Set(
             VERCEL_APP_PROJECTS.flatMap(({ productionDomain }) => [
               productionDomain,
@@ -349,17 +324,24 @@ jobs:
             isProductionDeploymentEnvironment(environmentName) ||
             productionHosts.has(parsedUrl.hostname.toLowerCase());
           const environment = isProduction ? "Production" : "Preview";
-          const isProtectedVercelDeploymentUrl =
+          // A production *.vercel.app URL only proves the build answered, and
+          // it is protected, so an unauthenticated request gets HTTP 200 with
+          // Vercel's login page. The public domain is what has to be up and is
+          // the only target that catches a DNS, alias or host-routing failure,
+          // so production always smokes it. A bypass secret cannot pick this:
+          // per-project production events run under the Preview GitHub
+          // environment, so the secret they see is the preview one rather than
+          // an operator opting in to smoke the deployment URL.
+          const smokesPublicDomain =
             environment === "Production" &&
-            parsedUrl.hostname.endsWith(".vercel.app") &&
-            !bypassSecret;
-          const smokeUrls = isProtectedVercelDeploymentUrl && app
+            parsedUrl.hostname.endsWith(".vercel.app");
+          const smokeUrls = smokesPublicDomain && app
             ? [`https://${app.productionDomain}`]
             : [targetUrl];
 
-          if (isProtectedVercelDeploymentUrl && app) {
+          if (smokesPublicDomain && app) {
             console.log(
-              "Production deployment URL is Vercel-protected and no Production bypass secret is configured; smoking the public production domains instead.",
+              `Smoking the public production domain instead of the protected deployment URL: ${smokeUrls.join(", ")}`,
             );
           }
 
@@ -667,7 +649,13 @@ jobs:
           async function main() {
             const webhookUrl = process.env.SLACK_WEBHOOK_URL;
             if (!webhookUrl) {
-              console.warn("SLACK_WEBHOOK_URL is missing; production smoke failure was not posted to Slack.");
+              // ::warning:: puts this in the run summary. Per-project
+              // production deployments run under the Preview environment, so
+              // a webhook stored only on Production is unreadable here and the
+              // alert would otherwise be dropped in silence.
+              console.log(
+                "::warning::SLACK_WEBHOOK_URL is not readable from this job; the production smoke failure was not posted to Slack.",
+              );
               return;
             }
 

--- a/.github/workflows/smoke-deploy.yml
+++ b/.github/workflows/smoke-deploy.yml
@@ -28,15 +28,20 @@ jobs:
       !startsWith(github.event.deployment_status.environment, 'visual-review') &&
       (github.event.deployment.creator.login == 'vercel[bot]' ||
         github.event.deployment_status.creator.login == 'vercel[bot]' ||
-        ((github.event.deployment.environment == 'Production' ||
-          github.event.deployment.environment == 'production' ||
-          github.event.deployment_status.environment == 'Production' ||
-          github.event.deployment_status.environment == 'production' ||
+        ((startsWith(github.event.deployment.environment, 'Production') ||
+          startsWith(github.event.deployment_status.environment, 'Production') ||
           contains(github.event.deployment_status.environment_url, 'warondisease.org') ||
           contains(github.event.deployment_status.environment_url, 'optimitron.com')) &&
           github.event.deployment_status.state == 'success'))
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # Only the plain "Production" deployment that deploy-production creates maps
+    # to the Production GitHub environment. Its branch policy accepts protected
+    # branches only, and Vercel's own "Production <en dash> <project>"
+    # deployments carry a commit sha as their ref, so routing those here would
+    # block the job instead of smoking them. They stay on Preview, which is also
+    # where the per-app VERCEL_AUTOMATION_BYPASS_SECRET_<APP> secrets live; the
+    # smoke target step below still classifies them as production.
     environment:
       name: ${{ (github.event.deployment.environment == 'Production' || github.event.deployment.environment == 'production' || github.event.deployment_status.environment == 'Production' || github.event.deployment_status.environment == 'production' || contains(github.event.deployment_status.environment_url, 'warondisease.org') || contains(github.event.deployment_status.environment_url, 'optimitron.com')) && 'Production' || 'Preview' }}
       deployment: false
@@ -55,6 +60,10 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            const { pathToFileURL } = require("node:url");
+            const { isProductionDeploymentEnvironment } = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/vercel-app-projects.mjs`).href
+            );
             const { owner, repo } = context.repo;
             const eventDeployment = context.payload.deployment || {};
             const initialStatus = context.payload.deployment_status || {};
@@ -104,7 +113,7 @@ jobs:
                 status.environment || deployment.environment || "",
               );
               return (
-                /^production$/i.test(environment) ||
+                isProductionDeploymentEnvironment(environment) ||
                 isProductionUrl(status.environment_url)
               );
             }
@@ -267,6 +276,28 @@ jobs:
 
             core.setFailed(`Deployment did not reach success with an environment URL before smoke timeout; last status: ${lastStatus}.`);
 
+      # Resolving the app first is what lets the step below read the same
+      # per-app bypass secret the smoke step uses. Reading the optimitron-only
+      # secret there made every app look unprotected, so the public-domain
+      # fallback never ran and protected deployment URLs were smoked instead.
+      - name: Resolve smoke app
+        id: smoke_app
+        if: steps.deployment_status.outputs.state != 'skipped'
+        env:
+          RESOLVED_DEPLOYMENT_URL: ${{ steps.deployment_status.outputs.environment_url }}
+        run: |
+          node --input-type=module <<'NODE'
+          import { appendFileSync } from "node:fs";
+          import { getVercelAppByUrl } from "./.github/scripts/vercel-app-projects.mjs";
+
+          const targetUrl = String(process.env.RESOLVED_DEPLOYMENT_URL || "").trim();
+          const app = getVercelAppByUrl(targetUrl);
+          appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `app=${app?.appName ?? "unknown"}\n`,
+          );
+          NODE
+
       - name: Resolve smoke target
         id: target
         if: steps.deployment_status.outputs.state != 'skipped'
@@ -275,12 +306,15 @@ jobs:
           DEPLOYMENT_STATUS_JSON: ${{ toJSON(github.event.deployment_status) }}
           RESOLVED_DEPLOYMENT_ENVIRONMENT: ${{ steps.deployment_status.outputs.environment }}
           RESOLVED_DEPLOYMENT_URL: ${{ steps.deployment_status.outputs.environment_url }}
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          # Same expression as the smoke step below; they must agree about
+          # whether this app can reach its protected deployment URL.
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets[format('VERCEL_AUTOMATION_BYPASS_SECRET_{0}', steps.smoke_app.outputs.app)] || (steps.smoke_app.outputs.app == 'optimitron' && secrets.VERCEL_AUTOMATION_BYPASS_SECRET) || '' }}
         run: |
           node --input-type=module <<'NODE'
           import { appendFileSync } from "node:fs";
           import {
             getVercelAppByUrl,
+            isProductionDeploymentEnvironment,
             VERCEL_APP_PROJECTS,
           } from "./.github/scripts/vercel-app-projects.mjs";
 
@@ -312,7 +346,7 @@ jobs:
             ]),
           );
           const isProduction =
-            /^production$/i.test(environmentName) ||
+            isProductionDeploymentEnvironment(environmentName) ||
             productionHosts.has(parsedUrl.hostname.toLowerCase());
           const environment = isProduction ? "Production" : "Preview";
           const isProtectedVercelDeploymentUrl =
@@ -699,10 +733,8 @@ jobs:
         github.event.deployment_status.creator.login == 'vercel[bot]') &&
       !startsWith(github.event.deployment.environment, 'visual-review') &&
       !startsWith(github.event.deployment_status.environment, 'visual-review') &&
-      github.event.deployment.environment != 'Production' &&
-      github.event.deployment.environment != 'production' &&
-      github.event.deployment_status.environment != 'Production' &&
-      github.event.deployment_status.environment != 'production'
+      !startsWith(github.event.deployment.environment, 'Production') &&
+      !startsWith(github.event.deployment_status.environment, 'Production')
     runs-on: ubuntu-latest
     timeout-minutes: 105
     environment:


### PR DESCRIPTION
Every merge to `main` leaves five red `Smoke deployed URL` checks. They are not required contexts, so nothing is blocked, but production smoke has not actually been running for the seven split apps, and a real outage on one of them would be invisible.

## Root cause

Once a repository has more than one Vercel project, Vercel names each project's GitHub deployment environment `Production – <project>` rather than plain `Production`. `smoke-deploy.yml` compared that name for equality, so all seven apps' production deploys were classified as previews.

Misclassified as a preview, the job smoked the raw `*.vercel.app` production deployment URL. That URL is protected, answers HTTP 200 with Vercel's authentication page, and trips the `Vercel Authentication` marker in `.github/scripts/smoke-site-deployment.mjs`:

```
Resolved Preview wishocracy smoke target(s): https://wishocracy-l245m1ibn-mike-p-sinns-projects.vercel.app
FAIL https://wishocracy-l245m1ibn-mike-p-sinns-projects.vercel.app/ HTTP 200
```

Two further consequences of the same misclassification: production failures posted a `Preview deploy smoke failed` comment onto the already-merged pull request instead of alerting Slack, and the preview-only `Playwright preview smoke` job ran against production deployments.

## Evidence on `17fcdd96` (the #334 merge)

| Deployment environment | Smoke |
| --- | --- |
| `Production – courtofhumanity` | fail |
| `Production – dfda` | fail |
| `Production – curedao` | fail |
| `Production – trialabundancesurvey` | fail |
| `Production – wishocracy` | fail |
| `Production – warondisease` | pass (through the preview path) |
| `Production – acceleratedmedicine` | pass (through the preview path) |
| `Production` (from `deploy-production`) | pass |

Only the last row is named `Production`, which is why it is the only one classified correctly. The same five failures are present on `7a697d8f`, `380aceb5` and `47020c68`, so this is long-standing rather than a regression from the recent survey work.

## Changes

- `isProductionDeploymentEnvironment` in `.github/scripts/vercel-app-projects.mjs` — one definition of the rule, matching the leading word and still excluding `Preview – <project>`. Both inline scripts in the workflow import it.
- A production deployment on a `*.vercel.app` host always smokes `https://<productionDomain>`. The workflow previously made this conditional on there being no bypass secret, but that condition cannot work: it only means "the operator opted in to smoke the deployment URL" when the secret is read from the Production environment, and per-project production events run under Preview, so what they see is the preview secret. Every app with a preview secret would have kept smoking its protected deployment URL — the one target that cannot catch a DNS, alias or host-routing failure. Dropping the condition also removes a `secrets[format(...)]` lookup.
- `Playwright preview smoke` excludes production deployments by prefix.
- A production failure with no readable `SLACK_WEBHOOK_URL` now emits a `::warning::` instead of a silent console line.
- The job's `environment:` mapping deliberately keeps its equality check. The `Production` GitHub environment allows protected branches only and Vercel's per-project deployments carry a commit sha as their ref, so routing them there would block the job rather than smoke it. A comment records this.

## Owner action, separate from this PR

Slack alerting for a split app's production failure needs `SLACK_WEBHOOK_URL` readable from a job running under the `Preview` environment — as a repository secret, or added to `Preview`. Today it exists only on `Production`. This is not a regression: before this change these failures were classified as previews, so the Slack step never ran at all. Either way the job fails red; only the notification is missing.

## Verification

- `node --test .github/scripts/*.test.mjs scripts/app-preview-urls.test.mjs scripts/capture-lane.test.mjs` — 102 pass, including two new tests: one asserting the helper accepts `Production – <project>` for every declared project and rejects the `Preview` and `visual-review` forms, one asserting the Playwright job's gate stays prefix-based.
- Both inline scripts extracted from the YAML and checked with `node --check`.
- Replayed real payloads through the target logic: `Production – wishocracy` → `https://wishocracy.org`, `Production – warondisease` → `https://warondisease.org`, `Production` → `https://optimitron.com`, `Preview – warondisease` → unchanged deployment URL, and an unrecognised host still falls through to `app=unknown` so the existing skip step catches it.

**Not verified from here:** this container's egress policy blocks the production domains, so I could not confirm that `wishocracy.org`, `dfda.earth`, `curedao.org`, `trialabundancesurvey.org` and `courtofhumanity.org` each answer the smoke with the expected markers. If one of those domains is not serving yet — `courtofhumanity.org` is the likely candidate, since its DNS cutover was deliberately deferred — its check will still fail after this change, but it will then be failing about the real thing rather than about an authentication page. The first merge to `main` is what proves it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgYULvPW89bMAV3C6mXmtG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected production deployment detection for deployments labeled with a project name, such as “Production – project.”
  * Improved smoke-test routing to reliably distinguish production and preview deployments.
  * Smoke tests now resolve the appropriate application and target its public production domain when applicable.
  * Updated workflow warnings and deployment checks for more consistent smoke-test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->