### PR TITLE
Improve allocation comparisons across campaign and survey results

### DIFF
--- a/apps/wishocracy/components/wishocracy/BudgetAllocationBars.tsx
+++ b/apps/wishocracy/components/wishocracy/BudgetAllocationBars.tsx
@@ -14,6 +14,12 @@ interface BudgetAllocationBarsProps {
   comparisons: Comparison[]
 }
 
+const allocationLabels = {
+  user: "Your preferred allocation",
+  average: "Average preferred allocation",
+  government: "Current government allocation",
+}
+
 export function BudgetAllocationBars({ comparisons }: BudgetAllocationBarsProps) {
   const [sortBy, setSortBy] = useState<"user" | "government" | "average">("user")
   const [searchQuery, setSearchQuery] = useState("")
@@ -96,10 +102,10 @@ export function BudgetAllocationBars({ comparisons }: BudgetAllocationBarsProps)
           )}
           variant="outline"
           size="sm"
-          className="w-full font-bold uppercase border-2 border-primary"
+          className="h-auto min-h-8 w-full whitespace-normal py-2 font-bold uppercase border-2 border-primary"
         >
           <ArrowUpDown className="w-4 h-4 mr-2" />
-          Sort by: {sortBy === "user" ? "Your Priorities" : sortBy === "average" ? "Community Average" : "Gov Spending"}
+          Sort by: {allocationLabels[sortBy]}
         </Button>
       </div>
 
@@ -112,19 +118,19 @@ export function BudgetAllocationBars({ comparisons }: BudgetAllocationBarsProps)
                 <span className="uppercase">{category.name}</span>
               </div>
               <AllocationBar
-                label="Your priorities"
+                label={allocationLabels.user}
                 size="compact"
-                segments={[{ label: "Your priorities", value: percentage, displayValue: percentage.toFixed(1) + "%", colorClassName: "bg-brutal-cyan" }]}
+                segments={[{ label: allocationLabels.user, value: percentage, displayValue: percentage.toFixed(1) + "%", colorClassName: "bg-brutal-cyan" }]}
               />
               <AllocationBar
-                label="Community average"
+                label={allocationLabels.average}
                 size="compact"
-                segments={[{ label: "Community average", value: avgPercent, displayValue: avgPercent.toFixed(1) + "%", colorClassName: "bg-brutal-pink" }]}
+                segments={[{ label: allocationLabels.average, value: avgPercent, displayValue: avgPercent.toFixed(1) + "%", colorClassName: "bg-brutal-pink" }]}
               />
               <AllocationBar
-                label="Government spending"
+                label={allocationLabels.government}
                 size="compact"
-                segments={[{ label: "Government spending", value: govPercent, displayValue: govPercent.toFixed(1) + "%", colorClassName: "bg-black" }]}
+                segments={[{ label: allocationLabels.government, value: govPercent, displayValue: govPercent.toFixed(1) + "%", colorClassName: "bg-black" }]}
               />
             </div>
           )
@@ -134,15 +140,15 @@ export function BudgetAllocationBars({ comparisons }: BudgetAllocationBarsProps)
         <div className="flex items-center justify-center gap-3 text-xs mb-2 flex-wrap">
           <div className="flex items-center gap-2">
             <div className="w-4 h-4 bg-brutal-cyan border-2 border-primary" />
-            <span className="font-bold">Your Priorities</span>
+            <span className="font-bold">{allocationLabels.user}</span>
           </div>
           <div className="flex items-center gap-2">
             <div className="w-4 h-4 bg-brutal-pink border-2 border-brutal-pink" />
-            <span className="font-bold">Community Avg</span>
+            <span className="font-bold">{allocationLabels.average}</span>
           </div>
           <div className="flex items-center gap-2">
             <div className="w-4 h-4 bg-black border-2 border-primary" />
-            <span className="font-bold">Gov Spending</span>
+            <span className="font-bold">{allocationLabels.government}</span>
           </div>
         </div>
         <p className="text-center text-[10px] text-muted-foreground">

