### PR TITLE
Show survey results first and open optional profiles

### DIFF
--- a/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
+++ b/apps/trialabundancesurvey/tests/e2e/auth-email.spec.ts
@@ -30,7 +30,7 @@ async function requestLink(page: Page, email: string) {
 
 async function expectDashboard(page: Page) {
   await expect(page).toHaveURL(/\/dashboard$/u)
-  await expect(page.getByRole("heading", { name: "Your survey response" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Your survey dashboard" })).toBeVisible()
   const session = await (await page.request.get("/api/auth/session")).json()
   expect(Boolean(session.user?.id), "Email verification must create a real session").toBe(true)
 }
@@ -112,15 +112,14 @@ test("survey email link saves the answers and lands on the dashboard", async ({ 
   await capture(page, "survey-auth-dashboard")
 
   const profile = page.locator("#survey-profile")
-  await expect(profile).not.toHaveAttribute("open")
-  await profile.getByText("About you (optional)", { exact: true }).click()
+  await expect(profile).toHaveAttribute("open", "")
   await expect(profile.getByRole("combobox", { name: /^Country/ })).toHaveValue("")
   await expect(profile.getByRole("checkbox")).not.toBeChecked()
   await profile.getByRole("combobox", { name: /^Your role/ }).selectOption("patient-or-caregiver")
   await profile.getByRole("button", { name: "Save details", exact: true }).click()
   await expect(profile.getByRole("status")).toHaveText("Details saved.")
   await page.reload()
-  await profile.getByText("About you (optional)", { exact: true }).click()
+  await expect(profile).toHaveAttribute("open", "")
   await expect(profile.getByRole("combobox", { name: /^Your role/ })).toHaveValue("patient-or-caregiver")
   await expect(profile.getByRole("combobox", { name: /^Country/ })).toHaveValue("")
   const submissionsWithProfile = await savedSubmissions(email)
@@ -210,7 +209,7 @@ test("an already-issued homepage callback finishes on the dashboard in a new bro
     const freshPage = await freshContext.newPage()
     await freshPage.goto(link.href)
     await expect(freshPage).toHaveURL(/\/dashboard$/u)
-    await expect(freshPage.getByRole("heading", { name: "Your survey response" })).toBeVisible()
+    await expect(freshPage.getByRole("heading", { name: "Your survey dashboard" })).toBeVisible()
     const session = await (await freshPage.request.get(new URL("/api/auth/session", link.origin).href)).json()
     expect(Boolean(session.user?.id)).toBe(true)
   } finally {

--- a/apps/trialabundancesurvey/tests/unit/survey-profile-preview.test.tsx
+++ b/apps/trialabundancesurvey/tests/unit/survey-profile-preview.test.tsx
@@ -8,7 +8,7 @@ describe("survey profile visual preview", () => {
   it("cannot write synthetic profile values to the signed-in account", () => {
     const fetch = vi.fn()
     vi.stubGlobal("fetch", fetch)
-    const { container } = render(<SurveyProfileSection visualPreview defaultOpen />)
+    const { container } = render(<SurveyProfileSection visualPreview />)
 
     expect(screen.getByRole("button", { name: "Save details" })).toBeDisabled()
     expect(screen.getByRole("combobox", { name: /^Country/ })).toBeDisabled()

--- a/packages/site-kit/src/components/dashboard/SurveyResultsCard.tsx
+++ b/packages/site-kit/src/components/dashboard/SurveyResultsCard.tsx
@@ -27,16 +27,32 @@ function FundingBar({ label, military }: { label: string; military: number }) {
   )
 }
 
-export function SurveyResultsCard({ results, headingAs: Heading = "h2" }: {
+export function SurveyResultsCard({ results, headingAs: Heading = "h2", fundingFirst = false }: {
   results: DashboardSurveyResults
   headingAs?: "h1" | "h2"
+  fundingFirst?: boolean
 }) {
   const ratio = MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO.value
   const QuestionHeading = Heading === "h1" ? "h2" : "h3"
+  const fundingSection = (
+    <div className={fundingFirst ? "mb-10" : "mt-10"}>
+      <QuestionHeading className="text-lg font-black mb-2">Military or clinical trials?</QuestionHeading>
+      <p className="text-sm font-bold mb-6">How survey respondents would divide funding between the two.</p>
+      {results.funding.average !== null ? (
+        <div className={`grid gap-6 ${results.funding.user === null ? "lg:grid-cols-2" : "lg:grid-cols-3"}`}>
+          <FundingBar label="Average response" military={results.funding.average} />
+          {results.funding.user !== null ? <FundingBar label="Your response" military={results.funding.user} /> : null}
+          <FundingBar label="Current government spending" military={ratio / (ratio + 1) * 100} />
+        </div>
+      ) : <p className="text-sm font-bold text-muted-foreground">Funding results will appear after a response is saved.</p>}
+      {results.funding.median !== null ? <p className="mt-4 text-sm font-bold text-muted-foreground">Median response: {percent(100 - results.funding.median)} to clinical trials.</p> : null}
+    </div>
+  )
   return (
     <Card className="border-4 border-primary bg-background p-5 sm:p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
       <section aria-labelledby="survey-results-heading">
         <Heading id="survey-results-heading" className="text-2xl sm:text-3xl font-black uppercase mb-6">Survey results</Heading>
+        {fundingFirst ? fundingSection : null}
         <div className={`grid gap-8 ${results.questions.length === 2 ? "lg:grid-cols-2" : "lg:grid-cols-3"}`}>
           {results.questions.map(({ slug, title, question, percentages }) => (
             <div key={slug} className="flex flex-col gap-3">
@@ -62,18 +78,7 @@ export function SurveyResultsCard({ results, headingAs: Heading = "h2" }: {
             </div>
           ))}
         </div>
-        <div className="mt-10">
-          <QuestionHeading className="text-lg font-black mb-2">Military or clinical trials?</QuestionHeading>
-          <p className="text-sm font-bold mb-6">How survey respondents would divide funding between the two.</p>
-          {results.funding.average !== null ? (
-            <div className={`grid gap-6 ${results.funding.user === null ? "lg:grid-cols-2" : "lg:grid-cols-3"}`}>
-              <FundingBar label="Average response" military={results.funding.average} />
-              {results.funding.user !== null ? <FundingBar label="Your response" military={results.funding.user} /> : null}
-              <FundingBar label="Current government spending" military={ratio / (ratio + 1) * 100} />
-            </div>
-          ) : <p className="text-sm font-bold text-muted-foreground">Funding results will appear after a response is saved.</p>}
-          {results.funding.median !== null ? <p className="mt-4 text-sm font-bold text-muted-foreground">Median response: {percent(100 - results.funding.median)} to clinical trials.</p> : null}
-        </div>
+        {fundingFirst ? null : fundingSection}
       </section>
     </Card>
   )

--- a/packages/site-kit/src/components/survey/SurveyDashboardPage.tsx
+++ b/packages/site-kit/src/components/survey/SurveyDashboardPage.tsx
@@ -25,7 +25,7 @@ import { SurveyProfileSection } from "./SurveyProfileSection"
 export const dynamic = "force-dynamic"
 
 interface LiteDashboardPageProps {
-  searchParams?: Promise<{ recovery?: string; visual?: string; profile?: string }>
+  searchParams?: Promise<{ recovery?: string; visual?: string }>
 }
 
 /**
@@ -63,8 +63,8 @@ export default async function LiteDashboardPage({
         getUserTrialAbundanceAllocation(sessionUser.id),
       ]),
     visualPreview
-      ? getSurveyResultsVisualFixture("1", !recoveryPreview)!
-      : getTrialAbundanceSurveyResults(sessionUser.id),
+      ? getSurveyResultsVisualFixture("1")!
+      : getTrialAbundanceSurveyResults(),
   ])
   const resultsUrl = getSiteConfig().domain === "trialabundancesurvey.org"
     ? ROUTES.surveyResults
@@ -89,9 +89,28 @@ export default async function LiteDashboardPage({
       <SectionContainer bgColor="background" borderPosition="none" padding="lg">
         <Container>
           <h1 className="text-4xl sm:text-5xl font-black uppercase mb-6">
-            Your survey response
+            Your survey dashboard
           </h1>
+
+          <SurveyResultsCard results={results} fundingFirst />
+          <p className="my-6 font-bold">
+            <Link href={resultsUrl} className="underline underline-offset-4">View public survey results</Link>
+          </p>
+
+          <SurveyProfileSection visualPreview={visualPreview} />
+
+          <ReferralLinkCard
+            referralLink={surveyUrl}
+            shareTemplates={shareTemplates}
+            hashtags="PragmaticTrials,ClinicalResearch"
+            introText="Invite someone else to answer the same three questions with your personal referral link."
+            copyLinkLabel="COPY SURVEY LINK"
+            linkContentType="trial_abundance_referral"
+            className="mb-6"
+          />
+
           <Card className="border-4 border-primary p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] mb-6">
+            <h2 className="text-2xl font-black uppercase mb-4">Your responses</h2>
             <PendingResponseRecovery
               hasRecordedResponse={Boolean(vote)}
               visualState={recoveryPreview ? "error" : undefined}
@@ -124,24 +143,6 @@ export default async function LiteDashboardPage({
             ) : null}
           </Card>
 
-          <SurveyResultsCard results={results} />
-          <p className="my-6 font-bold">
-            <Link href={resultsUrl} className="underline underline-offset-4">View public survey results</Link>
-          </p>
-
-          <ReferralLinkCard
-            referralLink={surveyUrl}
-            shareTemplates={shareTemplates}
-            hashtags="PragmaticTrials,ClinicalResearch"
-            introText="Invite someone else to answer the same three questions with your personal referral link."
-            copyLinkLabel="COPY SURVEY LINK"
-            linkContentType="trial_abundance_referral"
-            className="mb-6"
-          />
-          <SurveyProfileSection
-            visualPreview={visualPreview}
-            defaultOpen={visualPreview && resolvedSearchParams?.profile === "1"}
-          />
         </Container>
       </SectionContainer>
     </Layout>

--- a/packages/site-kit/src/components/survey/SurveyProfileSection.tsx
+++ b/packages/site-kit/src/components/survey/SurveyProfileSection.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { Button } from "@optimitron/neobrutalist-ui/ui/button"
 import { AlertCard } from "@optimitron/neobrutalist-ui/ui/alert-card"
 import { SurveyParticipantFields } from "../landing/survey-participant-fields"
@@ -13,17 +13,19 @@ export const EMPTY_SURVEY_PROFILE: SurveyProfile = {
   countryCode: "", regionCode: "", role: "", story: "", updates: false,
 }
 
-export function SurveyProfileSection({ visualPreview = false, defaultOpen = false }: {
+export function SurveyProfileSection({ visualPreview = false, defaultOpen = true }: {
   visualPreview?: boolean
   defaultOpen?: boolean
 }) {
   const [profile, setProfile] = useState<ParticipantDraft>(EMPTY_SURVEY_PROFILE)
   const [loaded, setLoaded] = useState(visualPreview)
-  const [status, setStatus] = useState<"idle" | "loading" | "saving" | "saved">("idle")
+  const [status, setStatus] = useState<"idle" | "loading" | "saving" | "saved">(
+    defaultOpen && !visualPreview ? "loading" : "idle",
+  )
   const [error, setError] = useState<string | null>(null)
   const inFlight = useRef(false)
 
-  async function loadProfile() {
+  const loadProfile = useCallback(async () => {
     if (inFlight.current) return
     inFlight.current = true
     setStatus("loading")
@@ -46,7 +48,11 @@ export function SurveyProfileSection({ visualPreview = false, defaultOpen = fals
       inFlight.current = false
       setStatus("idle")
     }
-  }
+  }, [])
+
+  useEffect(() => {
+    if (defaultOpen && !visualPreview) void loadProfile()
+  }, [defaultOpen, loadProfile, visualPreview])
 
   async function saveProfile() {
     if (visualPreview || inFlight.current || !loaded) return


### PR DESCRIPTION
The Trial Abundance Survey and Accelerated Medicine dashboards now lead with the military-versus-clinical-trials comparison, followed by patient-access results. About you opens and loads saved details automatically. Sharing follows the profile, and the participant's three answers appear at the bottom.

The aggregate results omit the repeated personal allocation bar. Profile fields remain optional and collapsible. Public results and the War on Disease dashboard keep their existing result order.

Validation: both production builds and type checks passed; Trial Abundance lint and the read-only preview regression passed. Desktop/mobile screenshots cover both dashboards, the open profile, collapse, and response recovery. Screenshots were captured and inspected locally with fixed data, clock, fonts, and animations; no horizontal overflow was found. Four local production-build browser tests passed for email sign-in, automatic profile loading, role save, and reload against local PostgreSQL. GitHub CI and deployment checks are green; all review threads are resolved.

Review pages: [Accelerated Medicine dashboard](https://acceleratedmedicine-git-feature-su-101d65-mike-p-sinns-projects.vercel.app/dashboard) and [sign-in with dashboard return](https://acceleratedmedicine-git-feature-su-101d65-mike-p-sinns-projects.vercel.app/auth/signin?callbackUrl=%2Fdashboard). No Trial Abundance branch preview was posted on this PR; its `/dashboard` is covered by the local review and CI browser tests. These pages require sign-in.

- [ ] Review the dashboard order and expanded profile.
- [ ] Approve the change for merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Survey profile details now open automatically and load when the dashboard is opened.
  - The survey dashboard has an updated layout, with profile and referral information arranged alongside survey results.
  - Funding information may now appear before the survey results for a clearer presentation.

- **Updates**
  - The dashboard heading now reads “Your survey dashboard.”
  - Profile details remain expanded after saving and reloading the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