--- a/apps/wishocracy/components/wishocracy/BudgetAllocationBars.tsx
+++ b/apps/wishocracy/components/wishocracy/BudgetAllocationBars.tsx
@@ -3,9 +3,12 @@
 import { useMemo, useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { BUDGET_CATEGORIES, BudgetCategoryId, getActualGovernmentAllocations } from "@/lib/wishocracy-data"
-import { calculateAllocationsFromPairwise, Comparison } from "@/lib/wishocracy-calculations"
+import { BUDGET_CATEGORIES, getActualGovernmentAllocations } from "@/lib/wishocracy-data"
+import type { BudgetCategoryId } from "@/lib/wishocracy-data"
+import { calculateAllocationsFromPairwise } from "@/lib/wishocracy-calculations"
+import type { Comparison } from "@/lib/wishocracy-calculations"
 import { ArrowUpDown } from "lucide-react"
+import { AllocationBar } from "@optimitron/neobrutalist-ui/ui/allocation-bar"
 
 interface BudgetAllocationBarsProps {
   comparisons: Comparison[]
@@ -108,45 +111,21 @@ export function BudgetAllocationBars({ comparisons }: BudgetAllocationBarsProps)
                 <span className="text-lg">{category.icon}</span>
                 <span className="uppercase">{category.name}</span>
               </div>
-              {/* Your allocation bar */}
-              <div className="h-6 bg-muted border-2 border-primary relative overflow-visible">
-                <div
-                  className="h-full bg-brutal-cyan border-r-2 border-primary transition-all duration-300"
-                  style={{ width: `${percentage}%` }}
-                />
-                <span
-                  className="absolute top-1/2 -translate-y-1/2 text-xs font-black whitespace-nowrap"
-                  style={{ left: `calc(${percentage}% + 4px)` }}
-                >
-                  {percentage.toFixed(1)}% YOU
-                </span>
-              </div>
-              {/* Community average allocation bar */}
-              <div className="h-6 bg-muted border-2 border-brutal-pink relative overflow-visible">
-                <div
-                  className="h-full bg-brutal-pink border-r-2 border-primary transition-all duration-300"
-                  style={{ width: `${avgPercent}%` }}
-                />
-                <span
-                  className="absolute top-1/2 -translate-y-1/2 text-xs font-bold whitespace-nowrap"
-                  style={{ left: `calc(${avgPercent}% + 4px)` }}
-                >
-                  {avgPercent.toFixed(1)}% AVG
-                </span>
-              </div>
-              {/* Government allocation bar */}
-              <div className="h-6 border-2 border-black relative overflow-visible">
-                <div
-                  className="h-full bg-black transition-all duration-300"
-                  style={{ width: `${govPercent}%` }}
-                />
-                <span
-                  className="absolute top-1/2 -translate-y-1/2 text-xs font-bold whitespace-nowrap text-black"
-                  style={{ left: `calc(${govPercent}% + 4px)` }}
-                >
-                  {govPercent.toFixed(1)}% GOVT
-                </span>
-              </div>
+              <AllocationBar
+                label="Your priorities"
+                size="compact"
+                segments={[{ label: "Your priorities", value: percentage, displayValue: percentage.toFixed(1) + "%", colorClassName: "bg-brutal-cyan" }]}
+              />
+              <AllocationBar
+                label="Community average"
+                size="compact"
+                segments={[{ label: "Community average", value: avgPercent, displayValue: avgPercent.toFixed(1) + "%", colorClassName: "bg-brutal-pink" }]}
+              />
+              <AllocationBar
+                label="Government spending"
+                size="compact"
+                segments={[{ label: "Government spending", value: govPercent, displayValue: govPercent.toFixed(1) + "%", colorClassName: "bg-black" }]}
+              />
             </div>
           )
         })}

--- a/packages/neobrutalist-ui/src/ui/allocation-bar.tsx
+++ b/packages/neobrutalist-ui/src/ui/allocation-bar.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react"
+import { cn } from "../cn"
+
+export interface AllocationBarSegment {
+  label: string
+  value: number
+  displayValue: string
+  colorClassName: string
+  valueClassName?: string
+  content?: ReactNode
+}
+
+interface AllocationBarProps {
+  label: ReactNode
+  segments: readonly AllocationBarSegment[]
+  /** All bars in a comparison must use the same scale. */
+  maxValue?: number
+  size?: "compact" | "default" | "large"
+  showTrack?: boolean
+}
+
+export function AllocationBar({
+  label,
+  segments,
+  maxValue = 100,
+  size = "default",
+  showTrack = true,
+}: AllocationBarProps) {
+  const single = segments.length === 1 ? segments[0] : undefined
+  const scale = Number.isFinite(maxValue) && maxValue > 0 ? maxValue : 100
+
+  return (
+    <figure className="min-w-0 space-y-2">
+      <figcaption className={cn(
+        "flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 font-bold",
+        size === "compact" ? "text-xs" : size === "large" ? "text-lg sm:text-2xl font-black uppercase" : "text-base sm:text-lg",
+      )}>
+        <div>{label}</div>
+        {single ? <span className={cn("tabular-nums font-black", single.valueClassName, size === "large" && "text-2xl sm:text-3xl")}>{single.displayValue}</span> : null}
+      </figcaption>
+      <div
+        aria-hidden="true"
+        className={cn(
+          "flex w-full overflow-hidden",
+          showTrack && "border-2 border-primary bg-muted",
+          size === "compact" ? "h-6" : size === "large" ? "h-24" : "h-10 sm:h-12",
+        )}
+      >
+        {segments.map((segment) => (
+          <div
+            key={segment.label}
+            className={cn("flex h-full shrink-0 items-center justify-center", segment.colorClassName, !showTrack && segment.value > 0 && "border-2 border-primary")}
+            style={{ width: `${Number.isFinite(segment.value) ? Math.min(100, Math.max(0, segment.value / scale * 100)) : 0}%` }}
+          >
+            {segment.content}
+          </div>
+        ))}
+      </div>
+      {!single ? (
+        <dl className="flex flex-wrap justify-between gap-x-6 gap-y-2">
+          {segments.map((segment) => (
+            <div key={segment.label}>
+              <dt className="flex items-center gap-2 text-sm font-bold">
+                <span aria-hidden="true" className={cn("h-3 w-3 shrink-0", segment.colorClassName)} />
+                {segment.label}
+              </dt>
+              <dd className="text-2xl sm:text-3xl font-black tabular-nums">{segment.displayValue}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+    </figure>
+  )
+}

--- a/packages/site-kit/src/components/dashboard/SurveyResultsCard.tsx
+++ b/packages/site-kit/src/components/dashboard/SurveyResultsCard.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@optimitron/neobrutalist-ui/ui/card"
+import { AllocationBar } from "@optimitron/neobrutalist-ui/ui/allocation-bar"
 import { MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO } from "@optimitron/data/parameters"
 import type { DashboardSurveyResults } from "../../lib/survey-results"
 
@@ -13,17 +14,13 @@ const percent = (value: number) => `${value.toLocaleString("en-US", { maximumFra
 function FundingBar({ label, military }: { label: string; military: number }) {
   const trials = 100 - military
   return (
-    <div className="space-y-2">
-      <h4 className="font-black">{label}</h4>
-      <div className="flex h-7 overflow-hidden border-2 border-primary" aria-hidden="true">
-        <div className="bg-brutal-cyan" style={{ width: `${trials}%` }} />
-        <div className="bg-brutal-pink" style={{ width: `${military}%` }} />
-      </div>
-      <div className="flex justify-between gap-4 text-sm font-bold">
-        <span>Clinical trials <span className="tabular-nums">{percent(trials)}</span></span>
-        <span className="text-right">Military <span className="tabular-nums">{percent(military)}</span></span>
-      </div>
-    </div>
+    <AllocationBar
+      label={<h4>{label}</h4>}
+      segments={[
+        { label: "Clinical trials", value: trials, displayValue: percent(trials), colorClassName: "bg-brutal-cyan" },
+        { label: "Military", value: military, displayValue: percent(military), colorClassName: "bg-brutal-pink" },
+      ]}
+    />
   )
 }
 
@@ -39,8 +36,8 @@ export function SurveyResultsCard({ results, headingAs: Heading = "h2", fundingF
       <QuestionHeading className="text-lg font-black mb-2">Military or clinical trials?</QuestionHeading>
       <p className="text-sm font-bold mb-6">How survey respondents would divide funding between the two.</p>
       {results.funding.average !== null ? (
-        <div className={`grid gap-6 ${results.funding.user === null ? "lg:grid-cols-2" : "lg:grid-cols-3"}`}>
-          <FundingBar label="Average response" military={results.funding.average} />
+        <div className="space-y-8">
+          <FundingBar label="Average desired allocation" military={results.funding.average} />
           {results.funding.user !== null ? <FundingBar label="Your response" military={results.funding.user} /> : null}
           <FundingBar label="Current government spending" military={ratio / (ratio + 1) * 100} />
         </div>

--- a/packages/site-kit/src/components/landing/war-vs-cures-chart.tsx
+++ b/packages/site-kit/src/components/landing/war-vs-cures-chart.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { motion } from "framer-motion"
+import { AllocationBar } from "@optimitron/neobrutalist-ui/ui/allocation-bar"
 import { Container } from "@optimitron/neobrutalist-ui/ui/container"
 import { SectionContainer } from "@optimitron/neobrutalist-ui/ui/section-container"
 import { getSiteConfig } from "../../lib/site-config"
@@ -24,8 +25,6 @@ export default function WarVsCuresChart({ showReasonLabel = true }: WarVsCuresCh
   const ratio = getParameterValue(MILITARY_TO_GOVERNMENT_CLINICAL_TRIALS_SPENDING_RATIO, "round")
   const militaryLabel = showPoliticalContent ? "WEAPONS AND MILITARY" : "MILITARY"
   const trialLabel = showPoliticalContent ? "PUBLICLY FUNDED CLINICAL TRIALS" : "CLINICAL TRIALS"
-
-  const trialsBarWidth = (GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.value / GLOBAL_MILITARY_SPENDING_ANNUAL_2024.value * 100).toFixed(2)
 
   return (
     <SectionContainer bgColor="background" borderPosition="bottom" padding="lg" className="overflow-hidden">
@@ -69,73 +68,38 @@ export default function WarVsCuresChart({ showReasonLabel = true }: WarVsCuresCh
           THAN {trialLabel}
         </motion.p>
 
-        <div className="max-w-4xl mx-auto">
-          <div className="space-y-6">
-            {/* Military Bar */}
-            <div>
-              <motion.div
-                initial={{ opacity: 0, x: -50 }}
-                whileInView={{ opacity: 1, x: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.4, delay: 0.6 }}
-                className="flex items-center justify-between mb-2"
-              >
-                <div className="text-lg sm:text-xl md:text-2xl font-black uppercase">{militaryLabel}</div>
-                <div className="text-xl sm:text-2xl md:text-3xl font-black text-brutal-pink">{militarySpending}</div>
-              </motion.div>
-              <motion.div
-                data-visual-force-complete
-                initial={{ scaleX: 0 }}
-                whileInView={{ scaleX: 1 }}
-                viewport={{ once: true }}
-                transition={{ duration: 1, ease: [0.87, 0, 0.13, 1], delay: 0.7 }}
-                style={{ originX: 0 }}
-                className="relative h-24 bg-brutal-pink border-2 border-primary"
-              >
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <span className="text-lg sm:text-xl md:text-2xl font-black text-brutal-pink-foreground uppercase">
-                    {militarySpending} FOR <br />
-                    {militaryLabel}
-                  </span>
-                </div>
-              </motion.div>
-            </div>
-
-            {/* Medical Research Bar */}
-            <div>
-              <motion.div
-                initial={{ opacity: 0, x: -50 }}
-                whileInView={{ opacity: 1, x: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.4, delay: 0.9 }}
-                className="flex items-center justify-between mb-2"
-              >
-                <div className="text-lg sm:text-xl md:text-2xl font-black uppercase">{trialLabel}</div>
-                <div className="text-xl sm:text-2xl md:text-3xl font-black text-brutal-cyan">{clinicalTrials}</div>
-              </motion.div>
-              <div className="flex items-center gap-4">
-                <motion.div
-                  data-visual-force-complete
-                  initial={{ scaleX: 0 }}
-                  whileInView={{ scaleX: 1 }}
-                  viewport={{ once: true }}
-                  transition={{ duration: 1, ease: [0.87, 0, 0.13, 1], delay: 1 }}
-                  style={{ originX: 0, width: `${trialsBarWidth}%` }}
-                  className="relative h-24 bg-brutal-cyan border-2 border-primary"
-                />
-                <motion.span
-                  initial={{ opacity: 0, x: -20 }}
-                  whileInView={{ opacity: 1, x: 0 }}
-                  viewport={{ once: true }}
-                  transition={{ duration: 0.4, delay: 1.3 }}
-                  className="min-w-0 text-base font-black uppercase leading-tight text-foreground sm:text-xl"
-                >
-                  {clinicalTrials} FOR <br />
-                  {trialLabel}
-                </motion.span>
-              </div>
-            </div>
-          </div>
+        <div className="max-w-4xl mx-auto space-y-6">
+          <AllocationBar
+            label={militaryLabel}
+            size="large"
+            showTrack={false}
+            maxValue={GLOBAL_MILITARY_SPENDING_ANNUAL_2024.value}
+            segments={[{
+              label: militaryLabel,
+              value: GLOBAL_MILITARY_SPENDING_ANNUAL_2024.value,
+              displayValue: militarySpending,
+              colorClassName: "bg-brutal-pink",
+              valueClassName: "text-brutal-pink",
+              content: (
+                <span className="text-lg sm:text-xl md:text-2xl font-black text-brutal-pink-foreground uppercase text-center">
+                  {militarySpending} FOR<br />{militaryLabel}
+                </span>
+              ),
+            }]}
+          />
+          <AllocationBar
+            label={trialLabel}
+            size="large"
+            showTrack={false}
+            maxValue={GLOBAL_MILITARY_SPENDING_ANNUAL_2024.value}
+            segments={[{
+              label: trialLabel,
+              value: GLOBAL_GOVERNMENT_CLINICAL_TRIALS_SPENDING_ANNUAL.value,
+              displayValue: clinicalTrials,
+              colorClassName: "bg-brutal-cyan",
+              valueClassName: "text-brutal-cyan",
+            }]}
+          />
         </div>
       </Container>
     </SectionContainer>

--- a/scripts/site-app-visual-routes.mjs
+++ b/scripts/site-app-visual-routes.mjs
@@ -7,7 +7,11 @@ const campaignPlanPageFile =
   "packages/site-kit/src/components/campaign-plan-page.tsx";
 const researchPageFile =
   "packages/site-kit/src/components/research-page.tsx";
+const allocationBarFile = "packages/neobrutalist-ui/src/ui/allocation-bar.tsx";
+const spendingChartFile = "packages/site-kit/src/components/landing/war-vs-cures-chart.tsx";
+const wishocracyBarsFile = "apps/wishocracy/components/wishocracy/BudgetAllocationBars.tsx";
 const surveyResultsFiles = [
+  allocationBarFile,
   "packages/site-kit/src/components/dashboard/SurveyResultsCard.tsx",
   "packages/site-kit/src/lib/survey-results.ts",
   "packages/site-kit/src/lib/survey-results.server.ts",
@@ -36,6 +40,8 @@ const dfdaHowItWorksFiles = [
   "packages/site-kit/src/components/how-it-works/steps/Step7FDAiAgent.tsx",
 ];
 const campaignHomeSharedFiles = [
+  allocationBarFile,
+  spendingChartFile,
   "packages/site-kit/src/components/campaign-home-page.tsx",
   "packages/site-kit/src/components/landing/decentralized-fda-section.tsx",
   "packages/site-kit/src/components/landing/final-cta.tsx",
@@ -67,6 +73,7 @@ function getCampaignHomeFiles(appName) {
 }
 
 const warOnDiseaseDashboardFiles = [
+  allocationBarFile,
   "packages/site-kit/src/components/dashboard/DashboardClient.tsx",
   "packages/site-kit/src/components/dashboard/SurveyResultsCard.tsx",
   "packages/site-kit/src/lib/survey-results.ts",
@@ -223,6 +230,8 @@ export const authenticatedSiteAppRoutes = Object.freeze({
       covers: [
         "apps/wishocracy/app/dashboard/page.tsx",
         "apps/wishocracy/app/dashboard/dashboard-client.tsx",
+        wishocracyBarsFile,
+        allocationBarFile,
       ],
       label: "Allocation dashboard — signed-in user",
       routeName: "dashboard-authenticated",
@@ -320,6 +329,8 @@ export const publicSiteAppRoutes = Object.freeze({
       covers: [
         "apps/warondisease/app/research/page.tsx",
         researchPageFile,
+        spendingChartFile,
+        allocationBarFile,
       ],
       label: "Research and evidence",
       routeName: "research",


### PR DESCRIPTION
Allocation comparisons now use aligned, full-width bars with larger percentages. Survey dashboards and public results make the average desired allocation easier to compare with current government spending. Wishocracy keeps percentage labels within the page even when an allocation reaches 100%.

The shared `AllocationBar` renderer serves survey results, the War on Disease/CureDAO spending chart, and Wishocracy's budget bars. Each consumer keeps its existing data and scale: the campaign chart compares annual dollar amounts, while surveys and Wishocracy compare percentages. The campaign chart retains its large pink bar and headline; duplicate clinical-trial copy beside the tiny bar is removed.

Wishocracy uses "Your preferred allocation", "Average preferred allocation", and "Current government allocation" consistently in the bars, legend, and sort control. The sort control wraps on narrow screens.

Validation:
- Typechecks passed for War on Disease, Wishocracy, Trial Abundance Survey, Accelerated Medicine, and CureDAO.
- War on Disease and Wishocracy lint passed. All 19 navigation and visual-route coverage tests passed.
- Captured and inspected 24 local before/after component screenshots at desktop and mobile widths, using deterministic examples. Confirmed the old Wishocracy 100% label caused horizontal overflow at 390px and the new layout does not. Search and sort work.
- Corrected capture noise from unfinished entrance animations and interactions before hydration. Local preview scaffolding was removed before commit. The screenshots are component fixtures, not full authenticated-page captures or production survey data.
- Enrolled the shared chart files in the affected visual-review routes.
- Verified all three Wishocracy sort states at 320px, 390px, and 1440px after the label update. No clipped text or horizontal overflow. Captured and inspected nine additional local component screenshots. Wishocracy typecheck and lint passed.

Review:
- [ ] Review the allocation charts on desktop and mobile.
- [ ] Review the generated copy and page previews when CI publishes them.

Branch preview pages (deployment checks must finish first):
- War on Disease: [homepage](https://warondisease-git-feature-survey-da-410615-mike-p-sinns-projects.vercel.app/?logout=1), [research](https://warondisease-git-feature-survey-da-410615-mike-p-sinns-projects.vercel.app/research?logout=1), [dashboard](https://warondisease-git-feature-survey-da-410615-mike-p-sinns-projects.vercel.app/dashboard?login=demo).
- Accelerated Medicine: [results](https://acceleratedmedicine-git-feature-su-101d65-mike-p-sinns-projects.vercel.app/results?logout=1), [dashboard](https://acceleratedmedicine-git-feature-su-101d65-mike-p-sinns-projects.vercel.app/dashboard?login=demo).
- Additional affected routes: Trial Abundance Survey `/results` and `/dashboard`; Wishocracy `/dashboard` and `/` after three comparisons; CureDAO `/`. Their preview links are supplied by the site-app build workflow.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared allocation bars for clearer visualization of budgets, funding, and spending comparisons.
  * Allocation bars now support proportional segments, labels, legends, value displays, and multiple sizes.
  * Improved allocation sorting controls with taller, wrapping labels.

* **Improvements**
  * Updated survey results terminology to “Average desired allocation.”
  * Standardized allocation visualizations across wishocracy, survey results, and spending charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->